### PR TITLE
Add dark mode toggle via VueUse

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "socket.io-client": "^4.8.1",
     "vue": "^3.3.4",
     "vue-qrcode-reader": "^5.7.2",
-    "vuetify": "^3.7.5"
+    "vuetify": "^3.7.5",
+    "@vueuse/core": "^10.9.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "devDependencies": {

--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -1,7 +1,11 @@
 <template>
   <v-app class="container1">
     <v-main>
-      <Navbar @changePage="setPage($event)"></Navbar>
+      <Navbar
+        :isDark="isDark"
+        :toggleDark="toggleDark"
+        @changePage="setPage($event)"
+      ></Navbar>
       <component v-bind:is="page" class="mx-4 md-4"></component>
     </v-main>
   </v-app>
@@ -11,8 +15,20 @@
 import Navbar from './components/Navbar.vue';
 import POS from './components/pos/Pos.vue';
 import Payments from './components/payments/Pay.vue';
+import { useDark, useToggle } from '@vueuse/core';
+import { useTheme } from 'vuetify';
+import { watch } from 'vue';
 
 export default {
+  setup() {
+    const isDark = useDark();
+    const toggleDark = useToggle(isDark);
+    const theme = useTheme();
+    watch(isDark, (val) => {
+      theme.global.name.value = val ? 'dark' : 'light';
+    }, { immediate: true });
+    return { isDark, toggleDark };
+  },
   data: function () {
     return {
       page: 'POS',

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -101,6 +101,18 @@
               </div>
             </v-list-item>
 
+            <v-list-item @click="toggleDark()" class="menu-item-compact neutral-action">
+              <template v-slot:prepend>
+                <div class="menu-icon-wrapper-compact neutral-icon">
+                  <v-icon color="white" size="16">mdi-theme-light-dark</v-icon>
+                </div>
+              </template>
+              <div class="menu-content-compact">
+                <v-list-item-title class="menu-item-title-compact">{{ isDark ? __('Light Mode') : __('Dark Mode') }}</v-list-item-title>
+                <v-list-item-subtitle class="menu-item-subtitle-compact">{{ __('Toggle theme') }}</v-list-item-subtitle>
+              </div>
+            </v-list-item>
+
             <v-divider class="menu-section-divider-compact"></v-divider>
 
             <v-list-item @click="goAbout" class="menu-item-compact neutral-action">
@@ -260,6 +272,10 @@ import OfflineInvoicesDialog from './OfflineInvoices.vue';
 
 export default {
   name: 'NavBar', // Component name
+  props: {
+    isDark: { type: Boolean, default: false },
+    toggleDark: { type: Function, required: true }
+  },
   components: { OfflineInvoicesDialog },
   data() {
     return {

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -27,21 +27,32 @@ frappe.PosApp.posapp = class {
                     rtl: frappe.utils.is_rtl()
                 },
                 theme: {
+                    defaultTheme: 'light',
                     themes: {
                         light: {
-                            background: '#FFFFFF',
-                            primary: '#0097A7',
-                            secondary: '#00BCD4',
-                            accent: '#9575CD',
-                            success: '#66BB6A',
-                            info: '#2196F3',
-                            warning: '#FF9800',
-                            error: '#E86674',
-                            orange: '#E65100',
-                            golden: '#A68C59',
-                            badge: '#F5528C',
-                            customPrimary: '#085294',
+                            dark: false,
+                            colors: {
+                                background: '#FFFFFF',
+                                primary: '#0097A7',
+                                secondary: '#00BCD4',
+                                accent: '#9575CD',
+                                success: '#66BB6A',
+                                info: '#2196F3',
+                                warning: '#FF9800',
+                                error: '#E86674',
+                                orange: '#E65100',
+                                golden: '#A68C59',
+                                badge: '#F5528C',
+                                customPrimary: '#085294'
+                            }
                         },
+                        dark: {
+                            dark: true,
+                            colors: {
+                                background: '#121212',
+                                primary: '#0097A7'
+                            }
+                        }
                     },
                 },
             }


### PR DESCRIPTION
## Summary
- install `@vueuse/core`
- define light & dark themes in Vuetify init
- watch theme state in `Home.vue`
- expose and toggle dark mode from `Navbar`
