### PR TITLE
UI: maintain dark card color

### DIFF
--- a/posawesome/public/css/responsive.css
+++ b/posawesome/public/css/responsive.css
@@ -57,7 +57,7 @@
   --table-row-hover: rgba(25, 118, 210, 0.05);
   
   /* Form field colors */
-  --field-bg: #ffffff;
+  --field-bg: var(--surface-secondary);
   --field-border: #e0e0e0;
   --field-focus: rgba(25, 118, 210, 0.1);
 }
@@ -112,7 +112,7 @@ body {
   --table-row-hover: rgba(187, 134, 252, 0.1);
   
   /* Form field colors */
-  --field-bg: #1E1E1E;
+  --field-bg: var(--surface-secondary);
   --field-border: #373737;
   --field-focus: rgba(187, 134, 252, 0.1);
 }
@@ -261,6 +261,12 @@ body {
   background-color: var(--surface-secondary);
 }
 
+/* Keep cards dark in dark theme */
+:root.dark-theme .cards,
+.v-theme--dark .cards {
+  background-color: #121212;
+}
+
 /* ===== COMMON TABLE STYLES ===== */
 .pos-table {
   border-radius: var(--border-radius-lg);
@@ -333,6 +339,16 @@ body {
 
 .pos-form-field .v-field__overlay {
   background-color: var(--field-bg);
+}
+
+/* Background color for fields to match item selector */
+.dark-field {
+  background-color: var(--surface-secondary) !important;
+}
+
+:root.dark-theme .dark-field,
+.v-theme--dark .dark-field {
+  background-color: #1E1E1E !important;
 }
 
 /* ===== SLEEK FIELD STYLES ===== */

--- a/posawesome/public/js/posapp/components/payments/Pay.vue
+++ b/posawesome/public/js/posapp/components/payments/Pay.vue
@@ -29,7 +29,7 @@
             </v-row>
             <v-row align="center" no-gutters class="mb-1">
               <v-col md="4" cols="12">
-                <v-select density="compact" variant="outlined" hide-details clearable
+                <v-select density="compact" variant="outlined" hide-details clearable class="dark-field"
                   :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" v-model="pos_profile_search" :items="pos_profiles_list"
                   item-value="name" label="Select POS Profile"></v-select>
               </v-col>
@@ -123,12 +123,12 @@
             <v-row align="center" no-gutters class="mb-1">
               <v-col md="4" cols="12" class="mr-1">
                 <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Search by Name')"
-                  :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" hide-details v-model="mpesa_search_name"
+                  :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" hide-details class="dark-field" v-model="mpesa_search_name"
                   clearable></v-text-field>
               </v-col>
               <v-col md="4" cols="12" class="mr-1">
                 <v-text-field density="compact" variant="outlined" color="primary" :label="frappe._('Search by Mobile')"
-                  :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" hide-details v-model="mpesa_search_mobile"
+                  :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" hide-details class="dark-field" v-model="mpesa_search_mobile"
                   clearable></v-text-field>
               </v-col>
               <v-col> </v-col>

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -254,8 +254,8 @@
           <v-col cols="6" v-if="is_credit_sale">
             <VueDatePicker v-model="new_credit_due_date" model-type="format" format="dd-MM-yyyy" :min-date="new Date()"
               auto-apply :dark="isDarkTheme" class="dark-field sleek-field" @update:model-value="update_credit_due_date()" />
-            <v-text-field class="mt-2" density="compact" variant="solo" type="number" min="0" max="365"
-              v-model.number="credit_due_days" :label="frappe._('Days until due')" hide-details
+            <v-text-field class="mt-2 dark-field sleek-field" density="compact" variant="solo" type="number" min="0" max="365"
+              :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" v-model.number="credit_due_days" :label="frappe._('Days until due')" hide-details
               @change="applyDuePreset(credit_due_days)"></v-text-field>
             <div class="mt-1">
               <v-chip v-for="d in credit_due_presets" :key="d" size="small" class="ma-1" variant="solo"
@@ -340,6 +340,7 @@
         <v-card-text class="pa-0">
           <v-container>
             <v-text-field density="compact" variant="solo" type="number" min="0" max="365"
+              class="dark-field sleek-field" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
               v-model.number="custom_days_value" :label="frappe._('Days')" hide-details></v-text-field>
           </v-container>
         </v-card-text>


### PR DESCRIPTION
## Summary
- keep card background black in dark theme so only field colors change

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687155a332548326977ea3afeaeef7c3