### PR TITLE
Fix inclusive tax error for Actual charges

### DIFF
--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -236,15 +236,20 @@ def apply_tax_inclusive(doc):
 	except Exception:
 		tax_inclusive = 0
 
-	if not tax_inclusive:
-		return
 
 	has_changes = False
 	for tax in doc.get("taxes", []):
-		if not tax.included_in_print_rate:
+		if tax.charge_type == "Actual":
+			if tax.included_in_print_rate:
+				tax.included_in_print_rate = 0
+				has_changes = True
+				continue
+		if tax_inclusive and not tax.included_in_print_rate:
 			tax.included_in_print_rate = 1
 			has_changes = True
-
+		elif not tax_inclusive and tax.included_in_print_rate:
+			tax.included_in_print_rate = 0
+			has_changes = True
 	if has_changes:
 		doc.calculate_taxes_and_totals()
 

--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -776,11 +776,13 @@ def update_invoice(data):
 
 		add_taxes_from_tax_template(item, invoice_doc)
 
-	if frappe.get_cached_value("POS Profile", invoice_doc.pos_profile, "posa_tax_inclusive"):
-		if invoice_doc.get("taxes"):
-			for tax in invoice_doc.taxes:
-				tax.included_in_print_rate = 1
-
+	inclusive = frappe.get_cached_value("POS Profile", invoice_doc.pos_profile, "posa_tax_inclusive")
+	if invoice_doc.get("taxes"):
+		for tax in invoice_doc.taxes:
+			if tax.charge_type == "Actual":
+				tax.included_in_print_rate = 0
+			else:
+				tax.included_in_print_rate = 1 if inclusive else 0
 	invoice_doc.flags.ignore_permissions = True
 	frappe.flags.ignore_account_permission = True
 	invoice_doc.docstatus = 0

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -409,7 +409,7 @@ export default {
 						charge_type: row.charge_type || "On Net Total",
 						description: row.description,
 						rate: row.rate,
-						included_in_print_rate: inclusive ? 1 : 0,
+						included_in_print_rate: row.charge_type === "Actual" ? 0 : inclusive ? 1 : 0,
 						tax_amount: tax_amount,
 						total: runningTotal,
 						base_tax_amount: tax_amount * (this.exchange_rate || 1),


### PR DESCRIPTION
## Summary
- prevent inclusive flag on Actual taxes
- skip inclusive for Actual charge rows on POS