### PR TITLE
Fix column button overlap

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -1161,6 +1161,7 @@ export default {
 
 .items-table-wrapper {
   position: relative;
+  margin-top: var(--dynamic-xl);
 }
 
 /* New styles for improved column switches */
@@ -1179,5 +1180,4 @@ export default {
 
 :deep(.column-switch .v-label) {
   opacity: 0.9;
-  font-size: 0.95rem;
-}</style>
+  font-size: 0.95rem;}</style>


### PR DESCRIPTION
## Summary
- adjust items table wrapper margin so the column button doesn't overlap customer balance