### PR TITLE
Allow multiple serial number selection

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -90,6 +90,7 @@
           :currencySymbol="currencySymbol" :isNumber="isNumber" :setFormatedQty="setFormatedQty"
           :calcStockQty="calc_stock_qty" :setFormatedCurrency="setFormatedCurrency" :calcPrices="calc_prices"
           :calcUom="calc_uom" :removeItem="remove_item" :subtractOne="subtract_one" :addOne="add_one"
+          :setSerialNo="update_serial_no" :setBatchQty="set_batch_qty"
           @update:expanded="expanded = $event" @reorder-items="handleItemReorder" @add-item-from-drag="handleItemDrop"
           @show-drop-feedback="showDropFeedback" @item-dropped="showDropFeedback(false)" />
       </div>

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -150,8 +150,8 @@
               <div class="form-row" v-if="item.has_serial_no || item.has_batch_no">
                 <div class="form-field" v-if="item.has_serial_no">
                   <v-autocomplete density="compact" variant="outlined" color="primary" :label="frappe._('Serial Numbers')"
-                    :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details clearable
-                    v-model="item.serial_no" :items="item.serial_no_data" item-title="serial_no" item-value="serial_no"
+                    :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field" hide-details clearable multiple chips
+                    v-model="item.serial_no_selected" :items="item.serial_no_data" item-title="serial_no" item-value="serial_no"
                     @update:model-value="setSerialNo(item, $event)" :disabled="!!item.posa_is_replace"
                     prepend-inner-icon="mdi-numeric"></v-autocomplete>
                 </div>

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -2051,6 +2051,19 @@ export default {
       }
     },
 
+    // Update serial numbers selection for an item
+    update_serial_no(item, value) {
+      if (!item) return;
+      if (Array.isArray(value)) {
+        item.serial_no_selected = value;
+      } else if (value) {
+        item.serial_no_selected = [value];
+      } else {
+        item.serial_no_selected = [];
+      }
+      this.set_serial_no(item);
+    },
+
     // Set batch number for an item (and update batch data)
     set_batch_qty(item, value, update = true) {
       console.log('Setting batch quantity:', item, value);


### PR DESCRIPTION
## Summary
- enable multiple selection for serial numbers in items table
- wire ItemsTable to update serial numbers via new update method
- add helper method to update selected serial numbers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bf7ebecac832693c11d9a57d73c9e