### PR TITLE
Fix multiple serial number selection

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -195,10 +195,20 @@
                 </div>
                 <div class="form-row">
                   <div class="form-field full-width">
-                    <v-autocomplete v-model="item.serial_no_selected" :items="item.serial_no_data" item-title="serial_no"
-                      variant="outlined" density="compact" chips color="primary" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field"
+                    <v-autocomplete
+                      v-model="item.serial_no_selected"
+                      :items="item.serial_no_data"
+                      item-title="serial_no"
+                      item-value="serial_no"
+                      variant="outlined"
+                      density="compact"
+                      chips
+                      color="primary"
+                      :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+                      class="dark-field"
                       :label="frappe._('Serial No')" multiple
-                      @update:model-value="setSerialNo(item)"></v-autocomplete>
+                      @update:model-value="setSerialNo(item)"
+                    ></v-autocomplete>
                   </div>
                 </div>
               </div>

--- a/posawesome/public/js/posapp/components/pos/invoice-item/itemAddition.js
+++ b/posawesome/public/js/posapp/components/pos/invoice-item/itemAddition.js
@@ -169,6 +169,10 @@ export default {
       new_item.posa_notes = "";
       new_item.posa_delivery_date = "";
       new_item.posa_row_id = this.makeid(20);
+      if (new_item.has_serial_no && !new_item.serial_no_selected) {
+        new_item.serial_no_selected = [];
+        new_item.serial_no_selected_count = 0;
+      }
       // Expand row if batch/serial required
       if (
         (!this.pos_profile.posa_auto_set_batch && new_item.has_batch_no) ||

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -175,6 +175,10 @@ export default {
       new_item.posa_notes = "";
       new_item.posa_delivery_date = "";
       new_item.posa_row_id = this.makeid(20);
+      if (new_item.has_serial_no && !new_item.serial_no_selected) {
+        new_item.serial_no_selected = [];
+        new_item.serial_no_selected_count = 0;
+      }
       // Expand row if batch/serial required
       if (
         (!this.pos_profile.posa_auto_set_batch && new_item.has_batch_no) ||


### PR DESCRIPTION
## Summary
- allow the serial number autocomplete to return values instead of objects
- initialise `serial_no_selected` when adding items