### PR TITLE
Fix missing customer_id argument error

### DIFF
--- a/posawesome/posawesome/api/customers.py
+++ b/posawesome/posawesome/api/customers.py
@@ -157,7 +157,7 @@ def get_customer_info(customer):
 
 @frappe.whitelist()
 def create_customer(
-    customer_id,
+    customer_id=None,
     customer_name,
     company,
     pos_profile_doc,

--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -1401,7 +1401,7 @@ def get_stock_availability(item_code, warehouse):
 
 @frappe.whitelist()
 def create_customer(
-    customer_id,
+    customer_id=None,
     customer_name,
     company,
     pos_profile_doc,


### PR DESCRIPTION
## Summary
- make `customer_id` optional in the API for creating a customer