### PR TITLE
Fix missing offline modules

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -23,15 +23,16 @@ export const memory = {
 	pos_opening_storage: null,
 	opening_dialog_storage: null,
 	sales_persons_storage: [],
-	price_list_cache: {},
-	item_details_cache: {},
-	tax_template_cache: {},
-	translation_cache: {},
-	// Track the current cache schema version
-	cache_version: CACHE_VERSION,
-	cache_ready: false,
-	tax_inclusive: false,
-	manual_offline: false,
+        price_list_cache: {},
+        item_details_cache: {},
+        tax_template_cache: {},
+        translation_cache: {},
+        coupons_cache: {},
+        // Track the current cache schema version
+        cache_version: CACHE_VERSION,
+        cache_ready: false,
+        tax_inclusive: false,
+        manual_offline: false,
 };
 
 // Initialize memory from IndexedDB and expose a promise for consumers
@@ -290,9 +291,10 @@ export async function clearAllCache() {
 	memory.offline_customers = [];
 	memory.offline_payments = [];
 	memory.pos_last_sync_totals = { pending: 0, synced: 0, drafted: 0 };
-	memory.uom_cache = {};
-	memory.offers_cache = [];
-	memory.customer_balance_cache = {};
+        memory.uom_cache = {};
+        memory.offers_cache = [];
+        memory.coupons_cache = {};
+        memory.customer_balance_cache = {};
 	memory.local_stock_cache = {};
 	memory.stock_cache_ready = false;
 	memory.items_storage = [];
@@ -325,9 +327,10 @@ export async function forceClearAllCache() {
 	memory.offline_customers = [];
 	memory.offline_payments = [];
 	memory.pos_last_sync_totals = { pending: 0, synced: 0, drafted: 0 };
-	memory.uom_cache = {};
-	memory.offers_cache = [];
-	memory.customer_balance_cache = {};
+        memory.uom_cache = {};
+        memory.offers_cache = [];
+        memory.coupons_cache = {};
+        memory.customer_balance_cache = {};
 	memory.local_stock_cache = {};
 	memory.stock_cache_ready = false;
 	memory.items_storage = [];

--- a/posawesome/public/js/offline/coupons.js
+++ b/posawesome/public/js/offline/coupons.js
@@ -1,0 +1,41 @@
+import { memory } from "./cache.js";
+import { persist } from "./core.js";
+
+export function saveCoupons(customer, coupons) {
+    try {
+        const cache = memory.coupons_cache || {};
+        const clean = JSON.parse(JSON.stringify(coupons));
+        cache[customer] = clean;
+        memory.coupons_cache = cache;
+        persist("coupons_cache", memory.coupons_cache);
+    } catch (e) {
+        console.error("Failed to cache coupons", e);
+    }
+}
+
+export function getCachedCoupons(customer) {
+    try {
+        const cache = memory.coupons_cache || {};
+        return cache[customer] || [];
+    } catch (e) {
+        console.error("Failed to get cached coupons", e);
+        return [];
+    }
+}
+
+export function clearCoupons(customer) {
+    try {
+        const cache = memory.coupons_cache || {};
+        if (customer) {
+            delete cache[customer];
+        } else {
+            for (const key in cache) {
+                delete cache[key];
+            }
+        }
+        memory.coupons_cache = cache;
+        persist("coupons_cache", memory.coupons_cache);
+    } catch (e) {
+        console.error("Failed to clear coupons cache", e);
+    }
+}

--- a/posawesome/public/js/offline/index.js
+++ b/posawesome/public/js/offline/index.js
@@ -98,11 +98,18 @@ export {
 
 // Customers exports
 export {
-	saveCustomerBalance,
-	getCachedCustomerBalance,
-	clearCustomerBalanceCache,
-	clearExpiredCustomerBalances,
+        saveCustomerBalance,
+        getCachedCustomerBalance,
+        clearCustomerBalanceCache,
+        clearExpiredCustomerBalances,
 } from "./customers.js";
+
+// Coupons exports
+export {
+        saveCoupons,
+        getCachedCoupons,
+        clearCoupons,
+} from "./coupons.js";
 
 // Translation cache exports
 export { getTranslationsCache, saveTranslationsCache } from "./cache.js";

--- a/posawesome/public/js/offline/translations.js
+++ b/posawesome/public/js/offline/translations.js
@@ -1,0 +1,1 @@
+export { getTranslationsCache, saveTranslationsCache } from "./cache.js";


### PR DESCRIPTION
## Summary
- support offline coupon caching by adding a new `coupons.js` module
- re-export translation helpers from a new `translations.js` module
- wire new modules in `offline/index.js`
- track `coupons_cache` in `cache.js`