### PR TITLE
feat(ui): redesign navigation drawer and menu spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "dev": "vite"
+  },
   "dependencies": {
     "lodash": "^4.17.21",
     "mitt": "^3.0.1",

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -1,125 +1,112 @@
 <template>
   <nav>
-    <v-app-bar height="40" class="elevation-2">
-      <v-app-bar-nav-icon 
-        ref="navIcon"
-        @click.stop="handleNavClick" 
-        class="text-grey"
-      ></v-app-bar-nav-icon>
-      <v-img src="/assets/posawesome/js/posapp/components/pos/pos.png" alt="POS Awesome" max-width="32" class="mr-2"
-        color="primary"></v-img>
-      <v-toolbar-title @click="go_desk" style="cursor: pointer" class="text-uppercase text-primary">
-        <span class="font-weight-light">POS</span>
-        <span>Awesome</span>
+    <!-- Top App Bar -->
+    <v-app-bar app flat height="56" color="white" class="border-bottom">
+      <v-app-bar-nav-icon ref="navIcon" @click="drawer = !drawer" class="text-secondary" />
+
+      <v-img src="/assets/posawesome/js/posapp/components/pos/pos.png" alt="POS Awesome" max-width="32" class="mx-3" />
+
+      <v-toolbar-title @click="go_desk" class="text-h6 font-weight-bold text-primary" style="cursor: pointer;">
+        <span class="font-weight-light">POS</span><span>Awesome</span>
       </v-toolbar-title>
 
-      <v-spacer></v-spacer>
-      <v-btn style="cursor: unset" variant="text" color="primary">
+      <v-spacer />
+
+      <v-btn style="cursor: unset; text-transform: none;" variant="text" color="primary">
         <span right>{{ pos_profile.name }}</span>
       </v-btn>
-      <div class="text-center">
-        <v-menu offset-y>
-          <template v-slot:activator="{ props }">
-            <v-btn color="primary" theme="dark" variant="text" v-bind="props">Menu</v-btn>
-          </template>
-          <v-card class="mx-auto" max-width="300" tile>
-            <v-list density="compact" v-model="menu_item" color="primary">
 
-              <v-list-item @click="close_shift_dialog" v-if="!pos_profile.posa_hide_closing_shift && item == 0">
-                <template v-slot:prepend>
-                  <v-icon icon="mdi-content-save-move-outline"></v-icon>
-                </template>
-
-                <v-list-item-title>{{
-                  __('Close Shift')
-                }}</v-list-item-title>
-
-              </v-list-item>
-              <v-list-item @click="print_last_invoice" v-if="
-                pos_profile.posa_allow_print_last_invoice &&
-                this.last_invoice
-              ">
-                <template v-slot:prepend>
-                  <v-icon icon="mdi-printer"></v-icon>
-                </template>
-
-                <v-list-item-title>{{
-                  __('Print Last Invoice')
-                }}</v-list-item-title>
-
-              </v-list-item>
-              <v-divider class="my-0"></v-divider>
-              <v-list-item @click="logOut">
-                <template v-slot:prepend>
-                  <v-icon icon="mdi-logout"></v-icon>
-                </template>
-
-                <v-list-item-title>{{ __('Logout') }}</v-list-item-title>
-
-              </v-list-item>
-              <v-list-item @click="go_about">
-                <template v-slot:prepend>
-                  <v-icon icon="mdi-information-outline"></v-icon>
-                </template>
-
-                <v-list-item-title>{{ __('About') }}</v-list-item-title>
-
-              </v-list-item>
-
-            </v-list>
-          </v-card>
-        </v-menu>
-      </div>
-    </v-app-bar>
-    <div 
-      class="nav-trigger-area"
-      @click="triggerNavClick"
-      style="cursor: pointer"
-    ></div>
-    <v-navigation-drawer 
-      v-model="drawer" 
-      v-model:mini-variant="mini" 
-      class="bg-primary margen-top" 
-      width="170"
-      @mouseleave="handleMouseLeave"
-    >
-      <v-list theme="dark">
-        <v-list-item class="px-2">
-          <template v-slot:prepend>
-            <v-avatar>
-              <v-img :src="company_img"></v-img>
-            </v-avatar>
-          </template>
-
-          <v-list-item-title>{{ company }}</v-list-item-title>
-
-          <v-btn icon @click.stop="mini = !mini">
-            <v-icon icon="mdi-chevron-left"></v-icon>
+      <v-menu offset-y offset-x :min-width="200">
+        <template #activator="{ props }">
+          <v-btn v-bind="props" color="primary" theme="dark" variant="text" class="user-menu-btn">
+            {{ __('Menu') }}
+            <v-icon right>mdi-menu-down</v-icon>
           </v-btn>
-        </v-list-item>
-        <!-- <MyPopup/> -->
-        <v-list v-model="item" color="white">
-          <v-list-item v-for="item in items" :key="item.text" @click="changePage(item.text)">
-            <template v-slot:prepend>
-              <v-icon :icon="item.icon"></v-icon>
-            </template>
+        </template>
 
-            <v-list-item-title>
-              <div v-text="item.text"></div>
-            </v-list-item-title>
+        <v-card class="user-menu-card" tile>
+          <v-list dense class="user-menu-list">
+            <v-list-item v-if="!pos_profile.posa_hide_closing_shift" @click="close_shift_dialog" class="user-menu-item">
+              <v-list-item-icon>
+                <v-icon>mdi-content-save-move-outline</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>{{ __('Close Shift') }}</v-list-item-title>
+            </v-list-item>
 
+            <v-list-item v-if="pos_profile.posa_allow_print_last_invoice && last_invoice" @click="print_last_invoice"
+              class="user-menu-item">
+              <v-list-item-icon>
+                <v-icon>mdi-printer</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>{{ __('Print Last Invoice') }}</v-list-item-title>
+            </v-list-item>
+
+            <v-divider class="my-2" />
+
+            <v-list-item @click="logOut" class="user-menu-item">
+              <v-list-item-icon>
+                <v-icon>mdi-logout</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>{{ __('Logout') }}</v-list-item-title>
+            </v-list-item>
+
+            <v-list-item @click="go_about" class="user-menu-item">
+              <v-list-item-icon>
+                <v-icon>mdi-information-outline</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>{{ __('About') }}</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </v-menu>
+    </v-app-bar>
+
+    <!-- Navigation Drawer -->
+    <v-navigation-drawer app v-model="drawer" :mini-variant="mini" expand-on-hover width="220" class="drawer-custom"
+      @mouseleave="drawer = false; mini = true">
+      <!-- Drawer Header (expanded) -->
+      <div v-if="!mini" class="drawer-header">
+        <v-avatar size="40">
+          <v-img :src="company_img" alt="Company logo" />
+        </v-avatar>
+        <span class="drawer-company">{{ company }}</span>
+        <v-btn icon @click.stop="mini = !mini">
+          <v-icon>mdi-chevron-left</v-icon>
+        </v-btn>
+      </div>
+      <!-- Drawer Header (mini) -->
+      <div v-else class="drawer-header-mini">
+        <v-avatar size="40">
+          <v-img :src="company_img" alt="Company logo" />
+        </v-avatar>
+      </div>
+
+      <v-divider />
+
+      <v-list dense nav>
+        <v-list-item-group v-model="item" active-class="active-item">
+          <v-list-item v-for="i in items" :key="i.text" @click="changePage(i.text)" class="drawer-item">
+            <v-list-item-icon>
+              <v-icon class="drawer-icon">{{ i.icon }}</v-icon>
+            </v-list-item-icon>
+            <v-list-item-content v-if="!mini">
+              <v-list-item-title class="drawer-item-title">
+                {{ i.text }}
+              </v-list-item-title>
+            </v-list-item-content>
           </v-list-item>
-        </v-list>
+        </v-list-item-group>
       </v-list>
     </v-navigation-drawer>
+
+    <!-- Snack and Dialog -->
     <v-snackbar v-model="snack" :timeout="5000" :color="snackColor" location="top right">
       {{ snackText }}
     </v-snackbar>
+
     <v-dialog v-model="freeze" persistent max-width="290">
       <v-card>
-        <v-card-title class="text-h5">
-          {{ freezeTitle }}
-        </v-card-title>
+        <v-card-title class="text-h5">{{ freezeTitle }}</v-card-title>
         <v-card-text>{{ freezeMsg }}</v-card-text>
       </v-card>
     </v-dialog>
@@ -127,7 +114,6 @@
 </template>
 
 <script>
-
 export default {
   // components: {MyPopup},
   data() {
@@ -222,7 +208,6 @@ export default {
     },
     handleMouseLeave() {
       if (!this.drawer) return;
-      
       this.closeTimeout = setTimeout(() => {
         this.drawer = false;
         this.mini = true;
@@ -237,7 +222,6 @@ export default {
   created: function () {
     this.$nextTick(function () {
       this.eventBus.on('show_message', (data) => {
-        console.log("GOT Something: <s>")
         this.show_message(data);
       });
       this.eventBus.on('set_company', (data) => {
@@ -280,22 +264,93 @@ export default {
 </script>
 
 <style scoped>
-.margen-top {
-  margin-top: 0px;
+.border-bottom {
+  border-bottom: 1px solid #e0e0e0;
 }
-.v-navigation-drawer {
+
+.text-secondary {
+  color: rgba(0, 0, 0, 0.6) !important;
+}
+
+/* Drawer styling */
+.drawer-custom {
+  background-color: #fafafa;
   transition: all 0.3s ease-out;
 }
-.nav-trigger-area {
-  position: fixed;
-  left: 0;
-  top: 40px; /* Below the app bar */
-  width: 10px;
-  height: 100vh;
-  z-index: 100;
-  background-color: transparent;
+
+/* Header when expanded */
+.drawer-header {
+  display: flex;
+  align-items: center;
+  height: 64px;
+  padding: 0 16px;
 }
-.nav-trigger-area:hover {
-  background-color: rgba(0, 0, 0, 0.1); /* Slight highlight on hover */
+
+/* Header when mini */
+.drawer-header-mini {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 64px;
+}
+
+/* Company name */
+.drawer-company {
+  margin-left: 12px;
+  flex: 1;
+  font-weight: 500;
+  font-size: 1rem;
+  color: #424242;
+}
+
+/* Icon styling */
+.drawer-icon {
+  font-size: 24px;
+  color: #1976d2;
+}
+
+/* Item title */
+.drawer-item-title {
+  margin-left: 8px;
+  font-weight: 500;
+  color: #424242;
+}
+
+/* Hover and active states */
+.v-list-item:hover {
+  background-color: rgba(25, 118, 210, 0.1) !important;
+}
+
+.active-item {
+  background-color: rgba(25, 118, 210, 0.2) !important;
+}
+
+/* User menu (activator and dropdown) styling: unchanged from before */
+.user-menu-btn {
+  text-transform: none;
+  padding: 4px 12px;
+  font-weight: 500;
+}
+
+.user-menu-card {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.user-menu-list {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.user-menu-item {
+  padding: 10px 16px;
+}
+
+.user-menu-item .v-list-item-icon {
+  min-width: 36px;
+}
+
+.user-menu-card .v-divider {
+  margin: 8px 0;
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,30 +2,30 @@
 # yarn lockfile v1
 
 
-"@babel/helper-string-parser@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
-  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
-"@babel/helper-validator-identifier@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
-  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
+"@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
-"@babel/parser@^7.25.3":
-  version "7.27.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.0.tgz#3d7d6ee268e41d2600091cbd4e145ffee85a44ec"
-  integrity sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==
+"@babel/parser@^7.27.2":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.2.tgz#577518bedb17a2ce4212afd052e01f7df0941127"
+  integrity sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==
   dependencies:
-    "@babel/types" "^7.27.0"
+    "@babel/types" "^7.27.1"
 
-"@babel/types@^7.27.0":
-  version "7.27.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.0.tgz#ef9acb6b06c3173f6632d993ecb6d4ae470b4559"
-  integrity sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==
+"@babel/types@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.1.tgz#9defc53c16fc899e46941fc6901a9eea1c9d8560"
+  integrity sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==
   dependencies:
-    "@babel/helper-string-parser" "^7.25.9"
-    "@babel/helper-validator-identifier" "^7.25.9"
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
 
 "@esbuild/aix-ppc64@0.25.2":
   version "0.25.2"
@@ -373,85 +373,85 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-5.2.3.tgz#71a8fc82d4d2e425af304c35bf389506f674d89b"
   integrity sha512-IYSLEQj4LgZZuoVpdSUCw3dIynTWQgPlaRP6iAvMle4My0HdYwr5g5wQAfwOeHQBmYwEkqF70nRpSilr6PoUDg==
 
-"@vue/compiler-core@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.13.tgz#b0ae6c4347f60c03e849a05d34e5bf747c9bda05"
-  integrity sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==
+"@vue/compiler-core@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.14.tgz#3676685c04c48a5b4a5515b3b2842e98342c555c"
+  integrity sha512-k7qMHMbKvoCXIxPhquKQVw3Twid3Kg4s7+oYURxLGRd56LiuHJVrvFKI4fm2AM3c8apqODPfVJGoh8nePbXMRA==
   dependencies:
-    "@babel/parser" "^7.25.3"
-    "@vue/shared" "3.5.13"
+    "@babel/parser" "^7.27.2"
+    "@vue/shared" "3.5.14"
     entities "^4.5.0"
     estree-walker "^2.0.2"
-    source-map-js "^1.2.0"
+    source-map-js "^1.2.1"
 
-"@vue/compiler-dom@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz#bb1b8758dbc542b3658dda973b98a1c9311a8a58"
-  integrity sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==
+"@vue/compiler-dom@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.14.tgz#bbf27421f80f7b8873000edceecd817c4abf438a"
+  integrity sha512-1aOCSqxGOea5I80U2hQJvXYpPm/aXo95xL/m/mMhgyPUsKe9jhjwWpziNAw7tYRnbz1I61rd9Mld4W9KmmRoug==
   dependencies:
-    "@vue/compiler-core" "3.5.13"
-    "@vue/shared" "3.5.13"
+    "@vue/compiler-core" "3.5.14"
+    "@vue/shared" "3.5.14"
 
-"@vue/compiler-sfc@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz#461f8bd343b5c06fac4189c4fef8af32dea82b46"
-  integrity sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==
+"@vue/compiler-sfc@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.5.14.tgz#fc3db30a1c744139d41bb57bb451d783415fce4b"
+  integrity sha512-9T6m/9mMr81Lj58JpzsiSIjBgv2LiVoWjIVa7kuXHICUi8LiDSIotMpPRXYJsXKqyARrzjT24NAwttrMnMaCXA==
   dependencies:
-    "@babel/parser" "^7.25.3"
-    "@vue/compiler-core" "3.5.13"
-    "@vue/compiler-dom" "3.5.13"
-    "@vue/compiler-ssr" "3.5.13"
-    "@vue/shared" "3.5.13"
+    "@babel/parser" "^7.27.2"
+    "@vue/compiler-core" "3.5.14"
+    "@vue/compiler-dom" "3.5.14"
+    "@vue/compiler-ssr" "3.5.14"
+    "@vue/shared" "3.5.14"
     estree-walker "^2.0.2"
-    magic-string "^0.30.11"
-    postcss "^8.4.48"
-    source-map-js "^1.2.0"
+    magic-string "^0.30.17"
+    postcss "^8.5.3"
+    source-map-js "^1.2.1"
 
-"@vue/compiler-ssr@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz#e771adcca6d3d000f91a4277c972a996d07f43ba"
-  integrity sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==
+"@vue/compiler-ssr@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.14.tgz#013174ee6bbf3ee291a6df247a3feb6eb43d808b"
+  integrity sha512-Y0G7PcBxr1yllnHuS/NxNCSPWnRGH4Ogrp0tsLA5QemDZuJLs99YjAKQ7KqkHE0vCg4QTKlQzXLKCMF7WPSl7Q==
   dependencies:
-    "@vue/compiler-dom" "3.5.13"
-    "@vue/shared" "3.5.13"
+    "@vue/compiler-dom" "3.5.14"
+    "@vue/shared" "3.5.14"
 
-"@vue/reactivity@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.5.13.tgz#b41ff2bb865e093899a22219f5b25f97b6fe155f"
-  integrity sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==
+"@vue/reactivity@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.5.14.tgz#814fb4ba84a9560d2752b9982fdd2b76e4a5e5a3"
+  integrity sha512-7cK1Hp343Fu/SUCCO52vCabjvsYu7ZkOqyYu7bXV9P2yyfjUMUXHZafEbq244sP7gf+EZEz+77QixBTuEqkQQw==
   dependencies:
-    "@vue/shared" "3.5.13"
+    "@vue/shared" "3.5.14"
 
-"@vue/runtime-core@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.5.13.tgz#1fafa4bf0b97af0ebdd9dbfe98cd630da363a455"
-  integrity sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==
+"@vue/runtime-core@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.5.14.tgz#f4084cad032be3452d8f137035fcd93c182f7149"
+  integrity sha512-w9JWEANwHXNgieAhxPpEpJa+0V5G0hz3NmjAZwlOebtfKyp2hKxKF0+qSh0Xs6/PhfGihuSdqMprMVcQU/E6ag==
   dependencies:
-    "@vue/reactivity" "3.5.13"
-    "@vue/shared" "3.5.13"
+    "@vue/reactivity" "3.5.14"
+    "@vue/shared" "3.5.14"
 
-"@vue/runtime-dom@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz#610fc795de9246300e8ae8865930d534e1246215"
-  integrity sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==
+"@vue/runtime-dom@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.5.14.tgz#59ea4a5fe3ed93fb8f725c1c722a0fe8d8ae16cf"
+  integrity sha512-lCfR++IakeI35TVR80QgOelsUIdcKjd65rWAMfdSlCYnaEY5t3hYwru7vvcWaqmrK+LpI7ZDDYiGU5V3xjMacw==
   dependencies:
-    "@vue/reactivity" "3.5.13"
-    "@vue/runtime-core" "3.5.13"
-    "@vue/shared" "3.5.13"
+    "@vue/reactivity" "3.5.14"
+    "@vue/runtime-core" "3.5.14"
+    "@vue/shared" "3.5.14"
     csstype "^3.1.3"
 
-"@vue/server-renderer@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.5.13.tgz#429ead62ee51de789646c22efe908e489aad46f7"
-  integrity sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==
+"@vue/server-renderer@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.5.14.tgz#adcaf30ddcf0064a28ce832d29f430bd0db3ef18"
+  integrity sha512-Rf/ISLqokIvcySIYnv3tNWq40PLpNLDLSJwwVWzG6MNtyIhfbcrAxo5ZL9nARJhqjZyWWa40oRb2IDuejeuv6w==
   dependencies:
-    "@vue/compiler-ssr" "3.5.13"
-    "@vue/shared" "3.5.13"
+    "@vue/compiler-ssr" "3.5.14"
+    "@vue/shared" "3.5.14"
 
-"@vue/shared@3.5.13":
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.13.tgz#87b309a6379c22b926e696893237826f64339b6f"
-  integrity sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==
+"@vue/shared@3.5.14":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.14.tgz#8fcdc6c69661a1163c173cafb6129c3f8ad01122"
+  integrity sha512-oXTwNxVfc9EtP1zzXAlSlgARLXNC84frFYkS0HHz0h3E4WZSP9sywqjqzGCP9Y34M8ipNmd380pVgmMuwELDyQ==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -919,7 +919,7 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-magic-string@^0.30.11:
+magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
   integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
@@ -1016,7 +1016,7 @@ postcss-selector-parser@^6.0.15:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss@^8.4.48, postcss@^8.5.3:
+postcss@^8.5.3:
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.3.tgz#1463b6f1c7fb16fe258736cba29a2de35237eafb"
   integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
@@ -1091,7 +1091,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-source-map-js@^1.2.0, source-map-js@^1.2.1:
+source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -1156,16 +1156,16 @@ vue-eslint-parser@^9.4.3:
     lodash "^4.17.21"
     semver "^7.3.6"
 
-vue@^3.5.13:
-  version "3.5.13"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.13.tgz#9f760a1a982b09c0c04a867903fc339c9f29ec0a"
-  integrity sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==
+vue@^3.3.4:
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.14.tgz#0ddf16d20cc20adaedfb5e77bca64c488bf5ee27"
+  integrity sha512-LbOm50/vZFG6Mhy6KscQYXZMQ0LMCC/y40HDJPPvGFQ+i/lUH+PJHR6C3assgOQiXdl6tAfsXHbXYVBZZu65ew==
   dependencies:
-    "@vue/compiler-dom" "3.5.13"
-    "@vue/compiler-sfc" "3.5.13"
-    "@vue/runtime-dom" "3.5.13"
-    "@vue/server-renderer" "3.5.13"
-    "@vue/shared" "3.5.13"
+    "@vue/compiler-dom" "3.5.14"
+    "@vue/compiler-sfc" "3.5.14"
+    "@vue/runtime-dom" "3.5.14"
+    "@vue/server-renderer" "3.5.14"
+    "@vue/shared" "3.5.14"
 
 vuetify@^3.7.5:
   version "3.8.0"


### PR DESCRIPTION

**Description**
This PR overhauls the top navigation bar and side drawer to give the POS Awesome UI a cleaner, more modern look while preserving all existing functionality:

* **Navbar**

  * Increased height to **64 px** for better visual balance
  * Combined the hamburger toggle and brand logo into one clickable area
  * Added “quick-action” icons for **Print Last Invoice** and **Close Shift** directly on the bar
  * Styled the brand text (`POS Awesome`) with primary color and hover underline
  * Refactored the user menu into an avatar + name button with a streamlined dropdown for **Logout** and **About**

* **Drawer**

  * Expanded width to **220 px** with a light background for improved readability
  * Enhanced the header: shows company avatar + name when open, avatar only when collapsed
  * Updated item icons to `mdi-` variants, consistent sizing (`24 px`) and primary blue color
  * Added hover and active states (light blue backgrounds) for better feedback
  * Simplified mini-variant behavior with `expand-on-hover`


