### PR TITLE
Fix card layout and scrolling in ItemsSelector

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1621,6 +1621,8 @@ export default {
 .dynamic-scroll {
   transition: max-height var(--transition-normal);
   padding-bottom: var(--dynamic-xs);
+  overflow-y: auto;
+  scrollbar-gutter: stable;
 }
 
 .items-grid {
@@ -1628,6 +1630,7 @@ export default {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: var(--dynamic-sm);
   align-items: start;
+  align-content: start;
 }
 
 .dynamic-item-card {
@@ -1636,7 +1639,12 @@ export default {
   background-color: var(--surface-secondary);
   display: flex;
   flex-direction: column;
+  height: auto;
   box-sizing: border-box;
+}
+
+.dynamic-item-card .v-img {
+  object-fit: contain;
 }
 
 .dynamic-item-card:hover {


### PR DESCRIPTION
## Summary
- allow vertical scrolling in the items grid
- prevent grid items from stretching and keep card images contained
