### PR TITLE
Fix offline invoice sync call

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -78,7 +78,10 @@ export async function syncOfflineInvoices() {
     try {
       await frappe.call({
         method: 'posawesome.posawesome.api.posapp.submit_invoice',
-        args: inv
+        args: {
+          invoice: inv.invoice,
+          data: inv.data,
+        },
       });
       synced++;
     } catch (error) {


### PR DESCRIPTION
## Summary
- syncOfflineInvoices should explicitly send invoice and data keys

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844ab42efdc8326b471abeac37d5c3d