### PR TITLE
Fix number validation for shift dialogs

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
@@ -138,7 +138,13 @@ export default {
 				sortable: true,
 			},
 		],
-		max25chars: (v) => v.length <= 20 || "Input too long!", // TODO : should validate as number
+		max25chars(v) {
+			const pattern = /^-?(\d+|\d{1,3}(?:\.\d{3})*)(,\d+)?$/;
+			if (!pattern.test(v)) {
+				return "invalid number";
+			}
+			return String(v).length <= 20 || "Input too long!";
+		},
 		pagination: {},
 	}),
 	watch: {},

--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -163,7 +163,13 @@ export default {
 				},
 			],
 			itemsPerPage: 100,
-			max25chars: (v) => v.length <= 12 || "Input too long!",
+			max25chars(v) {
+				const pattern = /^-?(\d+|\d{1,3}(?:\.\d{3})*)(,\d+)?$/;
+				if (!pattern.test(v)) {
+					return "invalid number";
+				}
+				return String(v).length <= 12 || "Input too long!";
+			},
 			pagination: {},
 			snack: false,
 			snackColor: "",


### PR DESCRIPTION
## Summary
- ensure closing amount input enforces numeric format
- apply same validation for opening dialog