### PR TITLE
Add price list dropdown on invoice

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5424,6 +5424,16 @@
   {
     "doctype": "Custom Field",
     "dt": "POS Profile",
+    "fieldname": "posa_enable_price_list_dropdown",
+    "fieldtype": "Check",
+    "insert_after": "posa_show_customer_balance",
+    "label": "Enable Price List Dropdown",
+    "default": "1",
+    "name": "POS Profile-posa_enable_price_list_dropdown"
+  },
+  {
+    "doctype": "Custom Field",
+    "dt": "POS Profile",
     "fieldname": "posa_decimal_precision",
     "fieldtype": "Select",
     "insert_after": "posa_allow_multi_currency",

--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -2288,8 +2288,19 @@ def validate_return_items(return_against, items):
 @frappe.whitelist()
 def get_available_currencies():
     """Get list of available currencies from ERPNext"""
-    return frappe.get_all("Currency", fields=["name", "currency_name"], 
+    return frappe.get_all("Currency", fields=["name", "currency_name"],
                          filters={"enabled": 1}, order_by="currency_name")
+
+
+@frappe.whitelist()
+def get_selling_price_lists():
+    """Return all selling price lists"""
+    return frappe.get_all(
+        "Price List",
+        filters={"selling": 1},
+        fields=["name"],
+        order_by="name",
+    )
 
 
 

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -45,8 +45,11 @@
           :pos_profile="pos_profile"
           :posting_date_display="posting_date_display"
           :customer_balance="customer_balance"
+          :price-list="selected_price_list"
+          :price-lists="price_lists"
           :formatCurrency="formatCurrency"
           @update:posting_date_display="(val) => { posting_date_display = val; }"
+          @update:priceList="(val) => { selected_price_list = val; }"
         />
 
         <!-- Multi-Currency Section (Only if enabled in POS profile) -->
@@ -194,6 +197,8 @@ export default {
       selected_currency: "", // Currently selected currency
       exchange_rate: 1, // Current exchange rate
       available_currencies: [], // List of available currencies
+      price_lists: [], // Available selling price lists
+      selected_price_list: "", // Currently selected price list
     };
   },
 
@@ -361,8 +366,29 @@ export default {
           value: defaultCurrency,
           title: defaultCurrency
         }];
-        this.selected_currency = defaultCurrency;
-        return this.available_currencies;
+      this.selected_currency = defaultCurrency;
+      return this.available_currencies;
+    }
+  },
+
+    async fetch_price_lists() {
+      try {
+        const r = await frappe.call({
+          method: "posawesome.posawesome.api.posapp.get_selling_price_lists"
+        });
+        if (r.message) {
+          this.price_lists = r.message.map(pl => pl.name);
+          if (!this.selected_price_list) {
+            this.selected_price_list = this.pos_profile.selling_price_list;
+          }
+          return this.price_lists;
+        }
+        return [];
+      } catch (error) {
+        console.error("Error fetching price lists:", error);
+        this.price_lists = [this.pos_profile.selling_price_list];
+        this.selected_price_list = this.pos_profile.selling_price_list;
+        return this.price_lists;
       }
     },
 
@@ -706,6 +732,9 @@ export default {
           });
         });
       }
+
+      this.fetch_price_lists();
+      this.update_price_list();
     });
     this.eventBus.on("add_item", this.add_item);
     this.eventBus.on("update_customer", (customer) => {

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -181,6 +181,9 @@ export default {
         this.get_items();
       }
     },
+    customer_price_list() {
+      this.get_items();
+    },
     new_line() {
       this.eventBus.emit("set_new_line", this.new_line);
     },

--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row align="center" class="items px-3 py-2 mt-0" v-if="pos_profile.posa_allow_change_posting_date">
-    <v-col cols="6" class="pb-2">
+    <v-col cols="4" class="pb-2">
       <VueDatePicker
         v-model="internal_posting_date_display"
         model-type="format"
@@ -11,7 +11,19 @@
         @update:model-value="onUpdate"
       />
     </v-col>
-    <v-col v-if="pos_profile.posa_show_customer_balance" cols="6" class="pb-2 d-flex align-center">
+    <v-col v-if="pos_profile.posa_enable_price_list_dropdown" cols="4" class="pb-2">
+      <v-select
+        density="compact"
+        variant="outlined"
+        color="primary"
+        :items="priceLists"
+        :label="frappe._('Price List')"
+        v-model="internal_price_list"
+        hide-details
+        @update:model-value="onPriceListUpdate"
+      />
+    </v-col>
+    <v-col v-if="pos_profile.posa_show_customer_balance" cols="4" class="pb-2 d-flex align-center justify-end text-right">
       <div class="balance-field">
         <strong>Balance:</strong>
         <span class="balance-value">{{ formatCurrency(customer_balance) }}</span>
@@ -27,10 +39,13 @@ export default {
     posting_date_display: String,
     customer_balance: Number,
     formatCurrency: Function,
+    priceList: String,
+    priceLists: Array,
   },
   data() {
     return {
       internal_posting_date_display: this.posting_date_display,
+      internal_price_list: this.priceList,
     };
   },
   computed: {
@@ -42,11 +57,17 @@ export default {
     posting_date_display(val) {
       this.internal_posting_date_display = val;
     },
+    priceList(val) {
+      this.internal_price_list = val;
+    },
   },
   methods: {
     onUpdate(val) {
       this.$emit('update:posting_date_display', val);
     },
+    onPriceListUpdate(val) {
+      this.$emit('update:priceList', val);
+    }
   },
 };
 </script>

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1528,9 +1528,12 @@ export default {
     update_price_list() {
       let price_list = this.get_price_list();
       if (price_list == this.pos_profile.selling_price_list) {
-        price_list = null;
+        this.selected_price_list = this.pos_profile.selling_price_list;
+        this.eventBus.emit("update_customer_price_list", null);
+      } else {
+        this.selected_price_list = price_list;
+        this.eventBus.emit("update_customer_price_list", price_list);
       }
-      this.eventBus.emit("update_customer_price_list", price_list);
     },
 
     // Update additional discount amount based on percentage

--- a/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
@@ -62,4 +62,9 @@ export default {
     posting_date_display(newVal) {
       this.posting_date = this.formatDateForBackend(newVal);
     },
+
+    selected_price_list(newVal) {
+      const price_list = newVal === this.pos_profile.selling_price_list ? null : newVal;
+      this.eventBus.emit("update_customer_price_list", price_list);
+    },
 };


### PR DESCRIPTION
## Summary
- show customer balance on the right and include price list dropdown in posting row
- support price list selection with POS profile setting
- refresh items when price list changes
- expose API to fetch selling price lists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ffa31e6a8832698f96e2f935a9b62