### PR TITLE
Fix dark mode background for item selector

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1167,6 +1167,14 @@ export default {
   transition: all 0.3s ease;
 }
 
+/* Ensure card background turns black when dark theme is active */
+:deep(.dark-theme) .dynamic-card,
+:deep(.v-theme--dark) .dynamic-card,
+::v-deep(.dark-theme) .dynamic-card,
+::v-deep(.v-theme--dark) .dynamic-card {
+  background-color: #000 !important;
+}
+
 .dynamic-padding {
   padding: var(--dynamic-xs) var(--dynamic-sm) var(--dynamic-xs) var(--dynamic-sm);
 }


### PR DESCRIPTION
## Summary
- make item selector card use black background in dark theme
