### PR TITLE
Apply dark mode styling across invoice and payment fields

### DIFF
--- a/posawesome/public/js/posapp/components/payments/Pay.vue
+++ b/posawesome/public/js/posapp/components/payments/Pay.vue
@@ -29,7 +29,7 @@
             </v-row>
             <v-row align="center" no-gutters class="mb-1">
               <v-col md="4" cols="12">
-                <v-select density="compact" variant="outlined" hide-details clearable bg-color="white"
+                <v-select density="compact" variant="outlined" hide-details clearable :bg-color="isDarkTheme ? '#000' : 'white'"
                   v-model="pos_profile_search" :items="pos_profiles_list" item-value="name"
                   label="Select POS Profile"></v-select>
               </v-col>
@@ -133,11 +133,11 @@
             <v-row align="center" no-gutters class="mb-1">
               <v-col md="4" cols="12" class="mr-1">
                 <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Search by Name')"
-                  bg-color="white" hide-details v-model="mpesa_search_name" clearable></v-text-field>
+                  :bg-color="isDarkTheme ? '#000' : 'white'" hide-details v-model="mpesa_search_name" clearable></v-text-field>
               </v-col>
               <v-col md="4" cols="12" class="mr-1">
                 <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Search by Mobile')"
-                  bg-color="white" hide-details v-model="mpesa_search_mobile" clearable></v-text-field>
+                  :bg-color="isDarkTheme ? '#000' : 'white'" hide-details v-model="mpesa_search_mobile" clearable></v-text-field>
               </v-col>
               <v-col> </v-col>
               <v-col md="3" cols="12">
@@ -167,7 +167,7 @@
                 <span>{{ __("Total Invoices:") }}</span>
               </v-col>
               <v-col md="5">
-                <v-text-field class="p-0 m-0" density="compact" color="primary" bg-color="white" hide-details
+                <v-text-field class="p-0 m-0 dark-field" density="compact" color="primary" :bg-color="isDarkTheme ? '#000' : 'white'" hide-details
                   :model-value="formatCurrency(total_selected_invoices)" readonly flat
                   :prefix="currencySymbol(pos_profile.currency)"></v-text-field>
                 <small v-if="selected_invoices.length" class="text-primary">{{ selected_invoices.length }} invoice(s) selected</small>
@@ -177,7 +177,7 @@
             <v-row v-if="total_selected_payments">
               <v-col md="7" class="mt-1"><span>{{ __("Total Payments:") }}</span></v-col>
               <v-col md="5">
-                <v-text-field class="p-0 m-0" density="compact" color="primary" bg-color="white" hide-details
+                <v-text-field class="p-0 m-0 dark-field" density="compact" color="primary" :bg-color="isDarkTheme ? '#000' : 'white'" hide-details
                   :model-value="formatCurrency(total_selected_payments)" readonly flat
                   :prefix="currencySymbol(pos_profile.currency)"></v-text-field>
               </v-col>
@@ -186,7 +186,7 @@
             <v-row v-if="total_selected_mpesa_payments">
               <v-col md="7" class="mt-1"><span>{{ __("Total Mpesa:") }}</span></v-col>
               <v-col md="5">
-                <v-text-field class="p-0 m-0" density="compact" color="primary" bg-color="white" hide-details
+                <v-text-field class="p-0 m-0 dark-field" density="compact" color="primary" :bg-color="isDarkTheme ? '#000' : 'white'" hide-details
                   :model-value="formatCurrency(total_selected_mpesa_payments)" readonly flat
                   :prefix="currencySymbol(pos_profile.currency)"></v-text-field>
               </v-col>
@@ -201,7 +201,7 @@
                 <v-col md="5">
                   <div class="d-flex align-center">
                     <div class="mr-1 text-primary">{{ currencySymbol(pos_profile.currency) }}</div>
-                    <v-text-field class="p-0 m-0" density="compact" color="primary" bg-color="white"
+                    <v-text-field class="p-0 m-0 dark-field" density="compact" color="primary" :bg-color="isDarkTheme ? '#000' : 'white'"
                       hide-details v-model="method.amount" type="number" flat 
                       @input="$forceUpdate()"></v-text-field>
                   </div>
@@ -215,7 +215,7 @@
                 <h4 class="text-primary mt-1">{{ __("Difference:") }}</h4>
               </v-col>
               <v-col md="5">
-                <v-text-field class="p-0 m-0" density="compact" color="primary" bg-color="white" hide-details
+                <v-text-field class="p-0 m-0 dark-field" density="compact" color="primary" :bg-color="isDarkTheme ? '#000' : 'white'" hide-details
                   :model-value="formatCurrency(total_of_diff)" readonly flat
                   :prefix="currencySymbol(pos_profile.currency)"></v-text-field>
               </v-col>
@@ -917,8 +917,8 @@ export default {
     total_of_diff() {
       // Calculate difference between invoice total and payment total
       const invoiceTotal = this.total_selected_invoices || 0;
-      const paymentTotal = (this.total_selected_payments || 0) + 
-                          (this.total_selected_mpesa_payments || 0) + 
+      const paymentTotal = (this.total_selected_payments || 0) +
+                          (this.total_selected_mpesa_payments || 0) +
                           (this.total_payment_methods || 0);
       
       console.log('Difference calculation:', {
@@ -931,6 +931,9 @@ export default {
       
       return flt(invoiceTotal - paymentTotal);
     },
+    isDarkTheme() {
+      return this.$theme.current === 'dark';
+    }
   },
 
   mounted: function () {
@@ -957,6 +960,36 @@ export default {
 </script>
 
 <style>
+/* Dark mode input styling */
+:deep(.dark-theme) .dark-field,
+:deep(.v-theme--dark) .dark-field,
+::v-deep(.dark-theme) .dark-field,
+::v-deep(.v-theme--dark) .dark-field {
+  background-color: #000 !important;
+}
+
+:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
+:deep(.dark-theme) .dark-field :deep(input),
+:deep(.v-theme--dark) .dark-field :deep(input),
+:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep(.v-theme--dark) .dark-field :deep(.v-label),
+::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep(.v-theme--dark) .dark-field .v-field__input,
+::v-deep(.dark-theme) .dark-field input,
+::v-deep(.v-theme--dark) .dark-field input,
+::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep(.v-theme--dark) .dark-field .v-label {
+  color: #fff !important;
+}
+
+:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
+::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
+  background-color: #000 !important;
+}
+
 input[total_of_diff] {
   text-align: right;
 }

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -18,7 +18,8 @@
           </v-col>
           <!-- Invoice Type Selection (Only shown if sales orders are allowed) -->
           <v-col v-if="pos_profile.posa_allow_sales_order" cols="3" class="pb-0">
-            <v-select density="compact" hide-details variant="outlined" color="primary" bg-color="white"
+            <v-select density="compact" hide-details variant="outlined" color="primary"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               :items="invoiceTypes" :label="frappe._('Type')" v-model="invoiceType"
               :disabled="invoiceType == 'Return'"></v-select>
           </v-col>
@@ -203,7 +204,12 @@ export default {
     CancelSaleDialog,
     ItemsTable,
   },
-  computed: invoiceComputed,
+  computed: {
+    ...invoiceComputed,
+    isDarkTheme() {
+      return this.$theme.current === 'dark';
+    }
+  },
 
 
   methods: {
@@ -815,6 +821,36 @@ export default {
 </script>
 
 <style scoped>
+/* Dark mode input styling */
+:deep(.dark-theme) .dark-field,
+:deep(.v-theme--dark) .dark-field,
+::v-deep(.dark-theme) .dark-field,
+::v-deep(.v-theme--dark) .dark-field {
+  background-color: #000 !important;
+}
+
+:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
+:deep(.dark-theme) .dark-field :deep(input),
+:deep(.v-theme--dark) .dark-field :deep(input),
+:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep(.v-theme--dark) .dark-field :deep(.v-label),
+::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep(.v-theme--dark) .dark-field .v-field__input,
+::v-deep(.dark-theme) .dark-field input,
+::v-deep(.v-theme--dark) .dark-field input,
+::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep(.v-theme--dark) .dark-field .v-label {
+  color: #fff !important;
+}
+
+:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
+::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
+  background-color: #000 !important;
+}
+
 /* Style for selected checkbox button */
 .v-checkbox-btn.v-selected {
   background-color: #4CAF50 !important;

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -11,7 +11,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Paid Amount')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               v-model="total_payments_display"
               readonly
@@ -25,7 +25,7 @@
               variant="outlined"
               color="primary"
               label="To Be Paid"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               v-model="diff_payment_display"
               :prefix="currencySymbol(invoice_doc.currency)"
@@ -41,7 +41,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Paid Change')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               :model-value="formatCurrency(paid_change)"
               :prefix="currencySymbol(invoice_doc.currency)"
               :rules="paid_change_rules"
@@ -58,7 +58,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Credit Change')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               :model-value="formatCurrency(credit_change)"
               :prefix="currencySymbol(invoice_doc.currency)"
               density="compact"
@@ -79,7 +79,7 @@
                 variant="outlined"
                 color="primary"
                 :label="frappe._(payment.mode_of_payment)"
-                bg-color="white"
+                :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :model-value="formatCurrency(payment.amount)"
               @change="setFormatedCurrency(payment, 'amount', null, false, $event)"
@@ -125,7 +125,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Redeem Loyalty Points')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :model-value="formatCurrency(loyalty_amount)"
               type="text"
@@ -139,7 +139,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('You can redeem up to')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :value="formatFloat(available_points_amount)"
               :prefix="currencySymbol(invoice_doc.currency)"
@@ -156,7 +156,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Redeemed Customer Credit')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :model-value="formatCurrency(redeemed_customer_credit)"
               type="text"
@@ -171,7 +171,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('You can redeem credit up to')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :value="formatCurrency(available_customer_credit)"
               :prefix="currencySymbol(invoice_doc.currency)"
@@ -190,7 +190,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Net Total')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               :value="formatCurrency(invoice_doc.net_total, displayCurrency)"
               readonly
               :prefix="currencySymbol()"
@@ -203,7 +203,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Tax and Charges')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :value="formatCurrency(invoice_doc.total_taxes_and_charges, displayCurrency)"
               readonly
@@ -217,7 +217,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Total Amount')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :value="formatCurrency(invoice_doc.total, displayCurrency)"
               readonly
@@ -231,7 +231,7 @@
               variant="outlined"
               color="primary"
               :label="diff_label"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :value="formatCurrency(diff_payment, displayCurrency)"
               readonly
@@ -245,7 +245,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Discount Amount')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :value="formatCurrency(invoice_doc.discount_amount)"
               readonly
@@ -259,7 +259,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Grand Total')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :value="formatCurrency(invoice_doc.grand_total)"
               readonly
@@ -273,7 +273,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Rounded Total')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               :value="formatCurrency(invoice_doc.rounded_total)"
               readonly
@@ -306,7 +306,7 @@
               :items="addresses"
               item-title="address_title"
               item-value="name"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               no-data-text="Address not found"
               hide-details
               :customFilter="addressFilter"
@@ -349,10 +349,10 @@
           <!-- Additional Notes (if enabled in POS profile) -->
           <v-col cols="12" v-if="pos_profile.posa_display_additional_notes">
             <v-textarea
-              class="pa-0"
+              class="pa-0 dark-field"
               variant="outlined"
               density="compact"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'"
               clearable
               color="primary"
               auto-grow
@@ -373,7 +373,7 @@
                 :label="frappe._('Purchase Order')"
                 variant="outlined"
                 density="compact"
-                bg-color="white"
+                :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
                 clearable
                 color="primary"
                 hide-details
@@ -468,7 +468,7 @@
                 variant="outlined"
                 color="primary"
                 :label="frappe._('Available Credit')"
-                bg-color="white"
+                :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
                 hide-details
                 :value="formatCurrency(row.total_credit)"
                 readonly
@@ -481,7 +481,7 @@
                 variant="outlined"
                 color="primary"
                 :label="frappe._('Redeem Credit')"
-                bg-color="white"
+                :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
                 hide-details
                 type="text"
                 :model-value="formatCurrency(row.credit_to_redeem)"
@@ -509,7 +509,7 @@
               :items="sales_persons"
               item-title="title"
               item-value="value"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               :no-data-text="__('Sales Person not found')"
               hide-details
               :disabled="readonly"
@@ -553,7 +553,7 @@
               variant="outlined"
               color="primary"
               :label="frappe._('Mobile Number')"
-              bg-color="white"
+              :bg-color="isDarkTheme ? '#000' : 'white'" class="dark-field"
               hide-details
               v-model="invoice_doc.contact_mobile"
               type="number"
@@ -755,6 +755,9 @@ export default {
         (el) => el.fieldtype === "Button" && el.fieldname === "request_for_payment"
       ) || false;
     },
+    isDarkTheme() {
+      return this.$theme.current === 'dark';
+    }
   },
   watch: {
     // Watch diff_payment to update paid_change
@@ -1726,6 +1729,36 @@ export default {
 </script>
 
 <style scoped>
+/* Dark mode input styling */
+:deep(.dark-theme) .dark-field,
+:deep(.v-theme--dark) .dark-field,
+::v-deep(.dark-theme) .dark-field,
+::v-deep(.v-theme--dark) .dark-field {
+  background-color: #000 !important;
+}
+
+:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
+:deep(.dark-theme) .dark-field :deep(input),
+:deep(.v-theme--dark) .dark-field :deep(input),
+:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep(.v-theme--dark) .dark-field :deep(.v-label),
+::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep(.v-theme--dark) .dark-field .v-field__input,
+::v-deep(.dark-theme) .dark-field input,
+::v-deep(.v-theme--dark) .dark-field input,
+::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep(.v-theme--dark) .dark-field .v-label {
+  color: #fff !important;
+}
+
+:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
+::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
+  background-color: #000 !important;
+}
+
 .v-text-field {
   cursor: text;
 }


### PR DESCRIPTION
## Summary
- add dark theme detection to Invoice, Payments and Pay components
- toggle field backgrounds using the detected theme
- introduce `.dark-field` CSS for consistent dark styling
- fix duplicate `class` attributes causing build errors
