### PR TITLE
Fix stock cache refresh when updating item details

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -525,6 +525,29 @@ export function getLocalStock(itemCode) {
   }
 }
 
+// Update the local stock cache with latest quantities
+export function updateLocalStockCache(items) {
+  try {
+    const stockCache = memory.local_stock_cache || {};
+
+    items.forEach(item => {
+      if (!item || !item.item_code) return;
+
+      if (item.actual_qty !== undefined) {
+        stockCache[item.item_code] = {
+          actual_qty: item.actual_qty,
+          last_updated: new Date().toISOString()
+        };
+      }
+    });
+
+    memory.local_stock_cache = stockCache;
+    persist('local_stock_cache');
+  } catch (e) {
+    console.error('Failed to refresh local stock cache', e);
+  }
+}
+
 export function clearLocalStockCache() {
   memory.local_stock_cache = {};
   persist('local_stock_cache');

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -129,7 +129,7 @@
 import format from "../../format";
 import _ from "lodash";
 import CameraScanner from './CameraScanner.vue';
-import { saveItemUOMs, getItemUOMs, getLocalStock, isOffline, initializeStockCache, getItemsStorage, setItemsStorage, getLocalStockCache, setLocalStockCache, initPromise, getCachedPriceListItems, savePriceListItems } from '../../../offline.js';
+import { saveItemUOMs, getItemUOMs, getLocalStock, isOffline, initializeStockCache, getItemsStorage, setItemsStorage, getLocalStockCache, setLocalStockCache, initPromise, getCachedPriceListItems, savePriceListItems, updateLocalStockCache } from '../../../offline.js';
 import { responsiveMixin } from '../../mixins/responsive.js';
 
 export default {
@@ -709,6 +709,9 @@ export default {
                 }
               }
             });
+
+            // Update local stock cache with latest quantities
+            updateLocalStockCache(r.message);
 
             // Force update if any item's quantity changed significantly
             if (qtyChanged) {


### PR DESCRIPTION
## Summary
- maintain local quantity cache when fetching item details
- expose `updateLocalStockCache` helper to refresh cached stock values
