### PR TITLE
Increase price list field size

### DIFF
--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -14,9 +14,9 @@
         @update:model-value="onUpdate"
       />
     </v-col>
-    <v-col v-if="pos_profile.posa_enable_price_list_dropdown" cols="4" class="pb-2 d-flex align-center">
+    <v-col v-if="pos_profile.posa_enable_price_list_dropdown" cols="6" class="pb-2 d-flex align-center">
       <v-select
-        density="compact"
+        density="comfortable"
         variant="outlined"
         color="primary"
         :items="priceLists"


### PR DESCRIPTION
## Summary
- make price list dropdown larger in `PostingDateRow.vue`
- adjust size to 6 columns for price list field
