### PR TITLE
Fix responsive layout for price rows

### DIFF
--- a/posawesome/public/js/posapp/components/pos/DeliveryCharges.vue
+++ b/posawesome/public/js/posapp/components/pos/DeliveryCharges.vue
@@ -1,6 +1,10 @@
 <template>
-  <v-row align="center" class="items px-3 py-2 mt-0" v-if="pos_profile.posa_use_delivery_charges">
-    <v-col cols="8" class="pb-0 mb-0 pr-0 pt-0">
+  <v-row
+    align="center"
+    class="items px-3 py-2 mt-0"
+    v-if="pos_profile.posa_use_delivery_charges"
+  >
+    <v-col cols="12" sm="8" class="pb-0 mb-0 pr-0 pt-0">
       <v-autocomplete density="compact" clearable auto-select-first variant="solo" color="primary"
         :label="frappe._('Delivery Charges')" v-model="internal_selected_delivery_charge" :items="delivery_charges"
         item-title="name" item-value="name" return-object
@@ -16,7 +20,7 @@
         </template>
       </v-autocomplete>
     </v-col>
-    <v-col cols="4" class="pb-0 mb-0 pt-0">
+    <v-col cols="12" sm="4" class="pb-0 mb-0 pt-0">
       <v-text-field density="compact" variant="solo" color="primary"
         :label="frappe._('Delivery Charges Rate')"
         :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -1068,6 +1068,7 @@ export default {
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  flex-wrap: nowrap;
 }
 
 /* Style for balance value text */

--- a/posawesome/public/js/posapp/components/pos/MultiCurrencyRow.vue
+++ b/posawesome/public/js/posapp/components/pos/MultiCurrencyRow.vue
@@ -1,19 +1,19 @@
 <template>
   <v-row align="center" class="items px-3 py-2 mt-0" v-if="pos_profile.posa_allow_multi_currency">
-    <v-col cols="4" class="pb-2">
+    <v-col cols="12" sm="4" class="pb-2">
       <v-select density="compact" variant="solo" color="primary" :label="frappe._('Currency')"
         :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
         v-model="internal_selected_currency" :items="available_currencies"
         @update:model-value="onCurrencyUpdate"></v-select>
     </v-col>
-    <v-col cols="4" class="pb-2">
+    <v-col cols="12" sm="4" class="pb-2">
       <v-text-field density="compact" variant="solo" color="primary"
         :label="'Price List ' + price_list_currency + ' to ' + internal_selected_currency"
         :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
         v-model="internal_plc_rate" :rules="[isNumber]"
         @change="onPlcRateChange"></v-text-field>
     </v-col>
-    <v-col cols="4" class="pb-2">
+    <v-col cols="12" sm="4" class="pb-2">
       <v-text-field density="compact" variant="solo" color="primary"
         :label="frappe._('Conversion Rate')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
         v-model="internal_conversion_rate" :rules="[isNumber]"

--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row align="center" class="items px-3 py-2 mt-0" v-if="pos_profile.posa_allow_change_posting_date">
-    <v-col cols="4" class="pb-2">
+    <v-col cols="12" sm="4" class="pb-2">
       <VueDatePicker
         v-model="internal_posting_date_display"
         model-type="format"
@@ -12,7 +12,7 @@
         @update:model-value="onUpdate"
       />
     </v-col>
-    <v-col v-if="pos_profile.posa_enable_price_list_dropdown" cols="6" class="pb-2 d-flex align-center">
+    <v-col v-if="pos_profile.posa_enable_price_list_dropdown" cols="12" sm="6" class="pb-2 d-flex align-center">
       <v-select
         density="comfortable"
         variant="solo"
@@ -34,7 +34,7 @@
     </v-col>
     <v-col
       v-else-if="pos_profile.posa_show_customer_balance"
-      cols="8"
+      cols="12" sm="8"
       class="pb-2 d-flex align-center"
     >
       <div class="balance-field">


### PR DESCRIPTION
## Summary
- keep Delivery Charges fields in a row until screen is narrow
- make Posting Date and Price List rows responsive
- make multi-currency row responsive
- avoid wrapping of customer balance text