### PR TITLE
Add setting for offline invoice deletion

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5411,4 +5411,14 @@
     "__unsaved": 1,
     "default": "0"
   }
-]
+ ,
+  {
+    "doctype": "Custom Field",
+    "dt": "POS Profile",
+    "fieldname": "posa_allow_delete_offline_invoice",
+    "fieldtype": "Check",
+    "insert_after": "posa_allow_delete",
+    "label": "Allow Delete Offline Invoice",
+    "default": "0"
+  }
+ ]

--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -164,6 +164,7 @@ fixtures = [
                     "Item Barcode-posa_uom",
                     "POS Profile-posa_pos_awesome_settings",
                     "POS Profile-posa_allow_delete",
+                    "POS Profile-posa_allow_delete_offline_invoice",
                     "POS Profile-posa_allow_user_to_edit_rate",
                     "POS Profile-posa_allow_user_to_edit_additional_discount",
                     "POS Profile-posa_allow_user_to_edit_item_discount",

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -126,7 +126,11 @@
       </v-card>
     </v-dialog>
 
-    <OfflineInvoicesDialog v-model="showOfflineInvoices" @deleted="updateAfterDelete" />
+    <OfflineInvoicesDialog
+      v-model="showOfflineInvoices"
+      :pos-profile="posProfile"
+      @deleted="updateAfterDelete"
+    />
   </nav>
 </template>
 

--- a/posawesome/public/js/posapp/components/OfflineInvoices.vue
+++ b/posawesome/public/js/posapp/components/OfflineInvoices.vue
@@ -27,7 +27,13 @@
                     {{ formatCurrency(item.invoice.grand_total || item.invoice.rounded_total) }}
                   </template>
                   <template #item.actions="{ index }">
-                    <v-btn icon color="error" size="small" @click="removeInvoice(index)">
+                    <v-btn
+                      icon
+                      color="error"
+                      size="small"
+                      @click="removeInvoice(index)"
+                      v-if="posProfile.posa_allow_delete_offline_invoice"
+                    >
                       <v-icon size="18">mdi-delete</v-icon>
                     </v-btn>
                   </template>
@@ -54,7 +60,11 @@ export default {
   name: 'OfflineInvoicesDialog',
   mixins: [format],
   props: {
-    modelValue: Boolean
+    modelValue: Boolean,
+    posProfile: {
+      type: Object,
+      default: () => ({})
+    }
   },
   emits: ['update:modelValue', 'deleted'],
   data() {
@@ -85,6 +95,9 @@ export default {
       this.invoices = getOfflineInvoices();
     },
     removeInvoice(index) {
+      if (!this.posProfile.posa_allow_delete_offline_invoice) {
+        return;
+      }
       deleteOfflineInvoice(index);
       this.loadInvoices();
       this.$emit('deleted', getPendingOfflineInvoiceCount());

--- a/posawesome/translations/pt.csv
+++ b/posawesome/translations/pt.csv
@@ -23,6 +23,7 @@ DocType: POS Offer,Apply Rule On Item Group,Aplicar Regra no Grupo do Item
 DocType: POS Offer,Apply Type,Aplicar Tipo
 DocType: POS Offer,Auto Apply,Auto Aplicar
 Custom Field - label: POS Profile-posa_allow_delete,Auto Delete Draft Invoice,Auto Apagar Factura Rascunho
+Custom Field - label: POS Profile-posa_allow_delete_offline_invoice,Allow Delete Offline Invoice,Permitir Apagar Faturas Offline
 Custom Field - label: POS Profile-posa_auto_set_batch,Auto Set Batch,Auto Definir Lote
 DocType: POS Offer,Brand,Marca
 DocType: POS Opening Shift,Cancelled,Cancelado


### PR DESCRIPTION
## Summary
- allow enabling/disabling deletion of offline invoices
- include new option in hooks fixtures
- wire setting into UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846a328f7a48326ae3913f806b24e1d