### PR TITLE
Fix dark mode card styling

### DIFF
--- a/posawesome/public/js/posapp/components/payments/Pay.vue
+++ b/posawesome/public/js/posapp/components/payments/Pay.vue
@@ -2,8 +2,11 @@
   <div fluid>
     <v-row v-show="!dialog">
       <v-col md="8" cols="12" class="pb-2 pr-0">
-        <v-card class="main mx-auto bg-grey-lighten-5 mt-3 p-3 pb-16 overflow-y-auto"
-          style="max-height: 94vh; height: 94vh">
+        <v-card
+          :class="['main mx-auto mt-3 p-3 pb-16 overflow-y-auto', isDarkTheme ? '' : 'bg-grey-lighten-5']"
+          :style="isDarkTheme ? 'background-color:#000' : ''"
+          style="max-height: 94vh; height: 94vh"
+        >
           <Customer></Customer>
           <v-divider></v-divider>
           <div>
@@ -159,7 +162,11 @@
         </v-card>
       </v-col>
       <v-col md="4" cols="12" class="pb-3">
-        <v-card class="invoices mx-auto bg-grey-lighten-5 mt-3 p-3" style="max-height: 94vh; height: 94vh">
+        <v-card
+          :class="['invoices mx-auto mt-3 p-3', isDarkTheme ? '' : 'bg-grey-lighten-5']"
+          :style="isDarkTheme ? 'background-color:#000' : ''"
+          style="max-height: 94vh; height: 94vh"
+        >
           <strong>
             <h4 class="text-primary">Totals</h4>
             <v-row>

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -5,8 +5,10 @@
     <CancelSaleDialog v-model="cancel_dialog" @confirm="cancel_invoice" />
 
     <!-- Main Invoice Card (contains all invoice content) -->
-    <v-card :style="{ height: 'var(--container-height)', maxHeight: 'var(--container-height)' }"
-      :class="['cards my-0 py-0 mt-3 bg-grey-lighten-5', { 'return-mode': isReturnInvoice }]">
+    <v-card
+      :style="{ height: 'var(--container-height)', maxHeight: 'var(--container-height)', backgroundColor: isDarkTheme ? '#000' : '' }"
+      :class="['cards my-0 py-0 mt-3', isDarkTheme ? '' : 'bg-grey-lighten-5', { 'return-mode': isReturnInvoice }]"
+    >
 
       <!-- Dynamic padding wrapper -->
       <div class="dynamic-padding">

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="pa-0">
-    <v-card class="selection mx-auto bg-grey-lighten-5 pa-1 my-0 py-0 mt-3" style="max-height: 68vh; height: 68vh">
+    <v-card
+      :class="['selection mx-auto pa-1 my-0 py-0 mt-3', isDarkTheme ? '' : 'bg-grey-lighten-5']"
+      :style="isDarkTheme ? 'background-color:#000' : ''"
+      style="max-height: 68vh; height: 68vh"
+    >
       <v-progress-linear :active="loading" :indeterminate="loading" absolute location="top" color="info"></v-progress-linear>
       <div class="overflow-y-auto px-2 pt-2" style="max-height: 67vh">
         

--- a/posawesome/public/js/posapp/components/pos/PosCoupons.vue
+++ b/posawesome/public/js/posapp/components/pos/PosCoupons.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <v-card class="selection mx-auto bg-grey-lighten-5 mt-3" style="max-height: 80vh; height: 80vh">
+    <v-card
+      :class="['selection mx-auto mt-3', isDarkTheme ? '' : 'bg-grey-lighten-5']"
+      :style="isDarkTheme ? 'background-color:#000' : ''"
+      style="max-height: 80vh; height: 80vh"
+    >
       <v-card-title>
         <span class="text-h6 text-primary">{{ __('Coupons') }}</span>
       </v-card-title>
@@ -79,6 +83,9 @@ export default {
     },
     appliedCouponsCount() {
       return this.posa_coupons.filter((el) => !!el.applied).length;
+    },
+    isDarkTheme() {
+      return this.$theme?.current === 'dark';
     },
   },
 

--- a/posawesome/public/js/posapp/components/pos/PosOffers.vue
+++ b/posawesome/public/js/posapp/components/pos/PosOffers.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <v-card class="selection mx-auto bg-grey-lighten-5 mt-3" style="max-height: 80vh; height: 80vh">
+    <v-card
+      :class="['selection mx-auto mt-3', isDarkTheme ? '' : 'bg-grey-lighten-5']"
+      :style="isDarkTheme ? 'background-color:#000' : ''"
+      style="max-height: 80vh; height: 80vh"
+    >
       <v-card-title>
         <span class="text-h6 text-primary">{{ __('Offers') }}</span>
       </v-card-title>
@@ -76,6 +80,9 @@ export default {
     },
     appliedOffersCount() {
       return this.pos_offers.filter((el) => !!el.offer_applied).length;
+    },
+    isDarkTheme() {
+      return this.$theme?.current === 'dark';
     },
   },
 


### PR DESCRIPTION
## Summary
- add dynamic dark-mode background styles for Payments.vue
- update Invoice.vue, PosCoupons.vue, PosOffers.vue, Pay.vue to support dark backgrounds
