### PR TITLE
Handle offline invoice as draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ After switching branches or pulling latest changes:
 31. Accept new payments from customers against existing invoices
 32. Payments Reconciliation
 33. A lot more bug fixes from the version 14
+34. Offline invoices that fail to submit are saved as draft documents
 
 ### How to Install
 

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -574,11 +574,19 @@ export default {
         return;
       }
       const result = await syncOfflineInvoices();
-      if (result && result.synced) {
-        this.showMessage({
-          title: `${result.synced} offline invoice${result.synced > 1 ? 's' : ''} synced`,
-          color: 'success'
-        });
+      if (result && (result.synced || result.drafted)) {
+        if (result.synced) {
+          this.showMessage({
+            title: `${result.synced} offline invoice${result.synced > 1 ? 's' : ''} synced`,
+            color: 'success'
+          });
+        }
+        if (result.drafted) {
+          this.showMessage({
+            title: `${result.drafted} offline invoice${result.drafted > 1 ? 's' : ''} saved as draft`,
+            color: 'warning'
+          });
+        }
       }
       this.updatePendingInvoices();
       this.eventBus.emit('pending_invoices_changed', this.pendingInvoices);

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1551,11 +1551,19 @@ export default {
         return;
       }
       const result = await syncOfflineInvoices();
-      if (result && result.synced) {
-        this.eventBus.emit("show_message", {
-          title: `${result.synced} offline invoice${result.synced > 1 ? 's' : ''} synced`,
-          color: "success",
-        });
+      if (result && (result.synced || result.drafted)) {
+        if (result.synced) {
+          this.eventBus.emit("show_message", {
+            title: `${result.synced} offline invoice${result.synced > 1 ? 's' : ''} synced`,
+            color: "success",
+          });
+        }
+        if (result.drafted) {
+          this.eventBus.emit("show_message", {
+            title: `${result.drafted} offline invoice${result.drafted > 1 ? 's' : ''} saved as draft`,
+            color: "warning",
+          });
+        }
       }
       this.eventBus.emit("pending_invoices_changed", getPendingOfflineInvoiceCount());
     }


### PR DESCRIPTION
## Summary
- keep failed offline invoices as drafts
- show separate messages for submitted vs drafted invoices
- document failed offline sync behavior

## Testing
- `npx eslint posawesome/public/js/offline.js` *(fails: Cannot find package 'globals')*
- `python -m py_compile posawesome/posawesome/api/posapp.py`


------
https://chatgpt.com/codex/tasks/task_e_6842d6edf0ec8326b91fa12b407f6c18