### PR TITLE
Fix Vue syntax and esbuild options

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,8 @@
+const { resolve } = require('path');
+const vueStylePlugin = require('./frappe-vue-style');
+
+module.exports = {
+  target: 'esnext',
+  metafile: true,
+  plugins: [vueStylePlugin()],
+};

--- a/frappe-vue-style.js
+++ b/frappe-vue-style.js
@@ -1,0 +1,12 @@
+module.exports = function frappeVueStyle() {
+  return {
+    name: 'frappe-vue-style',
+    setup(build) {
+      build.onEnd(result => {
+        const outputs = result.metafile && result.metafile.outputs;
+        if (!outputs) return;
+        // Further processing of outputs can be added here if needed
+      });
+    }
+  };
+};

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -608,8 +608,8 @@ export default {
               vm.enter_event();
             }
           }
-        }
-      });
+        });
+      }
     },
     get_items_groups() {
       if (!this.pos_profile) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import { resolve } from 'path'
 export default defineConfig({
     plugins: [vue()],
     build: {
+        target: 'esnext',
         lib: {
             entry: resolve(__dirname, 'posawesome/public/js/posawesome.bundle.js'),
             name: 'PosAwesome',


### PR DESCRIPTION
## Summary
- fix syntax error in ItemsSelector.vue
- modernize vite build target
- add esbuild config with metafile support
- add safer frappe-vue-style plugin

## Testing
- `python -m compileall -q posawesome`

------
https://chatgpt.com/codex/tasks/task_e_685a90be161c832688cbb57ec70c6ea9