### PR TITLE
Adjust customer field dark mode background

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -3,7 +3,7 @@
   <div class="customer-input-wrapper">
     <v-autocomplete ref="customerDropdown" class="customer-autocomplete sleek-field" density="compact" clearable
       variant="solo" color="primary" :label="frappe._('Customer')" v-model="internalCustomer" :items="customers"
-      item-title="customer_name" item-value="name" :bg-color="isDarkTheme ? '#000' : 'white'" :no-data-text="__('Customers not found')"
+      item-title="customer_name" item-value="name" :bg-color="isDarkTheme ? '#424242' : 'white'" :no-data-text="__('Customers not found')"
       hide-details :customFilter="customFilter" :disabled="readonly || loadingCustomers"
       :menu-props="{ closeOnContentClick: false }" @update:menu="onCustomerMenuToggle"
       @update:modelValue="onCustomerChange" @keydown.enter="handleEnter">
@@ -87,8 +87,8 @@
 :deep(.v-theme--dark) .customer-autocomplete,
 ::v-deep(.dark-theme) .customer-autocomplete,
 ::v-deep(.v-theme--dark) .customer-autocomplete {
-  /* Match item selector dark mode color */
-  background-color: #1e1e1e !important;
+  /* Use lighter gray for dark mode */
+  background-color: #424242 !important;
 }
 
 :deep(.dark-theme) .customer-autocomplete :deep(.v-field__input),
@@ -110,7 +110,7 @@
 :deep(.v-theme--dark) .customer-autocomplete :deep(.v-field__overlay),
 ::v-deep(.dark-theme) .customer-autocomplete .v-field__overlay,
 ::v-deep(.v-theme--dark) .customer-autocomplete .v-field__overlay {
-  background-color: #1e1e1e !important;
+  background-color: #424242 !important;
 }
 
 .icon-button {


### PR DESCRIPTION
## Summary
- set `bg-color` on customer autocomplete to a lighter grey for dark mode
- tweak dark theme CSS for the customer field so it matches item search styling
