### PR TITLE
Improve numeric formatting

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5420,5 +5420,16 @@
     "label": "Allow Delete Offline Invoice",
     "default": "0",
     "name": "POS Profile-posa_allow_delete_offline_invoice"
+  },
+  {
+    "doctype": "Custom Field",
+    "dt": "POS Profile",
+    "fieldname": "posa_decimal_precision",
+    "fieldtype": "Select",
+    "insert_after": "posa_allow_multi_currency",
+    "label": "Decimal Precision",
+    "options": "0\n1\n2\n3\n4\n5",
+    "default": "2",
+    "name": "POS Profile-posa_decimal_precision"
   }
 ]

--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -275,7 +275,8 @@ fixtures = [
                 "name",
                 "in",
                 [
-                    "POS Profile-posa_allow_multi_currency"
+                    "POS Profile-posa_allow_multi_currency",
+                    "POS Profile-posa_decimal_precision"
                 ]
             ]
         ]

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -557,38 +557,7 @@ export default {
     },
 
     formatCurrency(value) {
-      if (!value) return "0.00";
-
-      // Convert to absolute value for comparison
-      const absValue = Math.abs(value);
-
-      // Determine precision based on value size
-      let precision;
-      if (absValue >= 1) {
-        // Normal values use standard precision (2)
-        precision = 2;
-      } else if (absValue >= 0.01) {
-        // Small values between 0.01 and 1 use 4 decimal places
-        precision = 4;
-      } else {
-        // Very small values use higher precision (6)
-        precision = 6;
-      }
-
-      // Format the number with determined precision
-      const formattedValue = this.flt(value, precision).toFixed(precision);
-
-      // Remove trailing zeros after decimal point while keeping at least 2 decimals
-      const parts = formattedValue.split('.');
-      if (parts.length === 2) {
-        const decimalPart = parts[1].replace(/0+$/, '');
-        if (decimalPart.length < 2) {
-          return `${parts[0]}.${decimalPart.padEnd(2, '0')}`;
-        }
-        return `${parts[0]}.${decimalPart}`;
-      }
-
-      return formattedValue;
+      return this.$options.mixins[0].methods.formatCurrency.call(this, value, 2);
     },
 
     flt(value, precision = null) {
@@ -705,9 +674,11 @@ export default {
       this.customer = data.pos_profile.customer;
       this.pos_opening_shift = data.pos_opening_shift;
       this.stock_settings = data.stock_settings;
-      // Increase precision for better handling of small amounts
-      this.float_precision = 6;  // Changed from 2 to 6
-      this.currency_precision = 6;  // Changed from 2 to 6
+      const prec = parseInt(data.pos_profile.posa_decimal_precision);
+      if (!isNaN(prec)) {
+        this.float_precision = prec;
+        this.currency_precision = prec;
+      }
       this.invoiceType = this.pos_profile.posa_default_sales_order
         ? "Order"
         : "Invoice";

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -24,8 +24,8 @@
           </v-col>
           <v-col cols="3" class="pb-0" v-if="pos_profile.posa_input_qty">
             <v-text-field density="compact" variant="solo" color="primary" :label="frappe._('QTY')" bg-color="white"
-              hide-details v-model.number="qty" type="number" @keydown.enter="enter_event"
-              @keydown.esc="esc_event"></v-text-field>
+              hide-details :model-value="formatFloat(qty)" type="text" @change="setFormatedFloat(this, 'qty', null, false, $event)"
+              @keydown.enter="enter_event" @keydown.esc="esc_event"></v-text-field>
           </v-col>
           <v-col cols="2" class="pb-0" v-if="pos_profile.posa_new_line">
             <v-checkbox v-model="new_line" color="accent" value="true" label="NLine" density="default"
@@ -897,32 +897,10 @@ export default {
       return get_currency_symbol(currency);
     },
     format_currency(value, currency, precision) {
-      if (!value) return '0';
-
-      // Convert to string for checking decimal points
-      let valueStr = value.toString();
-
-      // If value has decimal points, show 4 decimal places
-      if (valueStr.includes('.')) {
-        return flt(value, 4).toString();
-      }
-
-      // For whole numbers, return as is
-      return valueStr;
+      return this.formatCurrency(value, precision || 2);
     },
     format_number(value, precision) {
-      if (!value) return '0';
-
-      // Convert to string for checking decimal points
-      let valueStr = value.toString();
-
-      // If value has decimal points, show 4 decimal places
-      if (valueStr.includes('.')) {
-        return flt(value, 4).toString();
-      }
-
-      // For whole numbers, return as is
-      return valueStr;
+      return this.formatFloat(value, precision || 2);
     },
     hasDecimalPrecision(value) {
       // Check if the value has any decimal precision when multiplied by exchange rate

--- a/posawesome/public/js/posapp/components/pos/Mpesa-Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Mpesa-Payments.vue
@@ -128,8 +128,7 @@ export default {
       }
     },
     formatCurrency(value) {
-      value = parseFloat(value);
-      return value.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,');
+      return this.$options.mixins[0].methods.formatCurrency.call(this, value, 2);
     },
   },
   created: function () {

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -42,12 +42,12 @@
               color="primary"
               :label="frappe._('Paid Change')"
               bg-color="white"
-              v-model.number="paid_change"
+              :model-value="formatCurrency(paid_change)"
               :prefix="currencySymbol(invoice_doc.currency)"
               :rules="paid_change_rules"
               density="compact"
               readonly
-              type="number"
+              type="text"
               @click="showPaidChange"
             ></v-text-field>
           </v-col>
@@ -59,11 +59,11 @@
               color="primary"
               :label="frappe._('Credit Change')"
               bg-color="white"
-              v-model.number="credit_change"
+              :model-value="formatCurrency(credit_change)"
               :prefix="currencySymbol(invoice_doc.currency)"
               density="compact"
-              type="number"
-              @input="updateCreditChange"
+              type="text"
+              @change="setFormatedCurrency(this, 'credit_change', null, false, $event); updateCreditChange(this.credit_change)"
             ></v-text-field>
           </v-col>
         </v-row>
@@ -80,9 +80,10 @@
                 color="primary"
                 :label="frappe._(payment.mode_of_payment)"
                 bg-color="white"
-                hide-details
-                v-model.number="payment.amount"
-                :rules="[
+              hide-details
+              :model-value="formatCurrency(payment.amount)"
+              @change="setFormatedCurrency(payment, 'amount', null, false, $event)"
+              :rules="[
                   isNumber,
                   v => !payment.mode_of_payment.toLowerCase().includes('cash') || 
                        this.is_credit_sale || 
@@ -126,8 +127,9 @@
               :label="frappe._('Redeem Loyalty Points')"
               bg-color="white"
               hide-details
-              v-model.number="loyalty_amount"
-              type="number"
+              :model-value="formatCurrency(loyalty_amount)"
+              type="text"
+              @change="setFormatedCurrency(this, 'loyalty_amount', null, false, $event)"
               :prefix="currencySymbol(invoice_doc.currency)"
             ></v-text-field>
           </v-col>
@@ -156,8 +158,9 @@
               :label="frappe._('Redeemed Customer Credit')"
               bg-color="white"
               hide-details
-              v-model.number="redeemed_customer_credit"
-              type="number"
+              :model-value="formatCurrency(redeemed_customer_credit)"
+              type="text"
+              @change="setFormatedCurrency(this, 'redeemed_customer_credit', null, false, $event)"
               :prefix="currencySymbol(invoice_doc.currency)"
               readonly
             ></v-text-field>
@@ -480,8 +483,9 @@
                 :label="frappe._('Redeem Credit')"
                 bg-color="white"
                 hide-details
-                type="number"
-                v-model.number="row.credit_to_redeem"
+                type="text"
+                :model-value="formatCurrency(row.credit_to_redeem)"
+                @change="setFormatedCurrency(row, 'credit_to_redeem', null, false, $event)"
                 :prefix="currencySymbol(invoice_doc.currency)"
               ></v-text-field>
             </v-col>
@@ -1556,8 +1560,7 @@ export default {
     },
     // Format currency value
     formatCurrency(value) {
-      if (!value) return "0.00";
-      return this.flt(value, this.currency_precision).toFixed(this.currency_precision);
+      return this.$options.mixins[0].methods.formatCurrency.call(this, value, this.currency_precision);
     },
     // Get change amount for display
     get_change_amount() {

--- a/posawesome/public/js/posapp/components/pos/Variants.vue
+++ b/posawesome/public/js/posapp/components/pos/Variants.vue
@@ -73,8 +73,7 @@ export default {
       this.varaintsDialog = false;
     },
     formatCurrency(value) {
-      value = parseFloat(value);
-      return value.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,');
+      return this.$options.mixins[0].methods.formatCurrency.call(this, value, 2);
     },
     updateFiltredItems() {
       this.$nextTick(function () {


### PR DESCRIPTION
## Summary
- format numbers with locale separators and two decimals
- use formatted input for quantity field
- show formatted payment and credit fields
- centralize currency formatting across components
- add setting for decimal precision in POS Profile
