### PR TITLE
Fix currency conversion logic when price list currency matches selection

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -557,6 +557,15 @@ export default {
           item.price_list_rate = item.base_price_list_rate;
           item.rate = item.base_rate;
           item.discount_amount = item.base_discount_amount;
+        } else if (item.original_currency === this.selected_currency) {
+          // When selected currency matches the price list currency,
+          // no conversion should be applied
+          console.log(
+            `Using original currency rates for ${item.item_code}`
+          );
+          item.price_list_rate = item.base_price_list_rate;
+          item.rate = item.base_rate;
+          item.discount_amount = item.base_discount_amount;
         } else {
           // When switching to another currency, convert from base rates
           console.log(`Converting rates for ${item.item_code} to ${this.selected_currency}`);

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1176,12 +1176,21 @@ export default {
 
       // original_rate is in price list currency
       const price_list_rate = item.original_rate;
+
+      // Determine base rate using available conversion info
       const base_rate = price_list_rate * (item.plc_conversion_rate || 1);
 
       item.base_rate = base_rate;
       item.base_price_list_rate = price_list_rate;
 
-      item.rate = this.flt(price_list_rate * (this.exchange_rate || 1), this.currency_precision);
+      // If the price list currency matches the selected currency,
+      // don't apply any conversion
+      const converted_rate =
+        item.original_currency === this.selected_currency
+          ? price_list_rate
+          : price_list_rate * (this.exchange_rate || 1);
+
+      item.rate = this.flt(converted_rate, this.currency_precision);
       item.currency = this.selected_currency;
       item.price_list_rate = item.rate;
     },


### PR DESCRIPTION
## Summary
- prevent exchange rate conversion if the price list currency is the same as the currently selected currency
- keep original item rates intact when updating invoice items in this scenario