### PR TITLE
Defer offline database initialization

### DIFF
--- a/posawesome/public/js/posapp/components/payments/Pay.vue
+++ b/posawesome/public/js/posapp/components/payments/Pay.vue
@@ -415,12 +415,13 @@ export default {
   methods: {
     async check_opening_entry() {
       var vm = this;
-      await initPromise;
+      const offlineReady = initPromise.catch(() => {});
       return frappe
         .call("posawesome.posawesome.api.posapp.check_opening_shift", {
           user: frappe.session.user,
         })
-        .then((r) => {
+        .then(async (r) => {
+          await offlineReady;
           if (r.message) {
             this.pos_profile = r.message.pos_profile;
             this.pos_opening_shift = r.message.pos_opening_shift;
@@ -472,7 +473,8 @@ export default {
             this.create_opening_voucher();
           }
         })
-        .catch(() => {
+        .catch(async () => {
+          await offlineReady;
           const data = getOpeningStorage();
           if (data) {
               this.pos_profile = data.pos_profile;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -200,7 +200,6 @@ export default {
       this.eventBus.emit("show_coupons", "true");
     },
     async get_items(force_server = false) {
-      await initPromise;
       if (!this.pos_profile) {
         console.error("No POS Profile");
         return;
@@ -1147,14 +1146,16 @@ export default {
 
   created: function () {
     this.$nextTick(function () { });
-    this.eventBus.on("register_pos_profile", async (data) => {
-      await initPromise;
+    this.eventBus.on("register_pos_profile", (data) => {
       this.pos_profile = data.pos_profile;
-      await this.get_items();
-      this.get_items_groups();
       this.items_view = this.pos_profile.posa_default_card_view
         ? "card"
         : "list";
+
+      initPromise.then(async () => {
+        await this.get_items();
+        this.get_items_groups();
+      });
     });
     this.eventBus.on("update_cur_items_details", () => {
       this.update_cur_items_details();

--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -199,20 +199,20 @@ export default {
 
     async get_opening_dialog_data() {
       const vm = this;
-      await initPromise;
 
-      // Load cached data first for offline usage
-      const cached = getOpeningDialogStorage();
-      if (cached) {
-        try {
-          vm.companies = cached.companies.map(c => c.name);
-          vm.pos_profiles_data = cached.pos_profiles_data || [];
-          vm.payments_method_data = cached.payments_method || [];
-          vm.company = vm.companies[0] || '';
-        } catch (e) {
-          console.error('Failed to parse opening dialog cache', e);
+      initPromise.then(() => {
+        const cached = getOpeningDialogStorage();
+        if (cached) {
+          try {
+            vm.companies = cached.companies.map(c => c.name);
+            vm.pos_profiles_data = cached.pos_profiles_data || [];
+            vm.payments_method_data = cached.payments_method || [];
+            vm.company = vm.companies[0] || '';
+          } catch (e) {
+            console.error('Failed to parse opening dialog cache', e);
+          }
         }
-      }
+      });
 
       frappe.call({
         method: 'posawesome.posawesome.api.posapp.get_opening_dialog_data',

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -81,12 +81,13 @@ export default {
 
   methods: {
     async check_opening_entry() {
-      await initPromise;
+      const offlineReady = initPromise.catch(() => {});
       return frappe
         .call('posawesome.posawesome.api.posapp.check_opening_shift', {
           user: frappe.session.user,
         })
-        .then((r) => {
+        .then(async (r) => {
+          await offlineReady;
           if (r.message) {
             this.pos_profile = r.message.pos_profile;
             this.pos_opening_shift = r.message.pos_opening_shift;
@@ -123,7 +124,8 @@ export default {
             this.create_opening_voucher();
           }
         })
-        .catch(() => {
+        .catch(async () => {
+          await offlineReady;
           const data = getOpeningStorage();
           if (data) {
             this.pos_profile = data.pos_profile;


### PR DESCRIPTION
## Summary
- avoid blocking IndexedDB init before loading items
- start items loading after offline initialization completes
- fetch cached opening dialog data once offline data is ready
- run opening entry checks without waiting for IndexedDB
