### PR TITLE
Fix worker path for offline use

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -6,9 +6,10 @@ db.version(1).stores({ keyval: "&key" });
 
 let persistWorker = null;
 if (typeof Worker !== "undefined") {
-	try {
-		const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js?worker";
-		persistWorker = new Worker(workerUrl, { type: "classic" });
+        try {
+                // Use the plain URL so the service worker cache matches when offline
+                const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
+                persistWorker = new Worker(workerUrl, { type: "classic" });
 	} catch (e) {
 		console.error("Failed to init persist worker", e);
 		persistWorker = null;

--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -9,8 +9,10 @@ let sharedWorker = null;
 
 if (typeof Worker !== "undefined") {
 	try {
-		const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js?worker";
-		persistWorker = new Worker(workerUrl, { type: "classic" });
+                // Load the worker without a query string so the service worker
+                // can serve the cached version when offline.
+                const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
+                persistWorker = new Worker(workerUrl, { type: "classic" });
 	} catch (e) {
 		console.error("Failed to init persist worker", e);
 		persistWorker = null;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1498,7 +1498,10 @@ export default {
   created: function () {
     if (typeof Worker !== 'undefined') {
       try {
-        const workerUrl = '/assets/posawesome/js/posapp/workers/itemWorker.js?worker';
+        // Use the plain URL so the service worker can match the cached file
+        // even when offline. Using a query string causes cache lookups to fail
+        // which results in "Failed to fetch a worker script" errors.
+        const workerUrl = '/assets/posawesome/js/posapp/workers/itemWorker.js';
         this.itemWorker = new Worker(workerUrl, { type: 'classic' });
 
         this.itemWorker.onerror = function (event) {


### PR DESCRIPTION
## Summary
- load `itemWorker.js` using plain URL
- remove query string from worker URL in offline helpers
