### PR TITLE
Integrate VueDatePicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,56 +1,29 @@
 {
-
   "name": "posawesome",
-
   "scripts": {
-
     "dev": "vite",
-
     "prebuild": "npm install"
-
   },
-
   "dependencies": {
-
+    "@vuepic/vue-datepicker": "11.0.2",
     "dexie": "^4.0.11",
-
     "lodash": "^4.17.21",
-
     "mitt": "^3.0.1",
-
     "socket.io-client": "^4.8.1",
-
     "vue": "^3.3.4",
-
     "vue-qrcode-reader": "^5.7.2",
-
     "vuetify": "^3.7.5"
-
   },
-
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
-
   "devDependencies": {
-
     "@eslint/js": "^9.16.0",
-
     "@vitejs/plugin-vue": "^5.2.3",
-
     "esbuild": "^0.25.5",
-
     "eslint": "^9.16.0",
-
     "eslint-plugin-vue": "^9.32.0",
-
     "eslint-plugin-vuetify": "^2.5.1",
-
     "globals": "^15.13.0",
-
     "vite": "^6.2.4",
-
     "vue": "^3.3.4"
-
   }
-
 }
-

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -74,24 +74,13 @@
         <v-row align="center" class="items px-3 py-2 mt-0" v-if="pos_profile.posa_allow_change_posting_date">
           <!-- Posting Date Selection with Date Picker -->
           <v-col cols="6" class="pb-2">
-            <v-menu v-model="posting_date_menu" :close-on-content-click="false" transition="scale-transition"
-              density="default">
-              <template v-slot:activator="{ props }">
-                <v-text-field v-model="formatted_posting_date" :label="frappe._('Posting Date')" readonly variant="solo"
-                  density="compact" clearable color="primary" hide-details prepend-inner-icon="mdi-calendar"
-                  v-bind="props"></v-text-field>
-              </template>
-              <v-date-picker v-model="posting_date" no-title scrollable color="primary"
-                :min="frappe.datetime.add_days(frappe.datetime.nowdate(true), -7)"
-                :max="frappe.datetime.add_days(frappe.datetime.nowdate(true), 7)">
-                <template #actions>
-                  <v-spacer></v-spacer>
-                  <v-btn text color="primary" @click="posting_date = null; posting_date_menu = false">{{ __('Clear')
-                  }}</v-btn>
-                  <v-btn text color="primary" @click="posting_date_menu = false">{{ __('OK') }}</v-btn>
-                </template>
-              </v-date-picker>
-            </v-menu>
+            <VueDatePicker
+              v-model="posting_date"
+              model-type="format"
+              format="yyyy-MM-dd"
+              :min-date="new Date(frappe.datetime.add_days(frappe.datetime.nowdate(true), -7))"
+              :max-date="new Date(frappe.datetime.add_days(frappe.datetime.nowdate(true), 7))"
+            />
           </v-col>
           <!-- Customer Balance Display (Only if enabled in POS profile) -->
           <v-col v-if="pos_profile.posa_show_customer_balance" cols="6" class="pb-2 d-flex align-center">
@@ -325,28 +314,13 @@
 
                   <!-- Delivery Date (if sales order and order type) -->
                   <v-col cols="12" sm="4" v-if="pos_profile.posa_allow_sales_order && invoiceType == 'Order'">
-                    <v-menu ref="item_delivery_date" v-model="item.item_delivery_date" :close-on-content-click="false"
-                      v-model:return-value="item.posa_delivery_date" transition="scale-transition">
-                      <template v-slot:activator="{ props }">
-                        <v-text-field v-model="item.posa_delivery_date" :label="frappe._('Delivery Date')" readonly
-                          variant="outlined" density="compact" clearable color="primary" hide-details
-                          v-bind="props"></v-text-field>
-                      </template>
-                      <v-date-picker v-model="item.posa_delivery_date" no-title scrollable color="primary"
-                        :min="frappe.datetime.now_date()">
-                        <v-spacer></v-spacer>
-                        <v-btn variant="text" color="primary" @click="item.item_delivery_date = false">
-                          Cancel
-                        </v-btn>
-                        <v-btn variant="text" color="primary" @click="
-                          [
-                            $refs.item_delivery_date.save(item.posa_delivery_date),
-                            validate_due_date(item),
-                          ]">
-                          OK
-                        </v-btn>
-                      </v-date-picker>
-                    </v-menu>
+                    <VueDatePicker
+                      v-model="item.posa_delivery_date"
+                      model-type="format"
+                      format="yyyy-MM-dd"
+                      :min-date="new Date()"
+                      @update:model-value="validate_due_date(item)"
+                    />
                   </v-col>
                 </v-row>
               </td>
@@ -487,7 +461,6 @@ export default {
       selected_delivery_charge: "", // Selected delivery charge object
       invoice_posting_date: false, // Posting date dialog
       posting_date: frappe.datetime.nowdate(), // Invoice posting date
-      posting_date_menu: false, // Posting date menu visibility
       items_headers: [
         // Table headers for items
         {

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -281,37 +281,13 @@
 
           <!-- Delivery Date and Address (if applicable) -->
           <v-col cols="6" v-if="pos_profile.posa_allow_sales_order && invoiceType === 'Order'">
-            <v-menu 
-              ref="order_delivery_date" 
-              v-model="order_delivery_date" 
-              :close-on-content-click="false" 
-              transition="scale-transition" 
-              density="default"
-              location="bottom"
-            >
-              <template v-slot:activator="{ props }">
-                <v-text-field
-                  v-model="invoice_doc.posa_delivery_date"
-                  :label="frappe._('Delivery Date')"
-                  readonly
-                  variant="outlined"
-                  density="compact"
-                  bg-color="white"
-                  clearable
-                  color="primary"
-                  hide-details
-                  v-bind="props"
-                ></v-text-field>
-              </template>
-              <v-date-picker
-                v-model="new_delivery_date"
-                no-title
-                color="primary"
-                :min="frappe.datetime.now_date()"
-                @update:model-value="order_delivery_date = false; update_delivery_date()"
-                class="custom-date-picker"
-              ></v-date-picker>
-            </v-menu>
+            <VueDatePicker
+              v-model="new_delivery_date"
+              model-type="format"
+              format="yyyy-MM-dd"
+              :min-date="new Date()"
+              @update:model-value="update_delivery_date()"
+            />
           </v-col>
           <!-- Shipping Address Selection (if delivery date is set) -->
           <v-col cols="12" v-if="invoice_doc.posa_delivery_date">
@@ -400,28 +376,22 @@
               ></v-text-field>
             </v-col>
             <v-col cols="6">
-              <v-menu ref="po_date_menu" v-model="po_date_menu" :close-on-content-click="false" transition="scale-transition">
-                <template v-slot:activator="{ on, attrs }">
-                  <v-text-field
-                    v-model="invoice_doc.po_date"
-                    :label="frappe._('Purchase Order Date')"
-                    readonly
-                    variant="outlined"
-                    density="compact"
-                    hide-details
-                    v-bind="attrs"
-                    v-on="on"
-                    color="primary"
-                  ></v-text-field>
-                </template>
-                <v-date-picker
-                  v-model="new_po_date"
-                  no-title
-                  scrollable
-                  color="primary"
-                  @input="po_date_menu = false; update_po_date()"
-                ></v-date-picker>
-              </v-menu>
+              <VueDatePicker
+                v-model="new_po_date"
+                model-type="format"
+                format="yyyy-MM-dd"
+                :min-date="new Date()"
+                @update:model-value="update_po_date()"
+              />
+              <v-text-field
+                v-model="invoice_doc.po_date"
+                :label="frappe._('Purchase Order Date')"
+                readonly
+                variant="outlined"
+                density="compact"
+                hide-details
+                color="primary"
+              ></v-text-field>
             </v-col>
           </v-row>
         </div>
@@ -453,30 +423,11 @@
             ></v-switch>
           </v-col>
           <v-col cols="6" v-if="is_credit_sale">
-            <v-menu ref="date_menu" v-model="date_menu" :close-on-content-click="false" transition="scale-transition" min-width="auto">
-              <template v-slot:activator="{ props }">
-                <v-text-field
-                  v-model="invoice_doc.due_date"
-                  :label="frappe._('Due Date')"
-                  readonly
-                  variant="outlined"
-                  density="compact"
-                  hide-details
-                  v-bind="props"
-                  color="primary"
-                  clearable
-                  @click:clear="invoice_doc.due_date = ''"
-                ></v-text-field>
-              </template>
-              <v-date-picker
-                v-model="new_credit_due_date"
-                no-title
-                scrollable
-                color="primary"
-                :min="frappe.datetime.now_date()"
-                @update:model-value="date_menu = false; update_credit_due_date()"
-              ></v-date-picker>
-            </v-menu>
+            <VueDatePicker
+              v-model="new_credit_due_date"
+              :min-date="new Date()"
+              @update:model-value="update_credit_due_date()"
+            />
           </v-col>
           <v-col cols="6" v-if="!invoice_doc.is_return && pos_profile.use_customer_credit">
             <v-switch
@@ -641,11 +592,8 @@ export default {
       customer_credit_dict: [], // List of available customer credits
       paid_change_rules: [], // Validation rules for paid change
       phone_dialog: false, // Show phone payment dialog
-      order_delivery_date: false, // Delivery date menu state
       new_delivery_date: null, // New delivery date value
-      po_date_menu: false, // PO date menu state
       new_po_date: null, // New PO date value
-      date_menu: false, // Due date menu state
       new_credit_due_date: null, // New credit due date value
       customer_info: "", // Customer info
       mpesa_modes: [], // List of available M-Pesa modes

--- a/posawesome/public/js/posapp/components/pos/Returns.vue
+++ b/posawesome/public/js/posapp/components/pos/Returns.vue
@@ -28,64 +28,22 @@
                 v-model="invoice_name" density="compact" clearable></v-text-field>
             </v-col>
             <v-col cols="12" sm="3">
-              <v-menu
-                v-model="fromDateMenu"
-                :close-on-content-click="false"
-                transition="scale-transition"
-                offset-y
-                min-width="auto"
-              >
-                <template v-slot:activator="{ props }">
-                  <v-text-field
-                    v-model="from_date_formatted"
-                    :label="frappe._('From Date')"
-                    prepend-icon="mdi-calendar"
-                    readonly
-                    v-bind="props"
-                    clearable
-                    @click:clear="clearFromDate"
-                    hide-details
-                    dense
-                    color="primary"
-                    outlined
-                  ></v-text-field>
-                </template>
-                <v-date-picker
-                  v-model="from_date"
-                  no-title
-                  @update:model-value="fromDateMenu = false; formatFromDate();"
-                ></v-date-picker>
-              </v-menu>
+              <VueDatePicker
+                v-model="from_date"
+                model-type="format"
+                format="yyyy-MM-dd"
+                :enable-time-picker="false"
+                @update:model-value="formatFromDate()"
+              />
             </v-col>
             <v-col cols="12" sm="3">
-              <v-menu
-                v-model="toDateMenu"
-                :close-on-content-click="false"
-                transition="scale-transition"
-                offset-y
-                min-width="auto"
-              >
-                <template v-slot:activator="{ props }">
-                  <v-text-field
-                    v-model="to_date_formatted"
-                    :label="frappe._('To Date')"
-                    prepend-icon="mdi-calendar"
-                    readonly
-                    v-bind="props"
-                    clearable
-                    @click:clear="clearToDate"
-                    hide-details
-                    dense
-                    color="primary"
-                    outlined
-                  ></v-text-field>
-                </template>
-                <v-date-picker
-                  v-model="to_date"
-                  no-title
-                  @update:model-value="toDateMenu = false; formatToDate();"
-                ></v-date-picker>
-              </v-menu>
+              <VueDatePicker
+                v-model="to_date"
+                model-type="format"
+                format="yyyy-MM-dd"
+                :enable-time-picker="false"
+                @update:model-value="formatToDate()"
+              />
             </v-col>
           </v-row>
 
@@ -272,8 +230,6 @@ export default {
     to_date_formatted: null,
     min_amount: '',
     max_amount: '',
-    fromDateMenu: false,
-    toDateMenu: false,
     pos_profile: '',
     page: 1,
     has_more_invoices: false,

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -1,5 +1,7 @@
 import { createVuetify } from 'vuetify';
 import { createApp } from 'vue';
+import VueDatePicker from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
 import eventBus from './bus';
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
@@ -45,6 +47,7 @@ frappe.PosApp.posapp = class {
             }
         );
         const app = createApp(Home)
+        app.component('VueDatePicker', VueDatePicker)
         app.use(eventBus);
         app.use(vuetify)
         app.mount(this.$el[0]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,13 @@
   resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz"
   integrity sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==
 
+"@vuepic/vue-datepicker@11.0.2":
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/@vuepic/vue-datepicker/-/vue-datepicker-11.0.2.tgz#3641fda890b6906a9e97b96d1e91e0cdc37a2aec"
+  integrity sha512-uHh78mVBXCEjam1uVfTzZ/HkyDwut/H6b2djSN9YTF+l/EA+XONfdCnOVSi1g+qVGSy65DcQAwyBNidAssnudQ==
+  dependencies:
+    date-fns "^4.1.0"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
@@ -561,6 +568,11 @@ csstype@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.4.0"


### PR DESCRIPTION
## Summary
- add `@vuepic/vue-datepicker` dependency
- register VueDatePicker globally in the app
- replace Vuetify due date picker with VueDatePicker
- use VueDatePicker for invoice and return filters
- clean up obsolete menu states

## Testing
- `npm run dev -- --version`


------
https://chatgpt.com/codex/tasks/task_e_6848178e1c8c8326a5f11c1d694ce50e