### PR TITLE
Fix build script to use Vite and clean up

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,4 +4,4 @@ console.log("Installing dependencies...");
 execSync("yarn install", { stdio: "inherit" });
 
 console.log("Building the application...");
-execSync("node esbuild --production --apps posawesome --run-build-command", { stdio: "inherit" });
+execSync("npx vite build", { stdio: "inherit" });

--- a/posawesome/__init__.py
+++ b/posawesome/__init__.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 try:
-	import frappe
+       import frappe
 except ModuleNotFoundError:  # pragma: no cover - frappe may not be installed during setup
-	frappe = None
+       frappe = None
 
 __version__ = "15.3.36"
 


### PR DESCRIPTION
## Summary
- clean up unused future import in `posawesome/__init__.py`
- run Vite build instead of esbuild in `build.js`
