### PR TITLE
Remove legacy build.js to disable esbuild

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,7 +1,0 @@
-const { execSync } = require("child_process");
-
-console.log("Installing dependencies...");
-execSync("yarn install", { stdio: "inherit" });
-
-console.log("Building the application with Vite...");
-execSync("npx vite build", { stdio: "inherit" });


### PR DESCRIPTION
## Summary
- remove the old build.js fallback script