### PR TITLE
Ensure offers load on existing shifts

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -103,7 +103,7 @@ export default {
 		Variants,
 		MpesaPayments,
 		SalesOrders,
-	},
+       },
 
        methods: {
                create_opening_voucher() {
@@ -116,7 +116,15 @@ export default {
                },
        },
 
-	mounted: function () {
+       watch: {
+               pos_profile(val) {
+                       if (val && val.name) {
+                               this.get_offers(val.name);
+                       }
+               },
+       },
+
+       mounted: function () {
 		this.$nextTick(function () {
 			this.check_opening_entry();
 			this.get_pos_setting();

--- a/posawesome/public/js/posapp/composables/usePosShift.js
+++ b/posawesome/public/js/posapp/composables/usePosShift.js
@@ -56,6 +56,7 @@ export function usePosShift(openDialog) {
                     } catch (e) {
                         console.error("Failed to cache opening data", e);
                     }
+                    eventBus?.emit("register_pos_data", r.message);
                 } else {
                     const data = getOpeningStorage();
                     if (data) {
@@ -69,6 +70,7 @@ export function usePosShift(openDialog) {
                             console.warn("Realtime emit failed", e);
                         }
                         console.info("LoadPosProfile (cached)");
+                        eventBus?.emit("register_pos_data", data);
                         return;
                     }
                     openDialog && openDialog();
@@ -87,6 +89,7 @@ export function usePosShift(openDialog) {
                         console.warn("Realtime emit failed", e);
                     }
                     console.info("LoadPosProfile (cached)");
+                    eventBus?.emit("register_pos_data", data);
                     return;
                 }
                 openDialog && openDialog();


### PR DESCRIPTION
## Summary
- emit `register_pos_data` when retrieving an opening shift
- watch `pos_profile` in `Pos.vue` and fetch offers when it changes
