### PR TITLE
Fix variant chips update

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -488,7 +488,7 @@ def get_item_variants(pos_profile, parent_item_code, price_list=None, customer=N
                 attributes_meta.setdefault(row.attribute, set()).add(row.attribute_value)
         attributes_meta = {k: sorted(list(v)) for k, v in attributes_meta.items()}
 
-        return {"variants": result, "attributes_meta": attributes_meta}
+        return {"variants": result, "attributes_meta": attributes_meta or {}}
 
 
 @frappe.whitelist()

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -977,6 +977,21 @@ export default {
 					} catch (e) {
 						console.error("Failed to fetch variants", e);
 					}
+				} else {
+					// Build attribute metadata from already loaded variants
+					variants.forEach((it) => {
+						if (Array.isArray(it.item_attributes)) {
+							it.item_attributes.forEach((attr) => {
+								if (!attrsMeta[attr.attribute]) {
+									attrsMeta[attr.attribute] = new Set();
+								}
+								attrsMeta[attr.attribute].add(attr.attribute_value);
+							});
+						}
+					});
+					Object.keys(attrsMeta).forEach((k) => {
+						attrsMeta[k] = Array.from(attrsMeta[k]);
+					});
 				}
 				this.eventBus.emit("show_message", {
 					title: __("This is an item template. Please choose a variant."),

--- a/posawesome/public/js/posapp/components/pos/Variants.vue
+++ b/posawesome/public/js/posapp/components/pos/Variants.vue
@@ -115,6 +115,21 @@ export default {
 			this.filterdItems = this.variantsItems;
 			this.displayCount = 100;
 		},
+		attributes_meta: {
+			handler(val) {
+				if (this.parentItem && val && Object.keys(val).length) {
+					this.parentItem.attributes = Object.keys(val).map((attr) => ({
+						attribute: attr,
+						values: val[attr].map((v) => ({ attribute_value: v, abbr: v })),
+					}));
+					this.$nextTick(() => {
+						this.filterdItems = this.variantsItems;
+						this.displayCount = 100;
+					});
+				}
+			},
+			deep: true,
+		},
 	},
 
 	methods: {
@@ -214,6 +229,7 @@ export default {
 					"filtered items",
 					this.filterdItems.map((it) => it.item_code),
 				);
+				this.displayCount = 100;
 			});
 		}, 200),
 		loadMore() {


### PR DESCRIPTION
## Summary
- guarantee `attributes_meta` always returned as object
- compute attribute metadata when variants already cached
- watch `attributes_meta` in `Variants.vue` to rebuild chips
- reset lazy load counter when filtering