### PR TITLE
Fix ItemsSelector syntax and modernize build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ After switching branches or pulling latest changes:
 4. cd ../..
 5. bench build --app posawesome
 6. bench --site your.site migrate
+   - If the build exits with code 143, verify that your system has enough RAM or swap space.
+   - You can also try building the app in smaller parts to reduce memory usage.
 
 ### Main Features
 

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,16 @@
+const esbuild = require('esbuild');
+const vuePlugin = require('@vitejs/plugin-vue');
+
+const frappeVueStyle = require('./frappe-vue-style.js');
+
+esbuild.build({
+  entryPoints: ['posawesome/public/js/posawesome.bundle.js'],
+  bundle: true,
+  outdir: 'posawesome/public/dist/js',
+  format: 'esm',
+  target: 'esnext',
+  plugins: [frappeVueStyle(), vuePlugin()],
+  metafile: true,
+}).then(result => {
+  console.log('Build outputs:', Object.keys(result.metafile.outputs));
+}).catch(() => process.exit(1));

--- a/frappe-vue-style.js
+++ b/frappe-vue-style.js
@@ -1,0 +1,18 @@
+module.exports = function frappeVueStyle() {
+  return {
+    name: 'frappe-vue-style',
+    setup(build) {
+      build.onLoad({ filter: /\.vue$/ }, async (args) => {
+        const fs = require('fs');
+        const contents = await fs.promises.readFile(args.path, 'utf8');
+        const styleMatch = contents.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+        if (styleMatch) {
+          const stylePath = args.path + '.css';
+          await fs.promises.writeFile(stylePath, styleMatch[1]);
+          return { contents, loader: 'vue' };
+        }
+        return { contents, loader: 'vue' };
+      });
+    }
+  };
+};

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -610,6 +610,7 @@ export default {
           }
         }
       });
+      }
     },
     get_items_groups() {
       if (!this.pos_profile) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import { resolve } from 'path'
 export default defineConfig({
     plugins: [vue()],
     build: {
+        target: 'esnext',
         lib: {
             entry: resolve(__dirname, 'posawesome/public/js/posawesome.bundle.js'),
             name: 'PosAwesome',
@@ -27,3 +28,4 @@ export default defineConfig({
         }
     }
 })
+


### PR DESCRIPTION
## Summary
- fix missing brace in `ItemsSelector.vue`
- update Vite build target to `esnext`
- add custom esbuild configuration with metafile output
- add example `frappe-vue-style` plugin
- document troubleshooting for build failures
