### PR TITLE
Restore POS item fields

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -145,29 +145,106 @@
                     prepend-inner-icon="mdi-tag-minus"></v-text-field>
                 </div>
               </div>
-              
-              <!-- Third row for serial/batch numbers if applicable -->
-              <div class="form-row" v-if="item.has_serial_no || item.has_batch_no">
-                <div class="form-field" v-if="item.has_serial_no">
-                  <v-autocomplete density="compact" variant="outlined" color="primary" :label="frappe._('Serial Numbers')"
-                    :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details clearable
-                    v-model="item.serial_no" :items="item.serial_no_data" item-title="serial_no" item-value="serial_no"
-                    @update:model-value="setSerialNo(item, $event)" :disabled="!!item.posa_is_replace"
-                    prepend-inner-icon="mdi-numeric"></v-autocomplete>
+
+              <!-- Third row of fields -->
+              <div class="form-row">
+                <div class="form-field">
+                  <v-text-field density="compact" variant="outlined" color="primary"
+                    :label="frappe._('Price list Rate')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+                    class="dark-field" hide-details :model-value="formatCurrency(item.price_list_rate)" disabled
+                    :prefix="currencySymbol(pos_profile.currency)"></v-text-field>
                 </div>
-                <div class="form-field" v-if="item.has_batch_no">
-                  <v-autocomplete density="compact" variant="outlined" color="primary" :label="frappe._('Batch No')"
-                    :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details clearable
-                    v-model="item.batch_no" :items="item.batch_no_data" item-title="batch_no" item-value="batch_no"
-                    @update:model-value="setBatchQty(item, $event)" :disabled="!!item.posa_is_replace"
-                    prepend-inner-icon="mdi-package-variant"></v-autocomplete>
+                <div class="form-field">
+                  <v-text-field density="compact" variant="outlined" color="primary"
+                    :label="frappe._('Available QTY')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+                    class="dark-field" hide-details :model-value="formatFloat(item.actual_qty)" disabled></v-text-field>
                 </div>
-                <div class="form-field" v-if="item.has_batch_no">
-                  <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Expiry Date')"
+                <div class="form-field">
+                  <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Group')"
                     :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details
-                    v-model="item.expiry_date" type="date" @change="validateDueDate(item, $event.target.value)"
-                    :disabled="!!item.posa_is_replace"
-                    prepend-inner-icon="mdi-calendar"></v-text-field>
+                    v-model="item.item_group" disabled></v-text-field>
+                </div>
+              </div>
+
+              <!-- Fourth row of fields -->
+              <div class="form-row">
+                <div class="form-field">
+                  <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Stock QTY')"
+                    :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details
+                    :model-value="formatFloat(item.stock_qty)" disabled></v-text-field>
+                </div>
+                <div class="form-field">
+                  <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Stock UOM')"
+                    :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details v-model="item.stock_uom"
+                    disabled></v-text-field>
+                </div>
+                <div class="form-field" v-if="item.posa_offer_applied">
+                  <v-checkbox density="compact" :label="frappe._('Offer Applied')" v-model="item.posa_offer_applied"
+                    readonly hide-details class="mt-1"></v-checkbox>
+                </div>
+              </div>
+
+              <!-- Serial Number Section -->
+              <div class="form-section" v-if="item.has_serial_no == 1 || item.serial_no">
+                <div class="form-row">
+                  <div class="form-field">
+                    <v-text-field density="compact" variant="outlined" color="primary"
+                      :label="frappe._('Serial No QTY')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details
+                      v-model="item.serial_no_selected_count" type="number" disabled></v-text-field>
+                  </div>
+                </div>
+                <div class="form-row">
+                  <div class="form-field full-width">
+                    <v-autocomplete v-model="item.serial_no_selected" :items="item.serial_no_data" item-title="serial_no"
+                      variant="outlined" density="compact" chips color="primary" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field"
+                      :label="frappe._('Serial No')" multiple
+                      @update:model-value="setSerialNo(item)"></v-autocomplete>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Batch Number Section -->
+              <div class="form-section" v-if="item.has_batch_no == 1 || item.batch_no">
+                <div class="form-row">
+                  <div class="form-field">
+                    <v-text-field density="compact" variant="outlined" color="primary"
+                      :label="frappe._('Batch No. Available QTY')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details
+                      :model-value="formatFloat(item.actual_batch_qty)" disabled></v-text-field>
+                  </div>
+                  <div class="form-field">
+                    <v-text-field density="compact" variant="outlined" color="primary"
+                      :label="frappe._('Batch No Expiry Date')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details
+                      v-model="item.batch_no_expiry_date" disabled></v-text-field>
+                  </div>
+                  <div class="form-field">
+                    <v-autocomplete v-model="item.batch_no" :items="item.batch_no_data" item-title="batch_no"
+                      variant="outlined" density="compact" color="primary" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" :label="frappe._('Batch No')"
+                      @update:model-value="setBatchQty(item, $event)" hide-details>
+                      <template v-slot:item="{ props, item }">
+                        <v-list-item v-bind="props">
+                          <v-list-item-title v-html="item.raw.batch_no"></v-list-item-title>
+                          <v-list-item-subtitle v-html="`Available QTY  '${item.raw.batch_qty}' - Expiry Date ${item.raw.expiry_date}`"></v-list-item-subtitle>
+                        </v-list-item>
+                      </template>
+                    </v-autocomplete>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Delivery Date Section -->
+              <div class="form-section" v-if="pos_profile.posa_allow_sales_order && invoiceType == 'Order'">
+                <div class="form-row">
+                  <div class="form-field">
+                    <VueDatePicker
+                      v-model="item.posa_delivery_date"
+                      model-type="format"
+                      format="dd-MM-yyyy"
+                      :min-date="new Date()"
+                      auto-apply
+                      :dark="isDarkTheme"
+                      @update:model-value="validateDueDate(item)"
+                    />
+                  </div>
                 </div>
               </div>
               

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -117,6 +117,9 @@ export default {
     // Create a new item object with default and calculated fields
     get_new_item(item) {
       const new_item = { ...item };
+      if (!new_item.warehouse) {
+        new_item.warehouse = this.pos_profile.warehouse;
+      }
       if (!item.qty) {
         item.qty = 1;
       }


### PR DESCRIPTION
## Summary
- restore removed fields in expanded item rows such as available quantity and batch details
- default warehouse to POS profile when adding items

## Testing
- `yarn install`

------
https://chatgpt.com/codex/tasks/task_e_686bd2e5411483268a74f35eb4b0232d