### PR TITLE
Fix malformed custom field fixture JSON

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5477,9 +5477,6 @@
   {
     "doctype": "Custom Field",
     "dt": "POS Profile",
-  {
-    "doctype": "Custom Field",
-    "dt": "POS Profile",
     "fieldname": "posa_allow_price_list_rate_change",
     "fieldtype": "Check",
     "insert_after": "posa_allow_delete_offline_invoice",
@@ -5487,15 +5484,18 @@
     "default": "0",
     "name": "POS Profile-posa_allow_price_list_rate_change"
   },
+  {
+    "doctype": "Custom Field",
+    "dt": "POS Profile",
     "fieldname": "posa_decimal_precision",
     "fieldtype": "Select",
     "insert_after": "hide_expected_amount",
     "label": "Decimal Precision",
     "options": "0\n1\n2\n3\n4\n5",
-  "default": "2",
-  "name": "POS Profile-posa_decimal_precision"
-  }
-  ,{
+    "default": "2",
+    "name": "POS Profile-posa_decimal_precision"
+  },
+  {
     "allow_in_quick_entry": 0,
     "allow_on_submit": 0,
     "bold": 0,


### PR DESCRIPTION
## Summary
- fix invalid JSON around `posa_allow_price_list_rate_change` and `posa_decimal_precision` fixtures