### PR TITLE
Fix variant price display

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Variants.vue
+++ b/posawesome/public/js/posapp/components/pos/Variants.vue
@@ -57,10 +57,14 @@
 										</v-img>
 										<v-card-text class="text--primary pa-1">
 											<div class="text-caption text-primary accent-3">
-												{{ formatCurrency(item.price_list_rate || item.rate || 0) }}
 												{{
-													item.currency || (posProfile && posProfile.currency) || ""
+													currencySymbol(
+														item.currency ||
+															(posProfile && posProfile.currency) ||
+															"",
+													)
 												}}
+												{{ formatCurrency(item.price_list_rate || item.rate || 0) }}
 											</div>
 										</v-card-text>
 									</v-card>


### PR DESCRIPTION
## Summary
- ensure variant prices have correct currency symbol
- revert variant list to track parent item updates so rates populate

## Testing
- `npm install`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687a8887b17c83268bbba5b8676288b3