### PR TITLE
Improve debugging for missing frontend build

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ The Vue frontend is built using Vite. Its configuration file is located at
 
 1. `bench get-app --branch Version-15 https://github.com/defendicon/POS-Awesome-V15`
 2. `bench setup requirements`
-3. `bench build --app posawesome`
-4. `bench restart`
-5. `bench --site [your.site.name] install-app posawesome`
-6. `bench --site [your.site.name] migrate`
+3. `cd apps/posawesome && yarn install && cd ../..`
+4. `yarn build`
+5. `bench build --app posawesome`
+6. `bench restart`
+7. `bench --site [your.site.name] install-app posawesome`
+8. `bench --site [your.site.name] migrate`
 
 ---
 

--- a/posawesome/posawesome/page/posapp/posapp.js
+++ b/posawesome/posawesome/page/posapp/posapp.js
@@ -2,6 +2,15 @@
 frappe.pages['posapp'].on_page_load = async function (wrapper) {
         await setupLanguage();
 
+        if (!(frappe.PosApp && frappe.PosApp.posapp)) {
+                console.error(
+                        'frappe.PosApp.posapp is undefined. ' +
+                        'Ensure that "/assets/posawesome/frontend/main.js" exists ' +
+                        'and that you ran `yarn build && bench build --app posawesome`.'
+                );
+                return;
+        }
+
         var page = frappe.ui.make_app_page({
                 parent: wrapper,
                 title: 'POS Awesome',


### PR DESCRIPTION
## Summary
- log a clear error if `frappe.PosApp.posapp` isn't available during page load

## Testing
- `pytest -q`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68700246b8388326a6d126e025020765