### PR TITLE
Fix DataCloneError when using worker

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -122,13 +122,19 @@ export const initPromise = new Promise((resolve) => {
 });
 
 function persist(key) {
-	if (persistWorker) {
-		persistWorker.postMessage({ type: "persist", key, value: memory[key] });
-		return;
-	}
-	db.table("keyval")
-		.put({ key, value: memory[key] })
-		.catch((e) => console.error(`Failed to persist ${key}`, e));
+        if (persistWorker) {
+                let clean = memory[key];
+                try {
+                        clean = JSON.parse(JSON.stringify(memory[key]));
+                } catch (e) {
+                        console.error("Failed to serialize", key, e);
+                }
+                persistWorker.postMessage({ type: "persist", key, value: clean });
+                return;
+        }
+        db.table("keyval")
+                .put({ key, value: memory[key] })
+                .catch((e) => console.error(`Failed to persist ${key}`, e));
 
 	if (typeof localStorage !== "undefined") {
 		try {

--- a/posawesome/public/js/posapp/workers/itemWorker.js
+++ b/posawesome/public/js/posapp/workers/itemWorker.js
@@ -25,8 +25,17 @@ self.onmessage = async (event) => {
 	const data = event.data || {};
 	if (data.type === "parse_and_cache") {
 		try {
-			const parsed = JSON.parse(data.json);
-			const items = parsed.message || parsed;
+                        const parsed = JSON.parse(data.json);
+                        const itemsRaw = parsed.message || parsed;
+                        let items;
+                        try {
+                                // Ensure data passed back is cloneable
+                                items = JSON.parse(JSON.stringify(itemsRaw));
+                        } catch (e) {
+                                console.error("Failed to clone items", e);
+                                self.postMessage({ type: "error", error: e.message });
+                                return;
+                        }
 			let cache = {};
 			try {
 				const stored = await db.table("keyval").get("price_list_cache");


### PR DESCRIPTION
## Summary
- ensure offline persistence sends plain data to worker
- clone items in worker before posting back
