### PR TITLE
Fix frontend build path

### DIFF
--- a/posawesome/frontend/vite.config.js
+++ b/posawesome/frontend/vite.config.js
@@ -25,7 +25,11 @@ export default defineConfig({
     },
     build: {
         // Output compiled assets to the Frappe app's public directory
-        outDir: '../posawesome/public/frontend',
+        // The compiled assets should end up in the app's "public" folder
+        // Using a relative path of "../public/frontend" keeps a single
+        // "posawesome/public" directory instead of creating a nested
+        // "posawesome/posawesome/public" tree.
+        outDir: '../public/frontend',
         emptyOutDir: true,
         sourcemap: true,
         rollupOptions: {


### PR DESCRIPTION
## Summary
- correct `outDir` in `vite.config.js` so built files go to `posawesome/public/frontend`

## Testing
- `ruff check posawesome` *(fails: Found 441 errors)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687006c5bed48326a4dff90c0ee32283