### PR TITLE
Fix header alignment for item table

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -244,12 +244,12 @@ export default {
       // Define all available columns
       this.available_columns = [
         { title: __('Name'), align: 'start', sortable: true, key: 'item_name', required: true },
-        { title: __('QTY'), key: 'qty', align: 'center', required: true },
+        { title: __('QTY'), key: 'qty', align: 'start', required: true },
         { title: __('UOM'), key: 'uom', align: 'center', required: false },
-        { title: __('Rate'), key: 'rate', align: 'center', required: true },
-        { title: __('Discount %'), key: 'discount_value', align: 'center', required: false },
-        { title: __('Discount Amount'), key: 'discount_amount', align: 'center', required: false },
-        { title: __('Amount'), key: 'amount', align: 'center', required: true },
+        { title: __('Rate'), key: 'rate', align: 'start', required: true },
+        { title: __('Discount %'), key: 'discount_value', align: 'start', required: false },
+        { title: __('Discount Amount'), key: 'discount_amount', align: 'start', required: false },
+        { title: __('Amount'), key: 'amount', align: 'start', required: true },
         { title: __('Offer?'), key: 'posa_is_offer', align: 'center', required: false },
       ];
 

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -633,7 +633,7 @@ export default {
 .currency-display {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .currency-symbol {
@@ -644,7 +644,7 @@ export default {
 
 .amount-value {
   font-weight: 500;
-  text-align: right;
+  text-align: left;
 }
 
 /* Drag and drop styles */


### PR DESCRIPTION
## Summary
- left align item table headers and numeric values

## Testing
- `yarn install`
- `npx eslint posawesome/public/js/posapp/components/pos/Invoice.vue posawesome/public/js/posapp/components/pos/ItemsTable.vue` *(fails: ConfigError: Key "plugins": Cannot redefine plugin "vue")*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871653c9bc88326ae50cb52410c49d2