### PR TITLE
Fix limit parameter handling in get_items

### DIFF
--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -206,10 +206,29 @@ def get_items(
 
         limit_clause = ""
 
+        # Normalize limit and offset values so blank strings don't cause errors
+        try:
+            limit = int(limit) if str(limit).strip() else None
+        except (ValueError, TypeError):
+            frappe.log_error(
+                f"Invalid limit value: {limit}",
+                "POS Awesome",
+            )
+            limit = None
+
+        try:
+            offset = int(offset) if str(offset).strip() else None
+        except (ValueError, TypeError):
+            frappe.log_error(
+                f"Invalid offset value: {offset}",
+                "POS Awesome",
+            )
+            offset = None
+
         if limit is not None:
-            limit_clause = f" LIMIT {int(limit)}"
+            limit_clause = f" LIMIT {limit}"
             if offset:
-                limit_clause += f" OFFSET {int(offset)}"
+                limit_clause += f" OFFSET {offset}"
 
         condition += get_item_group_condition(pos_profile.get("name"))
 


### PR DESCRIPTION
## Summary
- guard against blank limit and offset values in `get_items`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ba7d8d2d083269da5efe458927cda