### PR TITLE
Ensure tax inclusive flag refreshes online

### DIFF
--- a/posawesome/posawesome/page/posapp/posapp.js
+++ b/posawesome/posawesome/page/posapp/posapp.js
@@ -50,22 +50,8 @@ frappe.pages['posapp'].on_page_load = async function (wrapper) {
                                 }
                         };
 
-                        if (cachedValue !== null) {
-                                try {
-                                        const val = JSON.parse(cachedValue);
-                                        applySetting(val);
-                                        import('/assets/posawesome/js/offline/index.js').then(m => {
-                                                if (m && m.setTaxInclusiveSetting) {
-                                                        m.setTaxInclusiveSetting(val);
-                                                }
-                                        }).catch(() => {});
-                                        return;
-                                } catch (e) {
-                                        console.warn('Failed to parse cached tax inclusive value', e);
-                                }
-                        }
-
-                        frappe.call({
+                        const fetchAndCache = () => {
+                                frappe.call({
                                 method: 'frappe.get_cached_value',
                                 args: {
                                         doctype: 'POS Profile',
@@ -91,6 +77,29 @@ frappe.pages['posapp'].on_page_load = async function (wrapper) {
                                        }
                                }
                        });
+                        };
+
+                        if (navigator.onLine) {
+                                fetchAndCache();
+                                return;
+                        }
+
+                        if (cachedValue !== null) {
+                                try {
+                                        const val = JSON.parse(cachedValue);
+                                        applySetting(val);
+                                        import('/assets/posawesome/js/offline/index.js').then(m => {
+                                                if (m && m.setTaxInclusiveSetting) {
+                                                        m.setTaxInclusiveSetting(val);
+                                                }
+                                        }).catch(() => {});
+                                } catch (e) {
+                                        console.warn('Failed to parse cached tax inclusive value', e);
+                                }
+                                return;
+                        }
+
+                        fetchAndCache();
                 };
 
                 update_totals_based_on_tax_inclusive();


### PR DESCRIPTION
## Summary
- check network before using cached tax inclusive flag in posapp
- refresh the cached tax flag when POS profile registers or network reconnects
- add `refreshTaxInclusiveSetting` helper

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687099846c488326bcd7e84bd009e3a2