### PR TITLE
Fix DataCloneError when caching items

### DIFF
--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -59,10 +59,20 @@ function flushPersistQueue() {
 }
 
 export function persist(key, value) {
-	if (persistWorker) {
-		persistWorker.postMessage({ type: "persist", key, value });
-		return;
-	}
+        if (persistWorker) {
+                let cleanValue = value;
+                try {
+                        cleanValue = JSON.parse(JSON.stringify(value));
+                } catch (e) {
+                        console.error("Failed to serialize", key, e);
+                }
+                try {
+                        persistWorker.postMessage({ type: "persist", key, value: cleanValue });
+                } catch (e) {
+                        console.error(`Failed to postMessage for ${key}`, e);
+                }
+                return;
+        }
 	
 	db.table("keyval")
 		.put({ key, value })

--- a/posawesome/public/js/offline/items.js
+++ b/posawesome/public/js/offline/items.js
@@ -43,17 +43,24 @@ export function getCachedOffers() {
 
 // Price list items caching functions
 export function savePriceListItems(priceList, items) {
-	try {
-		const cache = memory.price_list_cache || {};
-		cache[priceList] = {
-			items,
-			timestamp: Date.now(),
-		};
-		memory.price_list_cache = cache;
-		persist("price_list_cache", memory.price_list_cache);
-	} catch (e) {
-		console.error("Failed to cache price list items", e);
-	}
+        try {
+                const cache = memory.price_list_cache || {};
+                let cleanItems;
+                try {
+                        cleanItems = JSON.parse(JSON.stringify(items));
+                } catch (err) {
+                        console.error("Failed to serialize price list items", err);
+                        cleanItems = [];
+                }
+                cache[priceList] = {
+                        items: cleanItems,
+                        timestamp: Date.now(),
+                };
+                memory.price_list_cache = cache;
+                persist("price_list_cache", memory.price_list_cache);
+        } catch (e) {
+                console.error("Failed to cache price list items", e);
+        }
 }
 
 export function getCachedPriceListItems(priceList) {
@@ -82,23 +89,30 @@ export function clearPriceListCache() {
 
 // Item details caching functions
 export function saveItemDetailsCache(profileName, priceList, items) {
-	try {
-		const cache = memory.item_details_cache || {};
-		const profileCache = cache[profileName] || {};
-		const priceCache = profileCache[priceList] || {};
-		items.forEach((item) => {
-			priceCache[item.item_code] = {
-				data: item,
-				timestamp: Date.now(),
-			};
-		});
-		profileCache[priceList] = priceCache;
-		cache[profileName] = profileCache;
-		memory.item_details_cache = cache;
-		persist("item_details_cache", memory.item_details_cache);
-	} catch (e) {
-		console.error("Failed to cache item details", e);
-	}
+        try {
+                const cache = memory.item_details_cache || {};
+                const profileCache = cache[profileName] || {};
+                const priceCache = profileCache[priceList] || {};
+                items.forEach((item) => {
+                        let cleanItem;
+                        try {
+                                cleanItem = JSON.parse(JSON.stringify(item));
+                        } catch (err) {
+                                console.error("Failed to serialize item details", err);
+                                cleanItem = {};
+                        }
+                        priceCache[item.item_code] = {
+                                data: cleanItem,
+                                timestamp: Date.now(),
+                        };
+                });
+                profileCache[priceList] = priceCache;
+                cache[profileName] = profileCache;
+                memory.item_details_cache = cache;
+                persist("item_details_cache", memory.item_details_cache);
+        } catch (e) {
+                console.error("Failed to cache item details", e);
+        }
 }
 
 export function getCachedItemDetails(profileName, priceList, itemCodes, ttl = 15 * 60 * 1000) {


### PR DESCRIPTION
## Summary
- clean data before sending to item worker
- clone price list items before caching
- clone item detail data before caching
