### PR TITLE
Fix open shift dialog after closing POS

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -182,6 +182,8 @@ export default {
               title: `POS Shift Closed`,
               color: 'success',
             });
+            // Immediately show the opening dialog for the next shift
+            this.create_opening_voucher();
             this.check_opening_entry();
           } else {
             console.log(r);


### PR DESCRIPTION
## Summary
- ensure the opening dialog shows immediately after submitting a closing shift

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846aba14d708326a46faeb6c1b20f27