### PR TITLE
Fix offline.js import paths

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -125,7 +125,7 @@
 import format from "../../format";
 import _ from "lodash";
 import CameraScanner from './CameraScanner.vue';
-import { saveItemUOMs, getItemUOMs } from '../../offline.js';
+import { saveItemUOMs, getItemUOMs } from '../../../offline.js';
 
 export default {
   mixins: [format],

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -44,7 +44,7 @@ import NewAddress from './NewAddress.vue';
 import Variants from './Variants.vue';
 import Returns from './Returns.vue';
 import MpesaPayments from './Mpesa-Payments.vue';
-import { getCachedOffers, saveOffers } from '../../offline.js';
+import { getCachedOffers, saveOffers } from '../../../offline.js';
 
 export default {
   data: function () {


### PR DESCRIPTION
## Summary
- correct relative paths to `offline.js` from `Pos.vue` and `ItemsSelector.vue`

## Testing
- `yarn install --frozen-lockfile`
- `npx eslint .` *(fails: 84 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843007b9e3c8326a7fe53c50768a1b3