### PR TITLE
Ensure UOM cache for all POS items

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -226,8 +226,8 @@ export default {
 
         // Even when loading from localStorage, refresh the quantities
         setTimeout(() => {
-          if (vm.filtered_items && vm.filtered_items.length > 0) {
-            vm.update_items_details(vm.filtered_items);
+          if (vm.items && vm.items.length > 0) {
+            vm.update_items_details(vm.items);
           }
         }, 300);
       }
@@ -253,8 +253,8 @@ export default {
 
             // Always refresh quantities after items are loaded
             setTimeout(() => {
-              if (vm.filtered_items && vm.filtered_items.length > 0) {
-                vm.update_items_details(vm.filtered_items);
+              if (vm.items && vm.items.length > 0) {
+                vm.update_items_details(vm.items);
               }
             }, 300);
 


### PR DESCRIPTION
## Summary
- always refresh item details for all loaded items

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*
- `npm test` *(fails: Missing script "test")*
- `yarn test` *(fails: Command "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_684302b00c7083269ff21573640f5457