### PR TITLE
Change datepicker format to dd-MM-yyyy

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -284,7 +284,7 @@
             <VueDatePicker
               v-model="new_delivery_date"
               model-type="format"
-              format="yyyy-MM-dd"
+              format="dd-MM-yyyy"
               :min-date="new Date()"
               @update:model-value="update_delivery_date()"
             />
@@ -376,13 +376,13 @@
               ></v-text-field>
             </v-col>
             <v-col cols="6">
-              <VueDatePicker
-                v-model="new_po_date"
-                model-type="format"
-                format="yyyy-MM-dd"
-                :min-date="new Date()"
-                @update:model-value="update_po_date()"
-              />
+            <VueDatePicker
+              v-model="new_po_date"
+              model-type="format"
+              format="dd-MM-yyyy"
+              :min-date="new Date()"
+              @update:model-value="update_po_date()"
+            />
               <v-text-field
                 v-model="invoice_doc.po_date"
                 :label="frappe._('Purchase Order Date')"
@@ -425,6 +425,8 @@
           <v-col cols="6" v-if="is_credit_sale">
             <VueDatePicker
               v-model="new_credit_due_date"
+              model-type="format"
+              format="dd-MM-yyyy"
               :min-date="new Date()"
               @update:model-value="update_credit_due_date()"
             />
@@ -1457,11 +1459,39 @@ export default {
     // Format date to YYYY-MM-DD
     formatDate(date) {
       if (!date) return null;
+      if (typeof date === 'string') {
+        if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+          return date;
+        }
+        if (/^\d{1,2}-\d{1,2}-\d{4}$/.test(date)) {
+          const [d, m, y] = date.split('-');
+          return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+        }
+      }
       const d = new Date(date);
-      const year = d.getFullYear();
-      const month = (`0${d.getMonth() + 1}`).slice(-2);
-      const day = (`0${d.getDate()}`).slice(-2);
-      return `${year}-${month}-${day}`;
+      if (!isNaN(d.getTime())) {
+        const year = d.getFullYear();
+        const month = (`0${d.getMonth() + 1}`).slice(-2);
+        const day = (`0${d.getDate()}`).slice(-2);
+        return `${year}-${month}-${day}`;
+      }
+      return date;
+    },
+
+    formatDateDisplay(date) {
+      if (!date) return '';
+      if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        const [y, m, d] = date.split('-');
+        return `${d}-${m}-${y}`;
+      }
+      const d = new Date(date);
+      if (!isNaN(d.getTime())) {
+        const year = d.getFullYear();
+        const month = (`0${d.getMonth() + 1}`).slice(-2);
+        const day = (`0${d.getDate()}`).slice(-2);
+        return `${day}-${month}-${year}`;
+      }
+      return date;
     },
     // Show paid amount info message
     showPaidAmount() {
@@ -1601,7 +1631,7 @@ export default {
           this.invoice_doc.shipping_address_name = null;
         } else if (this.invoice_doc && data === "Order") {
           // Initialize delivery date to today when switching to Order type
-          this.new_delivery_date = frappe.datetime.now_date();
+          this.new_delivery_date = this.formatDateDisplay(frappe.datetime.now_date());
           this.update_delivery_date();
         }
         // Handle return invoices properly

--- a/posawesome/public/js/posapp/components/pos/Returns.vue
+++ b/posawesome/public/js/posapp/components/pos/Returns.vue
@@ -31,7 +31,7 @@
               <VueDatePicker
                 v-model="from_date"
                 model-type="format"
-                format="yyyy-MM-dd"
+                format="dd-MM-yyyy"
                 :enable-time-picker="false"
                 @update:model-value="formatFromDate()"
               />
@@ -40,7 +40,7 @@
               <VueDatePicker
                 v-model="to_date"
                 model-type="format"
-                format="yyyy-MM-dd"
+                format="dd-MM-yyyy"
                 :enable-time-picker="false"
                 @update:model-value="formatToDate()"
               />
@@ -275,10 +275,10 @@ export default {
     formatDateDisplay(dateStr) {
       if (!dateStr) return '';
       try {
-        // Convert YYYY-MM-DD to DD/MM/YYYY
+        // Convert YYYY-MM-DD to DD-MM-YYYY
         const parts = dateStr.split('-');
         if (parts.length === 3) {
-          return `${parts[2]}/${parts[1]}/${parts[0]}`;
+          return `${parts[2]}-${parts[1]}-${parts[0]}`;
         }
       } catch (error) {
         console.error("Error formatting date:", error);
@@ -295,13 +295,13 @@ export default {
             const day = String(this.from_date.getDate()).padStart(2, '0');
             const month = String(this.from_date.getMonth() + 1).padStart(2, '0');
             const year = this.from_date.getFullYear();
-            dateString = `${day}/${month}/${year}`;
+            dateString = `${day}-${month}-${year}`;
           }
           // Handle string in YYYY-MM-DD format
           else if (typeof this.from_date === 'string' && this.from_date.includes('-')) {
             const parts = this.from_date.split('-');
             if (parts.length === 3) {
-              dateString = `${parts[2]}/${parts[1]}/${parts[0]}`;
+              dateString = `${parts[2]}-${parts[1]}-${parts[0]}`;
             } else {
               dateString = this.from_date;
             }
@@ -330,13 +330,13 @@ export default {
             const day = String(this.to_date.getDate()).padStart(2, '0');
             const month = String(this.to_date.getMonth() + 1).padStart(2, '0');
             const year = this.to_date.getFullYear();
-            dateString = `${day}/${month}/${year}`;
+            dateString = `${day}-${month}-${year}`;
           }
           // Handle string in YYYY-MM-DD format
           else if (typeof this.to_date === 'string' && this.to_date.includes('-')) {
             const parts = this.to_date.split('-');
             if (parts.length === 3) {
-              dateString = `${parts[2]}/${parts[1]}/${parts[0]}`;
+              dateString = `${parts[2]}-${parts[1]}-${parts[0]}`;
             } else {
               dateString = this.to_date;
             }
@@ -417,8 +417,14 @@ export default {
               formattedFromDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
             }
           } else if (vm.from_date.includes('-')) {
-            // Already in YYYY-MM-DD format
-            formattedFromDate = vm.from_date;
+            const parts = vm.from_date.split('-');
+            if (parts.length === 3) {
+              if (parts[0].length === 4) {
+                formattedFromDate = vm.from_date; // Already YYYY-MM-DD
+              } else {
+                formattedFromDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
+              }
+            }
           } else {
             // Invalid format, skip date filter
             formattedFromDate = null;
@@ -442,8 +448,14 @@ export default {
               formattedToDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
             }
           } else if (vm.to_date.includes('-')) {
-            // Already in YYYY-MM-DD format
-            formattedToDate = vm.to_date;
+            const parts = vm.to_date.split('-');
+            if (parts.length === 3) {
+              if (parts[0].length === 4) {
+                formattedToDate = vm.to_date; // Already YYYY-MM-DD
+              } else {
+                formattedToDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
+              }
+            }
           } else {
             // Invalid format, skip date filter
             formattedToDate = null;


### PR DESCRIPTION
## Summary
- display date pickers using `dd-MM-yyyy`
- keep ERPNext compatible `YYYY-MM-DD` values when sending data
- update invoice, payment and returns components for conversions
