### PR TITLE
Fix payment dialog trigger timing

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1219,7 +1219,9 @@ export default {
 
         console.log('Showing payment dialog with currency:', invoice_doc.currency);
         this.eventBus.emit("show_payment", "true");
-        this.eventBus.emit("send_invoice_doc_payment", invoice_doc);
+        this.$nextTick(() => {
+          this.eventBus.emit("send_invoice_doc_payment", invoice_doc);
+        });
 
       } catch (error) {
         console.error('Error in show_payment:', error);


### PR DESCRIPTION
## Summary
- ensure the payment data event fires after payment view mounts
