### PR TITLE
Add screenshot placeholders in manifest

### DIFF
--- a/posawesome/public/screenshots/screenshot-mobile.txt
+++ b/posawesome/public/screenshots/screenshot-mobile.txt
@@ -1,0 +1,1 @@
+placeholder screenshot narrow

--- a/posawesome/public/screenshots/screenshot-wide.txt
+++ b/posawesome/public/screenshots/screenshot-wide.txt
@@ -1,0 +1,1 @@
+placeholder screenshot wide

--- a/posawesome/www/manifest.json
+++ b/posawesome/www/manifest.json
@@ -16,5 +16,19 @@
       "sizes": "512x512",
       "type": "text/plain"
     }
+  ],
+  "screenshots": [
+    {
+      "src": "/assets/posawesome/screenshots/screenshot-mobile.txt",
+      "sizes": "720x1280",
+      "type": "text/plain",
+      "form_factor": "narrow"
+    },
+    {
+      "src": "/assets/posawesome/screenshots/screenshot-wide.txt",
+      "sizes": "1280x720",
+      "type": "text/plain",
+      "form_factor": "wide"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add screenshot placeholders in public folder
- reference these screenshots in the PWA manifest

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842bfca585c8326ae4d1960f027149b