### PR TITLE
Fix Sales Order payment entries

### DIFF
--- a/posawesome/posawesome/api/sales_orders.py
+++ b/posawesome/posawesome/api/sales_orders.py
@@ -6,7 +6,9 @@ import json
 import frappe
 from erpnext.accounts.party import get_party_account
 from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
-from frappe.utils import nowdate
+from frappe.utils import getdate, nowdate
+
+from posawesome.posawesome.api.payment_entry import create_payment_entry
 
 
 @frappe.whitelist()
@@ -32,10 +34,37 @@ def search_orders(company, currency, order_name=None):
     return data
 
 
+def _map_delivery_dates(data):
+    """Ensure mandatory delivery_date fields are populated."""
+    def parse_date(value):
+        if not value:
+            return None
+        try:
+            return str(getdate(value))
+        except Exception:
+            return None
+
+    # Map order level delivery date
+    if not data.get("delivery_date") and data.get("posa_delivery_date"):
+        parsed = parse_date(data.get("posa_delivery_date"))
+        if parsed:
+            data["delivery_date"] = parsed
+
+    # Map item level delivery dates
+    for item in data.get("items", []):
+        if not item.get("delivery_date"):
+            delivery = item.get("posa_delivery_date") or data.get("delivery_date")
+            parsed = parse_date(delivery)
+            if parsed:
+                item["delivery_date"] = parsed
+
+
+
 @frappe.whitelist()
 def update_sales_order(data):
     """Create or update a Sales Order document."""
     data = json.loads(data)
+    _map_delivery_dates(data)
     if data.get("name") and frappe.db.exists("Sales Order", data.get("name")):
         so_doc = frappe.get_doc("Sales Order", data.get("name"))
         so_doc.update(data)
@@ -55,28 +84,28 @@ def _create_payment_entries(so_doc, payments):
         if not pay.get("amount"):
             continue
 
-        debit_to = get_party_account("Customer", so_doc.customer, so_doc.company)
-        pe = frappe.get_doc({
-            "doctype": "Payment Entry",
-            "posting_date": nowdate(),
-            "payment_type": "Receive",
-            "party_type": "Customer",
-            "party": so_doc.customer,
-            "paid_amount": pay.get("amount"),
-            "received_amount": pay.get("amount"),
-            "paid_from": debit_to,
-            "paid_to": pay.get("account"),
-            "company": so_doc.company,
-            "mode_of_payment": pay.get("mode_of_payment"),
-            "reference_no": so_doc.get("posa_pos_opening_shift"),
-            "reference_date": nowdate(),
-        })
+        # Create payment entry using helper to ensure exchange rates are set
+        pe = create_payment_entry(
+            company=so_doc.company,
+            customer=so_doc.customer,
+            amount=pay.get("amount"),
+            currency=pay.get("currency") or so_doc.currency,
+            mode_of_payment=pay.get("mode_of_payment"),
+            reference_no=so_doc.get("posa_pos_opening_shift"),
+            reference_date=nowdate(),
+            posting_date=nowdate(),
+            submit=0,
+        )
 
-        pe.append("references", {
-            "allocated_amount": pay.get("amount"),
-            "reference_doctype": "Sales Order",
-            "reference_name": so_doc.name,
-        })
+        # Link payment entry to the sales order
+        pe.append(
+            "references",
+            {
+                "allocated_amount": pay.get("amount"),
+                "reference_doctype": "Sales Order",
+                "reference_name": so_doc.name,
+            },
+        )
 
         pe.flags.ignore_permissions = True
         frappe.flags.ignore_account_permission = True
@@ -88,6 +117,7 @@ def _create_payment_entries(so_doc, payments):
 def submit_sales_order(order):
     """Submit sales order and create payment entries."""
     order = json.loads(order)
+    _map_delivery_dates(order)
     if order.get("name") and frappe.db.exists("Sales Order", order.get("name")):
         so_doc = frappe.get_doc("Sales Order", order.get("name"))
         so_doc.update(order)

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -313,13 +313,13 @@
     <v-card flat class="cards mb-0 mt-3 py-0">
       <v-row align="start" no-gutters>
         <v-col cols="6">
-          <v-btn block size="large" color="primary" theme="dark" @click="submit" :disabled="vaildatPayment">
+          <v-btn block size="large" color="primary" theme="dark" @click="submit" :loading="loading" :disabled="loading || vaildatPayment">
             {{ __("Submit") }}
           </v-btn>
         </v-col>
         <v-col cols="6" class="pl-1">
           <v-btn block size="large" color="success" theme="dark" @click="submit(undefined, false, true)"
-            :disabled="vaildatPayment">
+            :loading="loading" :disabled="loading || vaildatPayment">
             {{ __("Submit & Print") }}
           </v-btn>
         </v-col>
@@ -836,6 +836,7 @@ export default {
         return;
       }
       // Proceed to submit the invoice
+      this.loading = true;
       this.submit_invoice(print);
     },
     // Submit invoice to backend after all validations
@@ -878,12 +879,14 @@ export default {
           vm.eventBus.emit("clear_invoice");
           vm.eventBus.emit("reset_posting_date");
           vm.back_to_invoice();
+          vm.loading = false;
           return;
         } catch (error) {
           vm.eventBus.emit("show_message", {
             title: __("Cannot Save Offline Invoice: ") + (error.message || __("Unknown error")),
             color: "error"
           });
+          vm.loading = false;
           return;
         }
       }
@@ -927,6 +930,7 @@ export default {
                 color: "error",
               });
             }
+            vm.loading = false;
             return;
           }
           if (!r.message) {
@@ -934,6 +938,7 @@ export default {
               title: __("Error submitting invoice: No response from server"),
               color: "error",
             });
+            vm.loading = false;
             return;
           }
           if (print) {
@@ -960,6 +965,7 @@ export default {
           vm.eventBus.emit("clear_invoice");
           vm.eventBus.emit("reset_posting_date");
           vm.back_to_invoice();
+          vm.loading = false;
         }
       });
     },

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1080,6 +1080,14 @@ export default {
 
         let invoice_doc;
         if (
+          this.invoiceType === "Order" &&
+          this.pos_profile.posa_create_only_sales_order &&
+          !this.new_delivery_date &&
+          !this.invoice_doc.posa_delivery_date
+        ) {
+          console.log('Building local Sales Order doc for payment');
+          invoice_doc = this.get_invoice_doc();
+        } else if (
           this.invoice_doc.doctype == "Sales Order" &&
           !this.pos_profile.posa_create_only_sales_order
         ) {


### PR DESCRIPTION
## Summary
- map `posa_delivery_date` to mandatory `delivery_date` when saving sales orders
- create payment entries using helper to set exchange rates
- allow pay screen without delivery date
- block repeated submit until request completes