### PR TITLE
Fix Vite asset path

### DIFF
--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from . import __version__ as app_version
 
 app_name = "posawesome"
@@ -17,9 +15,7 @@ app_license = "GPLv3"
 # include js, css files in header of desk.html
 # app_include_css = "/assets/posawesome/css/posawesome.css"
 # app_include_js = "/assets/posawesome/js/posawesome.js"
-app_include_js = [
-	"posawesome.bundle.js",
-]
+app_include_js = "/assets/js/posawesome.bundle.js"
 
 # include js, css files in header of web template
 # web_include_css = "/assets/posawesome/css/posawesome.css"


### PR DESCRIPTION
## Summary
- reference built JS via `/assets/js/posawesome.bundle.js`
- clean up hooks formatting for linting