### PR TITLE
Add dark mode support to datepicker inputs

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -208,6 +208,7 @@
                 format="dd-MM-yyyy"
                 :min-date="new Date()"
                 auto-apply
+                :dark="isDarkTheme"
                 @update:model-value="validateDueDate(item)"
               />
             </v-col>

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -294,6 +294,7 @@
               format="dd-MM-yyyy"
               :min-date="new Date()"
               auto-apply
+              :dark="isDarkTheme"
               @update:model-value="update_delivery_date()"
             />
           </v-col>
@@ -390,6 +391,7 @@
               format="dd-MM-yyyy"
               :min-date="new Date()"
               auto-apply
+              :dark="isDarkTheme"
               @update:model-value="update_po_date()"
             />
               <v-text-field
@@ -446,6 +448,7 @@
             format="dd-MM-yyyy"
             :min-date="new Date()"
             auto-apply
+            :dark="isDarkTheme"
             @update:model-value="update_credit_due_date()"
           />
           </v-col>

--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -6,6 +6,7 @@
         model-type="format"
         format="dd-MM-yyyy"
         auto-apply
+        :dark="isDarkTheme"
         class="dark-field"
         @update:model-value="onUpdate"
       />
@@ -31,6 +32,11 @@ export default {
     return {
       internal_posting_date_display: this.posting_date_display,
     };
+  },
+  computed: {
+    isDarkTheme() {
+      return this.$theme?.current === 'dark';
+    }
   },
   watch: {
     posting_date_display(val) {

--- a/posawesome/public/js/posapp/components/pos/Returns.vue
+++ b/posawesome/public/js/posapp/components/pos/Returns.vue
@@ -34,6 +34,7 @@
             format="dd-MM-yyyy"
             :enable-time-picker="false"
             auto-apply
+            :dark="isDarkTheme"
             @update:model-value="formatFromDate()"
           />
             </v-col>
@@ -44,6 +45,7 @@
             format="dd-MM-yyyy"
             :enable-time-picker="false"
             auto-apply
+            :dark="isDarkTheme"
             @update:model-value="formatToDate()"
           />
             </v-col>
@@ -265,6 +267,11 @@ export default {
       },
     ],
   }),
+  computed: {
+    isDarkTheme() {
+      return this.$theme?.current === 'dark';
+    }
+  },
   watch: {
     from_date() {
       this.formatFromDate();


### PR DESCRIPTION
## Summary
- add `:dark="isDarkTheme"` binding for VueDatePicker components
- provide `isDarkTheme` computed helper in files missing it
