### PR TITLE
Fix currency conversion for item rates

### DIFF
--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -26,7 +26,7 @@ def get_latest_rate(from_currency: str, to_currency: str):
         "Currency Exchange",
         filters={"from_currency": from_currency, "to_currency": to_currency},
         fields=["exchange_rate", "date"],
-        order_by="date desc",
+        order_by="date desc, creation desc",
         limit=1,
     )
     if rate_doc:

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -680,6 +680,18 @@ export default {
           if (r2 && r2.message) {
             this.conversion_rate = r2.message.exchange_rate;
             this.exchange_rate_date = r2.message.date;
+            const posting_backend = this.formatDateForBackend(this.posting_date_display);
+            if (this.exchange_rate_date && posting_backend !== this.exchange_rate_date) {
+              this.eventBus.emit("show_message", {
+                title: __(
+                  "Exchange rate date " +
+                    this.exchange_rate_date +
+                    " differs from posting date " +
+                    posting_backend
+                ),
+                color: "warning",
+              });
+            }
           }
         }
       } catch (error) {

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -937,6 +937,18 @@ export default {
             vm.invoice_doc = r.message;
             if (r.message.exchange_rate_date) {
               vm.exchange_rate_date = r.message.exchange_rate_date;
+              const posting_backend = vm.formatDateForBackend(vm.posting_date_display);
+              if (posting_backend !== vm.exchange_rate_date) {
+                vm.eventBus.emit("show_message", {
+                  title: __(
+                    "Exchange rate date " +
+                      vm.exchange_rate_date +
+                      " differs from posting date " +
+                      posting_backend
+                  ),
+                  color: "warning",
+                });
+              }
             }
           }
         },
@@ -961,6 +973,21 @@ export default {
         callback: function (r) {
           if (r.message) {
             vm.invoice_doc = r.message;
+            if (r.message.exchange_rate_date) {
+              vm.exchange_rate_date = r.message.exchange_rate_date;
+              const posting_backend = vm.formatDateForBackend(vm.posting_date_display);
+              if (posting_backend !== vm.exchange_rate_date) {
+                vm.eventBus.emit("show_message", {
+                  title: __(
+                    "Exchange rate date " +
+                      vm.exchange_rate_date +
+                      " differs from posting date " +
+                      posting_backend
+                  ),
+                  color: "warning",
+                });
+              }
+            }
           }
         },
       });
@@ -1408,6 +1435,17 @@ export default {
         callback: function (r) {
           if (r.message) {
             const data = r.message;
+            // Ensure price list currency is synced from server response
+            if (data.price_list_currency) {
+              vm.price_list_currency = data.price_list_currency;
+            }
+
+            if (!item.original_currency) {
+              item.original_currency = data.price_list_currency || vm.price_list_currency || vm.selected_currency;
+            }
+            if (!item.original_rate) {
+              item.original_rate = data.price_list_rate;
+            }
             if (data.batch_no_data) {
               item.batch_no_data = data.batch_no_data;
             }
@@ -1439,29 +1477,37 @@ export default {
 
             // Only update rates if no offer is applied
             if (!item.posa_offer_applied) {
-              // Convert to selected currency if needed
-              const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
-              if (vm.selected_currency !== baseCurrency) {
+              const companyCurrency = vm.pos_profile.currency;
+              const baseCurrency = companyCurrency;
+
+              if (vm.selected_currency === vm.price_list_currency && vm.selected_currency !== companyCurrency) {
+                const conv = vm.conversion_rate || 1;
+                item.price_list_rate = vm.flt(item.base_price_list_rate / conv, vm.currency_precision);
+
+                if (!item._manual_rate_set) {
+                  item.rate = vm.flt(item.base_rate / conv, vm.currency_precision);
+                }
+              } else if (vm.selected_currency !== baseCurrency) {
                 const exchange_rate = vm.exchange_rate || 1;
-                // Convert base rates to the selected currency
                 item.price_list_rate = vm.flt(item.base_price_list_rate * exchange_rate, vm.currency_precision);
 
-                // In multi-currency mode, update the rate from base_rate
                 item.rate = vm.flt(item.base_rate * exchange_rate, vm.currency_precision);
               } else {
-                // When in default currency, use base rates directly for price_list_rate
                 item.price_list_rate = item.base_price_list_rate;
 
-                // IMPORTANT: For default currency, only set rate if it's not already set
-                // This preserves manually entered rates
                 if (!item._manual_rate_set) {
                   item.rate = item.base_rate;
                 }
               }
             } else {
               // For items with offers, only update price_list_rate
-              const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
-              if (vm.selected_currency !== baseCurrency) {
+              const companyCurrency = vm.pos_profile.currency;
+              const baseCurrency = companyCurrency;
+
+              if (vm.selected_currency === vm.price_list_currency && vm.selected_currency !== companyCurrency) {
+                const conv = vm.conversion_rate || 1;
+                item.price_list_rate = vm.flt(item.base_price_list_rate / conv, vm.currency_precision);
+              } else if (vm.selected_currency !== baseCurrency) {
                 const exchange_rate = vm.exchange_rate || 1;
                 item.price_list_rate = vm.flt(item.base_price_list_rate * exchange_rate, vm.currency_precision);
               } else {
@@ -1595,11 +1641,26 @@ export default {
           const newRate = ci.rate || ci.price_list_rate;
           const priceCurrency = ci.currency || this.selected_currency;
 
+          if (!item.original_currency) {
+            item.original_currency = priceCurrency;
+          }
+          if (!item.original_rate) {
+            item.original_rate = newRate;
+          }
+
           if (priceCurrency === this.selected_currency) {
-            // Rate already in selected currency
-            item.base_price_list_rate = newRate / this.exchange_rate;
-            if (!item._manual_rate_set) {
-              item.base_rate = newRate / this.exchange_rate;
+            const companyCurrency = this.pos_profile.currency;
+            if (priceCurrency !== companyCurrency) {
+              const conv = this.conversion_rate || 1;
+              item.base_price_list_rate = newRate * conv;
+              if (!item._manual_rate_set) {
+                item.base_rate = newRate * conv;
+              }
+            } else {
+              item.base_price_list_rate = newRate;
+              if (!item._manual_rate_set) {
+                item.base_rate = newRate;
+              }
             }
             item.price_list_rate = newRate;
             if (!item._manual_rate_set) {
@@ -1614,7 +1675,7 @@ export default {
               }
             }
 
-              const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+              const baseCurrency = this.pos_profile.currency;
               if (this.selected_currency !== baseCurrency) {
                 const conv = this.exchange_rate || 1;
               const convRate = this.flt(newRate * conv, this.currency_precision);
@@ -1624,7 +1685,7 @@ export default {
               if (!item._manual_rate_set && (newRate !== 0 || !item.rate)) {
                 item.rate = convRate;
               }
-            } else {
+              } else {
               if (newRate !== 0 || !item.price_list_rate) {
                 item.price_list_rate = newRate;
               }


### PR DESCRIPTION
## Summary
- avoid multiplying exchange rate when price list currency equals selected currency
- ensure base rates convert using conversion rate when applying cached prices
- warn when exchange rate date differs from posting date
- fetch latest currency exchange record if multiple present