### PR TITLE
Fix dark mode for shift dialogs

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
@@ -32,7 +32,8 @@
                   <template v-slot:item.closing_amount="props">
                     <v-text-field v-model="props.item.closing_amount" :rules="[max25chars]" :label="frappe._('Edit')"
                       single-line counter type="number" density="compact" variant="outlined" color="primary"
-                      bg-color="white" hide-details :prefix="currencySymbol(pos_profile.currency)"></v-text-field>
+                      :bg-color="isDarkTheme ? '#1E1E1E' : 'white'" hide-details
+                      :prefix="currencySymbol(pos_profile.currency)"></v-text-field>
                   </template>
                   <template v-slot:item.difference="{ item }">
                     {{ currencySymbol(pos_profile.currency) }}
@@ -105,6 +106,11 @@ export default {
     pagination: {},
   }),
   watch: {},
+  computed: {
+    isDarkTheme() {
+      return this.$theme?.current === 'dark';
+    }
+  },
 
   methods: {
     close_dialog() {
@@ -149,8 +155,8 @@ export default {
 <style scoped>
 /* Enhanced Header Styles */
 .closing-header {
-  background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-  border-bottom: 1px solid #e0e0e0;
+  background: linear-gradient(135deg, var(--dialog-bg-start) 0%, var(--dialog-bg-end) 100%);
+  border-bottom: 1px solid var(--dialog-border);
   padding: 24px !important;
 }
 
@@ -183,24 +189,24 @@ export default {
 .header-title {
   font-size: 1.5rem;
   font-weight: 600;
-  color: #1a1a1a;
+  color: var(--text-primary);
   margin: 0 0 4px 0;
   line-height: 1.2;
 }
 
 .header-subtitle {
   font-size: 0.95rem;
-  color: #666;
+  color: var(--text-secondary);
   margin: 0;
   font-weight: 400;
 }
 
 .header-divider {
-  border-color: #e0e0e0;
+  border-color: var(--dialog-border);
 }
 
 .white-background {
-  background-color: #ffffff;
+  background-color: var(--surface-primary);
 }
 
 .table-header {
@@ -208,14 +214,14 @@ export default {
 }
 
 .white-table {
-  background-color: white;
-  border: 1px solid #e0e0e0;
+  background-color: var(--surface-primary);
+  border: 1px solid var(--dialog-border);
 }
 
 /* Action Buttons */
 .dialog-actions-container {
-  background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-  border-top: 1px solid #e0e0e0;
+  background: linear-gradient(135deg, var(--dialog-bg-start) 0%, var(--dialog-bg-end) 100%);
+  border-top: 1px solid var(--dialog-border);
   padding: 16px 24px;
   gap: 12px;
 }

--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -237,8 +237,8 @@ export default {
 .opening-dialog-card {
   border-radius: 16px;
   overflow: hidden;
-  background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-  border: 1px solid rgba(25, 118, 210, 0.1);
+  background: linear-gradient(135deg, var(--dialog-bg-start) 0%, var(--dialog-bg-end) 100%);
+  border: 1px solid var(--dialog-border);
   transition: all 0.3s ease;
   max-height: 90vh;
   display: flex;
@@ -247,10 +247,10 @@ export default {
 
 /* Header Section - White Background with Blue Text */
 .opening-dialog-header {
-  background: white;
+  background: var(--surface-primary);
   color: #1976d2;
   padding: 16px 24px;
-  border-bottom: 2px solid rgba(25, 118, 210, 0.1);
+  border-bottom: 2px solid var(--dialog-border);
   flex-shrink: 0;
 }
 
@@ -284,7 +284,7 @@ export default {
   font-weight: 600;
   margin: 0;
   line-height: 1.2;
-  color: #1976d2;
+  color: var(--text-primary);
 }
 
 .header-subtitle {
@@ -292,13 +292,13 @@ export default {
   opacity: 0.8;
   margin: 2px 0 0 0;
   line-height: 1.3;
-  color: #1976d2;
+  color: var(--text-secondary);
 }
 
 /* Content Section - Optimized for minimal scrolling */
 .opening-dialog-content {
   padding: 20px 24px;
-  background: white;
+  background: var(--surface-primary);
   flex: 1;
   overflow-y: auto;
 }
@@ -353,10 +353,10 @@ export default {
 }
 
 .enhanced-table-compact :deep(th) {
-  background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
-  color: #1976d2;
+  background: var(--surface-secondary);
+  color: var(--text-primary);
   font-weight: 600;
-  border-bottom: 1px solid rgba(25, 118, 210, 0.1);
+  border-bottom: 1px solid var(--dialog-border);
   padding: 8px 12px;
 }
 
@@ -563,8 +563,8 @@ export default {
 
 /* Action buttons with improved naming and styling */
 .dialog-actions-container {
-  background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-  border-top: 1px solid #e0e0e0;
+  background: linear-gradient(135deg, var(--dialog-bg-start) 0%, var(--dialog-bg-end) 100%);
+  border-top: 1px solid var(--dialog-border);
   padding: 16px 24px;
   gap: 12px;
 }


### PR DESCRIPTION
## Summary
- support dark mode in `ClosingDialog.vue` and `OpeningDialog.vue`
- use Vuetify theme variables so the dialogs render correctly