### PR TITLE
Fix offline taxes for inclusive/exclusive settings

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -23,6 +23,7 @@ export const memory = {
         price_list_cache: {},
         item_details_cache: {},
         tax_template: [],
+        tax_inclusive: false,
         manual_offline: false,
 };
 
@@ -138,16 +139,22 @@ export function setOpeningDialogStorage(data) {
         }
 }
 
-export function setTaxTemplate(taxes) {
+export function setTaxTemplate(taxes, inclusive = false) {
         try {
                 const clean = Array.isArray(taxes)
                         ? JSON.parse(JSON.stringify(taxes))
                         : [];
                 memory.tax_template = clean;
+                memory.tax_inclusive = !!inclusive;
                 persist("tax_template", memory.tax_template);
+                persist("tax_inclusive", memory.tax_inclusive);
         } catch (e) {
                 console.error("Failed to set tax template", e);
         }
+}
+
+export function getTaxInclusive() {
+        return memory.tax_inclusive || false;
 }
 
 export function getTaxTemplate() {
@@ -232,9 +239,10 @@ export async function clearAllCache() {
 	memory.pos_opening_storage = null;
 	memory.opening_dialog_storage = null;
 	memory.sales_persons_storage = [];
-	memory.price_list_cache = {};
-	memory.item_details_cache = {};
-	memory.manual_offline = false;
+        memory.price_list_cache = {};
+        memory.item_details_cache = {};
+        memory.tax_inclusive = false;
+        memory.manual_offline = false;
 }
 
 /**

--- a/posawesome/public/js/offline/index.js
+++ b/posawesome/public/js/offline/index.js
@@ -26,6 +26,7 @@ export {
         setOpeningDialogStorage,
         setTaxTemplate,
         getTaxTemplate,
+        getTaxInclusive,
         setLastSyncTotals,
         getLastSyncTotals,
         isManualOffline,

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -92,7 +92,7 @@ export default {
             this.pos_profile = r.message.pos_profile;
             this.pos_opening_shift = r.message.pos_opening_shift;
             this.get_offers(this.pos_profile.name);
-            setTaxTemplate(this.pos_profile.taxes || []);
+            setTaxTemplate(this.pos_profile.taxes || [], this.pos_profile.posa_tax_inclusive);
             this.eventBus.emit('register_pos_profile', r.message);
             this.eventBus.emit('set_company', r.message.company);
             try {
@@ -112,7 +112,7 @@ export default {
               this.pos_profile = data.pos_profile;
               this.pos_opening_shift = data.pos_opening_shift;
               this.get_offers(this.pos_profile.name);
-              setTaxTemplate(this.pos_profile.taxes || []);
+              setTaxTemplate(this.pos_profile.taxes || [], this.pos_profile.posa_tax_inclusive);
               this.eventBus.emit('register_pos_profile', data);
               this.eventBus.emit('set_company', data.company);
               try {
@@ -132,7 +132,7 @@ export default {
             this.pos_profile = data.pos_profile;
             this.pos_opening_shift = data.pos_opening_shift;
             this.get_offers(this.pos_profile.name);
-            setTaxTemplate(this.pos_profile.taxes || []);
+            setTaxTemplate(this.pos_profile.taxes || [], this.pos_profile.posa_tax_inclusive);
             this.eventBus.emit('register_pos_profile', data);
             this.eventBus.emit('set_company', data.company);
             try {


### PR DESCRIPTION
## Summary
- store tax inclusive flag in offline cache
- export the flag helper and use it to compute taxes in offline mode
- send POS profile tax inclusive flag to offline cache