### PR TITLE
Improve cache readiness indicator

### DIFF
--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -47,6 +47,7 @@ import {
 	MAX_QUEUE_ITEMS,
 	initPromise,
 	memoryInitPromise,
+	isCacheReady,
 	toggleManualOffline,
 	isManualOffline,
 	syncOfflineInvoices,
@@ -119,6 +120,8 @@ export default {
 	},
 	mounted() {
 		this.remove_frappe_nav();
+		// Initialize cache ready state early from stored value
+		this.cacheReady = isCacheReady();
 		this.initializeData();
 		this.setupNetworkListeners();
 		this.setupEventListeners();


### PR DESCRIPTION
## Summary
- initialize cache status earlier in `Home.vue` to ensure the navbar status indicator is shown as soon as possible