### PR TITLE
Fix sync info persistence

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -56,15 +56,12 @@ export function getLastSyncTotals() {
 export async function syncOfflineInvoices() {
   const invoices = getOfflineInvoices();
   if (!invoices.length) {
-    const totals = { pending: 0, synced: 0, drafted: 0 };
-    setLastSyncTotals(totals);
-    return totals;
+    // No invoices to sync; keep previously stored totals
+    return getLastSyncTotals();
   }
   if (isOffline()) {
     // When offline just return the pending count without attempting a sync
-    const totals = { pending: invoices.length, synced: 0, drafted: 0 };
-    setLastSyncTotals(totals);
-    return totals;
+    return { pending: invoices.length, synced: 0, drafted: 0 };
   }
 
   const failures = [];

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -579,12 +579,6 @@ export default {
           color: 'warning'
         });
       }
-      this.syncTotals.pending = pending;
-      if (isOffline()) {
-        this.syncTotals.synced = 0;
-        this.syncTotals.drafted = 0;
-        return;
-      }
       const result = await syncOfflineInvoices();
       if (result && (result.synced || result.drafted)) {
         if (result.synced) {


### PR DESCRIPTION
## Summary
- retain previous sync totals when there are no offline invoices
- update navbar sync logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6842e2ba60ac8326b565111f797dfd59