### PR TITLE
Fix worker script for non-module environments

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -9,7 +9,8 @@ if (typeof Worker !== "undefined") {
 	try {
 		// Use the plain URL so the service worker cache matches when offline
                const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
-               persistWorker = new Worker(workerUrl, { type: "module" });
+               // Load the worker as a classic script since it now uses importScripts
+               persistWorker = new Worker(workerUrl);
 	} catch (e) {
 		console.error("Failed to init persist worker", e);
 		persistWorker = null;

--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -31,7 +31,8 @@ if (typeof Worker !== "undefined") {
 		// Load the worker without a query string so the service worker
 		// can serve the cached version when offline.
                const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
-               persistWorker = new Worker(workerUrl, { type: "module" });
+               // Worker uses importScripts, so load as a classic worker
+               persistWorker = new Worker(workerUrl);
 	} catch (e) {
 		console.error("Failed to init persist worker", e);
 		persistWorker = null;

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -383,7 +383,8 @@ export default {
                if (typeof Worker !== "undefined") {
                        try {
                                const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
-                               this.customerWorker = new Worker(workerUrl, { type: "module" });
+                               // Load as classic worker since itemWorker uses importScripts
+                               this.customerWorker = new Worker(workerUrl);
                        } catch (e) {
                                console.error("Failed to start customer worker", e);
                                this.customerWorker = null;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1933,7 +1933,8 @@ export default {
 				// even when offline. Using a query string causes cache lookups to fail
 				// which results in "Failed to fetch a worker script" errors.
                                const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
-                               this.itemWorker = new Worker(workerUrl, { type: "module" });
+                               // Load as classic worker since the script uses importScripts
+                               this.itemWorker = new Worker(workerUrl);
 
 				this.itemWorker.onerror = function (event) {
 					console.error("Worker error:", event);

--- a/posawesome/public/js/posapp/workers/itemWorker.js
+++ b/posawesome/public/js/posapp/workers/itemWorker.js
@@ -1,4 +1,7 @@
-import Dexie from "../../libs/dexie.min.js";
+// The worker is loaded as a classic script, so use importScripts to load Dexie
+// which exposes a global `Dexie` constructor. Using an absolute path ensures the
+// library can be resolved correctly regardless of the worker's location.
+importScripts("/assets/posawesome/js/libs/dexie.min.js");
 
 const db = new Dexie("posawesome_offline");
 db.version(1).stores({ keyval: "&key" });


### PR DESCRIPTION
## Summary
- load Dexie via `importScripts` in `itemWorker.js`
- create workers as classic scripts