### PR TITLE
Fix item selector dark mode

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1186,8 +1186,10 @@ export default {
 }
 
 :deep(.dark-theme) .dynamic-item-card,
-::v-deep(.dark-theme) .dynamic-item-card {
-  background-color: #1e1e1e !important;
+:deep(.v-theme--dark) .dynamic-item-card,
+::v-deep(.dark-theme) .dynamic-item-card,
+::v-deep(.v-theme--dark) .dynamic-item-card {
+  background-color: #000 !important;
 }
 
 .text-success {
@@ -1214,23 +1216,39 @@ export default {
 
 /* Dark mode adjustments */
 :deep(.dark-theme) .sleek-data-table,
-::v-deep(.dark-theme) .sleek-data-table {
+:deep(.v-theme--dark) .sleek-data-table,
+::v-deep(.dark-theme) .sleek-data-table,
+::v-deep(.v-theme--dark) .sleek-data-table {
   background-color: #000 !important;
 }
 
 :deep(.dark-theme) .sleek-data-table :deep(.v-data-table),
+:deep(.v-theme--dark) .sleek-data-table :deep(.v-data-table),
 :deep(.dark-theme) .sleek-data-table :deep(.v-data-table__wrapper),
+:deep(.v-theme--dark) .sleek-data-table :deep(.v-data-table__wrapper),
+:deep(.dark-theme) .sleek-data-table :deep(.v-table__wrapper),
+:deep(.v-theme--dark) .sleek-data-table :deep(.v-table__wrapper),
 :deep(.dark-theme) .sleek-data-table :deep(table),
+:deep(.v-theme--dark) .sleek-data-table :deep(table),
 ::v-deep(.dark-theme) .sleek-data-table .v-data-table,
+::v-deep(.v-theme--dark) .sleek-data-table .v-data-table,
 ::v-deep(.dark-theme) .sleek-data-table .v-data-table__wrapper,
-::v-deep(.dark-theme) .sleek-data-table table {
+::v-deep(.v-theme--dark) .sleek-data-table .v-data-table__wrapper,
+::v-deep(.dark-theme) .sleek-data-table .v-table__wrapper,
+::v-deep(.v-theme--dark) .sleek-data-table .v-table__wrapper,
+::v-deep(.dark-theme) .sleek-data-table table,
+::v-deep(.v-theme--dark) .sleek-data-table table {
   background-color: #000 !important;
 }
 
 :deep(.dark-theme) .sleek-data-table :deep(th),
+:deep(.v-theme--dark) .sleek-data-table :deep(th),
 :deep(.dark-theme) .sleek-data-table :deep(td),
+:deep(.v-theme--dark) .sleek-data-table :deep(td),
 ::v-deep(.dark-theme) .sleek-data-table th,
-::v-deep(.dark-theme) .sleek-data-table td {
+::v-deep(.v-theme--dark) .sleek-data-table th,
+::v-deep(.dark-theme) .sleek-data-table td,
+::v-deep(.v-theme--dark) .sleek-data-table td {
   color: #fff !important;
   background-color: #000 !important;
   border-color: #333 !important;
@@ -1238,8 +1256,14 @@ export default {
 
 /* Dark mode card backgrounds */
 :deep(.dark-theme) .selection,
-:deep(.dark-theme) .cards {
-  background-color: #1e1e1e !important;
+:deep(.v-theme--dark) .selection,
+:deep(.dark-theme) .cards,
+:deep(.v-theme--dark) .cards,
+::v-deep(.dark-theme) .selection,
+::v-deep(.v-theme--dark) .selection,
+::v-deep(.dark-theme) .cards,
+::v-deep(.v-theme--dark) .cards {
+  background-color: #000 !important;
 }
 
 /* Consistent spacing with navbar and system */

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -262,7 +262,8 @@ export default {
   flex-direction: column;
 }
 
-.enhanced-table-items :deep(.v-data-table__wrapper) {
+.enhanced-table-items :deep(.v-data-table__wrapper),
+.enhanced-table-items :deep(.v-table__wrapper) {
   border-radius: 8px;
   height: 100%;
   overflow-y: auto;
@@ -294,21 +295,40 @@ export default {
 
 /* Dark mode adjustments */
 :deep(.dark-theme) .enhanced-table-items,
-::v-deep(.dark-theme) .enhanced-table-items {
+:deep(.v-theme--dark) .enhanced-table-items,
+::v-deep(.dark-theme) .enhanced-table-items,
+::v-deep(.v-theme--dark) .enhanced-table-items {
   background-color: #000 !important;
 }
 
 :deep(.dark-theme) .enhanced-table-items :deep(th),
+:deep(.v-theme--dark) .enhanced-table-items :deep(th),
 :deep(.dark-theme) .enhanced-table-items :deep(td),
+:deep(.v-theme--dark) .enhanced-table-items :deep(td),
 ::v-deep(.dark-theme) .enhanced-table-items th,
-::v-deep(.dark-theme) .enhanced-table-items td {
+::v-deep(.v-theme--dark) .enhanced-table-items th,
+::v-deep(.dark-theme) .enhanced-table-items td,
+::v-deep(.v-theme--dark) .enhanced-table-items td {
   color: #fff !important;
   background-color: #000 !important;
   border-color: #333 !important;
 }
 
+:deep(.dark-theme) .enhanced-table-items :deep(.v-data-table__wrapper),
+:deep(.v-theme--dark) .enhanced-table-items :deep(.v-data-table__wrapper),
+:deep(.dark-theme) .enhanced-table-items :deep(.v-table__wrapper),
+:deep(.v-theme--dark) .enhanced-table-items :deep(.v-table__wrapper),
+::v-deep(.dark-theme) .enhanced-table-items .v-data-table__wrapper,
+::v-deep(.v-theme--dark) .enhanced-table-items .v-data-table__wrapper,
+::v-deep(.dark-theme) .enhanced-table-items .v-table__wrapper,
+::v-deep(.v-theme--dark) .enhanced-table-items .v-table__wrapper {
+  background-color: #000 !important;
+}
+
 :deep(.dark-theme) .enhanced-table-items :deep(.v-data-table__expanded),
-::v-deep(.dark-theme) .enhanced-table-items .v-data-table__expanded {
+:deep(.v-theme--dark) .enhanced-table-items :deep(.v-data-table__expanded),
+::v-deep(.dark-theme) .enhanced-table-items .v-data-table__expanded,
+::v-deep(.v-theme--dark) .enhanced-table-items .v-data-table__expanded {
   background-color: #111 !important;
 }
 


### PR DESCRIPTION
## Summary
- cover Vuetify `v-theme--dark` class when applying dark backgrounds
- ensure both item tables match in dark mode