### PR TITLE
Improve offline opening shift cache

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -18,7 +18,7 @@ const memory = {
   sales_persons_storage: []
 };
 
-async function init() {
+export const initPromise = (async () => {
   try {
     await db.open();
     for (const key of Object.keys(memory)) {
@@ -30,8 +30,7 @@ async function init() {
   } catch (e) {
     console.error('Failed to initialize offline DB', e);
   }
-}
-init();
+})();
 
 function persist(key) {
   db.table('keyval')
@@ -408,8 +407,12 @@ export function getOpeningStorage() {
 }
 
 export function setOpeningStorage(data) {
-  memory.pos_opening_storage = data;
-  persist('pos_opening_storage');
+  try {
+    memory.pos_opening_storage = JSON.parse(JSON.stringify(data));
+    persist('pos_opening_storage');
+  } catch (e) {
+    console.error('Failed to set opening storage', e);
+  }
 }
 
 export function getOpeningDialogStorage() {
@@ -417,8 +420,12 @@ export function getOpeningDialogStorage() {
 }
 
 export function setOpeningDialogStorage(data) {
-  memory.opening_dialog_storage = data;
-  persist('opening_dialog_storage');
+  try {
+    memory.opening_dialog_storage = JSON.parse(JSON.stringify(data));
+    persist('opening_dialog_storage');
+  } catch (e) {
+    console.error('Failed to set opening dialog storage', e);
+  }
 }
 
 export function getLocalStockCache() {

--- a/posawesome/public/js/posapp/components/payments/Pay.vue
+++ b/posawesome/public/js/posapp/components/payments/Pay.vue
@@ -246,7 +246,7 @@
 import format from "../../format";
 import Customer from "../pos/Customer.vue";
 import UpdateCustomer from "../pos/UpdateCustomer.vue";
-import { getOpeningStorage, setOpeningStorage } from "../../../offline.js";
+import { getOpeningStorage, setOpeningStorage, initPromise } from "../../../offline.js";
 
 export default {
   mixins: [format],
@@ -406,8 +406,9 @@ export default {
   },
 
   methods: {
-    check_opening_entry() {
+    async check_opening_entry() {
       var vm = this;
+      await initPromise;
       return frappe
         .call("posawesome.posawesome.api.posapp.check_opening_shift", {
           user: frappe.session.user,

--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -50,7 +50,7 @@
 <script>
 
 import format from '../../format';
-import { getOpeningDialogStorage, setOpeningDialogStorage, setOpeningStorage } from '../../../offline.js';
+import { getOpeningDialogStorage, setOpeningDialogStorage, setOpeningStorage, initPromise } from '../../../offline.js';
 export default {
   mixins: [format],
   props: ['dialog'],
@@ -119,8 +119,9 @@ export default {
     close_opening_dialog() {
       this.eventBus.emit('close_opening_dialog');
     },
-    get_opening_dialog_data() {
+    async get_opening_dialog_data() {
       const vm = this;
+      await initPromise;
       // Load cached data first for offline usage
       const cached = getOpeningDialogStorage();
       if (cached) {

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -44,7 +44,7 @@ import NewAddress from './NewAddress.vue';
 import Variants from './Variants.vue';
 import Returns from './Returns.vue';
 import MpesaPayments from './Mpesa-Payments.vue';
-import { getCachedOffers, saveOffers, getOpeningStorage, setOpeningStorage } from '../../../offline.js';
+import { getCachedOffers, saveOffers, getOpeningStorage, setOpeningStorage, initPromise } from '../../../offline.js';
 // Import the cache cleanup function
 import { clearExpiredCustomerBalances } from "../../../offline.js";
 import { responsiveMixin } from '../../mixins/responsive.js';
@@ -80,7 +80,8 @@ export default {
   },
 
   methods: {
-    check_opening_entry() {
+    async check_opening_entry() {
+      await initPromise;
       return frappe
         .call('posawesome.posawesome.api.posapp.check_opening_shift', {
           user: frappe.session.user,
@@ -92,7 +93,11 @@ export default {
             this.get_offers(this.pos_profile.name);
             this.eventBus.emit('register_pos_profile', r.message);
             this.eventBus.emit('set_company', r.message.company);
-            frappe.realtime.emit('pos_profile_registered');
+            try {
+              frappe.realtime.emit('pos_profile_registered');
+            } catch (e) {
+              console.warn('Realtime emit failed', e);
+            }
             console.info('LoadPosProfile');
             try {
               setOpeningStorage(r.message);
@@ -107,7 +112,11 @@ export default {
               this.get_offers(this.pos_profile.name);
               this.eventBus.emit('register_pos_profile', data);
               this.eventBus.emit('set_company', data.company);
-              frappe.realtime.emit('pos_profile_registered');
+              try {
+                frappe.realtime.emit('pos_profile_registered');
+              } catch (e) {
+                console.warn('Realtime emit failed', e);
+              }
               console.info('LoadPosProfile (cached)');
               return;
             }
@@ -122,7 +131,11 @@ export default {
             this.get_offers(this.pos_profile.name);
             this.eventBus.emit('register_pos_profile', data);
             this.eventBus.emit('set_company', data.company);
-            frappe.realtime.emit('pos_profile_registered');
+            try {
+              frappe.realtime.emit('pos_profile_registered');
+            } catch (e) {
+              console.warn('Realtime emit failed', e);
+            }
             console.info('LoadPosProfile (cached)');
             return;
           }


### PR DESCRIPTION
## Summary
- initialize offline DB with exported `initPromise`
- JSON-serialize opening shift cache before persisting
- wait for `initPromise` when loading cached data
- handle realtime emit failures gracefully

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68455c5693cc8326a10612fe4e367e3b