### PR TITLE
Fix offline sync count

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -90,13 +90,15 @@ export async function syncOfflineInvoices() {
     }
   }
 
-  if (failures.length) {
+  const pendingLeft = failures.length;
+
+  if (pendingLeft) {
     localStorage.setItem('offline_invoices', JSON.stringify(failures));
   } else {
     clearOfflineInvoices();
   }
 
-  const totals = { pending: invoices.length, synced, drafted };
+  const totals = { pending: pendingLeft, synced, drafted };
   setLastSyncTotals(totals);
   return totals;
 }


### PR DESCRIPTION
## Summary
- show `0` invoices pending after a successful offline sync

## Testing
- `npm install`
- `npx eslint posawesome/public/js/offline.js`


------
https://chatgpt.com/codex/tasks/task_e_6842e4e8e89c832694bc38a9b41f2178