### PR TITLE
Fix online stock refresh

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1093,6 +1093,13 @@ export default {
       this.customer = data;
     });
 
+    // Refresh item quantities when connection to server is restored
+    this.eventBus.on("server-online", async () => {
+      if (this.items && this.items.length > 0) {
+        await this.update_items_details(this.items);
+      }
+    });
+
     // Setup auto-refresh for item quantities
     this.refresh_interval = setInterval(() => {
       if (this.filtered_items && this.filtered_items.length > 0) {
@@ -1133,6 +1140,7 @@ export default {
     }
 
     this.eventBus.off("update_currency");
+    this.eventBus.off("server-online");
   },
 };
 </script>


### PR DESCRIPTION
## Summary
- ensure item quantities refresh once server connection is restored

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68458761bb58832691a35d1c682ab007