### PR TITLE
Fix offline customer cache not loading

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -99,7 +99,7 @@
 
 <script>
 import UpdateCustomer from './UpdateCustomer.vue';
-import { getCustomerStorage, setCustomerStorage, isOffline } from '../../../offline.js';
+import { getCustomerStorage, setCustomerStorage, isOffline, initPromise } from '../../../offline.js';
 
 export default {
   props: {
@@ -184,8 +184,9 @@ export default {
     },
 
     // Fetch customers list
-    get_customer_names() {
+    async get_customer_names() {
       var vm = this;
+      await initPromise;
       if (this.customers.length > 0) return;
 
       if (vm.pos_profile.posa_local_storage && getCustomerStorage().length) {
@@ -247,7 +248,8 @@ export default {
     },
   },
 
-  created() {
+  async created() {
+    await initPromise;
     // Load cached customers immediately for offline use
     if (getCustomerStorage().length) {
       try {


### PR DESCRIPTION
## Summary
- ensure offline DB initialization before loading cached customers

## Testing
- `npm install`
- `npx eslint posawesome/public/js/posapp/components/pos/Customer.vue` *(fails: Component name multi-word, no-deprecated-slots, vue/no-dupe-keys, vue/no-mutating-props)*

------
https://chatgpt.com/codex/tasks/task_e_684568364270832695093ea4825e4303