### PR TITLE
Improve offline detection for network disconnects

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -14,6 +14,13 @@ export function saveOfflineInvoice(entry) {
   }
 }
 
+export function isOffline() {
+  if (typeof window !== 'undefined' && typeof window.serverOnline === 'boolean') {
+    return !navigator.onLine || !window.serverOnline;
+  }
+  return !navigator.onLine;
+}
+
 export function getOfflineInvoices() {
   try {
     return JSON.parse(localStorage.getItem('offline_invoices')) || [];
@@ -33,7 +40,7 @@ export function getPendingOfflineInvoiceCount() {
 export async function syncOfflineInvoices() {
   const invoices = getOfflineInvoices();
   if (!invoices.length) return { pending: 0, synced: 0 };
-  if (!navigator.onLine) {
+  if (isOffline()) {
     // When offline just return the pending count without attempting a sync
     return { pending: invoices.length, synced: 0 };
   }

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -180,6 +180,7 @@ export default {
     const bootCompany = frappe?.boot?.user_info?.company;
     this.company = bootCompany || this.company; // Use boot company or default 'POS Awesome'
     console.log('Fetched company:', this.company);
+    window.serverOnline = this.serverOnline;
 
     // If a specific company name is found (not the default), fetch its logo from Frappe.
     if (this.company !== 'POS Awesome') {
@@ -341,6 +342,7 @@ export default {
          */
         this.socket.on('connect', () => {
           this.serverOnline = true;
+          window.serverOnline = true;
           this.serverConnecting = false;
           this.offlineMessageShown = false; // reset offline warning flag
           console.log('Socket.IO: Connected to server');
@@ -352,6 +354,7 @@ export default {
          */
         this.socket.on('disconnect', (reason) => {
           this.serverOnline = false;
+          window.serverOnline = false;
           this.serverConnecting = false;
           console.warn('Socket.IO: Disconnected from server. Reason:', reason);
 
@@ -371,6 +374,7 @@ export default {
          */
         this.socket.on('connect_error', (error) => {
           this.serverOnline = false;
+          window.serverOnline = false;
           this.serverConnecting = false;
           console.error('Socket.IO: Connection error:', error.message);
           this.eventBus.emit('server-offline');
@@ -385,6 +389,7 @@ export default {
         });
       } catch (err) {
         this.serverOnline = false;
+        window.serverOnline = false;
         this.serverConnecting = false;
         console.error('Failed to initialize Socket.IO connection:', err);
 
@@ -406,6 +411,7 @@ export default {
       console.log('Browser is online');
       this.offlineMessageShown = false; // allow future offline warnings
       this.eventBus.emit('network-online');
+      window.serverOnline = this.serverOnline;
       // If the server is not online and not currently connecting, and a socket instance exists,
       // explicitly try to connect the socket. This helps in re-establishing server connection
       // immediately after internet recovery.
@@ -424,6 +430,7 @@ export default {
     handleOffline() {
       this.networkOnline = false; // Browser is now offline
       this.serverOnline = false; // Server is considered unreachable if there's no internet
+      window.serverOnline = false;
       this.serverConnecting = false; // Stop any ongoing connection attempts
       console.log('Browser is offline');
       this.eventBus.emit('network-offline');

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -439,6 +439,7 @@
 
 import format from "../../format";
 import Customer from "./Customer.vue";
+import { isOffline } from "../../../offline";
 
 export default {
   mixins: [format],
@@ -1517,7 +1518,7 @@ export default {
     // Update invoice in backend
     update_invoice(doc) {
       var vm = this;
-      if (!navigator.onLine) {
+      if (isOffline()) {
         // When offline, simply merge the passed doc with the current invoice_doc
         // to allow offline invoice creation without server calls
         vm.invoice_doc = Object.assign({}, vm.invoice_doc || {}, doc);
@@ -1541,7 +1542,7 @@ export default {
     // Update invoice from order in backend
     update_invoice_from_order(doc) {
       var vm = this;
-      if (!navigator.onLine) {
+      if (isOffline()) {
         // Offline mode - merge doc locally without server update
         vm.invoice_doc = Object.assign({}, vm.invoice_doc || {}, doc);
         return vm.invoice_doc;

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -608,6 +608,7 @@ import {
   saveOfflineInvoice,
   syncOfflineInvoices,
   getPendingOfflineInvoiceCount,
+  isOffline,
 } from "../../../offline";
 
 export default {
@@ -1056,7 +1057,7 @@ export default {
       };
       const vm = this;
 
-      if (!navigator.onLine) {
+      if (isOffline()) {
         saveOfflineInvoice({ data: data, invoice: this.invoice_doc });
         this.eventBus.emit("pending_invoices_changed", getPendingOfflineInvoiceCount());
         vm.eventBus.emit("show_message", { title: __("Invoice saved offline"), color: "warning" });
@@ -1531,7 +1532,7 @@ export default {
         });
         this.eventBus.emit("pending_invoices_changed", pending);
       }
-      if (!navigator.onLine) {
+      if (isOffline()) {
         // Don't attempt to sync while offline; just update the counter
         return;
       }


### PR DESCRIPTION
## Summary
- add `isOffline` helper that also checks WebSocket connectivity
- expose server connectivity status globally in `Navbar`
- use `isOffline` in invoice/payment handling to save invoices offline when the network is unplugged

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/Payments.vue posawesome/public/js/posapp/components/pos/Invoice.vue posawesome/public/js/offline.js posawesome/public/js/posapp/components/Navbar.vue` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68429745427c832682fe690103e256bb