### PR TITLE
Fix price list dropdown

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -281,7 +281,9 @@ export default {
           return;
         }
       }
-      // No cache found; keep existing items without reloading from server
+      // No cache found - force a reload so prices are updated
+      this.items_loaded = false;
+      this.get_items(true);
     }, 300),
     new_line() {
       this.eventBus.emit("set_new_line", this.new_line);


### PR DESCRIPTION
## Summary
- load selling price lists from backend when dropdown enabled
- reload items from server if no cached rates after selecting a new price list