### PR TITLE
Add dark mode theme support

### DIFF
--- a/posawesome/public/css/responsive.css
+++ b/posawesome/public/css/responsive.css
@@ -7,6 +7,28 @@
   --container-height: 75vh;
   --card-height: 60vh;
   --font-scale: 1;
+
+  --cancel-start: #d32f2f;
+  --cancel-end: #c62828;
+  --submit-start: #388e3c;
+  --submit-end: #2e7d32;
+  --primary-start: #1976d2;
+  --primary-end: #1565c0;
+  --dialog-bg-start: #ffffff;
+  --dialog-bg-end: #f8f9fa;
+  --dialog-border: #e0e0e0;
+}
+
+:root.dark-theme {
+  --cancel-start: #b71c1c;
+  --cancel-end: #c62828;
+  --submit-start: #2e7d32;
+  --submit-end: #1b5e20;
+  --primary-start: #0d47a1;
+  --primary-end: #1565c0;
+  --dialog-bg-start: #424242;
+  --dialog-bg-end: #303030;
+  --dialog-border: #555555;
 }
 
 /* Base responsive utilities */
@@ -56,19 +78,19 @@
 
 /* Button Variants */
 .pos-action-btn.cancel-action-btn {
-  background: linear-gradient(135deg, #d32f2f 0%, #c62828 100%) !important;
+  background: linear-gradient(135deg, var(--cancel-start) 0%, var(--cancel-end) 100%) !important;
 }
 
 .pos-action-btn.submit-action-btn {
-  background: linear-gradient(135deg, #388e3c 0%, #2e7d32 100%) !important;
+  background: linear-gradient(135deg, var(--submit-start) 0%, var(--submit-end) 100%) !important;
 }
 
 .pos-action-btn.sync-action-btn {
-  background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%) !important;
+  background: linear-gradient(135deg, var(--primary-start) 0%, var(--primary-end) 100%) !important;
 }
 
 .pos-action-btn.primary-action-btn {
-  background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%) !important;
+  background: linear-gradient(135deg, var(--primary-start) 0%, var(--primary-end) 100%) !important;
 }
 
 /* Hover Effects */
@@ -104,8 +126,8 @@
 
 /* Dialog Actions Container */
 .dialog-actions-container {
-  background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%) !important;
-  border-top: 1px solid #e0e0e0 !important;
+  background: linear-gradient(135deg, var(--dialog-bg-start) 0%, var(--dialog-bg-end) 100%) !important;
+  border-top: 1px solid var(--dialog-border) !important;
   padding: 16px 24px !important;
   gap: 12px !important;
 }

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -116,6 +116,18 @@
               </div>
             </v-list-item>
 
+            <v-list-item @click="toggleTheme" class="menu-item-compact neutral-action">
+              <template v-slot:prepend>
+                <div class="menu-icon-wrapper-compact neutral-icon">
+                  <v-icon color="white" size="16">mdi-theme-light-dark</v-icon>
+                </div>
+              </template>
+              <div class="menu-content-compact">
+                <v-list-item-title class="menu-item-title-compact">{{ isDark ? __('Light Mode') : __('Dark Mode') }}</v-list-item-title>
+                <v-list-item-subtitle class="menu-item-subtitle-compact">{{ __('Toggle theme') }}</v-list-item-subtitle>
+              </div>
+            </v-list-item>
+
             <v-list-item @click="logOut" class="menu-item-compact danger-action">
               <template v-slot:prepend>
                 <div class="menu-icon-wrapper-compact danger-icon">
@@ -359,6 +371,9 @@ export default {
 
       // Online mode - show full status
       return `To Sync: ${pendingCount} | Synced: ${syncedCount} | Draft: ${draftedCount}`;
+    },
+    isDark() {
+      return this.$theme.current === 'dark';
     }
   },
   created() {
@@ -722,6 +737,10 @@ export default {
           this.appInfoError = true;
         }
       });
+    },
+
+    toggleTheme() {
+      this.$theme.toggle();
     },
 
 

--- a/posawesome/public/js/posapp/plugins/theme.js
+++ b/posawesome/public/js/posapp/plugins/theme.js
@@ -1,0 +1,25 @@
+export default {
+    install(app, { vuetify }) {
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const stored = localStorage.getItem('posawesome-theme');
+        const current = stored || (prefersDark ? 'dark' : 'light');
+
+        // apply initial theme
+        vuetify.theme.global.name.value = current;
+        document.documentElement.classList.toggle('dark-theme', current === 'dark');
+
+        const toggle = () => {
+            const newTheme = vuetify.theme.global.name.value === 'dark' ? 'light' : 'dark';
+            vuetify.theme.global.name.value = newTheme;
+            document.documentElement.classList.toggle('dark-theme', newTheme === 'dark');
+            localStorage.setItem('posawesome-theme', newTheme);
+        };
+
+        app.config.globalProperties.$theme = {
+            get current() {
+                return vuetify.theme.global.name.value;
+            },
+            toggle,
+        };
+    }
+};

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -3,6 +3,7 @@ import { createApp } from 'vue';
 import VueDatePicker from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 import eventBus from './bus';
+import themePlugin from './plugins/theme.js';
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import Home from './Home.vue';
@@ -27,22 +28,42 @@ frappe.PosApp.posapp = class {
                     rtl: frappe.utils.is_rtl()
                 },
                 theme: {
+                    defaultTheme: 'light',
                     themes: {
                         light: {
-                            background: '#FFFFFF',
-                            primary: '#0097A7',
-                            secondary: '#00BCD4',
-                            accent: '#9575CD',
-                            success: '#66BB6A',
-                            info: '#2196F3',
-                            warning: '#FF9800',
-                            error: '#E86674',
-                            orange: '#E65100',
-                            golden: '#A68C59',
-                            badge: '#F5528C',
-                            customPrimary: '#085294',
+                            colors: {
+                                background: '#FFFFFF',
+                                primary: '#0097A7',
+                                secondary: '#00BCD4',
+                                accent: '#9575CD',
+                                success: '#66BB6A',
+                                info: '#2196F3',
+                                warning: '#FF9800',
+                                error: '#E86674',
+                                orange: '#E65100',
+                                golden: '#A68C59',
+                                badge: '#F5528C',
+                                customPrimary: '#085294'
+                            }
                         },
-                    },
+                        dark: {
+                            dark: true,
+                            colors: {
+                                background: '#121212',
+                                primary: '#0097A7',
+                                secondary: '#00BCD4',
+                                accent: '#9575CD',
+                                success: '#66BB6A',
+                                info: '#2196F3',
+                                warning: '#FF9800',
+                                error: '#E86674',
+                                orange: '#FF6F00',
+                                golden: '#A68C59',
+                                badge: '#F5528C',
+                                customPrimary: '#4FC3F7'
+                            }
+                        }
+                    }
                 },
             }
         );
@@ -50,6 +71,7 @@ frappe.PosApp.posapp = class {
         app.component('VueDatePicker', VueDatePicker)
         app.use(eventBus);
         app.use(vuetify)
+        app.use(themePlugin, { vuetify })
         app.mount(this.$el[0]);
 
         if (!document.querySelector('link[rel="manifest"]')) {


### PR DESCRIPTION
## Summary
- implement new theme plugin to toggle Vuetify themes
- register the plugin and dark palette in `posapp.js`
- add a menu option in Navbar to toggle theme
- expose `isDark` computed helper and toggle method
- theme CSS variables with dark mode values
