### PR TITLE
Fix Cache API error on chrome-extension requests

### DIFF
--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -126,9 +126,9 @@ export default {
           const cached = JSON.parse(localStorage.getItem('opening_dialog_storage'));
           if (cached) {
             vm.companies = cached.companies.map(c => c.name);
-            vm.company = vm.companies[0] || '';
             vm.pos_profiles_data = cached.pos_profiles_data || [];
             vm.payments_method_data = cached.payments_method || [];
+            vm.company = vm.companies[0] || '';
           }
         } catch (e) {
           console.error('Failed to parse opening dialog cache', e);
@@ -141,9 +141,9 @@ export default {
         callback: function (r) {
           if (r.message) {
             vm.companies = r.message.companies.map(element => element.name);
-            vm.company = vm.companies[0] || '';
             vm.pos_profiles_data = r.message.pos_profiles_data;
             vm.payments_method_data = r.message.payments_method;
+            vm.company = vm.companies[0] || '';
             try {
               localStorage.setItem('opening_dialog_storage', JSON.stringify(r.message));
             } catch (e) {

--- a/posawesome/public/js/sw.js
+++ b/posawesome/public/js/sw.js
@@ -16,18 +16,21 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
+  if (!event.request.url.startsWith('http')) return;
+  if (event.request.url.includes('socket.io')) return;
+
   event.respondWith(
     caches.match(event.request).then(response => {
-      return (
-        response ||
-        fetch(event.request).then(resp => {
+      if (response) {
+        return response;
+      }
+      return fetch(event.request).then(resp => {
+        if (resp && resp.ok && resp.status === 200) {
           const respClone = resp.clone();
-          caches.open('posawesome-cache-v1').then(cache => {
-            cache.put(event.request, respClone);
-          });
-          return resp;
-        }).catch(() => response)
-      );
-    })
+          caches.open('posawesome-cache-v1').then(cache => cache.put(event.request, respClone));
+        }
+        return resp;
+      });
+    }).catch(() => caches.match(event.request).then(r => r || new Response('')))
   );
 });

--- a/posawesome/www/sw.js
+++ b/posawesome/www/sw.js
@@ -17,6 +17,8 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
+  if (!event.request.url.startsWith('http')) return;
+  if (event.request.url.includes('socket.io')) return;
 
   if (event.request.mode === 'navigate') {
     event.respondWith(
@@ -40,7 +42,7 @@ self.addEventListener('fetch', event => {
         }
         return resp;
       });
-    }).catch(() => caches.match(event.request))
+    }).catch(() => caches.match(event.request).then(r => r || new Response('')))
 
   );
 });


### PR DESCRIPTION
## Summary
- avoid caching non-http requests in Service Worker
- ensure cached opening shift data loads correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails to import `frappe`)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68407d42cb1483269f8b79653b3f2b36