### PR TITLE
Fix syntax error in utils.js

### DIFF
--- a/posawesome/public/js/posapp/components/pos/methods/utils.js
+++ b/posawesome/public/js/posapp/components/pos/methods/utils.js
@@ -564,7 +564,7 @@ export default {
       }
       this.calc_stock_qty(item, item.qty);
       this.$forceUpdate();
-    },
-  },
+    }
+  }
 
 };


### PR DESCRIPTION
## Summary
- fix trailing comma that caused build failure

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68497544e5688326ab51957122f5e395