### PR TITLE
Add frontend build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ After switching branches or pulling latest changes:
 2. git pull
 3. yarn install
 4. cd ../..
-5. bench build --app posawesome
-6. bench --site your.site migrate
+5. yarn build
+6. bench build --app posawesome
+7. bench --site your.site migrate
    - If the build exits with code 143, verify that your system has enough RAM or swap space.
    - You can also try building the app in smaller parts to reduce memory usage.
 
@@ -67,10 +68,11 @@ After switching branches or pulling latest changes:
 
 1. `bench get-app --branch Version-15 https://github.com/defendicon/POS-Awesome-V15`
 2. `bench setup requirements`
-3. `bench build --app posawesome`
-4. `bench restart`
-5. `bench --site [your.site.name] install-app posawesome`
-6. `bench --site [your.site.name] migrate`
+3. `yarn build`
+4. `bench build --app posawesome`
+5. `bench restart`
+6. `bench --site [your.site.name] install-app posawesome`
+7. `bench --site [your.site.name] migrate`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "posawesome",
   "scripts": {
     "dev": "vite",
-    "prebuild": "npm install"
+    "prebuild": "npm install",
+    "build": "vite build --config posawesome/frontend/vite.config.js"
   },
   "dependencies": {
     "@vuepic/vue-datepicker": "11.0.2",


### PR DESCRIPTION
## Summary
- add a dedicated build script in `package.json`
- instruct users to run `yarn build` before running `bench build`

## Testing
- `yarn build` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_686ff7a4eff08326864115f067758e98