### PR TITLE
Fix NODE_ENV reference in Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,10 @@ import { resolve } from "path";
 
 export default defineConfig({
        plugins: [vue(), vuetify({ autoImport: true })],
+       define: {
+               "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV || "production"),
+               "process.env": {},
+       },
         build: {
                 target: "esnext",
                lib: {


### PR DESCRIPTION
## Summary
- avoid `process` undefined error when POSAwesome runs in browser
- define `process.env.NODE_ENV` at build time and provide minimal `process.env` fallback