### PR TITLE
Fix UOM lookup when scanning barcodes 001

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -935,32 +935,32 @@ export default {
 
 			return items_headers;
 		},
-		click_item_row(event, { item }) {
-			this.add_item(item);
-		},
-		add_item(item) {
-			item = { ...item };
-			if (item.has_variants) {
-				this.eventBus.emit("open_variants_model", item, this.items);
-			} else {
-				if (item.actual_qty === 0 && this.pos_profile.posa_display_items_in_stock) {
-					this.eventBus.emit("show_message", {
-						title: `No stock available for ${item.item_name}`,
-						color: "warning",
-					});
-					this.update_items_details([item]);
-					return;
-				}
+               async click_item_row(event, { item }) {
+                       await this.add_item(item);
+               },
+               async add_item(item) {
+                       item = { ...item };
+                       if (item.has_variants) {
+                               this.eventBus.emit("open_variants_model", item, this.items);
+                       } else {
+                               if (item.actual_qty === 0 && this.pos_profile.posa_display_items_in_stock) {
+                                       this.eventBus.emit("show_message", {
+                                               title: `No stock available for ${item.item_name}`,
+                                               color: "warning",
+                                       });
+                                       await this.update_items_details([item]);
+                                       return;
+                               }
 
-				// Ensure UOMs are initialized before adding the item
-				if (!item.item_uoms || item.item_uoms.length === 0) {
-					// If UOMs are not available, fetch them first
-					this.update_items_details([item]);
+                               // Ensure UOMs are initialized before adding the item
+                               if (!item.item_uoms || item.item_uoms.length === 0) {
+                                       // If UOMs are not available, fetch them first
+                                       await this.update_items_details([item]);
 
-					// Add stock UOM as fallback
-					if (!item.item_uoms || item.item_uoms.length === 0) {
-						item.item_uoms = [{ uom: item.stock_uom, conversion_factor: 1.0 }];
-					}
+                                       // Add stock UOM as fallback
+                                       if (!item.item_uoms || item.item_uoms.length === 0) {
+                                               item.item_uoms = [{ uom: item.stock_uom, conversion_factor: 1.0 }];
+                                       }
 				}
 
 				// Ensure correct rate based on selected currency
@@ -988,7 +988,7 @@ export default {
 				this.qty = 1;
 			}
 		},
-		enter_event() {
+               async enter_event() {
 			let match = false;
 			if (!this.filtered_items.length || !this.first_search) {
 				return;
@@ -998,10 +998,8 @@ export default {
 			new_item.qty = flt(qty);
 			new_item.item_barcode.forEach((element) => {
 				if (this.search == element.barcode) {
-					new_item.uom = element.posa_uom;
-					// Call calc_uom to update rate based on new UOM
-					this.eventBus.emit("calc_uom", new_item, element.posa_uom);
-					match = true;
+                               new_item.uom = element.posa_uom;
+                               match = true;
 				}
 			});
 			if (
@@ -1031,8 +1029,9 @@ export default {
 			if (this.flags.batch_no) {
 				new_item.to_set_batch_no = this.flags.batch_no;
 			}
-			if (match) {
-				this.add_item(new_item);
+                       if (match) {
+                               await this.add_item(new_item);
+                               this.eventBus.emit("calc_uom", new_item, new_item.uom);
 				this.flags.serial_no = null;
 				this.flags.batch_no = null;
 				this.qty = 1;
@@ -1123,9 +1122,9 @@ export default {
 			this.qty = 1;
 			this.$refs.debounce_search.focus();
 		},
-		update_items_details(items) {
-			const vm = this;
-			if (!items || !items.length) return;
+               async update_items_details(items) {
+                       const vm = this;
+                       if (!items || !items.length) return;
 
 			// reset any pending retry timer
 			if (vm.itemDetailsRetryTimeout) {
@@ -1202,113 +1201,100 @@ export default {
 
 			const itemsToFetch = items.filter((it) => cacheResult.missing.includes(it.item_code));
 
-			vm.currentRequest = frappe.call({
-				method: "posawesome.posawesome.api.items.get_items_details",
-				args: {
-					pos_profile: JSON.stringify(vm.pos_profile),
-					items_data: JSON.stringify(itemsToFetch),
-					price_list: vm.active_price_list,
-				},
-				// Avoid freezing the UI while item details are fetched
-				freeze: false,
-				signal: vm.abortController.signal,
-				callback: function (r) {
-					if (r.message) {
-						vm.itemDetailsRetryCount = 0;
-						let qtyChanged = false;
-						let updatedItems = [];
+                        try {
+                                vm.currentRequest = await frappe.call({
+                                        method: "posawesome.posawesome.api.items.get_items_details",
+                                        args: {
+                                                pos_profile: JSON.stringify(vm.pos_profile),
+                                                items_data: JSON.stringify(itemsToFetch),
+                                                price_list: vm.active_price_list,
+                                        },
+                                        freeze: false,
+                                        signal: vm.abortController.signal,
+                                });
 
-						// Batch updates to minimize reactivity triggers
-						vm.$nextTick(() => {
-							items.forEach((item) => {
-								const updated_item = r.message.find(
-									(element) => element.item_code == item.item_code,
-								);
-								if (updated_item) {
-									// Save previous quantity for comparison
-									const prev_qty = item.actual_qty;
+                                const r = vm.currentRequest;
+                                if (r && r.message) {
+                                        vm.itemDetailsRetryCount = 0;
+                                        let qtyChanged = false;
+                                        let updatedItems = [];
 
-									// Prepare updates but don't apply them yet
-									updatedItems.push({
-										item: item,
-										updates: {
-											actual_qty: updated_item.actual_qty,
-											serial_no_data: updated_item.serial_no_data,
-											batch_no_data: updated_item.batch_no_data,
-											has_batch_no: updated_item.has_batch_no,
-											has_serial_no: updated_item.has_serial_no,
-											item_uoms:
-												updated_item.item_uoms && updated_item.item_uoms.length > 0
-													? updated_item.item_uoms
-													: item.item_uoms,
-										},
-									});
+                                        items.forEach((item) => {
+                                                const updated_item = r.message.find(
+                                                        (element) => element.item_code == item.item_code,
+                                                );
+                                                if (updated_item) {
+                                                        const prev_qty = item.actual_qty;
 
-									// Track significant quantity changes
-									if (prev_qty > 0 && updated_item.actual_qty === 0) {
-										qtyChanged = true;
-									}
+                                                        updatedItems.push({
+                                                                item: item,
+                                                                updates: {
+                                                                        actual_qty: updated_item.actual_qty,
+                                                                        serial_no_data: updated_item.serial_no_data,
+                                                                        batch_no_data: updated_item.batch_no_data,
+                                                                        has_batch_no: updated_item.has_batch_no,
+                                                                        has_serial_no: updated_item.has_serial_no,
+                                                                        item_uoms:
+                                                                                updated_item.item_uoms && updated_item.item_uoms.length > 0
+                                                                                        ? updated_item.item_uoms
+                                                                                        : item.item_uoms,
+                                                                },
+                                                        });
 
-									// Cache UOMs separately
-									if (updated_item.item_uoms && updated_item.item_uoms.length > 0) {
-										saveItemUOMs(item.item_code, updated_item.item_uoms);
-									}
-								}
-							});
+                                                        if (prev_qty > 0 && updated_item.actual_qty === 0) {
+                                                                qtyChanged = true;
+                                                        }
 
-							// Apply all updates in one batch
-							updatedItems.forEach(({ item, updates }) => {
-								Object.assign(item, updates);
-								vm.applyCurrencyConversionToItem(item);
-							});
+                                                        if (updated_item.item_uoms && updated_item.item_uoms.length > 0) {
+                                                                saveItemUOMs(item.item_code, updated_item.item_uoms);
+                                                        }
+                                                }
+                                        });
 
-							// Update local stock cache with latest quantities
-							updateLocalStockCache(r.message);
-							saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, r.message);
+                                        updatedItems.forEach(({ item, updates }) => {
+                                                Object.assign(item, updates);
+                                                vm.applyCurrencyConversionToItem(item);
+                                        });
 
-							// Force update if any item's quantity changed significantly
-							if (qtyChanged) {
-								vm.$forceUpdate();
-							}
-						});
-					}
-				},
-				error: function (err) {
-					if (err.name !== "AbortError") {
-						console.error("Error fetching item details:", err);
-						// Fallback to local stock if server call fails
-						items.forEach((item) => {
-							const localQty = getLocalStock(item.item_code);
-							if (localQty !== null) {
-								item.actual_qty = localQty;
-							}
-							// Fallback to cached UOMs when offline or request fails
-							if (!item.item_uoms || item.item_uoms.length === 0) {
-								const cached = getItemUOMs(item.item_code);
-								if (cached.length > 0) {
-									item.item_uoms = cached;
-								}
-							}
-						});
+                                        updateLocalStockCache(r.message);
+                                        saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, r.message);
 
-						// do not retry if offline, wait for "server-online" event instead
-						if (!isOffline()) {
-							vm.itemDetailsRetryCount += 1;
-							const delay = Math.min(32000, 1000 * Math.pow(2, vm.itemDetailsRetryCount - 1));
-							vm.itemDetailsRetryTimeout = setTimeout(() => {
-								vm.update_items_details(items);
-							}, delay);
-						}
-					}
-				},
-			});
+                                        if (qtyChanged) {
+                                                vm.$forceUpdate();
+                                        }
+                                }
+                        } catch (err) {
+                                if (err.name !== "AbortError") {
+                                        console.error("Error fetching item details:", err);
+                                        items.forEach((item) => {
+                                                const localQty = getLocalStock(item.item_code);
+                                                if (localQty !== null) {
+                                                        item.actual_qty = localQty;
+                                                }
+                                                if (!item.item_uoms || item.item_uoms.length === 0) {
+                                                        const cached = getItemUOMs(item.item_code);
+                                                        if (cached.length > 0) {
+                                                                item.item_uoms = cached;
+                                                        }
+                                                }
+                                        });
 
-			// Cleanup on component destroy
-			this.cleanupBeforeDestroy = () => {
-				if (vm.abortController) {
-					vm.abortController.abort();
-				}
-			};
+                                        if (!isOffline()) {
+                                                vm.itemDetailsRetryCount += 1;
+                                                const delay = Math.min(32000, 1000 * Math.pow(2, vm.itemDetailsRetryCount - 1));
+                                                vm.itemDetailsRetryTimeout = setTimeout(() => {
+                                                        vm.update_items_details(items);
+                                                }, delay);
+                                        }
+                                }
+                        }
+
+                        // Cleanup on component destroy
+                        this.cleanupBeforeDestroy = () => {
+                                if (vm.abortController) {
+                                        vm.abortController.abort();
+                                }
+                        };
 		},
 		update_cur_items_details() {
 			if (this.filtered_items && this.filtered_items.length > 0) {
@@ -1542,11 +1528,11 @@ export default {
 				);
 			});
 		},
-		addScannedItemToInvoice(item, scannedCode) {
-			console.log("Adding scanned item to invoice:", item, scannedCode);
+               async addScannedItemToInvoice(item, scannedCode) {
+                       console.log("Adding scanned item to invoice:", item, scannedCode);
 
-			// Use existing add_item method with enhanced feedback
-			this.add_item(item);
+                       // Use existing add_item method with enhanced feedback
+                       await this.add_item(item);
 
 			// Show success message
 			frappe.show_alert(


### PR DESCRIPTION
## Summary
- ensure UOM data is loaded before adding an item from the scanner
- make `enter_event`, `click_item_row`, and `addScannedItemToInvoice` async and await item addition
- call `calc_uom` only after item details are fetched