### PR TITLE
Fix Vuetify imports

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,5 +1,5 @@
 const esbuild = require("esbuild");
-const vuePlugin = require("@vitejs/plugin-vue");
+const vuePlugin = require("@vitejs/plugin-vue").default;
 
 const frappeVueStyle = require("./frappe-vue-style.js");
 

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -1,12 +1,12 @@
-import { createVuetify } from "vuetify";
+import { createVuetify } from "vuetify/lib/framework.js";
 import { createApp } from "vue";
 import Dexie from "dexie/dist/dexie.mjs";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import eventBus from "./bus";
 import themePlugin from "./plugins/theme.js";
-import * as components from "vuetify/components";
-import * as directives from "vuetify/directives";
+import * as components from "vuetify/lib/components/index.js";
+import * as directives from "vuetify/lib/directives/index.js";
 import Home from "./Home.vue";
 
 // Expose Dexie globally for libraries that expect a global Dexie instance


### PR DESCRIPTION
## Summary
- fix plugin import in esbuild config
- use explicit Vuetify module paths in `posapp.js`