### PR TITLE
Allow editing closing shift link

### DIFF
--- a/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
@@ -60,6 +60,14 @@ class POSClosingShift(Document):
         self.delete_draft_invoices()
         opening_entry.save()
 
+    def on_cancel(self):
+        if frappe.db.exists("POS Opening Shift", self.pos_opening_shift):
+            opening_entry = frappe.get_doc("POS Opening Shift", self.pos_opening_shift)
+            if opening_entry.pos_closing_shift == self.name:
+                opening_entry.pos_closing_shift = ""
+                opening_entry.set_status()
+                opening_entry.save()
+
     def delete_draft_invoices(self):
         if frappe.get_value("POS Profile", self.pos_profile, "posa_allow_delete"):
             data = frappe.db.sql(

--- a/posawesome/posawesome/doctype/pos_opening_shift/pos_opening_shift.json
+++ b/posawesome/posawesome/doctype/pos_opening_shift/pos_opening_shift.json
@@ -121,13 +121,14 @@
    "read_only": 1
   },
   {
-   "allow_on_submit": 1,
-   "fieldname": "pos_closing_shift",
-   "fieldtype": "Data",
-   "label": "POS Closing Shift",
-   "read_only": 1
-  }
- ],
+  "allow_on_submit": 1,
+  "fieldname": "pos_closing_shift",
+  "fieldtype": "Data",
+  "label": "POS Closing Shift",
+  "read_only": 0,
+  "read_only_depends_on": "eval:doc.docstatus==1"
+ }
+],
  "is_submittable": 1,
  "links": [],
  "modified": "2022-11-22 15:04:30.555123",


### PR DESCRIPTION
## Summary
- allow editing `POS Closing Shift` reference on cancelled opening shift
- clear closing shift reference when a closing shift is cancelled
