### PR TITLE
Fix UOM price list rate used on item add

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1280,6 +1280,12 @@ export default {
 		}
 		var vm = this;
 
+		// If a manual rate was set (e.g. via explicit UOM pricing), don't
+		// overwrite it on expand unless explicitly forced.
+		if (item._manual_rate_set && !force_update) {
+			return;
+		}
+
 		// Remove this block which was causing the issue - rates should persist regardless of currency
 		// if (item.price_list_rate && !item.posa_offer_applied) {
 		//   item.rate = item.price_list_rate;

--- a/posawesome/public/js/posapp/composables/useItemAddition.js
+++ b/posawesome/public/js/posapp/composables/useItemAddition.js
@@ -65,10 +65,34 @@ export function useItemAddition() {
 				await context.calc_uom(new_item, new_item.uom);
 			}
 
+			// Attempt to fetch an explicit rate for this UOM from the active price list
+			try {
+				const r = await frappe.call({
+					method: "posawesome.posawesome.api.items.get_price_for_uom",
+					args: {
+						item_code: new_item.item_code,
+						price_list: context.get_price_list ? context.get_price_list() : null,
+						uom: new_item.uom,
+					},
+				});
+				if (r.message) {
+					const price = parseFloat(r.message);
+					Object.assign(new_item, {
+						rate: price,
+						base_rate: price,
+						price_list_rate: price,
+						base_price_list_rate: price,
+						_manual_rate_set: true,
+						skip_force_update: true,
+					});
+				}
+			} catch (e) {
+				console.warn("UOM price fetch failed", e);
+			}
+
 			context.items.unshift(new_item);
-			// Force update of item rates when item is first added unless disabled
-			const forceUpdate = !new_item.skip_force_update;
-			if (context.update_item_detail) context.update_item_detail(new_item, forceUpdate);
+			// Skip recalculation to preserve the manually set rate
+			if (context.update_item_detail) context.update_item_detail(new_item, false);
 
 			// Expand new item if it has batch or serial number
 			if (

--- a/posawesome/public/js/posapp/composables/useStockUtils.js
+++ b/posawesome/public/js/posapp/composables/useStockUtils.js
@@ -66,11 +66,15 @@ export function useStockUtils() {
 			}
 		}
 
-		if (uomRate) {
-			item.base_price_list_rate = uomRate;
-			if (!item.posa_offer_applied) {
-				item.base_rate = uomRate;
-			}
+                if (uomRate) {
+                        // Mark rate as explicitly fetched from price list so
+                        // later updates don't override it automatically
+                        item._manual_rate_set = true;
+
+                        item.base_price_list_rate = uomRate;
+                        if (!item.posa_offer_applied) {
+                                item.base_rate = uomRate;
+                        }
 
 			const baseCurrency = context.price_list_currency || context.pos_profile.currency;
 			if (context.selected_currency !== baseCurrency) {
@@ -87,12 +91,18 @@ export function useStockUtils() {
 			if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);
 			if (context.forceUpdate) context.forceUpdate();
 			return;
-		}
+                }
 
-		// Reset discount if not offer
-		if (!item.posa_offer_applied) {
-			item.discount_amount = 0;
-			item.discount_percentage = 0;
+                // When no price list rate was found, treat rate as calculated
+                // so future updates may override it if needed
+                if (!uomRate) {
+                        item._manual_rate_set = false;
+                }
+
+                // Reset discount if not offer
+                if (!item.posa_offer_applied) {
+                        item.discount_amount = 0;
+                        item.discount_percentage = 0;
 		}
 
 		// Store original base rates if not already stored


### PR DESCRIPTION
## Summary
- fetch explicit price for selected UOM before adding item
- skip automatic recalculation for manually priced items
- avoid overwriting manual rate when row expands
- update `_manual_rate_set` when UOM changes so price list rate applies correctly