### PR TITLE
Add offline customer selection

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -99,7 +99,7 @@
 
 <script>
 import UpdateCustomer from './UpdateCustomer.vue';
-import { getCustomerStorage, setCustomerStorage } from '../../../offline.js';
+import { getCustomerStorage, setCustomerStorage, isOffline } from '../../../offline.js';
 
 export default {
   props: {
@@ -195,6 +195,11 @@ export default {
           console.error('Failed to parse customer cache:', e);
           vm.customers = [];
         }
+      }
+
+      if (isOffline()) {
+        vm.loadingCustomers = false;
+        return; // Skip server request when offline
       }
 
       this.loadingCustomers = true; // ? Start loading


### PR DESCRIPTION
## Summary
- expose cached customers in dropdown when offline

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684564ebbde88326aff7f8cb39eda30a