### PR TITLE
Fix variant price refresh

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Variants.vue
+++ b/posawesome/public/js/posapp/components/pos/Variants.vue
@@ -131,23 +131,20 @@ export default {
 					},
 				});
 				if (res.message) {
-					const itemsMap = {};
-					(this.items || []).forEach((it) => {
-						itemsMap[it.item_code] = it;
-					});
 					res.message.forEach((it) => {
 						if (it.price_list_rate != null) {
 							it.rate = it.price_list_rate;
 						}
-						if (itemsMap[it.item_code]) {
-							Object.assign(itemsMap[it.item_code], it);
+						const idx = (this.items || []).findIndex((x) => x.item_code === it.item_code);
+						if (idx > -1) {
+							const updated = { ...this.items[idx], ...it };
+							this.items.splice(idx, 1, updated);
 						} else {
 							this.items = this.items || [];
 							this.items.push(it);
 						}
 					});
-					// Force array reactivity so UI updates with new prices
-					this.items = [...this.items];
+					this.filterdItems = this.variantsItems;
 				}
 			} catch (e) {
 				console.error("Failed to fetch variants", e);


### PR DESCRIPTION
## Summary
- ensure variant prices update reactively when fetched by replacing items using `splice`
- keep filtered items list in sync after fetching variants