### PR TITLE
Fix missing module JS imports in POS Awesome

### DIFF
--- a/posawesome/public/js/posawesome.bundle.js
+++ b/posawesome/public/js/posawesome.bundle.js
@@ -1,3 +1,3 @@
-import "./toConsole";
-import "./posapp/posapp";
-import "./utils/clearAllCaches";
+import "./toConsole.js";
+import "./posapp/posapp.js";
+import "./utils/clearAllCaches.js";


### PR DESCRIPTION
## Summary
- include explicit `.js` extensions for module imports in `posawesome.bundle.js`