### PR TITLE
Fix currency mismatch on item expansion

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1381,8 +1381,9 @@ export default {
             doctype: "Sales Invoice",
             name: "New Sales Invoice 1",
             company: this.pos_profile.company,
-            conversion_rate: 1,
-            currency: this.pos_profile.currency,
+            // Use current exchange rate and currency when fetching item details
+            conversion_rate: this.exchange_rate || 1,
+            currency: this.selected_currency || this.pos_profile.currency,
             qty: item.qty,
             price_list_rate: item.base_price_list_rate || item.price_list_rate,
             child_docname: "New Sales Invoice Item 1",


### PR DESCRIPTION
## Summary
- ensure `update_item_detail` uses the current currency and exchange rate when requesting item details