### PR TITLE
Add dark mode toggle

### DIFF
--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -1,8 +1,8 @@
 <template>
-  <v-app class="container1">
+  <v-app :class="['container1', { 'dark-mode': darkMode }]">
     <v-main>
-      <Navbar @changePage="setPage($event)"></Navbar>
-      <component v-bind:is="page" class="mx-4 md-4"></component>
+      <Navbar :dark-mode="darkMode" @toggle-dark-mode="toggleDarkMode" @changePage="setPage($event)" />
+      <component v-bind:is="page" :dark-mode="darkMode" class="mx-4 md-4"></component>
     </v-main>
   </v-app>
 </template>
@@ -16,6 +16,7 @@ export default {
   data: function () {
     return {
       page: 'POS',
+      darkMode: localStorage.getItem('posa_dark_mode') === 'true',
     };
   },
   components: {
@@ -26,6 +27,10 @@ export default {
   methods: {
     setPage(page) {
       this.page = page;
+    },
+    toggleDarkMode() {
+      this.darkMode = !this.darkMode;
+      localStorage.setItem('posa_dark_mode', this.darkMode);
     },
     remove_frappe_nav() {
       this.$nextTick(function () {
@@ -49,5 +54,9 @@ export default {
 <style scoped>
 .container1 {
   margin-top: 0px;
+}
+.dark-mode {
+  background-color: #000;
+  color: #fff;
 }
 </style>

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -4,7 +4,7 @@
 
     <!-- Top App Bar: application header with nav toggle, logo, title, and actions -->
 
-    <v-app-bar app flat height="56" color="white" class="navbar-enhanced elevation-2 px-2 pb-1">
+    <v-app-bar app flat height="56" :color="darkMode ? 'black' : 'white'" class="navbar-enhanced elevation-2 px-2 pb-1">
       <v-app-bar-nav-icon ref="navIcon" @click="handleNavClick" class="text-secondary nav-icon" />
 
       <v-img src="/assets/posawesome/js/posapp/components/pos/pos.png" alt="POS Awesome" max-width="32" class="mx-2" />
@@ -44,6 +44,13 @@
         <v-icon v-else>mdi-file-document-multiple-outline</v-icon>
         <v-tooltip activator="parent" location="bottom">
           {{ __('Offline Invoices') }} ({{ pendingInvoices }})
+        </v-tooltip>
+      </v-btn>
+
+      <v-btn icon color="primary" class="mx-1" @click="emitToggleDarkMode">
+        <v-icon>{{ darkMode ? 'mdi-white-balance-sunny' : 'mdi-moon-waning-crescent' }}</v-icon>
+        <v-tooltip activator="parent" location="bottom">
+          {{ darkMode ? __('Light Mode') : __('Dark Mode') }}
         </v-tooltip>
       </v-btn>
 
@@ -261,6 +268,9 @@ import OfflineInvoicesDialog from './OfflineInvoices.vue';
 export default {
   name: 'NavBar', // Component name
   components: { OfflineInvoicesDialog },
+  props: {
+    darkMode: Boolean
+  },
   data() {
     return {
       drawer: false, // Controls the visibility of the side navigation drawer (true for open, false for closed)
@@ -453,6 +463,10 @@ export default {
     }
   },
   methods: {
+
+    emitToggleDarkMode() {
+      this.$emit('toggle-dark-mode');
+    },
 
     /**
      * Initializes a Socket.IO connection, adapting the URL based on the environment:

--- a/posawesome/public/js/posapp/components/payments/Pay.vue
+++ b/posawesome/public/js/posapp/components/payments/Pay.vue
@@ -2,7 +2,7 @@
   <div fluid>
     <v-row v-show="!dialog">
       <v-col md="8" cols="12" class="pb-2 pr-0">
-        <v-card class="main mx-auto bg-grey-lighten-5 mt-3 p-3 pb-16 overflow-y-auto"
+        <v-card :class="['main mx-auto mt-3 p-3 pb-16 overflow-y-auto', darkMode ? 'dark-card' : 'bg-grey-lighten-5']"
           style="max-height: 94vh; height: 94vh">
           <Customer></Customer>
           <v-divider></v-divider>
@@ -159,7 +159,7 @@
         </v-card>
       </v-col>
       <v-col md="4" cols="12" class="pb-3">
-        <v-card class="invoices mx-auto bg-grey-lighten-5 mt-3 p-3" style="max-height: 94vh; height: 94vh">
+        <v-card :class="['invoices mx-auto mt-3 p-3', darkMode ? 'dark-card' : 'bg-grey-lighten-5']" style="max-height: 94vh; height: 94vh">
           <strong>
             <h4 class="text-primary">Totals</h4>
             <v-row>
@@ -250,6 +250,9 @@ import { getOpeningStorage, setOpeningStorage, initPromise } from "../../../offl
 
 export default {
   mixins: [format],
+  props: {
+    darkMode: Boolean
+  },
   data: function () {
     return {
       dialog: false,
@@ -957,6 +960,10 @@ export default {
 </script>
 
 <style>
+.dark-card {
+  background-color: #000 !important;
+  color: #fff !important;
+}
 input[total_of_diff] {
   text-align: right;
 }

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -6,7 +6,7 @@
 
     <!-- Main Invoice Card (contains all invoice content) -->
     <v-card :style="{ height: 'var(--container-height)', maxHeight: 'var(--container-height)' }"
-      :class="['cards my-0 py-0 mt-3 bg-grey-lighten-5', { 'return-mode': isReturnInvoice }]">
+      :class="['cards my-0 py-0 mt-3', darkMode ? 'dark-card' : 'bg-grey-lighten-5', { 'return-mode': isReturnInvoice }]">
 
       <!-- Dynamic padding wrapper -->
       <div class="dynamic-padding">
@@ -137,6 +137,9 @@ import { isOffline, saveCustomerBalance, getCachedCustomerBalance } from "../../
 export default {
   name: 'POSInvoice',
   mixins: [format],
+  props: {
+    darkMode: Boolean
+  },
   data() {
     return {
       // POS profile settings
@@ -844,6 +847,10 @@ export default {
 </script>
 
 <style scoped>
+.dark-card {
+  background-color: #000 !important;
+  color: #fff !important;
+}
 /* Style for selected checkbox button */
 .v-checkbox-btn.v-selected {
   background-color: #4CAF50 !important;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1,6 +1,6 @@
 <template>
   <div :style="responsiveStyles">
-    <v-card class="selection mx-auto bg-grey-lighten-5 my-0 py-0 mt-3 dynamic-card"
+    <v-card :class="['selection mx-auto my-0 py-0 mt-3 dynamic-card', darkMode ? 'dark-card' : 'bg-grey-lighten-5']"
       :style="{ height: responsiveStyles['--container-height'], maxHeight: responsiveStyles['--container-height'] }">
       <v-progress-linear :active="loading" :indeterminate="loading" absolute location="top"
         color="info"></v-progress-linear>
@@ -87,7 +87,7 @@
         </v-row>
       </div>
     </v-card>
-    <v-card class="cards mb-0 mt-3 dynamic-padding bg-grey-lighten-5">
+    <v-card :class="['cards mb-0 mt-3 dynamic-padding', darkMode ? 'dark-card' : 'bg-grey-lighten-5']">
       <v-row no-gutters align="center" justify="center" class="dynamic-spacing-sm">
         <v-col cols="12" class="mb-2">
           <v-select :items="items_group" :label="frappe._('Items Group')" density="compact" variant="solo" hide-details
@@ -134,6 +134,9 @@ export default {
   mixins: [format, responsiveMixin],
   components: {
     CameraScanner
+  },
+  props: {
+    darkMode: Boolean
   },
   data: () => ({
     pos_profile: "",
@@ -1183,6 +1186,11 @@ export default {
 <style scoped>
 .dynamic-card {
   transition: all 0.3s ease;
+}
+
+.dark-card {
+  background-color: #000 !important;
+  color: #fff !important;
 }
 
 .dynamic-padding {

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="pa-0">
-    <v-card class="selection mx-auto bg-grey-lighten-5 pa-1 my-0 py-0 mt-3" style="max-height: 68vh; height: 68vh">
+    <v-card :class="['selection mx-auto pa-1 my-0 py-0 mt-3', darkMode ? 'dark-card' : 'bg-grey-lighten-5']" style="max-height: 68vh; height: 68vh">
       <v-progress-linear :active="loading" :indeterminate="loading" absolute location="top" color="info"></v-progress-linear>
       <div class="overflow-y-auto px-2 pt-2" style="max-height: 67vh">
         
@@ -586,6 +586,9 @@ import generateOfflineInvoiceHTML from "../../../offline_print_template";
 export default {
   // Using format mixin for shared formatting methods
   mixins: [format],
+  props: {
+    darkMode: Boolean
+  },
   data() {
     return {
       loading: false, // UI loading state
@@ -1723,6 +1726,10 @@ export default {
 </script>
 
 <style scoped>
+.dark-card {
+  background-color: #000 !important;
+  color: #fff !important;
+}
 .v-text-field {
   cursor: text;
 }

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -10,7 +10,7 @@
     <OpeningDialog v-if="dialog" :dialog="dialog"></OpeningDialog>
     <v-row v-show="!dialog" dense class="ma-0 dynamic-main-row">
       <v-col v-show="!payment && !offers && !coupons" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
-        <ItemsSelector></ItemsSelector>
+        <ItemsSelector :dark-mode="darkMode" />
       </v-col>
       <v-col v-show="offers" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
         <PosOffers></PosOffers>
@@ -19,11 +19,11 @@
         <PosCoupons></PosCoupons>
       </v-col>
       <v-col v-show="payment" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
-        <Payments></Payments>
+        <Payments :dark-mode="darkMode" />
       </v-col>
 
       <v-col xl="7" lg="7" md="7" sm="7" cols="12" class="pos dynamic-col">
-        <Invoice></Invoice>
+        <Invoice :dark-mode="darkMode" />
       </v-col>
     </v-row>
   </div>
@@ -51,6 +51,9 @@ import { responsiveMixin } from '../../mixins/responsive.js';
 
 export default {
   mixins: [responsiveMixin],
+  props: {
+    darkMode: Boolean
+  },
   data: function () {
     return {
       dialog: false,

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -27,6 +27,7 @@ frappe.PosApp.posapp = class {
                     rtl: frappe.utils.is_rtl()
                 },
                 theme: {
+                    defaultTheme: localStorage.getItem('posa_dark_mode') === 'true' ? 'dark' : 'light',
                     themes: {
                         light: {
                             background: '#FFFFFF',
@@ -42,6 +43,12 @@ frappe.PosApp.posapp = class {
                             badge: '#F5528C',
                             customPrimary: '#085294',
                         },
+                        dark: {
+                            dark: true,
+                            colors: {
+                                background: '#000000'
+                            }
+                        }
                     },
                 },
             }


### PR DESCRIPTION
## Summary
- allow dark mode setting persisted in localStorage
- wire dark mode toggle button in Navbar
- support dark backgrounds for main cards
- pass dark mode flag to POS pages
- configure Vuetify with a dark theme
