### PR TITLE
Fix offline invoice persistence after refresh

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -33,6 +33,10 @@ export function getPendingOfflineInvoiceCount() {
 export async function syncOfflineInvoices() {
   const invoices = getOfflineInvoices();
   if (!invoices.length) return { pending: 0, synced: 0 };
+  if (!navigator.onLine) {
+    // When offline just return the pending count without attempting a sync
+    return { pending: invoices.length, synced: 0 };
+  }
   const failures = [];
   let synced = 0;
   for (const inv of invoices) {

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1531,6 +1531,10 @@ export default {
         });
         this.eventBus.emit("pending_invoices_changed", pending);
       }
+      if (!navigator.onLine) {
+        // Don't attempt to sync while offline; just update the counter
+        return;
+      }
       const result = await syncOfflineInvoices();
       if (result && result.synced) {
         this.eventBus.emit("show_message", {


### PR DESCRIPTION
## Summary
- avoid syncing invoices when offline to prevent clearing local storage
- check network status in offline invoice sync

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840a429c63883268e053966bb16b40d