### PR TITLE
Add option to skip invoice when creating Sales Order

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5548,5 +5548,15 @@
     "options": "Country",
     "default": "Pakistan",
     "name": "POS Profile-posa_default_country"
+  },
+  {
+    "doctype": "Custom Field",
+    "dt": "POS Profile",
+    "fieldname": "posa_skip_invoice_on_order",
+    "fieldtype": "Check",
+    "insert_after": "posa_allow_sales_order",
+    "label": "Skip Invoice When Creating Order",
+    "default": "0",
+    "name": "POS Profile-posa_skip_invoice_on_order"
   }
 ]

--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -206,6 +206,7 @@ fixtures = [
                     "Sales Order Item-posa_notes",
                     "POS Profile-posa_allow_sales_order",
                     "POS Profile-custom_allow_select_sales_order",
+                    "POS Profile-posa_skip_invoice_on_order",
                     "POS Profile-posa_column_break_112",
                     "POS Profile-posa_show_template_items",
                     "POS Profile-posa_hide_variants_items",

--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -23,6 +23,7 @@ from .customers import (
 from .invoices import (
     update_invoice,
     submit_invoice,
+    create_sales_order_only,
     delete_invoice,
     get_draft_invoices,
     search_invoices_for_return,

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -626,3 +626,19 @@ def get_price_list_currency(price_list: str) -> str:
     if not price_list:
         return None
     return frappe.db.get_value("Price List", price_list, "currency")
+
+
+@frappe.whitelist()
+def create_sales_order_only(invoice):
+    """Create a Sales Order from invoice data and discard the invoice."""
+    if isinstance(invoice, dict):
+        invoice = json.dumps(invoice)
+    invoice_doc = update_invoice(invoice)
+    invoice_name = invoice_doc.get("name")
+    sales_order_doc = make_sales_order(invoice_name)
+    sales_order_doc.flags.ignore_permissions = True
+    sales_order_doc.flags.ignore_account_permission = True
+    sales_order_doc.save()
+    sales_order_doc.submit()
+    frappe.delete_doc("Sales Invoice", invoice_name)
+    return sales_order_doc

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -835,8 +835,12 @@ export default {
         frappe.utils.play_sound("error");
         return;
       }
-      // Proceed to submit the invoice
-      this.submit_invoice(print);
+      // Proceed to submit the document
+      if (this.invoiceType === 'Order' && this.pos_profile.posa_skip_invoice_on_order) {
+        this.submit_order_only(print);
+      } else {
+        this.submit_invoice(print);
+      }
     },
     // Submit invoice to backend after all validations
     submit_invoice(print) {
@@ -951,9 +955,36 @@ export default {
           updateLocalStock(vm.invoice_doc.items || []);
           vm.addresses = [];
           vm.eventBus.emit("clear_invoice");
+      vm.eventBus.emit("reset_posting_date");
+      vm.back_to_invoice();
+      }
+      });
+    },
+
+    // Submit Sales Order without creating an invoice
+    submit_order_only(print) {
+      const vm = this;
+      frappe.call({
+        method: "posawesome.posawesome.api.invoices.create_sales_order_only",
+        args: {
+          invoice: this.invoice_doc,
+        },
+        callback: function(r) {
+          if (r.exc || !r.message) {
+            vm.eventBus.emit("show_message", {
+              title: __("Error creating Sales Order"),
+              color: "error",
+            });
+            return;
+          }
+          vm.eventBus.emit("show_message", {
+            title: __("Sales Order {0} Created", [r.message.name]),
+            color: "success",
+          });
+          vm.eventBus.emit("clear_invoice");
           vm.eventBus.emit("reset_posting_date");
           vm.back_to_invoice();
-        }
+        },
       });
     },
     // Set full amount for a payment method (or negative for returns)


### PR DESCRIPTION
## Summary
- add `posa_skip_invoice_on_order` custom field for POS Profile
- export new custom field fixture in hooks
- expose `create_sales_order_only` API
- allow Payments component to submit order only