### PR TITLE
Improve offline caching

### DIFF
--- a/posawesome/public/js/sw.js
+++ b/posawesome/public/js/sw.js
@@ -6,6 +6,8 @@ self.addEventListener('install', event => {
       const resources = [
         '/assets/posawesome/js/posawesome.bundle.js',
         '/assets/posawesome/js/offline.js',
+        '/manifest.json',
+        '/offline.html',
       ];
       await Promise.all(resources.map(async url => {
         try {
@@ -46,6 +48,6 @@ self.addEventListener('fetch', event => {
         return resp;
       });
 
-    }).catch(() => caches.match(event.request).then(r => r || Response.error()))
+    }).catch(() => caches.match(event.request).then(r => r || caches.match('/offline.html') || Response.error()))
   );
 });

--- a/posawesome/www/sw.js
+++ b/posawesome/www/sw.js
@@ -6,7 +6,9 @@ self.addEventListener('install', event => {
       const resources = [
         '/app/posapp',
         '/assets/posawesome/js/posawesome.bundle.js',
-        '/assets/posawesome/js/offline.js'
+        '/assets/posawesome/js/offline.js',
+        '/manifest.json',
+        '/offline.html'
       ];
       await Promise.all(resources.map(async url => {
         try {
@@ -41,7 +43,7 @@ self.addEventListener('fetch', event => {
           return await fetch(event.request);
         } catch (err) {
           const cached = await caches.match(event.request, { ignoreSearch: true });
-          return cached || caches.match('/app/posapp');
+          return cached || caches.match('/app/posapp') || caches.match('/offline.html');
         }
       })()
     );


### PR DESCRIPTION
## Summary
- cache offline page & manifest in service workers
- fallback to offline page when offline

## Testing
- `npm install`
- `npx eslint posawesome/www/sw.js posawesome/public/js/sw.js`

------
https://chatgpt.com/codex/tasks/task_e_68431049b5d08326ad9a390379b5b2de