### PR TITLE
Fix rounding in payments totals

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -721,11 +721,11 @@ export default {
       // If multi-currency is enabled and selected currency is different from base currency
       if (this.pos_profile.posa_allow_multi_currency &&
         this.selected_currency !== this.pos_profile.currency) {
-        // For multi-currency, just keep 2 decimal places without rounding to nearest integer
-        return this.flt(amount, 2);
+        // For multi-currency keep the standard currency precision
+        return this.flt(amount, this.currency_precision);
       }
-      // For base currency or when multi-currency is disabled, round to nearest integer
-      return Math.round(amount);
+      // For base currency also keep precision instead of rounding to integer
+      return this.flt(amount, this.currency_precision);
     },
 
     // Increase quantity of an item (handles return logic)

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -155,7 +155,7 @@
               :value="formatCurrency(invoice_doc.grand_total)" readonly :prefix="currencySymbol(invoice_doc.currency)"
               persistent-placeholder></v-text-field>
           </v-col>
-          <v-col v-if="invoice_doc.rounded_total" cols="6">
+          <v-col v-if="invoice_doc.rounded_total && invoice_doc.rounded_total !== invoice_doc.grand_total" cols="6">
             <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Rounded Total')"
               :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details
               :value="formatCurrency(invoice_doc.rounded_total)" readonly :prefix="currencySymbol(invoice_doc.currency)"


### PR DESCRIPTION
## Summary
- keep decimal precision when rounding invoice totals
- show the rounded total field only when it differs from grand total
