### PR TITLE
Fix dark mode card backgrounds

### DIFF
--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -31,6 +31,9 @@ export default {
     toggleDarkMode() {
       this.darkMode = !this.darkMode;
       localStorage.setItem('posa_dark_mode', this.darkMode);
+      if (this.$vuetify && this.$vuetify.theme && this.$vuetify.theme.global) {
+        this.$vuetify.theme.global.name.value = this.darkMode ? 'dark' : 'light';
+      }
     },
     remove_frappe_nav() {
       this.$nextTick(function () {
@@ -41,6 +44,9 @@ export default {
   },
   mounted() {
     this.remove_frappe_nav();
+    if (this.$vuetify && this.$vuetify.theme && this.$vuetify.theme.global) {
+      this.$vuetify.theme.global.name.value = this.darkMode ? 'dark' : 'light';
+    }
   },
   updated() { },
   created: function () {
@@ -58,5 +64,9 @@ export default {
 .dark-mode {
   background-color: #000;
   color: #fff;
+}
+
+.dark-mode .text-primary {
+  color: #1976d2 !important;
 }
 </style>

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -103,6 +103,7 @@
       :currencySymbol="currencySymbol"
       :discount_percentage_offer_name="discount_percentage_offer_name"
       :isNumber="isNumber"
+      :dark-mode="darkMode"
       @update:additional_discount="val => additional_discount = val"
       @update:additional_discount_percentage="val => additional_discount_percentage = val"
       @update_discount_umount="update_discount_umount"

--- a/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
+++ b/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="cards mb-0 mt-3 py-2 px-3 rounded-lg bg-grey-lighten-4">
+  <v-card :class="['cards mb-0 mt-3 py-2 px-3 rounded-lg', darkMode ? 'dark-card' : 'bg-grey-lighten-4']">
     <v-row dense>
       <!-- Summary Info -->
       <v-col cols="12" md="7">
@@ -142,7 +142,8 @@ export default {
     formatCurrency: Function,
     currencySymbol: Function,
     discount_percentage_offer_name: [String, Number],
-    isNumber: Function
+    isNumber: Function,
+    darkMode: Boolean
   },
   emits: [
     'update:additional_discount',
@@ -158,3 +159,10 @@ export default {
   ]
 }
 </script>
+
+<style scoped>
+.dark-card {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+</style>

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -13,10 +13,10 @@
         <ItemsSelector :dark-mode="darkMode" />
       </v-col>
       <v-col v-show="offers" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
-        <PosOffers></PosOffers>
+        <PosOffers :dark-mode="darkMode" />
       </v-col>
       <v-col v-show="coupons" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
-        <PosCoupons></PosCoupons>
+        <PosCoupons :dark-mode="darkMode" />
       </v-col>
       <v-col v-show="payment" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
         <Payments :dark-mode="darkMode" />

--- a/posawesome/public/js/posapp/components/pos/PosCoupons.vue
+++ b/posawesome/public/js/posapp/components/pos/PosCoupons.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-card class="selection mx-auto bg-grey-lighten-5 mt-3" style="max-height: 80vh; height: 80vh">
+    <v-card :class="['selection mx-auto mt-3', darkMode ? 'dark-card' : 'bg-grey-lighten-5']" style="max-height: 80vh; height: 80vh">
       <v-card-title>
         <span class="text-h6 text-primary">{{ __('Coupons') }}</span>
       </v-card-title>
@@ -43,7 +43,7 @@
       </div>
     </v-card>
 
-    <v-card flat style="max-height: 11vh; height: 11vh" class="cards mb-0 mt-3 py-0">
+    <v-card flat style="max-height: 11vh; height: 11vh" :class="['cards mb-0 mt-3 py-0', darkMode ? 'dark-card' : '']">
       <v-row align="start" no-gutters>
         <v-col cols="12">
           <v-btn block class="pa-1" size="large" color="warning" theme="dark" @click="back_to_invoice">{{ __('Back')
@@ -57,6 +57,9 @@
 <script>
 
 export default {
+  props: {
+    darkMode: Boolean
+  },
   data: () => ({
     loading: false,
     pos_profile: '',
@@ -242,5 +245,10 @@ export default {
 .add-coupon-btn:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);
+}
+
+.dark-card {
+  background-color: #000 !important;
+  color: #fff !important;
 }
 </style>

--- a/posawesome/public/js/posapp/components/pos/PosOffers.vue
+++ b/posawesome/public/js/posapp/components/pos/PosOffers.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-card class="selection mx-auto bg-grey-lighten-5 mt-3" style="max-height: 80vh; height: 80vh">
+    <v-card :class="['selection mx-auto mt-3', darkMode ? 'dark-card' : 'bg-grey-lighten-5']" style="max-height: 80vh; height: 80vh">
       <v-card-title>
         <span class="text-h6 text-primary">{{ __('Offers') }}</span>
       </v-card-title>
@@ -37,7 +37,7 @@
       </div>
     </v-card>
 
-    <v-card flat style="max-height: 11vh; height: 11vh" class="cards mb-0 mt-3 py-0">
+    <v-card flat style="max-height: 11vh; height: 11vh" :class="['cards mb-0 mt-3 py-0', darkMode ? 'dark-card' : '']">
       <v-row align="start" no-gutters>
         <v-col cols="12">
           <v-btn block class="pa-1" size="large" color="warning" theme="dark" @click="back_to_invoice">{{ __('Back')
@@ -53,6 +53,9 @@
 import format from '../../format';
 export default {
   mixins: [format],
+  props: {
+    darkMode: Boolean
+  },
   data: () => ({
     loading: false,
     pos_profile: '',
@@ -253,3 +256,10 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.dark-card {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+</style>


### PR DESCRIPTION
## Summary
- propagate darkMode prop to offers and coupons
- allow cards to switch background color when dark mode is on
- keep primary text blue in dark mode
