### PR TITLE
Fix item card overflow in ItemSelector

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1636,6 +1636,7 @@ export default {
 
 .dynamic-scroll {
   transition: max-height var(--transition-normal);
+  padding-bottom: var(--dynamic-xs);
 }
 
 .dynamic-item-card {


### PR DESCRIPTION
## Summary
- adjust padding for scroll area in ItemsSelector so last card doesn't overflow in card view