### PR TITLE
Fix fixture file to include missing name

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5410,8 +5410,7 @@
     "__islocal": 1,
     "__unsaved": 1,
     "default": "0"
-  }
- ,
+  },
   {
     "doctype": "Custom Field",
     "dt": "POS Profile",
@@ -5419,6 +5418,7 @@
     "fieldtype": "Check",
     "insert_after": "posa_allow_delete",
     "label": "Allow Delete Offline Invoice",
-    "default": "0"
+    "default": "0",
+    "name": "POS Profile-posa_allow_delete_offline_invoice"
   }
- ]
+]


### PR DESCRIPTION
## Summary
- add a missing `name` field to the `posawesome` custom field fixture

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846a5863ae0832685cc7d0227c5e870