### PR TITLE
Fix offline fallback for socket.io requests

### DIFF
--- a/posawesome/public/js/sw.js
+++ b/posawesome/public/js/sw.js
@@ -16,18 +16,21 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
+  if (!event.request.url.startsWith('http')) return;
+  if (event.request.url.includes('socket.io')) return;
+
   event.respondWith(
     caches.match(event.request).then(response => {
-      return (
-        response ||
-        fetch(event.request).then(resp => {
+      if (response) {
+        return response;
+      }
+      return fetch(event.request).then(resp => {
+        if (resp && resp.ok && resp.status === 200) {
           const respClone = resp.clone();
-          caches.open('posawesome-cache-v1').then(cache => {
-            cache.put(event.request, respClone);
-          });
-          return resp;
-        }).catch(() => response)
-      );
-    })
+          caches.open('posawesome-cache-v1').then(cache => cache.put(event.request, respClone));
+        }
+        return resp;
+      });
+    }).catch(() => caches.match(event.request).then(r => r || new Response('')))
   );
 });

--- a/posawesome/www/sw.js
+++ b/posawesome/www/sw.js
@@ -17,6 +17,8 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
+  if (!event.request.url.startsWith('http')) return;
+  if (event.request.url.includes('socket.io')) return;
 
   if (event.request.mode === 'navigate') {
     event.respondWith(
@@ -40,7 +42,7 @@ self.addEventListener('fetch', event => {
         }
         return resp;
       });
-    }).catch(() => caches.match(event.request))
+    }).catch(() => caches.match(event.request).then(r => r || new Response('')))
 
   );
 });


### PR DESCRIPTION
## Summary
- skip socket.io polling requests in Service Worker
- return an empty Response when neither network nor cache is available

## Testing
- `npm test` *(fails: Missing script)*
- `pytest` *(fails to import `frappe`)*

------
https://chatgpt.com/codex/tasks/task_e_68407d42cb1483269f8b79653b3f2b36