### PR TITLE
Fix service worker import paths

### DIFF
--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -93,9 +93,9 @@ frappe.PosApp.posapp = class {
 			window.location.hostname === "localhost" ||
 			window.location.hostname === "127.0.0.1"
 		) {
-			navigator.serviceWorker
-				.register("/sw.js")
-				.catch((err) => console.error("SW registration failed", err));
+                       navigator.serviceWorker
+                               .register("/sw.js")
+                               .catch((err) => console.error("SW registration failed", err));
 		}
 	}
 	setup_header() {}

--- a/posawesome/www/sw-source.js
+++ b/posawesome/www/sw-source.js
@@ -1,6 +1,11 @@
-import { precacheAndRoute } from "workbox-precaching";
-import { registerRoute, setDefaultHandler } from "workbox-routing";
-import { NetworkFirst, StaleWhileRevalidate } from "workbox-strategies";
+importScripts(
+       "https://storage.googleapis.com/workbox-cdn/releases/7.3.0/workbox-sw.js"
+);
+
+const { precaching, routing, strategies } = workbox;
+const { precacheAndRoute } = precaching;
+const { registerRoute, setDefaultHandler } = routing;
+const { NetworkFirst, StaleWhileRevalidate } = strategies;
 
 precacheAndRoute(self.__WB_MANIFEST);
 

--- a/posawesome/www/sw.js
+++ b/posawesome/www/sw.js
@@ -1,8 +1,13 @@
-import { precacheAndRoute } from "workbox-precaching";
-import { registerRoute, setDefaultHandler } from "workbox-routing";
-import { NetworkFirst, StaleWhileRevalidate } from "workbox-strategies";
+importScripts(
+       "https://storage.googleapis.com/workbox-cdn/releases/7.3.0/workbox-sw.js"
+);
 
-precacheAndRoute([{"revision":"d882d32fc586c1c56dfb0ff4c9ca9ff9","url":"manifest.json"},{"revision":"0b2f8fe6908c2bc1aa82bc5593f15bd1","url":"offline.html"},{"revision":"b93b0f3bad1848ad38b2aa6cab11265e","url":"sw-old.js"}]);
+const { precaching, routing, strategies } = workbox;
+const { precacheAndRoute } = precaching;
+const { registerRoute, setDefaultHandler } = routing;
+const { NetworkFirst, StaleWhileRevalidate } = strategies;
+
+precacheAndRoute([{"revision":"d882d32fc586c1c56dfb0ff4c9ca9ff9","url":"manifest.json"},{"revision":"de35420b35ebe9d252e43e4802b2287b","url":"offline.html"},{"revision":"b93b0f3bad1848ad38b2aa6cab11265e","url":"sw-old.js"}]);
 
 // Cache application pages
 registerRoute(({ request }) => request.mode === "navigate", new NetworkFirst({ cacheName: "pages-cache" }));


### PR DESCRIPTION
## Summary
- load Workbox via `importScripts` instead of ESM imports
- register the service worker without the module type
