### PR TITLE
Fix payments alignment

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="pa-0">
-    <v-card class="selection mx-auto bg-grey-lighten-5 pa-1" style="max-height: 68vh; height: 68vh">
+    <v-card class="selection mx-auto bg-grey-lighten-5 pa-1 my-0 py-0 mt-3" style="max-height: 68vh; height: 68vh">
       <v-progress-linear :active="loading" :indeterminate="loading" absolute location="top" color="info"></v-progress-linear>
       <div class="overflow-y-auto px-2 pt-2" style="max-height: 67vh">
         


### PR DESCRIPTION
## Summary
- adjust payments card layout so it aligns below the navbar

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68444025a5848326bdd7ebd52cae1d39