### PR TITLE
Fix worker imports for Vite

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -1,5 +1,5 @@
 import Dexie from "dexie";
-import ItemWorkerURL from "./workers/itemWorker.js?worker";
+import ItemWorkerURL from "./workers/itemWorker.js?worker&url";
 
 // --- Dexie initialization ---------------------------------------------------
 const db = new Dexie("posawesome_offline");
@@ -8,7 +8,10 @@ db.version(1).stores({ keyval: "&key" });
 let persistWorker = null;
 if (typeof Worker !== "undefined") {
         try {
-                persistWorker = new Worker(ItemWorkerURL, { type: "module" });
+                persistWorker = new Worker(ItemWorkerURL, {
+                        type: "module",
+                        name: "itemWorker",
+                });
         } catch (e) {
                 console.error("Failed to init persist worker", e);
                 persistWorker = null;

--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -1,6 +1,6 @@
 import Dexie from "dexie";
 import { withWriteLock } from './db-utils.js';
-import ItemWorkerURL from "../workers/itemWorker.js?worker";
+import ItemWorkerURL from "../workers/itemWorker.js?worker&url";
 
 // --- Dexie initialization ---------------------------------------------------
 export const db = new Dexie("posawesome_offline");
@@ -29,7 +29,10 @@ let persistWorker = null;
 
 if (typeof Worker !== "undefined") {
         try {
-                persistWorker = new Worker(ItemWorkerURL, { type: "module" });
+                persistWorker = new Worker(ItemWorkerURL, {
+                        type: "module",
+                        name: "itemWorker",
+                });
         } catch (e) {
                 console.error("Failed to init persist worker", e);
                 persistWorker = null;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -181,7 +181,7 @@
 import format from "../../format";
 import _ from "lodash";
 import CameraScanner from './CameraScanner.vue';
-import ItemWorkerURL from '../../../workers/itemWorker.js?worker';
+import ItemWorkerURL from '../../../workers/itemWorker.js?worker&url';
 import { saveItemUOMs, getItemUOMs, getLocalStock, isOffline, initializeStockCache, getItemsStorage, setItemsStorage, getLocalStockCache, setLocalStockCache, initPromise, checkDbHealth, getCachedPriceListItems, savePriceListItems, updateLocalStockCache, isStockCacheReady, getCachedItemDetails, saveItemDetailsCache } from '../../../offline/index.js';
 import { responsiveMixin } from '../../mixins/responsive.js';
 
@@ -1738,7 +1738,10 @@ export default {
     this.loadItemSettings();
     if (typeof Worker !== 'undefined') {
       try {
-        this.itemWorker = new Worker(ItemWorkerURL, { type: 'module' });
+        this.itemWorker = new Worker(ItemWorkerURL, {
+          type: 'module',
+          name: 'itemWorker'
+        });
 
         this.itemWorker.onerror = function (event) {
           console.error('Worker error:', event);


### PR DESCRIPTION
## Summary
- make item worker import use `?worker&url`
- give item worker a name in `new Worker` options

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6873b374f7ec8326a7f7cb26d4adb4bc