### PR TITLE
Add offline cache readiness indicator

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -1,5 +1,6 @@
 import { db, persist, checkDbHealth } from "./core.js";
 import { getAllByCursor } from "./db-utils.js";
+import { isStockCacheReady } from "./stock.js";
 import Dexie from "dexie";
 
 export const MAX_QUEUE_ITEMS = 1000;
@@ -335,4 +336,16 @@ export async function getCacheUsageEstimate() {
 			percentage: 0,
 		};
 	}
+}
+
+export function isCacheReady() {
+        try {
+                return (
+                        isStockCacheReady() &&
+                        (memory.items_storage || []).length > 0 &&
+                        (memory.customer_storage || []).length > 0
+                );
+        } catch (e) {
+                return false;
+        }
 }

--- a/posawesome/public/js/offline/index.js
+++ b/posawesome/public/js/offline/index.js
@@ -33,9 +33,10 @@ export {
 	queueHealthCheck,
 	purgeOldQueueEntries,
 	MAX_QUEUE_ITEMS,
-	resetOfflineState,
-	clearAllCache,
-	getCacheUsageEstimate,
+        resetOfflineState,
+        clearAllCache,
+        getCacheUsageEstimate,
+        isCacheReady,
 } from "./cache.js";
 
 // Stock exports

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -21,14 +21,18 @@
 			</template>
 
 			<!-- Slot for cache usage meter -->
-			<template #cache-usage-meter>
-				<CacheUsageMeter
-					:cache-usage="cacheUsage"
-					:cache-usage-loading="cacheUsageLoading"
-					:cache-usage-details="cacheUsageDetails"
-					@refresh="refreshCacheUsage"
-				/>
-			</template>
+                        <template #cache-usage-meter>
+                                <CacheUsageMeter
+                                        :cache-usage="cacheUsage"
+                                        :cache-usage-loading="cacheUsageLoading"
+                                        :cache-usage-details="cacheUsageDetails"
+                                        @refresh="refreshCacheUsage"
+                                />
+                        </template>
+
+                        <template #cache-ready-indicator>
+                                <CacheReadyIndicator :cache-ready="cacheReady" />
+                        </template>
 
 			<!-- Slot for menu -->
 			<template #menu>
@@ -94,21 +98,23 @@ import NavbarDrawer from "./navbar/NavbarDrawer.vue";
 import NavbarMenu from "./navbar/NavbarMenu.vue";
 import StatusIndicator from "./navbar/StatusIndicator.vue";
 import CacheUsageMeter from "./navbar/CacheUsageMeter.vue";
+import CacheReadyIndicator from "./navbar/CacheReadyIndicator.vue";
 import AboutDialog from "./navbar/AboutDialog.vue";
 import OfflineInvoices from "./OfflineInvoices.vue";
 import { clearAllCache } from "../../offline/cache.js";
 
 export default {
 	name: "NavBar",
-	components: {
-		NavbarAppBar,
-		NavbarDrawer,
-		NavbarMenu,
-		StatusIndicator,
-		CacheUsageMeter,
-		AboutDialog,
-		OfflineInvoicesDialog: OfflineInvoices,
-	},
+        components: {
+                NavbarAppBar,
+                NavbarDrawer,
+                NavbarMenu,
+                StatusIndicator,
+                CacheUsageMeter,
+                CacheReadyIndicator,
+                AboutDialog,
+                OfflineInvoicesDialog: OfflineInvoices,
+        },
 	props: {
 		posProfile: {
 			type: Object,
@@ -137,11 +143,15 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		cacheUsageDetails: {
-			type: Object,
-			default: () => ({ total: 0, indexedDB: 0, localStorage: 0 }),
-		},
-	},
+                cacheUsageDetails: {
+                        type: Object,
+                        default: () => ({ total: 0, indexedDB: 0, localStorage: 0 }),
+                },
+                cacheReady: {
+                        type: Boolean,
+                        default: false,
+                },
+        },
 	data() {
 		return {
 			drawer: false,

--- a/posawesome/public/js/posapp/components/navbar/CacheReadyIndicator.vue
+++ b/posawesome/public/js/posapp/components/navbar/CacheReadyIndicator.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="cache-ready-section mx-1">
+    <v-tooltip location="bottom">
+      <template #activator="{ props }">
+        <div v-bind="props" class="cache-ready-icon">
+          <v-progress-circular
+            v-if="!cacheReady"
+            indeterminate
+            size="24"
+            width="2"
+            color="primary"
+          />
+          <v-icon v-else color="primary" size="24">mdi-check-circle</v-icon>
+        </div>
+      </template>
+      <span>{{ cacheReady ? __("Offline cache ready") : __("Caching data...") }}</span>
+    </v-tooltip>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "CacheReadyIndicator",
+  props: {
+    cacheReady: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>
+
+<style scoped>
+.cache-ready-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/posawesome/public/js/posapp/components/navbar/NavbarAppBar.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarAppBar.vue
@@ -29,8 +29,11 @@
 		<!-- Enhanced connectivity status indicator - Always visible -->
 		<slot name="status-indicator"></slot>
 
-		<!-- Cache Usage Meter -->
-		<slot name="cache-usage-meter"></slot>
+                <!-- Cache Usage Meter -->
+                <slot name="cache-usage-meter"></slot>
+
+                <!-- Cache Ready Indicator -->
+                <slot name="cache-ready-indicator"></slot>
 
 		<div class="profile-section mx-1">
 			<v-chip color="primary" variant="outlined" class="profile-chip">


### PR DESCRIPTION
## Summary
- track whether offline caches are fully populated
- expose new `isCacheReady` helper
- show cache readiness icon in Navbar
- poll readiness state from Home page