### PR TITLE
Fix Vite build output and hooks for hashed bundle

### DIFF
--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -15,7 +15,25 @@ app_license = "GPLv3"
 # include js, css files in header of desk.html
 # app_include_css = "/assets/posawesome/css/posawesome.css"
 # app_include_js = "/assets/posawesome/js/posawesome.js"
-app_include_js = "/assets/posawesome/dist/js/posawesome.bundle.js"
+import json
+from pathlib import Path
+
+
+def _get_bundle_path() -> str:
+    manifest_path = Path(__file__).parent / "public" / "dist" / ".vite" / "manifest.json"
+    try:
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        entry_key = "posawesome/public/js/posawesome.bundle.js"
+        bundle = manifest.get(entry_key, {}).get("file")
+        if bundle:
+            return f"/assets/posawesome/{bundle}"
+    except Exception:
+        pass
+    return "/assets/posawesome/dist/js/posawesome.bundle.js"
+
+
+app_include_js = _get_bundle_path()
 
 # include js, css files in header of web template
 # web_include_css = "/assets/posawesome/css/posawesome.css"

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,26 +9,24 @@ export default defineConfig({
                "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV || "production"),
                "process.env": {},
        },
-        build: {
-                target: "esnext",
-               lib: {
-                        entry: resolve(__dirname, "posawesome/public/js/posawesome.bundle.js"),
-                        name: "PosAwesome",
-                        fileName: () => "posawesome.bundle.js",
-                        formats: ["es"],
-                },
-                outDir: "posawesome/public/dist/js",
-                emptyOutDir: true,
+       build: {
+               target: "es2015",
+               manifest: true,
+               outDir: "posawesome/public/dist",
+               emptyOutDir: true,
                rollupOptions: {
-                        external: ["socket.io-client"],
-                        output: {
-                                inlineDynamicImports: true,
-                                globals: {
-                                        "socket.io-client": "io",
-                                },
-                        },
-                },
-	},
+                       input: resolve(__dirname, "posawesome/public/js/posawesome.bundle.js"),
+                       external: ["socket.io-client"],
+                       output: {
+                               format: "iife",
+                               inlineDynamicImports: true,
+                               entryFileNames: "js/[name].[hash].js",
+                               globals: {
+                                       "socket.io-client": "io",
+                               },
+                       },
+               },
+       },
 	resolve: {
 		alias: {
 			"@": resolve(__dirname, "posawesome/public/js"),


### PR DESCRIPTION
## Summary
- configure Vite to emit an IIFE bundle with hashed filename and manifest
- determine JS bundle path from manifest at runtime in `hooks.py`
