### PR TITLE
Adjust settings position and quantity display

### DIFF
--- a/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
+++ b/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
@@ -9,7 +9,7 @@
         <v-row dense>
           <!-- Total Qty -->
           <v-col cols="6">
-            <v-text-field :model-value="formatFloat(total_qty)" :label="frappe._('Total Qty')"
+            <v-text-field :model-value="formatFloat(total_qty, hide_qty_decimals ? 0 : undefined)" :label="frappe._('Total Qty')"
               prepend-inner-icon="mdi-format-list-numbered" variant="solo" density="compact" readonly
               color="accent" />
           </v-col>
@@ -163,6 +163,18 @@ export default {
   computed: {
     isDarkTheme() {
       return this.$theme?.current === 'dark';
+    },
+    hide_qty_decimals() {
+      try {
+        const saved = localStorage.getItem('posawesome_item_selector_settings');
+        if (saved) {
+          const opts = JSON.parse(saved);
+          return !!opts.hide_qty_decimals;
+        }
+      } catch (e) {
+        console.error('Failed to load item selector settings:', e);
+      }
+      return false;
     }
   }
 }

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -34,6 +34,34 @@
             <v-checkbox v-model="new_line" color="accent" value="true" label="NLine" density="default"
               hide-details></v-checkbox>
           </v-col>
+          <v-col cols="12" class="dynamic-margin-xs">
+            <div class="settings-container">
+              <v-btn density="compact" variant="text" color="primary" prepend-icon="mdi-cog-outline"
+                @click="toggleItemSettings" class="settings-btn">
+                {{ __('Settings') }}
+              </v-btn>
+
+              <v-dialog v-model="show_item_settings" max-width="400px">
+                <v-card>
+                  <v-card-title class="text-h6 pa-4 d-flex align-center">
+                    <span>{{ __('Item Selector Settings') }}</span>
+                    <v-spacer></v-spacer>
+                    <v-btn icon="mdi-close" variant="text" density="compact" @click="show_item_settings = false"></v-btn>
+                  </v-card-title>
+                  <v-divider></v-divider>
+                  <v-card-text class="pa-4">
+                    <v-switch v-model="temp_hide_qty_decimals" :label="__('Hide quantity decimals')" hide-details
+                      density="compact" color="primary" class="mb-2"></v-switch>
+                  </v-card-text>
+                  <v-card-actions class="pa-4 pt-0">
+                    <v-btn color="error" variant="text" @click="cancelItemSettings">{{ __('Cancel') }}</v-btn>
+                    <v-spacer></v-spacer>
+                    <v-btn color="primary" variant="tonal" @click="applyItemSettings">{{ __('Apply') }}</v-btn>
+                  </v-card-actions>
+                </v-card>
+              </v-dialog>
+            </div>
+          </v-col>
           <v-col cols="12" class="pt-0 mt-0">
             <div fluid class="items-grid dynamic-scroll" ref="itemsContainer" v-if="items_view == 'card'"
               :style="{ maxHeight: 'calc(' + responsiveStyles['--container-height'] + ' - 80px)' }">
@@ -112,41 +140,7 @@
               __("Coupons")
             }}</v-btn>
         </v-col>
-        <v-col cols="5" class="dynamic-margin-xs">
-          <v-btn size="small" block color="primary" variant="text" @click="show_offers" class="action-btn-consistent">{{
-            offersCount }} {{
-              __("Offers") }}
-            : {{ appliedOffersCount }}
-            {{ __("Applied") }}</v-btn>
-        </v-col>
-        <v-col cols="12" class="dynamic-margin-xs">
-          <div class="settings-container">
-            <v-btn density="compact" variant="text" color="primary" prepend-icon="mdi-cog-outline"
-              @click="toggleItemSettings" class="settings-btn">
-              {{ __('Settings') }}
-            </v-btn>
-
-            <v-dialog v-model="show_item_settings" max-width="400px">
-              <v-card>
-                <v-card-title class="text-h6 pa-4 d-flex align-center">
-                  <span>{{ __('Item Selector Settings') }}</span>
-                  <v-spacer></v-spacer>
-                  <v-btn icon="mdi-close" variant="text" density="compact" @click="show_item_settings = false"></v-btn>
-                </v-card-title>
-                <v-divider></v-divider>
-                <v-card-text class="pa-4">
-                  <v-switch v-model="temp_hide_qty_decimals" :label="__('Hide quantity decimals')" hide-details
-                    density="compact" color="primary" class="mb-2"></v-switch>
-                </v-card-text>
-                <v-card-actions class="pa-4 pt-0">
-                  <v-btn color="error" variant="text" @click="cancelItemSettings">{{ __('Cancel') }}</v-btn>
-                  <v-spacer></v-spacer>
-                  <v-btn color="primary" variant="tonal" @click="applyItemSettings">{{ __('Apply') }}</v-btn>
-                </v-card-actions>
-              </v-card>
-            </v-dialog>
-          </div>
-        </v-col>
+        
       </v-row>
     </v-card>
 

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -19,7 +19,7 @@
     >
       <!-- Custom cell renderers for numeric values with proper alignment -->
       <template v-slot:item.qty="{ item }">
-        <div class="amount-value">{{ formatFloat(item.qty) }}</div>
+        <div class="amount-value">{{ formatFloat(item.qty, hide_qty_decimals ? 0 : undefined) }}</div>
       </template>
 
       <template v-slot:item.rate="{ item }">
@@ -99,7 +99,7 @@
                 </div>
                 <div class="form-field">
                   <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('QTY')"
-                    :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details :model-value="formatFloat(item.qty)" @change="[
+                    :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details :model-value="formatFloat(item.qty, hide_qty_decimals ? 0 : undefined)" @change="[
                       setFormatedQty(item, 'qty', null, false, $event.target.value),
                       calcStockQty(item, item.qty),
                     ]" :rules="[isNumber]" :disabled="!!item.posa_is_replace"
@@ -293,6 +293,18 @@ export default {
     },
     isDarkTheme() {
       return this.$theme.current === 'dark';
+    },
+    hide_qty_decimals() {
+      try {
+        const saved = localStorage.getItem('posawesome_item_selector_settings');
+        if (saved) {
+          const opts = JSON.parse(saved);
+          return !!opts.hide_qty_decimals;
+        }
+      } catch (e) {
+        console.error('Failed to load item selector settings:', e);
+      }
+      return false;
     },
   },
 };


### PR DESCRIPTION
## Summary
- move the Item Selector settings under the search bar
- read local storage setting to hide quantity decimals in ItemsTable and InvoiceSummary
