### PR TITLE
Fix variant rate 0 issue

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Variants.vue
+++ b/posawesome/public/js/posapp/components/pos/Variants.vue
@@ -57,7 +57,8 @@
 										</v-img>
 										<v-card-text class="text--primary pa-1">
 											<div class="text-caption text-primary accent-3">
-												{{ item.rate || 0 }} {{ item.currency || "" }}
+												{{ item.price_list_rate || item.rate || 0 }}
+												{{ item.currency || "" }}
 											</div>
 										</v-card-text>
 									</v-card>
@@ -174,6 +175,12 @@ export default {
 			if (!this.items || this.items.length === 0) {
 				await this.fetchVariants(item.item_code, profile);
 			}
+			// Ensure rate is populated for all variant items
+			this.items.forEach((it) => {
+				if (!it.rate && it.price_list_rate) {
+					it.rate = it.price_list_rate;
+				}
+			});
 			this.$nextTick(() => {
 				this.filterdItems = this.variantsItems;
 			});

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -158,19 +158,25 @@ export default {
 		new_item.discount_amount = 0;
 		new_item.discount_percentage = 0;
 		new_item.discount_amount_per_item = 0;
-		new_item.price_list_rate = item.rate;
+		new_item.price_list_rate = item.price_list_rate || item.rate;
 
 		// Setup base rates properly for multi-currency
 		const baseCurrency = this.price_list_currency || this.pos_profile.currency;
 		if (this.selected_currency !== baseCurrency) {
 			// Store original base currency values
-			new_item.base_price_list_rate = item.base_price_list_rate || item.rate / this.exchange_rate;
-			new_item.base_rate = item.base_rate || item.rate / this.exchange_rate;
+			new_item.base_price_list_rate =
+				item.base_price_list_rate || item.price_list_rate || item.rate / this.exchange_rate;
+			new_item.base_rate =
+				item.base_rate ||
+				item.base_price_list_rate ||
+				item.price_list_rate ||
+				item.rate / this.exchange_rate;
 			new_item.base_discount_amount = 0;
 		} else {
 			// In base currency, base rates = displayed rates
-			new_item.base_price_list_rate = item.base_price_list_rate || item.rate;
-			new_item.base_rate = item.base_rate || item.rate;
+			new_item.base_price_list_rate = item.base_price_list_rate || item.price_list_rate || item.rate;
+			new_item.base_rate =
+				item.base_rate || item.base_price_list_rate || item.price_list_rate || item.rate;
 			new_item.base_discount_amount = 0;
 		}
 


### PR DESCRIPTION
## Summary
- ensure variant rate is shown using `price_list_rate`
- populate rate when variant modal opens
- handle missing rate when adding items