### PR TITLE
Fix build output name for POSAwesome

### DIFF
--- a/posawesome/frontend/vite.config.js
+++ b/posawesome/frontend/vite.config.js
@@ -27,7 +27,16 @@ export default defineConfig({
         // Output compiled assets to the Frappe app's public directory
         outDir: '../posawesome/public/frontend',
         emptyOutDir: true,
-        sourcemap: true
+        sourcemap: true,
+        rollupOptions: {
+            output: {
+                // Keep a stable filename so hooks.py and the service worker
+                // can reference the built file consistently
+                entryFileNames: 'main.js',
+                chunkFileNames: 'assets/[name]-[hash].js',
+                assetFileNames: 'assets/[name]-[hash][extname]',
+            }
+        }
     },
     server: {
         port: 8080,


### PR DESCRIPTION
## Summary
- ensure Vite build generates a stable `main.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ffe92a79c8326b1caf7cf8e6efca5