### PR TITLE
Add discount column in POS items table

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -184,6 +184,7 @@ export default {
         { title: __("QTY"), key: "qty", align: "center" },
         { title: __("UOM"), key: "uom", align: "center" },
         { title: __("Rate"), key: "rate", align: "center" },
+        { title: __("Discount"), key: "discount_value", align: "center" },
         { title: __("Amount"), key: "amount", align: "center" },
         { title: __("Offer?"), key: "posa_is_offer", align: "center" },
       ],

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -33,8 +33,11 @@
         </div>
       </template>
 
-      <template v-slot:item.discount_amount="{ item }">
-        <div class="currency-display">
+      <template v-slot:item.discount_value="{ item }">
+        <div v-if="item.discount_percentage" class="amount-value">
+          {{ formatFloat(item.discount_percentage) }}%
+        </div>
+        <div v-else class="currency-display">
           <span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
           <span class="amount-value">{{ formatCurrency(item.discount_amount) }}</span>
         </div>


### PR DESCRIPTION
## Summary
- show item discount percent/amount on POS screen
- move the Discount column between Rate and Amount
