### PR TITLE
Fix card dark mode background

### DIFF
--- a/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
+++ b/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
@@ -166,8 +166,10 @@ export default {
 
 :deep(.dark-theme) .cards,
 :deep(.v-theme--dark) .cards,
+:deep(.cards.v-theme--dark),
 ::v-deep(.dark-theme) .cards,
-::v-deep(.v-theme--dark) .cards {
+::v-deep(.v-theme--dark) .cards,
+::v-deep(.cards.v-theme--dark) {
   background-color: #000 !important;
 }
 </style>

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1273,10 +1273,12 @@ export default {
 :deep(.v-theme--dark) .selection,
 :deep(.dark-theme) .cards,
 :deep(.v-theme--dark) .cards,
+:deep(.cards.v-theme--dark),
 ::v-deep(.dark-theme) .selection,
 ::v-deep(.v-theme--dark) .selection,
 ::v-deep(.dark-theme) .cards,
-::v-deep(.v-theme--dark) .cards {
+::v-deep(.v-theme--dark) .cards,
+::v-deep(.cards.v-theme--dark) {
 
   background-color: #000 !important;
 }

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1825,8 +1825,10 @@ export default {
 
 :deep(.dark-theme) .cards,
 :deep(.v-theme--dark) .cards,
+:deep(.cards.v-theme--dark),
 ::v-deep(.dark-theme) .cards,
-::v-deep(.v-theme--dark) .cards {
+::v-deep(.v-theme--dark) .cards,
+::v-deep(.cards.v-theme--dark) {
   background-color: #000 !important;
 }
 </style>


### PR DESCRIPTION
## Summary
- ensure cards with `v-theme--dark` class use dark backgrounds in ItemsSelector
- cover direct dark-themed cards in Payments and InvoiceSummary