### PR TITLE
Update Vite build output path

### DIFF
--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -20,7 +20,7 @@ app_license = "GPLv3"
 # app_include_css = "/assets/posawesome/css/posawesome.css"
 # app_include_js = "/assets/posawesome/js/posawesome.js"
 app_include_js = [
-    "dist/js/posawesome.bundle.js",
+    "posawesome.bundle.js",
 ]
 
 # include js, css files in header of web template

--- a/posawesome/public/js/sw.js
+++ b/posawesome/public/js/sw.js
@@ -7,7 +7,7 @@ self.addEventListener("install", (event) => {
 			const cache = await caches.open(CACHE_NAME);
 
 			const resources = [
-                                "/assets/posawesome/dist/js/posawesome.bundle.js",
+                               "/assets/posawesome/js/posawesome.bundle.js",
 				"/assets/posawesome/js/offline/index.js",
 				"/manifest.json",
 				"/offline.html",

--- a/posawesome/www/sw.js
+++ b/posawesome/www/sw.js
@@ -18,7 +18,7 @@ self.addEventListener('install', event => {
       const cache = await caches.open(CACHE_NAME);
       const resources = [
         '/app/posapp',
-        '/assets/posawesome/dist/js/posawesome.bundle.js',
+        '/assets/posawesome/js/posawesome.bundle.js',
 
         '/assets/posawesome/js/offline/index.js',
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,17 +5,17 @@ import frappeVueStyle from './frappe-vue-style.vite.js';
 
 export default defineConfig({
         plugins: [frappeVueStyle(), vue()],
-	build: {
-		target: "esnext",
-                lib: {
-                        entry: resolve(__dirname, "posawesome/public/js/posawesome.bundle.js"),
-                        name: "PosAwesome",
-                        fileName: () => "posawesome.bundle.js",
-                        formats: ["es", "umd"],
-                },
-                outDir: "posawesome/public/dist/js",
-                emptyOutDir: true,
-                rollupOptions: {
+       build: {
+               target: "esnext",
+               outDir: "posawesome/public/js",
+               lib: {
+                       entry: resolve(__dirname, "posawesome/public/js/posawesome.bundle.js"),
+                       name: "PosAwesome",
+                       fileName: () => "posawesome.bundle.js",
+                       formats: ["es", "umd"],
+               },
+               emptyOutDir: true,
+               rollupOptions: {
                         external: ["socket.io-client", "dexie"],
                         output: {
                                 globals: {


### PR DESCRIPTION
## Summary
- configure Vite to output bundle directly in `public/js`
- load the built file from root in hooks
- update service workers to new asset path