### PR TITLE
Fix Cache API error on chrome-extension requests

### DIFF
--- a/posawesome/public/js/sw.js
+++ b/posawesome/public/js/sw.js
@@ -16,6 +16,7 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
+  if (!event.request.url.startsWith('http')) return;
   event.respondWith(
     caches.match(event.request).then(response => {
       return (

--- a/posawesome/www/sw.js
+++ b/posawesome/www/sw.js
@@ -17,6 +17,7 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
+  if (!event.request.url.startsWith('http')) return;
 
   if (event.request.mode === 'navigate') {
     event.respondWith(


### PR DESCRIPTION
## Summary
- avoid caching non-http requests in Service Worker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68407d42cb1483269f8b79653b3f2b36