### PR TITLE
Fix cache mixing when switching price lists

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
@@ -1,3 +1,5 @@
+import { clearPriceListCache } from "../../../offline/index.js";
+
 export default {
     // Watch for customer change and update related data
     customer() {
@@ -64,6 +66,9 @@ export default {
     },
 
     selected_price_list(newVal) {
+      // Clear cached price list items to avoid mixing rates
+      clearPriceListCache();
+
       const price_list = newVal === this.pos_profile.selling_price_list ? null : newVal;
       this.eventBus.emit("update_customer_price_list", price_list);
       const applied = newVal || this.pos_profile.selling_price_list;


### PR DESCRIPTION
## Summary
- clear cached price list items whenever the user selects a new price list