### PR TITLE
Improve currency handling

### DIFF
--- a/posawesome/public/js/posapp/components/pos/MultiCurrencyRow.vue
+++ b/posawesome/public/js/posapp/components/pos/MultiCurrencyRow.vue
@@ -25,7 +25,9 @@ export default {
   data() {
     return {
       internal_selected_currency: this.selected_currency,
-      internal_exchange_rate: this.exchange_rate,
+      // Display exchange rate in the intuitive orientation
+      // POS logic expects selected -> base but we show base -> selected
+      internal_exchange_rate: this.exchange_rate ? 1 / this.exchange_rate : 1,
     };
   },
   watch: {
@@ -33,7 +35,8 @@ export default {
       this.internal_selected_currency = val;
     },
     exchange_rate(val) {
-      this.internal_exchange_rate = val;
+      // Convert to user friendly orientation when prop updates
+      this.internal_exchange_rate = val ? 1 / val : 1;
     },
   },
   methods: {
@@ -41,7 +44,9 @@ export default {
       this.$emit('update:selected_currency', val);
     },
     onExchangeChange() {
-      this.$emit('update:exchange_rate', this.internal_exchange_rate);
+      // Convert back to selected -> base orientation before emitting
+      const rate = this.internal_exchange_rate ? 1 / this.internal_exchange_rate : 1;
+      this.$emit('update:exchange_rate', rate);
     },
   },
 };

--- a/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
@@ -78,8 +78,7 @@ export default {
             if (r.message) {
               // Store price list currency for later use
               this.price_list_currency = r.message;
-              // Sync invoice currency with price list currency
-              this.update_currency(r.message);
+              // Currency is selected manually in POS
             }
           },
         });


### PR DESCRIPTION
## Summary
- always use POS Profile currency as base
- let the cashier select the invoice currency manually
- show exchange rate to cashier in base→selected orientation