### PR TITLE
Improve return invoice highlighting

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -25,6 +25,15 @@
           </v-col>
         </v-row>
 
+        <!-- Highlight when return mode is active -->
+        <v-row v-if="isReturnInvoice" class="mb-2">
+          <v-col cols="12">
+            <v-alert type="error" variant="tonal" dense>
+              {{ __('Return Mode Active') }}
+            </v-alert>
+          </v-col>
+        </v-row>
+
         <!-- Delivery Charges Section (Only if enabled in POS profile) -->
         <DeliveryCharges :pos_profile="pos_profile" :delivery_charges="delivery_charges"
           :selected_delivery_charge="selected_delivery_charge" :delivery_charges_rate="delivery_charges_rate"
@@ -893,8 +902,10 @@ export default {
 }
 
 /* Red border and label for return mode card */
+
+/* Red border and label for return mode card */
 .return-mode {
-  border: 2px solid var(--error) !important;
+  border: 2px solid #ff5252 !important;
   position: relative;
 }
 
@@ -904,7 +915,7 @@ export default {
   position: absolute;
   top: 0;
   right: 0;
-  background-color: var(--error);
+  background-color: #ff5252;
   color: white;
   padding: 4px 12px;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- show a warning alert when return mode is active
- use brighter red color for return invoice border and label