### PR TITLE
Add offline invoices dialog

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -127,6 +127,17 @@ export function clearOfflineInvoices() {
   persist('offline_invoices');
 }
 
+export function deleteOfflineInvoice(index) {
+  if (
+    Array.isArray(memory.offline_invoices) &&
+    index >= 0 &&
+    index < memory.offline_invoices.length
+  ) {
+    memory.offline_invoices.splice(index, 1);
+    persist('offline_invoices');
+  }
+}
+
 export function getPendingOfflineInvoiceCount() {
   return memory.offline_invoices.length;
 }

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -38,6 +38,10 @@
         </v-chip>
       </div>
 
+      <v-btn icon color="primary" class="mx-2" @click="showOfflineInvoices = true">
+        <v-icon>mdi-table</v-icon>
+      </v-btn>
+
       <v-menu offset-y offset-x :min-width="200">
         <template #activator="{ props }">
           <v-btn v-bind="props" color="primary" variant="elevated" class="menu-btn-enhanced">
@@ -121,6 +125,8 @@
         <v-card-text>{{ freezeMsg }}</v-card-text>
       </v-card>
     </v-dialog>
+
+    <OfflineInvoicesDialog v-model="showOfflineInvoices" @deleted="updateAfterDelete" />
   </nav>
 </template>
 
@@ -129,9 +135,11 @@
 // This import is crucial for the server connectivity indicator.
 import { io } from 'socket.io-client';
 import { getPendingOfflineInvoiceCount, syncOfflineInvoices, isOffline, getLastSyncTotals } from '../../offline.js';
+import OfflineInvoicesDialog from './OfflineInvoices.vue';
 
 export default {
   name: 'NavBar', // Component name
+  components: { OfflineInvoicesDialog },
   data() {
     return {
       drawer: false, // Controls the visibility of the side navigation drawer (true for open, false for closed)
@@ -156,7 +164,8 @@ export default {
       serverOnline: false,             // Boolean: Reflects the real-time server health via WebSocket (true if connected, false if disconnected)
       serverConnecting: false,         // Boolean: Indicates if the client is currently attempting to establish a connection to the server via WebSocket
       socket: null,                    // Instance of the Socket.IO client, used for real-time communication with the server
-      offlineMessageShown: false       // Flag to avoid repeating offline warnings
+      offlineMessageShown: false,      // Flag to avoid repeating offline warnings
+      showOfflineInvoices: false       // Controls the Offline Invoices dialog
     };
   },
   computed: {
@@ -640,6 +649,10 @@ export default {
      */
     updatePendingInvoices() {
       this.pendingInvoices = getPendingOfflineInvoiceCount();
+    },
+    updateAfterDelete() {
+      this.updatePendingInvoices();
+      this.eventBus.emit('pending_invoices_changed', this.pendingInvoices);
     },
     /**
      * Displays a snackbar message at the top right of the screen.

--- a/posawesome/public/js/posapp/components/OfflineInvoices.vue
+++ b/posawesome/public/js/posapp/components/OfflineInvoices.vue
@@ -1,0 +1,94 @@
+<template>
+  <v-row justify="center">
+    <v-dialog v-model="dialog" max-width="900px">
+      <v-card>
+        <v-card-title>
+          <span class="text-h5 text-primary">{{ __('Offline Invoices') }}</span>
+        </v-card-title>
+        <v-card-text class="pa-0">
+          <v-container>
+            <v-row>
+              <v-col cols="12" class="pa-1">
+                <v-data-table
+                  v-if="invoices.length"
+                  :headers="headers"
+                  :items="invoices"
+                  class="elevation-1"
+                  :items-per-page="20"
+                >
+                  <template #item.customer="{ item }">
+                    {{ item.invoice.customer_name || item.invoice.customer }}
+                  </template>
+                  <template #item.posting_date="{ item }">
+                    {{ item.invoice.posting_date }}
+                  </template>
+                  <template #item.grand_total="{ item }">
+                    {{ currencySymbol(item.invoice.currency) }}
+                    {{ formatCurrency(item.invoice.grand_total || item.invoice.rounded_total) }}
+                  </template>
+                  <template #item.actions="{ index }">
+                    <v-btn icon color="error" size="small" @click="removeInvoice(index)">
+                      <v-icon size="18">mdi-delete</v-icon>
+                    </v-btn>
+                  </template>
+                </v-data-table>
+                <div v-else class="text-center py-4">{{ __('No offline invoices') }}</div>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="error" theme="dark" @click="dialog = false">{{ __('Close') }}</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-row>
+</template>
+
+<script>
+import format from '../format';
+import { getOfflineInvoices, deleteOfflineInvoice, getPendingOfflineInvoiceCount } from '../../offline.js';
+
+export default {
+  name: 'OfflineInvoicesDialog',
+  mixins: [format],
+  props: {
+    modelValue: Boolean
+  },
+  emits: ['update:modelValue', 'deleted'],
+  data() {
+    return {
+      dialog: this.modelValue,
+      invoices: [],
+      headers: [
+        { title: this.__('Customer'), value: 'customer', align: 'start' },
+        { title: this.__('Date'), value: 'posting_date', align: 'start' },
+        { title: this.__('Amount'), value: 'grand_total', align: 'end' },
+        { title: this.__('Actions'), value: 'actions', align: 'end' }
+      ]
+    };
+  },
+  watch: {
+    modelValue(val) {
+      this.dialog = val;
+      if (val) {
+        this.loadInvoices();
+      }
+    },
+    dialog(val) {
+      this.$emit('update:modelValue', val);
+    }
+  },
+  methods: {
+    loadInvoices() {
+      this.invoices = getOfflineInvoices();
+    },
+    removeInvoice(index) {
+      deleteOfflineInvoice(index);
+      this.loadInvoices();
+      this.$emit('deleted', getPendingOfflineInvoiceCount());
+    }
+  }
+};
+</script>


### PR DESCRIPTION
## Summary
- add ability to delete offline invoices in `offline.js`
- create `OfflineInvoices.vue` component to show local invoices
- integrate offline invoices dialog in navbar with new button

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68469f8c98a883269d620282a5d6cd9c