### PR TITLE
Fix shift close state reset

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
@@ -112,6 +112,10 @@ export default {
       this.dialog_data = data;
     });
     this.eventBus.on('register_pos_profile', (data) => {
+      if (!data || !data.pos_profile) {
+        this.pos_profile = null;
+        return;
+      }
       this.pos_profile = data.pos_profile;
       if (!this.pos_profile.hide_expected_amount) {
         this.headers.push({

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -4157,6 +4157,13 @@ export default {
   mounted() {
     // Register event listeners for POS profile, items, customer, offers, etc.
     this.eventBus.on("register_pos_profile", (data) => {
+      if (!data || !data.pos_profile) {
+        this.pos_profile = null;
+        this.customer = null;
+        this.pos_opening_shift = null;
+        this.stock_settings = null;
+        return;
+      }
       this.pos_profile = data.pos_profile;
       this.customer = data.pos_profile.customer;
       this.pos_opening_shift = data.pos_opening_shift;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1070,6 +1070,10 @@ export default {
     this.$nextTick(function () { });
     this.eventBus.on("register_pos_profile", async (data) => {
       await initPromise;
+      if (!data || !data.pos_profile) {
+        this.pos_profile = null;
+        return;
+      }
       this.pos_profile = data.pos_profile;
       await this.get_items();
       this.get_items_groups();

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1628,6 +1628,10 @@ export default {
         this.get_sales_person_names();
       });
       this.eventBus.on("register_pos_profile", (data) => {
+        if (!data || !data.pos_profile) {
+          this.pos_profile = null;
+          return;
+        }
         this.pos_profile = data.pos_profile;
         this.get_mpesa_modes();
       });

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -178,6 +178,9 @@ export default {
             // Clear from local storage
             clearOpeningStorage();
 
+            // notify other components that the profile has been cleared
+            this.eventBus.emit('register_pos_profile', null);
+
             this.eventBus.emit('show_message', {
               title: `POS Shift Closed`,
               color: 'success',

--- a/posawesome/public/js/posapp/components/pos/PosCoupons.vue
+++ b/posawesome/public/js/posapp/components/pos/PosCoupons.vue
@@ -181,6 +181,10 @@ export default {
   created: function () {
     this.$nextTick(function () {
       this.eventBus.on('register_pos_profile', (data) => {
+        if (!data || !data.pos_profile) {
+          this.pos_profile = null;
+          return;
+        }
         this.pos_profile = data.pos_profile;
       });
     });

--- a/posawesome/public/js/posapp/components/pos/PosOffers.vue
+++ b/posawesome/public/js/posapp/components/pos/PosOffers.vue
@@ -233,6 +233,10 @@ export default {
   created: function () {
     this.$nextTick(function () {
       this.eventBus.on('register_pos_profile', (data) => {
+        if (!data || !data.pos_profile) {
+          this.pos_profile = null;
+          return;
+        }
         this.pos_profile = data.pos_profile;
       });
     });

--- a/posawesome/public/js/posapp/components/pos/Returns.vue
+++ b/posawesome/public/js/posapp/components/pos/Returns.vue
@@ -630,6 +630,10 @@ export default {
     });
 
     this.eventBus.on('register_pos_profile', (data) => {
+      if (!data || !data.pos_profile) {
+        this.pos_profile = null;
+        return;
+      }
       this.pos_profile = data.pos_profile;
     });
   },

--- a/posawesome/public/js/posapp/components/pos/SalesOrders.vue
+++ b/posawesome/public/js/posapp/components/pos/SalesOrders.vue
@@ -187,6 +187,10 @@ export default {
   },
   mounted() {
     this.eventBus.on("register_pos_profile", (data) => {
+      if (!data || !data.pos_profile) {
+        this.pos_profile = null;
+        return;
+      }
       this.pos_profile = data.pos_profile;
     });
   },

--- a/posawesome/public/js/posapp/components/pos/UpdateCustomer.vue
+++ b/posawesome/public/js/posapp/components/pos/UpdateCustomer.vue
@@ -565,9 +565,17 @@ export default {
       }
     });
     this.eventBus.on('register_pos_profile', (data) => {
+      if (!data || !data.pos_profile) {
+        this.pos_profile = null;
+        return;
+      }
       this.pos_profile = data.pos_profile;
     });
     this.eventBus.on('payments_register_pos_profile', (data) => {
+      if (!data || !data.pos_profile) {
+        this.pos_profile = null;
+        return;
+      }
       this.pos_profile = data.pos_profile;
     });
     this.getCustomerGroups();


### PR DESCRIPTION
## Summary
- emit a null POS profile when closing the shift
- guard against null `pos_profile` in various components

## Testing
- `npm install`
- `npx eslint ./posawesome/public/js/posapp/components/pos/Invoice.vue` *(fails: 8 problems)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6846aceea1588326928ef8c2f475566d