### PR TITLE
Fix limit parameter handling in get_items

### DIFF
--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -206,10 +206,17 @@ def get_items(
 
         limit_clause = ""
 
-        if limit is not None:
-            limit_clause = f" LIMIT {int(limit)}"
-            if offset:
-                limit_clause += f" OFFSET {int(offset)}"
+        if limit not in [None, "", 0, "0"]:
+            try:
+                limit_val = int(limit)
+                limit_clause = f" LIMIT {limit_val}"
+                if offset not in [None, "", 0, "0"]:
+                    limit_clause += f" OFFSET {int(offset)}"
+            except (ValueError, TypeError):
+                frappe.log_error(
+                    f"Invalid limit/offset values: limit={limit}, offset={offset}",
+                    "POS Awesome",
+                )
 
         condition += get_item_group_condition(pos_profile.get("name"))
 


### PR DESCRIPTION
## Summary
- guard against blank limit and offset values in `get_items`
