### PR TITLE
Fix barcode scanning search clearing and UOM error

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1174,15 +1174,24 @@ export default {
       }
     },
     trigger_onscan(sCode) {
-      if (this.filtered_items.length == 0) {
-        this.eventBus.emit("show_message", {
-          title: `No Item has this barcode "${sCode}"`,
-          color: "error",
-        });
-        frappe.utils.play_sound("error");
-      } else {
-        this.enter_event();
-      }
+      // apply scanned code as search term
+      this.first_search = sCode;
+      this.search = sCode;
+
+      this.$nextTick(() => {
+        if (this.filtered_items.length == 0) {
+          this.eventBus.emit("show_message", {
+            title: `No Item has this barcode "${sCode}"`,
+            color: "error",
+          });
+          frappe.utils.play_sound("error");
+        } else {
+          this.enter_event();
+        }
+
+        // clear search field for next scan
+        this.clearSearch();
+      });
     },
     generateWordCombinations(inputString) {
       const words = inputString.split(" ");


### PR DESCRIPTION
## Summary
- clear barcode search after each scan so next item can be scanned
- set scanned code as search term before processing
- ensure calc_uom checks cached UOMs and uses stock UOM when available
