### PR TITLE
Fix build script in ItemsSelector.vue

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -608,7 +608,7 @@ export default {
               vm.enter_event();
             }
           }
-        },
+        }
       });
     },
     get_items_groups() {


### PR DESCRIPTION
## Summary
- close callback block in ItemsSelector to avoid compile errors

