### PR TITLE
Fix module loading error in POS Awesome

### DIFF
--- a/posawesome/posawesome/page/posapp/posapp.js
+++ b/posawesome/posawesome/page/posapp/posapp.js
@@ -1,7 +1,8 @@
 // Include onscan.js
 frappe.pages['posapp'].on_page_load = async function (wrapper) {
         // Ensure bundled assets are loaded before initializing the app
-        await frappe.require('/assets/posawesome/js/posawesome.bundle.js');
+       // Use dynamic import so the bundled script is loaded as an ES module
+       await import('/assets/posawesome/js/posawesome.bundle.js');
         await setupLanguage();
 
         var page = frappe.ui.make_app_page({


### PR DESCRIPTION
## Summary
- load the POS Awesome bundle with `import()` so it is treated as an ES module
