### PR TITLE
Fix item selector dark mode

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1187,7 +1187,7 @@ export default {
 
 :deep(.dark-theme) .dynamic-item-card,
 ::v-deep(.dark-theme) .dynamic-item-card {
-  background-color: #1e1e1e !important;
+  background-color: #000 !important;
 }
 
 .text-success {
@@ -1220,9 +1220,11 @@ export default {
 
 :deep(.dark-theme) .sleek-data-table :deep(.v-data-table),
 :deep(.dark-theme) .sleek-data-table :deep(.v-data-table__wrapper),
+:deep(.dark-theme) .sleek-data-table :deep(.v-table__wrapper),
 :deep(.dark-theme) .sleek-data-table :deep(table),
 ::v-deep(.dark-theme) .sleek-data-table .v-data-table,
 ::v-deep(.dark-theme) .sleek-data-table .v-data-table__wrapper,
+::v-deep(.dark-theme) .sleek-data-table .v-table__wrapper,
 ::v-deep(.dark-theme) .sleek-data-table table {
   background-color: #000 !important;
 }
@@ -1238,8 +1240,10 @@ export default {
 
 /* Dark mode card backgrounds */
 :deep(.dark-theme) .selection,
-:deep(.dark-theme) .cards {
-  background-color: #1e1e1e !important;
+:deep(.dark-theme) .cards,
+::v-deep(.dark-theme) .selection,
+::v-deep(.dark-theme) .cards {
+  background-color: #000 !important;
 }
 
 /* Consistent spacing with navbar and system */

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -262,7 +262,8 @@ export default {
   flex-direction: column;
 }
 
-.enhanced-table-items :deep(.v-data-table__wrapper) {
+.enhanced-table-items :deep(.v-data-table__wrapper),
+.enhanced-table-items :deep(.v-table__wrapper) {
   border-radius: 8px;
   height: 100%;
   overflow-y: auto;
@@ -305,6 +306,13 @@ export default {
   color: #fff !important;
   background-color: #000 !important;
   border-color: #333 !important;
+}
+
+:deep(.dark-theme) .enhanced-table-items :deep(.v-data-table__wrapper),
+:deep(.dark-theme) .enhanced-table-items :deep(.v-table__wrapper),
+::v-deep(.dark-theme) .enhanced-table-items .v-data-table__wrapper,
+::v-deep(.dark-theme) .enhanced-table-items .v-table__wrapper {
+  background-color: #000 !important;
 }
 
 :deep(.dark-theme) .enhanced-table-items :deep(.v-data-table__expanded),


### PR DESCRIPTION
## Summary
- cover Vuetify `v-table__wrapper` for dark-theme backgrounds
- ensure `ItemsTable` wrappers are black in dark mode
