### PR TITLE
Fix Vite build path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ tags
 posawesome/docs/current
 node_modules
 posawesome/public/dist
+posawesome/public/frontend
 /dist

--- a/posawesome/frontend/vite.config.js
+++ b/posawesome/frontend/vite.config.js
@@ -4,6 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
 
 export default defineConfig({
+    root: __dirname,
     plugins: [
         vue(),
         VitePWA({
@@ -11,7 +12,10 @@ export default defineConfig({
             strategies: 'injectManifest',
             srcDir: 'src',
             filename: 'sw.js',
-            injectRegister: null
+            injectRegister: null,
+            injectManifest: {
+                injectionPoint: null
+            }
         })
     ],
     resolve: {


### PR DESCRIPTION
## Summary
- fix PWA build issues by setting `root` in Vite config and disabling workbox injection
- ignore built frontend assets

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_686ffb4e7f508326b3c051d3a694b5c6