### PR TITLE
Add offline caching for UOMs and offers

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -102,3 +102,37 @@ export async function syncOfflineInvoices() {
   setLastSyncTotals(totals);
   return totals;
 }
+export function saveItemUOMs(itemCode, uoms) {
+  try {
+    const cache = JSON.parse(localStorage.getItem('uom_cache')) || {};
+    cache[itemCode] = uoms;
+    localStorage.setItem('uom_cache', JSON.stringify(cache));
+  } catch (e) {
+    console.error('Failed to cache UOMs', e);
+  }
+}
+
+export function getItemUOMs(itemCode) {
+  try {
+    const cache = JSON.parse(localStorage.getItem('uom_cache')) || {};
+    return cache[itemCode] || [];
+  } catch (e) {
+    return [];
+  }
+}
+
+export function saveOffers(offers) {
+  try {
+    localStorage.setItem('offers_cache', JSON.stringify(offers));
+  } catch (e) {
+    console.error('Failed to cache offers', e);
+  }
+}
+
+export function getCachedOffers() {
+  try {
+    return JSON.parse(localStorage.getItem('offers_cache')) || [];
+  } catch (e) {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add helper methods to cache UOMs and offers in `offline.js`
- cache UOMs in `ItemsSelector` and use them when offline
- cache POS offers in `Pos.vue` and fallback to cached data if API fails

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842f0703810832691cc0c81cb7f122e