### PR TITLE
Fix variant price display

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Variants.vue
+++ b/posawesome/public/js/posapp/components/pos/Variants.vue
@@ -114,6 +114,15 @@ export default {
 			try {
 				const posProfile = profile || this.posProfile || {};
 				const list = priceList || this.priceList || posProfile.selling_price_list;
+
+				if (!Array.isArray(this.variants)) {
+					this.variants = [];
+				}
+
+				const itemsMap = {};
+				this.variants.forEach((it) => {
+					itemsMap[it.item_code] = it;
+				});
 				const res = await frappe.call({
 					method: "posawesome.posawesome.api.items.get_item_variants",
 					args: {
@@ -124,12 +133,43 @@ export default {
 					},
 				});
 				if (res.message) {
-					this.variants = res.message.map((it) => {
+					res.message.forEach((it) => {
 						if (it.price_list_rate != null) {
 							it.rate = it.price_list_rate;
 						}
-						return it;
+						if (itemsMap[it.item_code]) {
+							Object.assign(itemsMap[it.item_code], it);
+						} else {
+							this.variants.push(it);
+						}
 					});
+
+					// If any variant lacks rate information, fetch it directly
+					if (list) {
+						await Promise.all(
+							this.variants.map(async (v) => {
+								if (!v.rate) {
+									try {
+										const r = await frappe.call({
+											method: "posawesome.posawesome.api.items.get_price_for_uom",
+											args: {
+												item_code: v.item_code,
+												price_list: list,
+												uom: v.stock_uom,
+											},
+										});
+										if (r.message) {
+											v.rate = r.message;
+											v.price_list_rate = r.message;
+										}
+									} catch (err) {
+										console.error("Failed to fetch price", err);
+									}
+								}
+							}),
+						);
+					}
+
 					this.variants = [...this.variants];
 				}
 			} catch (e) {


### PR DESCRIPTION
## Summary
- ensure variant prices load directly from server
- avoid runtime error by initializing items map
- ensure variants list always initialized
- avoid price fetch when no price list is defined
- load variants correctly when opening the dialog
- merge variant data before fetching prices

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687b2057860883269be7a83017568f7c