### PR TITLE
Fix posting date picker dark mode

### DIFF
--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -6,6 +6,7 @@
         model-type="format"
         format="dd-MM-yyyy"
         auto-apply
+        class="dark-field"
         @update:model-value="onUpdate"
       />
     </v-col>
@@ -45,6 +46,38 @@ export default {
 </script>
 
 <style scoped>
+/* Dark mode styling for input wrapper */
+:deep(.dark-theme) .dark-field,
+:deep(.v-theme--dark) .dark-field,
+::v-deep(.dark-theme) .dark-field,
+::v-deep(.v-theme--dark) .dark-field {
+  background-color: #1E1E1E !important;
+}
+
+/* Ensure input text and label are readable */
+:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
+:deep(.dark-theme) .dark-field :deep(input),
+:deep(.v-theme--dark) .dark-field :deep(input),
+:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep(.v-theme--dark) .dark-field :deep(.v-label),
+::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep(.v-theme--dark) .dark-field .v-field__input,
+::v-deep(.dark-theme) .dark-field input,
+::v-deep(.v-theme--dark) .dark-field input,
+::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep(.v-theme--dark) .dark-field .v-label {
+  color: #fff !important;
+}
+
+/* Overlay background in dark mode */
+:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
+::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
+  background-color: #1E1E1E !important;
+}
+
 /* Dark mode styling for date picker input */
 :deep(.dark-theme) .dp__input,
 :deep(.v-theme--dark) .dp__input,


### PR DESCRIPTION
## Summary
- apply `dark-field` styling to posting date picker input
- add scoped dark mode CSS for the date picker component
