### PR TITLE
Enable price list rate editing

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5477,6 +5477,16 @@
   {
     "doctype": "Custom Field",
     "dt": "POS Profile",
+  {
+    "doctype": "Custom Field",
+    "dt": "POS Profile",
+    "fieldname": "posa_allow_price_list_rate_change",
+    "fieldtype": "Check",
+    "insert_after": "posa_allow_delete_offline_invoice",
+    "label": "Allow Price List Rate Change",
+    "default": "0",
+    "name": "POS Profile-posa_allow_price_list_rate_change"
+  },
     "fieldname": "posa_decimal_precision",
     "fieldtype": "Select",
     "insert_after": "hide_expected_amount",

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -205,6 +205,7 @@
 						:subtractOne="subtract_one"
 						:addOne="add_one"
 						:toggleOffer="toggleOffer"
+						:changePriceListRate="change_price_list_rate"
 						@update:expanded="expanded = $event"
 						@reorder-items="handleItemReorder"
 						@add-item-from-drag="handleItemDrop"

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -273,8 +273,9 @@
 										class="dark-field"
 										hide-details
 										:model-value="formatCurrency(item.price_list_rate)"
-										disabled
+										:disabled="!pos_profile.posa_allow_price_list_rate_change"
 										:prefix="currencySymbol(pos_profile.currency)"
+										@change="changePriceListRate(item)"
 									></v-text-field>
 								</div>
 								<div class="form-field">
@@ -490,9 +491,17 @@
 										class="dark-field"
 										hide-details
 										:model-value="formatCurrency(item.price_list_rate || 0)"
-										disabled
+										:disabled="!pos_profile.posa_allow_price_list_rate_change"
 										prepend-inner-icon="mdi-format-list-numbered"
+										@change="changePriceListRate(item)"
 									></v-text-field>
+									<v-btn
+										v-if="pos_profile.posa_allow_price_list_rate_change"
+										size="x-small"
+										class="ml-1"
+										@click.stop="changePriceListRate(item)"
+										>{{ __("Change") }}</v-btn
+									>
 								</div>
 								<div class="form-field">
 									<v-text-field
@@ -547,6 +556,7 @@ export default {
 		addOne: Function,
 		isReturnInvoice: Boolean,
 		toggleOffer: Function,
+		changePriceListRate: Function,
 	},
 	data() {
 		return {

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1909,6 +1909,20 @@ export default {
 					}
 					break;
 
+				case "price_list_rate":
+					item._manual_rate_set = true;
+					item.base_price_list_rate = this.flt(
+						newValue * this.exchange_rate,
+						this.currency_precision,
+					);
+					item.price_list_rate = newValue;
+					item.base_rate = item.base_price_list_rate;
+					item.rate = newValue;
+					item.discount_amount = 0;
+					item.base_discount_amount = 0;
+					item.discount_percentage = 0;
+					break;
+
 				case "discount_amount":
 					console.log("[calc_prices] Event Target ID:", fieldId);
 					console.log("[calc_prices] RAW value received by function:", value); // <-- ADDED THIS
@@ -2373,5 +2387,48 @@ export default {
 
 		// Force UI update
 		this.$forceUpdate();
+	},
+
+	change_price_list_rate(item) {
+		const vm = this;
+		frappe.prompt(
+			[
+				{
+					fieldname: "new_rate",
+					fieldtype: "Float",
+					label: __("New Price List Rate"),
+					reqd: 1,
+				},
+			],
+			function (values) {
+				const rate = flt(values.new_rate);
+				frappe.call({
+					method: "posawesome.posawesome.api.items.update_price_list_rate",
+					args: {
+						item_code: item.item_code,
+						price_list: vm.get_price_list(),
+						rate: rate,
+						uom: item.uom,
+					},
+					callback: function (r) {
+						if (!r.exc) {
+							item.price_list_rate = rate;
+							item.base_price_list_rate = rate;
+							if (!item._manual_rate_set) {
+								item.rate = rate;
+								item.base_rate = rate;
+							}
+							vm.calc_item_price(item);
+							vm.eventBus.emit("show_message", {
+								title: r.message || __("Item price updated"),
+								color: "success",
+							});
+						}
+					},
+				});
+			},
+			__("Change Price"),
+			__("Update"),
+		);
 	},
 };

--- a/posawesome/translations/ar.csv
+++ b/posawesome/translations/ar.csv
@@ -25,6 +25,7 @@ DocType: POS Offer,Auto Apply,تطبيق تلقائي
 Custom Field - label: POS Profile-posa_allow_delete,Auto Delete Draft Invoice,حذف فاتورة حذف تلقائي
 Custom Field - label: POS Profile-posa_allow_delete_offline_invoice,Allow Delete Offline Invoice,السماح بحذف فاتورة في وضع عدم الاتصال
 Custom Field - label: POS Profile-posa_auto_set_batch,Auto Set Batch,مجموعة مجموعة السيارات
+Custom Field - label: POS Profile-posa_allow_price_list_rate_change,Allow Price List Rate Change,السماح بتغيير سعر قائمة الأسعار
 DocType: POS Offer,Brand,ماركة
 DocType: POS Opening Shift,Cancelled,ألغى
 Custom Field - label: POS Profile-posa_cash_mode_of_payment,Cash Mode of Payment,الوضع النقدي للدفع

--- a/posawesome/translations/pt.csv
+++ b/posawesome/translations/pt.csv
@@ -25,6 +25,7 @@ DocType: POS Offer,Auto Apply,Auto Aplicar
 Custom Field - label: POS Profile-posa_allow_delete,Auto Delete Draft Invoice,Auto Apagar Factura Rascunho
 Custom Field - label: POS Profile-posa_allow_delete_offline_invoice,Allow Delete Offline Invoice,Permitir Apagar Faturas Offline
 Custom Field - label: POS Profile-posa_auto_set_batch,Auto Set Batch,Auto Definir Lote
+Custom Field - label: POS Profile-posa_allow_price_list_rate_change,Allow Price List Rate Change,Permitir Alterar Preço da Lista
 DocType: POS Offer,Brand,Marca
 DocType: POS Opening Shift,Cancelled,Cancelado
 Custom Field - label: POS Profile-posa_cash_mode_of_payment,Cash Mode of Payment,Modo de Pagamento em Dinheiro


### PR DESCRIPTION
## Summary
- add POS profile option `posa_allow_price_list_rate_change`
- allow editing item price list rate from invoice item table
- implement server method `update_price_list_rate` to create or update Item Price
- wire change handler from invoice items
- add Arabic and Portuguese translations

## Testing
- `npm run format`
- `ruff check posawesome/posawesome/api/items.py` *(fails: UP009, UP010, I001, UP035, UP030, UP032, UP031, RUF010, F811)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6878dff7f6ec832694dcd727c3d012a3