### PR TITLE
Suppress socket disconnection console log

### DIFF
--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -430,7 +430,10 @@ export default {
           this.serverOnline = false;
           window.serverOnline = false;
           this.serverConnecting = false;
-          console.warn('Socket.IO: Disconnected from server. Reason:', reason);
+          // Connection status is tracked through state variables and UI
+          // notifications, so avoid cluttering the browser console with a
+          // disconnection warning.
+          // console.warn('Socket.IO: Disconnected from server. Reason:', reason);
 
           this.eventBus.emit('server-offline');
 


### PR DESCRIPTION
## Summary
- avoid logging the Socket.IO disconnect warning in `Navbar.vue`
