### PR TITLE
Add default country setting to POS Profile

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5537,5 +5537,16 @@
     "description": "Language for POS Awesome interface",
     "default": null,
     "name": "POS Profile-posa_language"
+  },
+  {
+    "doctype": "Custom Field",
+    "dt": "POS Profile",
+    "fieldname": "posa_default_country",
+    "fieldtype": "Link",
+    "insert_after": "posa_language",
+    "label": "Default Country",
+    "options": "Country",
+    "default": "Pakistan",
+    "name": "POS Profile-posa_default_country"
   }
 ]

--- a/posawesome/public/js/posapp/components/pos/UpdateCustomer.vue
+++ b/posawesome/public/js/posapp/components/pos/UpdateCustomer.vue
@@ -182,6 +182,7 @@ export default {
       'Sri Lanka',
       'Sweden',
       'Switzerland',
+      'Syria',
       'Thailand',
       'United Arab Emirates',
       'United Kingdom',
@@ -296,7 +297,8 @@ export default {
       this.mobile_no = '';
       this.address_line1 = '';
       this.city = '';
-      this.country = 'Pakistan';
+      this.country =
+        (this.pos_profile && this.pos_profile.posa_default_country) || 'Pakistan';
       this.email_id = '';
       this.referral_code = '';
       this.birthday = '';
@@ -543,7 +545,10 @@ export default {
         this.customer_id = data.name;
         this.address_line1 = data.address_line1 || "";
         this.city = data.city || "";
-        this.country = data.country || "Pakistan";
+        this.country =
+          data.country ||
+          (this.pos_profile && this.pos_profile.posa_default_country) ||
+          'Pakistan';
         this.tax_id = data.tax_id;
         this.mobile_no = data.mobile_no;
         this.email_id = data.email_id;
@@ -554,13 +559,20 @@ export default {
         this.loyalty_points = data.loyalty_points;
         this.loyalty_program = data.loyalty_program;
         this.gender = data.gender;
+      } else {
+        this.country =
+          (this.pos_profile && this.pos_profile.posa_default_country) || 'Pakistan';
       }
     });
     this.eventBus.on('register_pos_profile', (data) => {
       this.pos_profile = data.pos_profile;
+      this.country =
+        (this.pos_profile && this.pos_profile.posa_default_country) || 'Pakistan';
     });
     this.eventBus.on('payments_register_pos_profile', (data) => {
       this.pos_profile = data.pos_profile;
+      this.country =
+        (this.pos_profile && this.pos_profile.posa_default_country) || 'Pakistan';
     });
     this.getCustomerGroups();
     this.getCustomerTerritorys();


### PR DESCRIPTION
## Summary
- allow setting a default country in POS Profile
- use POS Profile default country when creating or editing customers
- include Syria in customer countries list