### PR TITLE
Fix currency conversion for cached rates

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1408,6 +1408,17 @@ export default {
         callback: function (r) {
           if (r.message) {
             const data = r.message;
+            // Ensure price list currency is synced from server response
+            if (data.price_list_currency) {
+              vm.price_list_currency = data.price_list_currency;
+            }
+
+            if (!item.original_currency) {
+              item.original_currency = data.price_list_currency || vm.price_list_currency || vm.selected_currency;
+            }
+            if (!item.original_rate) {
+              item.original_rate = data.price_list_rate;
+            }
             if (data.batch_no_data) {
               item.batch_no_data = data.batch_no_data;
             }
@@ -1439,9 +1450,16 @@ export default {
 
             // Only update rates if no offer is applied
             if (!item.posa_offer_applied) {
-              // Convert to selected currency if needed
               const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
-              if (vm.selected_currency !== baseCurrency) {
+
+              // If price list currency matches the selected currency, skip multiplication
+              if (vm.price_list_currency && vm.price_list_currency === vm.selected_currency) {
+                item.price_list_rate = item.base_price_list_rate;
+
+                if (!item._manual_rate_set) {
+                  item.rate = item.base_rate;
+                }
+              } else if (vm.selected_currency !== baseCurrency) {
                 const exchange_rate = vm.exchange_rate || 1;
                 // Convert base rates to the selected currency
                 item.price_list_rate = vm.flt(item.base_price_list_rate * exchange_rate, vm.currency_precision);
@@ -1449,10 +1467,10 @@ export default {
                 // In multi-currency mode, update the rate from base_rate
                 item.rate = vm.flt(item.base_rate * exchange_rate, vm.currency_precision);
               } else {
-                // When in default currency, use base rates directly for price_list_rate
+                // When in base currency, use base rates directly for price_list_rate
                 item.price_list_rate = item.base_price_list_rate;
 
-                // IMPORTANT: For default currency, only set rate if it's not already set
+                // IMPORTANT: Only set rate if it's not already set
                 // This preserves manually entered rates
                 if (!item._manual_rate_set) {
                   item.rate = item.base_rate;
@@ -1461,7 +1479,10 @@ export default {
             } else {
               // For items with offers, only update price_list_rate
               const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
-              if (vm.selected_currency !== baseCurrency) {
+
+              if (vm.price_list_currency && vm.price_list_currency === vm.selected_currency) {
+                item.price_list_rate = item.base_price_list_rate;
+              } else if (vm.selected_currency !== baseCurrency) {
                 const exchange_rate = vm.exchange_rate || 1;
                 item.price_list_rate = vm.flt(item.base_price_list_rate * exchange_rate, vm.currency_precision);
               } else {
@@ -1595,11 +1616,19 @@ export default {
           const newRate = ci.rate || ci.price_list_rate;
           const priceCurrency = ci.currency || this.selected_currency;
 
+          if (!item.original_currency) {
+            item.original_currency = priceCurrency;
+          }
+          if (!item.original_rate) {
+            item.original_rate = newRate;
+          }
+
           if (priceCurrency === this.selected_currency) {
             // Rate already in selected currency
-            item.base_price_list_rate = newRate / this.exchange_rate;
+            // Store base rates directly without conversion
+            item.base_price_list_rate = newRate;
             if (!item._manual_rate_set) {
-              item.base_rate = newRate / this.exchange_rate;
+              item.base_rate = newRate;
             }
             item.price_list_rate = newRate;
             if (!item._manual_rate_set) {


### PR DESCRIPTION
## Summary
- ensure cached price list items don't divide by exchange rate when already in the selected currency
- sync price list currency on item expansion to avoid unwanted conversions