### PR TITLE
Fix price list currency handling in multi-currency mode

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -440,18 +440,9 @@ export default {
         this.selected_price_list = this.pos_profile.selling_price_list;
       }
 
-      // Fetch and store currency for the applied price list
-      try {
-        const r = await frappe.call({
-          method: "posawesome.posawesome.api.invoices.get_price_list_currency",
-          args: { price_list: this.selected_price_list }
-        });
-        if (r && r.message) {
-          this.price_list_currency = r.message;
-        }
-      } catch (error) {
-        console.error("Failed fetching price list currency", error);
-      }
+      // In multi-currency mode set the price list currency to the POS
+      // default currency to avoid conversion issues
+      this.price_list_currency = this.pos_profile.currency;
 
       return this.price_lists;
     },

--- a/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
@@ -69,20 +69,11 @@ export default {
       const applied = newVal || this.pos_profile.selling_price_list;
       this.apply_cached_price_list(applied);
 
-      // If multi-currency is enabled, sync currency with the price list currency
+      // If multi-currency is enabled, force price list currency to POS default
+      // currency to avoid conversion issues
       if (this.pos_profile.posa_allow_multi_currency && applied) {
-        frappe.call({
-          method: "posawesome.posawesome.api.invoices.get_price_list_currency",
-          args: { price_list: applied },
-          callback: (r) => {
-            if (r.message) {
-              // Store price list currency for later use
-              this.price_list_currency = r.message;
-              // Sync invoice currency with price list currency
-              this.update_currency(r.message);
-            }
-          },
-        });
+        this.price_list_currency = this.pos_profile.currency;
+        this.update_currency(this.pos_profile.currency);
       }
     },
 


### PR DESCRIPTION
## Summary
- default price list currency to POS profile's currency
- ensure price list currency syncs to POS base currency when the price list changes