### PR TITLE
Apply pos action styles to invoice buttons

### DIFF
--- a/posawesome/public/js/posapp/components/invoice/InvoiceSummary.vue
+++ b/posawesome/public/js/posapp/components/invoice/InvoiceSummary.vue
@@ -50,9 +50,9 @@
           <v-col cols="6">
             <v-btn
               block
-              color="accent"
               theme="dark"
               prepend-icon="mdi-content-save"
+              class="pos-action-btn primary-action-btn"
               @click="$emit('save-and-clear')"
             >
               {{ __('Save & Clear') }}
@@ -61,11 +61,10 @@
           <v-col cols="6">
             <v-btn
               block
-              color="warning"
               theme="dark"
               prepend-icon="mdi-file-document"
+              class="pos-action-btn primary-action-btn white-text-btn"
               @click="$emit('load-drafts')"
-              class="white-text-btn"
             >
               {{ __('Load Drafts') }}
             </v-btn>
@@ -73,9 +72,9 @@
           <v-col cols="6" v-if="pos_profile.custom_allow_select_sales_order == 1">
             <v-btn
               block
-              color="info"
               theme="dark"
               prepend-icon="mdi-book-search"
+              class="pos-action-btn primary-action-btn"
               @click="$emit('select-order')"
             >
               {{ __('Select S.O') }}
@@ -84,9 +83,9 @@
           <v-col cols="6">
             <v-btn
               block
-              color="error"
               theme="dark"
               prepend-icon="mdi-close-circle"
+              class="pos-action-btn cancel-action-btn"
               @click="$emit('cancel-sale')"
             >
               {{ __('Cancel Sale') }}
@@ -95,9 +94,9 @@
           <v-col cols="6" v-if="pos_profile.posa_allow_return == 1">
             <v-btn
               block
-              color="secondary"
               theme="dark"
               prepend-icon="mdi-backup-restore"
+              class="pos-action-btn primary-action-btn"
               @click="$emit('open-returns')"
             >
               {{ __('Sales Return') }}
@@ -106,9 +105,9 @@
           <v-col cols="6" v-if="pos_profile.posa_allow_print_draft_invoices">
             <v-btn
               block
-              color="primary"
               theme="dark"
               prepend-icon="mdi-printer"
+              class="pos-action-btn primary-action-btn"
               @click="$emit('print-draft')"
             >
               {{ __('Print Draft') }}
@@ -117,10 +116,10 @@
           <v-col cols="12">
             <v-btn
               block
-              color="success"
               theme="dark"
               size="large"
               prepend-icon="mdi-credit-card"
+              class="pos-action-btn submit-action-btn"
               @click="$emit('show-payment')"
             >
               {{ __('PAY') }}


### PR DESCRIPTION
## Summary
- use existing `pos-action-btn` classes for invoice summary buttons