### PR TITLE
Fix item table dark mode background

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1185,9 +1185,9 @@ export default {
   transform: scale(calc(1 + 0.02 * var(--font-scale)));
 }
 
-:deep(.dark-theme) .dynamic-item-card,
-::v-deep(.dark-theme) .dynamic-item-card {
-  background-color: #1e1e1e !important;
+:deep(html.dark-theme) .dynamic-item-card,
+::v-deep(html.dark-theme) .dynamic-item-card {
+  background-color: #000 !important;
 }
 
 .text-success {
@@ -1213,33 +1213,35 @@ export default {
 }
 
 /* Dark mode adjustments */
-:deep(.dark-theme) .sleek-data-table,
-::v-deep(.dark-theme) .sleek-data-table {
+:deep(html.dark-theme) .sleek-data-table,
+::v-deep(html.dark-theme) .sleek-data-table {
   background-color: #000 !important;
 }
 
-:deep(.dark-theme) .sleek-data-table :deep(.v-data-table),
-:deep(.dark-theme) .sleek-data-table :deep(.v-data-table__wrapper),
-:deep(.dark-theme) .sleek-data-table :deep(table),
-::v-deep(.dark-theme) .sleek-data-table .v-data-table,
-::v-deep(.dark-theme) .sleek-data-table .v-data-table__wrapper,
-::v-deep(.dark-theme) .sleek-data-table table {
+:deep(html.dark-theme) .sleek-data-table :deep(.v-data-table),
+:deep(html.dark-theme) .sleek-data-table :deep(.v-data-table__wrapper),
+:deep(html.dark-theme) .sleek-data-table :deep(table),
+::v-deep(html.dark-theme) .sleek-data-table .v-data-table,
+::v-deep(html.dark-theme) .sleek-data-table .v-data-table__wrapper,
+::v-deep(html.dark-theme) .sleek-data-table table {
   background-color: #000 !important;
 }
 
-:deep(.dark-theme) .sleek-data-table :deep(th),
-:deep(.dark-theme) .sleek-data-table :deep(td),
-::v-deep(.dark-theme) .sleek-data-table th,
-::v-deep(.dark-theme) .sleek-data-table td {
+:deep(html.dark-theme) .sleek-data-table :deep(th),
+:deep(html.dark-theme) .sleek-data-table :deep(td),
+::v-deep(html.dark-theme) .sleek-data-table th,
+::v-deep(html.dark-theme) .sleek-data-table td {
   color: #fff !important;
   background-color: #000 !important;
   border-color: #333 !important;
 }
 
 /* Dark mode card backgrounds */
-:deep(.dark-theme) .selection,
-:deep(.dark-theme) .cards {
-  background-color: #1e1e1e !important;
+:deep(html.dark-theme) .selection,
+:deep(html.dark-theme) .cards,
+::v-deep(html.dark-theme) .selection,
+::v-deep(html.dark-theme) .cards {
+  background-color: #000 !important;
 }
 
 /* Consistent spacing with navbar and system */

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -293,22 +293,22 @@ export default {
 }
 
 /* Dark mode adjustments */
-:deep(.dark-theme) .enhanced-table-items,
-::v-deep(.dark-theme) .enhanced-table-items {
+:deep(html.dark-theme) .enhanced-table-items,
+::v-deep(html.dark-theme) .enhanced-table-items {
   background-color: #000 !important;
 }
 
-:deep(.dark-theme) .enhanced-table-items :deep(th),
-:deep(.dark-theme) .enhanced-table-items :deep(td),
-::v-deep(.dark-theme) .enhanced-table-items th,
-::v-deep(.dark-theme) .enhanced-table-items td {
+:deep(html.dark-theme) .enhanced-table-items :deep(th),
+:deep(html.dark-theme) .enhanced-table-items :deep(td),
+::v-deep(html.dark-theme) .enhanced-table-items th,
+::v-deep(html.dark-theme) .enhanced-table-items td {
   color: #fff !important;
   background-color: #000 !important;
   border-color: #333 !important;
 }
 
-:deep(.dark-theme) .enhanced-table-items :deep(.v-data-table__expanded),
-::v-deep(.dark-theme) .enhanced-table-items .v-data-table__expanded {
+:deep(html.dark-theme) .enhanced-table-items :deep(.v-data-table__expanded),
+::v-deep(html.dark-theme) .enhanced-table-items .v-data-table__expanded {
   background-color: #111 !important;
 }
 


### PR DESCRIPTION
## Summary
- use `html.dark-theme` selectors in `ItemsTable` styles
- keep item selector and table consistent in dark mode
