### PR TITLE
Revert limit search parameters

### DIFF
--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -145,8 +145,6 @@ def get_items(
     item_group="",
     search_value="",
     customer=None,
-    limit=None,
-    offset=None,
 ):
     _pos_profile = json.loads(pos_profile)
     use_price_list = _pos_profile.get("posa_use_server_cache")
@@ -158,8 +156,6 @@ def get_items(
         item_group,
         search_value,
         customer=None,
-        limit=None,
-        offset=None,
     ):
         return _get_items(
             pos_profile,
@@ -167,8 +163,6 @@ def get_items(
             item_group,
             search_value,
             customer,
-            limit,
-            offset,
         )
 
     def _get_items(
@@ -177,8 +171,6 @@ def get_items(
         item_group,
         search_value,
         customer=None,
-        limit=None,
-        offset=None,
     ):
         pos_profile = json.loads(pos_profile)
         condition = ""
@@ -204,16 +196,11 @@ def get_items(
         if not price_list:
             price_list = pos_profile.get("selling_price_list")
 
-        limit_clause = ""
-
-        if limit is not None:
-            limit_clause = f" LIMIT {int(limit)}"
-            if offset:
-                limit_clause += f" OFFSET {int(offset)}"
+        limit = ""
 
         condition += get_item_group_condition(pos_profile.get("name"))
 
-        if use_limit_search and limit is None:
+        if use_limit_search:
             search_limit = pos_profile.get("posa_search_limit") or 500
             data = {}
             if search_value:
@@ -242,16 +229,16 @@ def get_items(
                 # load (no explicit search value) to avoid heavy queries while
                 # still returning full results when the user searches.
                 if not search_value:
-                    limit_clause = " LIMIT {search_limit}".format(search_limit=search_limit)
+                    limit = " LIMIT {search_limit}".format(search_limit=search_limit)
                 else:
-                    limit_clause = ""
+                    limit = ""
             else:
                 # Default behaviour: limit results during a search to reduce
                 # payload when not forcing a reload of all items.
                 if search_value:
-                    limit_clause = " LIMIT {search_limit}".format(search_limit=search_limit)
+                    limit = " LIMIT {search_limit}".format(search_limit=search_limit)
                 else:
-                    limit_clause = ""
+                    limit = ""
 
         if not posa_show_template_items:
             condition += " AND has_variants = 0"
@@ -287,7 +274,7 @@ def get_items(
             {limit}
                 """.format(
                 condition=condition,
-                limit=limit_clause
+                limit=limit
             ),
             as_dict=1,
         )
@@ -419,8 +406,6 @@ def get_items(
             item_group,
             search_value,
             customer,
-            limit,
-            offset,
         )
     else:
         return _get_items(
@@ -429,8 +414,6 @@ def get_items(
             item_group,
             search_value,
             customer,
-            limit,
-            offset,
         )
 
 


### PR DESCRIPTION
## Summary
- remove `limit` and `offset` parameters from `get_items`
- restore older limit logic while keeping SQL sanitization for `item_group`