### PR TITLE
Fix item reload and speed up cache clearing

### DIFF
--- a/posawesome/__init__.py
+++ b/posawesome/__init__.py
@@ -6,7 +6,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - frappe may not be installed during setup
 	frappe = None
 
-__version__ = "15.3.38"
+__version__ = "15.3.39"
 
 
 def console(*data):

--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -1057,3 +1057,39 @@ export async function clearAllCache() {
 	memory.tax_inclusive = false;
 	memory.manual_offline = false;
 }
+
+export async function forceClearAllCache() {
+	if (typeof localStorage !== "undefined") {
+		Object.keys(localStorage).forEach((key) => {
+			if (key.startsWith("posa_")) {
+				localStorage.removeItem(key);
+			}
+		});
+	}
+
+	memory.offline_invoices = [];
+	memory.offline_customers = [];
+	memory.offline_payments = [];
+	memory.pos_last_sync_totals = { pending: 0, synced: 0, drafted: 0 };
+	memory.uom_cache = {};
+	memory.offers_cache = [];
+	memory.customer_balance_cache = {};
+	memory.local_stock_cache = {};
+	memory.stock_cache_ready = false;
+	memory.items_storage = [];
+	memory.customer_storage = [];
+	memory.pos_opening_storage = null;
+	memory.opening_dialog_storage = null;
+	memory.sales_persons_storage = [];
+	memory.price_list_cache = {};
+	memory.item_details_cache = {};
+	memory.tax_template_cache = {};
+	memory.tax_inclusive = false;
+	memory.manual_offline = false;
+
+	try {
+		await Dexie.delete("posawesome_offline");
+	} catch (e) {
+		console.error("Failed to clear IndexedDB cache", e);
+	}
+}

--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -255,6 +255,44 @@ export async function clearAllCache() {
 	memory.manual_offline = false;
 }
 
+// Faster cache clearing without reopening the database
+export async function forceClearAllCache() {
+	if (typeof localStorage !== "undefined") {
+		Object.keys(localStorage).forEach((key) => {
+			if (key.startsWith("posa_")) {
+				localStorage.removeItem(key);
+			}
+		});
+	}
+
+	memory.offline_invoices = [];
+	memory.offline_customers = [];
+	memory.offline_payments = [];
+	memory.pos_last_sync_totals = { pending: 0, synced: 0, drafted: 0 };
+	memory.uom_cache = {};
+	memory.offers_cache = [];
+	memory.customer_balance_cache = {};
+	memory.local_stock_cache = {};
+	memory.stock_cache_ready = false;
+	memory.items_storage = [];
+	memory.customer_storage = [];
+	memory.pos_opening_storage = null;
+	memory.opening_dialog_storage = null;
+	memory.sales_persons_storage = [];
+	memory.price_list_cache = {};
+	memory.item_details_cache = {};
+	memory.tax_template_cache = {};
+	memory.tax_inclusive = false;
+	memory.manual_offline = false;
+
+	// Delete the IndexedDB database in the background
+	try {
+		await Dexie.delete("posawesome_offline");
+	} catch (e) {
+		console.error("Failed to clear IndexedDB cache", e);
+	}
+}
+
 /**
  * Estimates the current cache usage size in bytes and percentage
  * @returns {Promise<Object>} Object containing total, localStorage, and indexedDB sizes in bytes, and usage percentage

--- a/posawesome/public/js/offline/index.js
+++ b/posawesome/public/js/offline/index.js
@@ -32,6 +32,7 @@ export {
 	MAX_QUEUE_ITEMS,
 	resetOfflineState,
 	clearAllCache,
+	forceClearAllCache,
 	getCacheUsageEstimate,
 } from "./cache.js";
 

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -96,7 +96,7 @@ import StatusIndicator from "./navbar/StatusIndicator.vue";
 import CacheUsageMeter from "./navbar/CacheUsageMeter.vue";
 import AboutDialog from "./navbar/AboutDialog.vue";
 import OfflineInvoices from "./OfflineInvoices.vue";
-import { clearAllCache } from "../../offline/cache.js";
+import { clearAllCache, forceClearAllCache } from "../../offline/cache.js";
 
 export default {
 	name: "NavBar",
@@ -232,7 +232,7 @@ export default {
 		},
 		async clearCache() {
 			try {
-				await clearAllCache();
+				await forceClearAllCache();
 				this.showMessage({ color: "success", title: this.__("Cache cleared successfully") });
 			} catch (e) {
 				console.error("Failed to clear cache", e);

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -625,6 +625,17 @@ export default {
 			this.eventBus.emit("show_coupons", "true");
 		},
 		forceReloadItems() {
+			// Always recreate the worker when forcing a reload so
+			// subsequent reloads fetch fresh data from the server.
+			if (!this.itemWorker && typeof Worker !== "undefined") {
+				try {
+					const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
+					this.itemWorker = new Worker(workerUrl, { type: "classic" });
+				} catch (e) {
+					console.error("Failed to start item worker", e);
+					this.itemWorker = null;
+				}
+			}
 			this.items_loaded = false;
 			this.get_items(true);
 		},


### PR DESCRIPTION
## Summary
- bump version to 15.3.39
- recreate worker for every item reload
- add `forceClearAllCache` helper
- use fast cache clear in the navbar