### PR TITLE
Fix variant selection event listener

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -1149,8 +1149,7 @@ export default {
 		this.eventBus.on("reset_posting_date", () => {
 			this.posting_date = frappe.datetime.nowdate();
 		});
-		this.eventBus.on("open_variants_model", this.open_variants_model);
-		this.eventBus.on("calc_uom", this.calc_uom);
+               this.eventBus.on("calc_uom", this.calc_uom);
 		this.eventBus.on("item-drag-start", (item) => {
 			this.showDropFeedback(true);
 		});


### PR DESCRIPTION
## Summary
- remove unused `open_variants_model` listener in `Invoice.vue`