### PR TITLE
Fix Dexie undefined

### DIFF
--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -1,5 +1,6 @@
 import { createVuetify } from "vuetify";
 import { createApp } from "vue";
+import Dexie from "dexie";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import eventBus from "./bus";
@@ -7,6 +8,11 @@ import themePlugin from "./plugins/theme.js";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import Home from "./Home.vue";
+
+// Expose Dexie globally for libraries that expect a global Dexie instance
+if (typeof window !== "undefined" && !window.Dexie) {
+    window.Dexie = Dexie;
+}
 
 frappe.provide("frappe.PosApp");
 


### PR DESCRIPTION
## Summary
- expose Dexie as a global before loading Vue components