### PR TITLE
Disable clearing cache in offline mode

### DIFF
--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -36,6 +36,8 @@
 					:pos-profile="posProfile"
 					:last-invoice-id="lastInvoiceId"
 					:manual-offline="manualOffline"
+					:network-online="networkOnline"
+					:server-online="serverOnline"
 					:is-dark="isDark"
 					@close-shift="openCloseShift"
 					@print-last-invoice="printLastInvoice"
@@ -98,6 +100,7 @@ import AboutDialog from "./navbar/AboutDialog.vue";
 import OfflineInvoices from "./OfflineInvoices.vue";
 import { forceClearAllCache } from "../../offline/cache.js";
 import { clearAllCaches } from "../../utils/clearAllCaches.js";
+import { isOffline } from "../../offline/index.js";
 
 export default {
 	name: "NavBar",
@@ -232,13 +235,26 @@ export default {
 			this.$emit("toggle-offline");
 		},
 		async clearCache() {
+			if (isOffline()) {
+				this.showMessage({
+					color: "warning",
+					title: this.__("Cannot clear cache while offline"),
+				});
+				return;
+			}
 			try {
 				await forceClearAllCache();
 				await clearAllCaches({ confirmBeforeClear: false }).catch(() => {});
-				this.showMessage({ color: "success", title: this.__("Cache cleared successfully") });
+				this.showMessage({
+					color: "success",
+					title: this.__("Cache cleared successfully"),
+				});
 			} catch (e) {
 				console.error("Failed to clear cache", e);
-				this.showMessage({ color: "error", title: this.__("Failed to clear cache") });
+				this.showMessage({
+					color: "error",
+					title: this.__("Failed to clear cache"),
+				});
 			} finally {
 				setTimeout(() => location.reload(), 1000);
 			}

--- a/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
@@ -89,7 +89,11 @@
 					</div>
 				</v-list-item>
 
-				<v-list-item @click="$emit('clear-cache')" class="menu-item-compact neutral-action">
+				<v-list-item
+					@click="$emit('clear-cache')"
+					:disabled="manualOffline || !networkOnline || !serverOnline"
+					class="menu-item-compact neutral-action"
+				>
 					<template v-slot:prepend>
 						<div class="menu-icon-wrapper-compact neutral-icon">
 							<v-icon color="white" size="16">mdi-delete-sweep-outline</v-icon>
@@ -172,6 +176,8 @@ export default {
 		},
 		lastInvoiceId: String,
 		manualOffline: Boolean,
+		networkOnline: Boolean,
+		serverOnline: Boolean,
 		isDark: Boolean,
 	},
 	emits: [


### PR DESCRIPTION
## Summary
- disable the *Clear Cache* menu item when POS Awesome is offline
- prevent cache clearing while offline