### PR TITLE
Fix invoice creation from sales orders in create-only mode

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -496,6 +496,13 @@ export default {
       } else {
         doc.doctype = "Sales Invoice";
       }
+
+      if (
+        doc.doctype === "Sales Invoice" &&
+        this.invoice_doc.doctype === "Sales Order"
+      ) {
+        delete doc.name;
+      }
       doc.is_pos = 1;
       doc.ignore_pricing_rule = 1;
       doc.company = doc.company || this.pos_profile.company;


### PR DESCRIPTION
## Summary
- ensure invoice creation from a Sales Order works when `Create Only Sales Order` is enabled by clearing the stale `name`