### PR TITLE
Fix editable install without frappe

### DIFF
--- a/posawesome/__init__.py
+++ b/posawesome/__init__.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import frappe
+
+try:
+    import frappe
+except ModuleNotFoundError:  # pragma: no cover - frappe may not be installed during setup
+    frappe = None
 
 __version__ = "15.3.2"
 
 
 def console(*data):
-    frappe.publish_realtime("toconsole", data, user=frappe.session.user)
+    if frappe:
+        frappe.publish_realtime("toconsole", data, user=frappe.session.user)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,18 @@
 # -*- coding: utf-8 -*-
+
+from pathlib import Path
 from setuptools import setup, find_packages
 
 with open("requirements.txt") as f:
     install_requires = f.read().strip().split("\n")
 
-# get version from __version__ variable in posawesome/__init__.py
-from posawesome import __version__ as version
+# get version from posawesome/__init__.py without importing frappe
+import re
+
+version_file = Path(__file__).parent / "posawesome" / "__init__.py"
+version_match = re.search(r'^__version__\s*=\s*[\'\"]([^\'\"]+)[\'\"]',
+                          version_file.read_text(), re.MULTILINE)
+version = version_match.group(1) if version_match else "0.0.0"
 
 setup(
     name="posawesome",


### PR DESCRIPTION
## Summary
- avoid importing `frappe` during package installation
- read version string without importing package