### PR TITLE
Fix worker paths and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ node_modules
 posawesome/public/dist
 /posawesome/public/css/posapp
 /dist
+
+# Vite build outputs
+/posawesome/public/js/posawesome.css
+/posawesome/public/js/itemWorker-*.js

--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -17,8 +17,8 @@ app_license = "GPLv3"
 # ------------------
 
 # include js, css files in header of desk.html
-app_include_js  = ["posawesome.bundle.js"]
-app_include_css = ["/assets/posawesome/js/posawesome.css"]
+app_include_js  = ["js/posawesome.bundle.js"]
+app_include_css = ["js/posawesome.css"]
 
 # include js, css files in header of web template
 # web_include_css = "/assets/posawesome/css/posawesome.css"

--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -1,5 +1,5 @@
 import Dexie from "dexie";
-import ItemWorkerURL from "./workers/itemWorker.js?worker";
+import ItemWorkerURL from "./workers/itemWorker.js?worker&url";
 
 // --- Dexie initialization ---------------------------------------------------
 const db = new Dexie("posawesome_offline");
@@ -8,7 +8,7 @@ db.version(1).stores({ keyval: "&key" });
 let persistWorker = null;
 if (typeof Worker !== "undefined") {
         try {
-                persistWorker = new Worker(ItemWorkerURL, { type: "module" });
+                persistWorker = new Worker(ItemWorkerURL, { type: "module", name: "itemWorker" });
         } catch (e) {
                 console.error("Failed to init persist worker", e);
                 persistWorker = null;

--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -1,6 +1,6 @@
 import Dexie from "dexie";
 import { withWriteLock } from './db-utils.js';
-import ItemWorkerURL from "../workers/itemWorker.js?worker";
+import ItemWorkerURL from "../workers/itemWorker.js?worker&url";
 
 // --- Dexie initialization ---------------------------------------------------
 export const db = new Dexie("posawesome_offline");
@@ -29,7 +29,7 @@ let persistWorker = null;
 
 if (typeof Worker !== "undefined") {
         try {
-                persistWorker = new Worker(ItemWorkerURL, { type: "module" });
+                persistWorker = new Worker(ItemWorkerURL, { type: "module", name: "itemWorker" });
         } catch (e) {
                 console.error("Failed to init persist worker", e);
                 persistWorker = null;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -181,7 +181,7 @@
 import format from "../../format";
 import _ from "lodash";
 import CameraScanner from './CameraScanner.vue';
-import ItemWorkerURL from '../../../workers/itemWorker.js?worker';
+import ItemWorkerURL from '../../../workers/itemWorker.js?worker&url';
 import { saveItemUOMs, getItemUOMs, getLocalStock, isOffline, initializeStockCache, getItemsStorage, setItemsStorage, getLocalStockCache, setLocalStockCache, initPromise, checkDbHealth, getCachedPriceListItems, savePriceListItems, updateLocalStockCache, isStockCacheReady, getCachedItemDetails, saveItemDetailsCache } from '../../../offline/index.js';
 import { responsiveMixin } from '../../mixins/responsive.js';
 
@@ -1738,7 +1738,7 @@ export default {
     this.loadItemSettings();
     if (typeof Worker !== 'undefined') {
       try {
-        this.itemWorker = new Worker(ItemWorkerURL, { type: 'module' });
+        this.itemWorker = new Worker(ItemWorkerURL, { type: 'module', name: 'itemWorker' });
 
         this.itemWorker.onerror = function (event) {
           console.error('Worker error:', event);

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -1,5 +1,6 @@
 import { createVuetify } from "vuetify";
 import { createApp } from "vue";
+import "vuetify/styles";
 import Dexie from "dexie";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,27 +1,30 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
-import frappeVueStyle from './frappe-vue-style.vite.js';
 
 export default defineConfig({
-  plugins: [frappeVueStyle(), vue()],
   base: '/assets/posawesome/js/',
+  plugins: [vue()],
   build: {
     outDir: 'posawesome/public/js',
     assetsDir: '.',
     cssCodeSplit: true,
     emptyOutDir: false,
     rollupOptions: {
-      input: 'posawesome/public/js/posawesome.bundle.js',
+      input: {
+        'posawesome.bundle': resolve(__dirname, 'posawesome/public/js/posawesome.bundle.js'),
+        offline: resolve(__dirname, 'posawesome/public/js/offline.js')
+      },
       output: {
-        entryFileNames: 'posawesome.bundle.js',
-        assetFileNames: 'posawesome.css'
+        entryFileNames: '[name].js',
+        assetFileNames: 'posawesome.css',
+        chunkFileNames: '[name]-[hash].js'
       }
     }
   },
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'posawesome/public/js'),
-    },
-  },
+      '@': resolve(__dirname, 'posawesome/public/js')
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- ensure desk assets use relative app paths
- add Vuetify styles so CSS bundle is produced
- generate worker URLs using the Vite `?worker&url` syntax
- add ignore rules for generated CSS and worker files

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68737ff332f48326ba831622cf743987