### PR TITLE
Fix offline customer dropdown

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -10,8 +10,8 @@
       <!-- Edit icon (left) -->
       <template #prepend-inner>
         <v-tooltip text="Edit customer">
-          <template #activator="{ on, attrs }">
-            <v-icon v-bind="attrs" v-on="on" class="icon-button" @mousedown.prevent.stop @click.stop="edit_customer">
+          <template #activator="{ props }">
+            <v-icon v-bind="props" class="icon-button" @mousedown.prevent.stop @click.stop="edit_customer">
               mdi-account-edit
             </v-icon>
           </template>
@@ -21,8 +21,8 @@
       <!-- Add icon (right) -->
       <template #append-inner>
         <v-tooltip text="Add new customer">
-          <template #activator="{ on, attrs }">
-            <v-icon v-bind="attrs" v-on="on" class="icon-button" @mousedown.prevent.stop @click.stop="new_customer">
+          <template #activator="{ props }">
+            <v-icon v-bind="props" class="icon-button" @mousedown.prevent.stop @click.stop="new_customer">
               mdi-plus
             </v-icon>
           </template>
@@ -102,12 +102,13 @@ import UpdateCustomer from './UpdateCustomer.vue';
 import { getCustomerStorage, setCustomerStorage, initPromise, isOffline } from '../../../offline.js';
 
 export default {
+  name: 'PosCustomer',
   props: {
     pos_profile: Object
   },
 
   data: () => ({
-    pos_profile: '',
+    internalPosProfile: '',
     customers: [],
     customer: '',                // Selected customer
     internalCustomer: null,      // Model bound to the dropdown
@@ -190,7 +191,7 @@ export default {
 
       await initPromise;
 
-      if (vm.pos_profile.posa_local_storage && getCustomerStorage().length) {
+      if (vm.internalPosProfile.posa_local_storage && getCustomerStorage().length) {
         try {
           vm.customers = getCustomerStorage();
         } catch (e) {
@@ -208,13 +209,13 @@ export default {
       frappe.call({
         method: 'posawesome.posawesome.api.posapp.get_customer_names',
         args: {
-          pos_profile: this.pos_profile.pos_profile,
+          pos_profile: this.internalPosProfile.pos_profile,
         },
         callback: function (r) {
           if (r.message) {
             vm.customers = r.message;
 
-            if (vm.pos_profile.posa_local_storage) {
+            if (vm.internalPosProfile.posa_local_storage) {
               setCustomerStorage(r.message);
             }
           }
@@ -222,6 +223,9 @@ export default {
         },
         error: function (err) {
           console.error('Failed to fetch customers:', err);
+          if (vm.internalPosProfile.posa_local_storage && getCustomerStorage().length) {
+            vm.customers = getCustomerStorage();
+          }
           vm.loadingCustomers = false; // Ensure field is re-enabled on failure
         }
       });
@@ -265,12 +269,12 @@ export default {
 
     this.$nextTick(() => {
       this.eventBus.on('register_pos_profile', (pos_profile) => {
-        this.pos_profile = pos_profile;
+        this.internalPosProfile = pos_profile;
         this.get_customer_names();
       });
 
       this.eventBus.on('payments_register_pos_profile', (pos_profile) => {
-        this.pos_profile = pos_profile;
+        this.internalPosProfile = pos_profile;
         this.get_customer_names();
       });
 


### PR DESCRIPTION
## Summary
- ensure cached customers are shown when server call fails
- avoid mutating props by using `internalPosProfile`
- name the customer component to satisfy linter

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/Customer.vue`

------
https://chatgpt.com/codex/tasks/task_e_68455ff8c18c832683f47e84bb7904de