### PR TITLE
Prevent price list changes on customer switch

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
@@ -66,5 +66,7 @@ export default {
     selected_price_list(newVal) {
       const price_list = newVal === this.pos_profile.selling_price_list ? null : newVal;
       this.eventBus.emit("update_customer_price_list", price_list);
+      const applied = newVal || this.pos_profile.selling_price_list;
+      this.apply_cached_price_list(applied);
     },
 };


### PR DESCRIPTION
## Summary
- avoid reloading items when changing customers
- stop updating price list automatically in `fetch_customer_details`
- reuse cached item prices on price list change instead of reloading
- use cached item details without server roundtrip when available
