### PR TITLE
Fix asset paths in hooks

### DIFF
--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -17,8 +17,8 @@ app_license = "GPLv3"
 # ------------------
 
 # include js, css files in header of desk.html
-app_include_js  = ["posawesome.bundle.js"]
-app_include_css = ["/assets/posawesome/js/posawesome.css"]
+app_include_js  = ["js/posawesome.bundle.js"]
+app_include_css = ["js/posawesome.css"]
 
 # include js, css files in header of web template
 # web_include_css = "/assets/posawesome/css/posawesome.css"


### PR DESCRIPTION
## Summary
- correct asset paths in `posawesome/hooks.py` to rely on Frappe's prefixing

## Testing
- `pre-commit` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6873b7c7ea988326b4b081698f687e01