### PR TITLE
Prevent duplicate transaction discount

### DIFF
--- a/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
+++ b/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
@@ -18,7 +18,7 @@
             <v-text-field :model-value="additional_discount" @update:model-value="$emit('update:additional_discount', $event)"
               :label="frappe._('Additional Discount')" prepend-inner-icon="mdi-cash-minus" variant="solo"
               density="compact" color="warning" :prefix="currencySymbol(pos_profile.currency)"
-              :disabled="!pos_profile.posa_allow_user_to_edit_additional_discount" />
+              :disabled="!pos_profile.posa_allow_user_to_edit_additional_discount || !!discount_percentage_offer_name" />
           </v-col>
 
           <v-col cols="6" v-else>

--- a/posawesome/public/js/posapp/components/pos/invoiceOfferMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceOfferMethods.js
@@ -823,6 +823,13 @@ export default {
         offer = this.posOffers.find((el) => el.name == offer.offer_name);
       }
       if (
+        this.discount_percentage_offer_name === offer.name &&
+        this.discount_amount !== 0
+      ) {
+        // Discount already applied, do not recalculate when items change
+        return;
+      }
+      if (
         (!this.discount_percentage_offer_name ||
           this.discount_percentage_offer_name == offer.name) &&
         offer.discount_percentage > 0 &&


### PR DESCRIPTION
## Summary
- disable manual discount input when a transaction offer is active
- avoid recalculating transaction discount after items change