### PR TITLE
Fix create_customer API bug

### DIFF
--- a/posawesome/posawesome/api/customers.py
+++ b/posawesome/posawesome/api/customers.py
@@ -157,10 +157,10 @@ def get_customer_info(customer):
 
 @frappe.whitelist()
 def create_customer(
-    customer_id,
     customer_name,
     company,
     pos_profile_doc,
+    customer_id=None,
     tax_id=None,
     mobile_no=None,
     email_id=None,

--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -1401,10 +1401,10 @@ def get_stock_availability(item_code, warehouse):
 
 @frappe.whitelist()
 def create_customer(
-    customer_id,
     customer_name,
     company,
     pos_profile_doc,
+    customer_id=None,
     tax_id=None,
     mobile_no=None,
     email_id=None,


### PR DESCRIPTION
## Summary
- make `customer_id` optional in API helper methods