### PR TITLE
Fix qty debounce formatting

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1098,7 +1098,8 @@ export default {
     },
     debounce_qty: {
       get() {
-        return this.qty === null || this.qty === '' ? '' : this.formatFloat(this.qty);
+        // Display the raw quantity while typing to avoid forced decimal format
+        return this.qty === null || this.qty === '' ? '' : this.qty;
       },
       set: _.debounce(function (value) {
         let parsed = parseFloat(String(value).replace(/,/g, ''));


### PR DESCRIPTION
## Summary
- show raw qty while typing so decimals aren't forced
