### PR TITLE
Fix missing worker script handling

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -6,13 +6,13 @@ db.version(1).stores({ keyval: "&key" });
 
 let persistWorker = null;
 if (typeof Worker !== "undefined") {
-	try {
-		const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js?worker";
-		persistWorker = new Worker(workerUrl, { type: "classic" });
-	} catch (e) {
-		console.error("Failed to init persist worker", e);
-		persistWorker = null;
-	}
+        try {
+                const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
+                persistWorker = new Worker(workerUrl, { type: "classic" });
+        } catch (e) {
+                console.error("Failed to init persist worker", e);
+                persistWorker = null;
+        }
 }
 
 // Add stock_cache_ready flag to memory object

--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -8,26 +8,29 @@ let persistWorker = null;
 let sharedWorker = null;
 
 if (typeof Worker !== "undefined") {
-	try {
-		const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js?worker";
-		persistWorker = new Worker(workerUrl, { type: "classic" });
-	} catch (e) {
-		console.error("Failed to init persist worker", e);
-		persistWorker = null;
-	}
+        try {
+                const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
+                persistWorker = new Worker(workerUrl, { type: "classic" });
+        } catch (e) {
+                console.error("Failed to init persist worker", e);
+                persistWorker = null;
+        }
 }
 
-// Initialize shared worker if available
-if (typeof SharedWorker !== "undefined") {
-	try {
-		const sharedWorkerUrl = "/assets/posawesome/js/posapp/workers/sharedWorker.js";
-		sharedWorker = new SharedWorker(sharedWorkerUrl, { type: "classic" });
-		sharedWorker.port.start();
-	} catch (e) {
-		console.error("Failed to init shared worker", e);
-		sharedWorker = null;
-	}
-}
+// Shared worker initialization is currently disabled because the worker script
+// is not included in the repository. Keeping this block commented avoids
+// browser errors when the file is missing.
+//
+// if (typeof SharedWorker !== "undefined") {
+//         try {
+//                 const sharedWorkerUrl = "/assets/posawesome/js/posapp/workers/sharedWorker.js";
+//                 sharedWorker = new SharedWorker(sharedWorkerUrl, { type: "classic" });
+//                 sharedWorker.port.start();
+//         } catch (e) {
+//                 console.error("Failed to init shared worker", e);
+//                 sharedWorker = null;
+//         }
+// }
 
 export function getSharedWorker() {
 	return sharedWorker;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1498,7 +1498,7 @@ export default {
   created: function () {
     if (typeof Worker !== 'undefined') {
       try {
-        const workerUrl = '/assets/posawesome/js/posapp/workers/itemWorker.js?worker';
+        const workerUrl = '/assets/posawesome/js/posapp/workers/itemWorker.js';
         this.itemWorker = new Worker(workerUrl, { type: 'classic' });
 
         this.itemWorker.onerror = function (event) {


### PR DESCRIPTION
## Summary
- load `itemWorker.js` without the `?worker` query
- comment out shared worker initialization because the script isn't provided
