### PR TITLE
Add offline item group caching

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -23,16 +23,17 @@ export const memory = {
 	pos_opening_storage: null,
 	opening_dialog_storage: null,
 	sales_persons_storage: [],
-        price_list_cache: {},
-        item_details_cache: {},
-        tax_template_cache: {},
-        translation_cache: {},
-        coupons_cache: {},
-        // Track the current cache schema version
-        cache_version: CACHE_VERSION,
-        cache_ready: false,
-        tax_inclusive: false,
-        manual_offline: false,
+	price_list_cache: {},
+	item_details_cache: {},
+	tax_template_cache: {},
+	translation_cache: {},
+	coupons_cache: {},
+	item_groups_cache: [],
+	// Track the current cache schema version
+	cache_version: CACHE_VERSION,
+	cache_ready: false,
+	tax_inclusive: false,
+	manual_offline: false,
 };
 
 // Initialize memory from IndexedDB and expose a promise for consumers
@@ -291,10 +292,10 @@ export async function clearAllCache() {
 	memory.offline_customers = [];
 	memory.offline_payments = [];
 	memory.pos_last_sync_totals = { pending: 0, synced: 0, drafted: 0 };
-        memory.uom_cache = {};
-        memory.offers_cache = [];
-        memory.coupons_cache = {};
-        memory.customer_balance_cache = {};
+	memory.uom_cache = {};
+	memory.offers_cache = [];
+	memory.coupons_cache = {};
+	memory.customer_balance_cache = {};
 	memory.local_stock_cache = {};
 	memory.stock_cache_ready = false;
 	memory.items_storage = [];
@@ -305,6 +306,7 @@ export async function clearAllCache() {
 	memory.price_list_cache = {};
 	memory.item_details_cache = {};
 	memory.tax_template_cache = {};
+	memory.item_groups_cache = [];
 	memory.cache_version = CACHE_VERSION;
 	memory.tax_inclusive = false;
 	memory.manual_offline = false;
@@ -327,10 +329,10 @@ export async function forceClearAllCache() {
 	memory.offline_customers = [];
 	memory.offline_payments = [];
 	memory.pos_last_sync_totals = { pending: 0, synced: 0, drafted: 0 };
-        memory.uom_cache = {};
-        memory.offers_cache = [];
-        memory.coupons_cache = {};
-        memory.customer_balance_cache = {};
+	memory.uom_cache = {};
+	memory.offers_cache = [];
+	memory.coupons_cache = {};
+	memory.customer_balance_cache = {};
 	memory.local_stock_cache = {};
 	memory.stock_cache_ready = false;
 	memory.items_storage = [];
@@ -341,6 +343,7 @@ export async function forceClearAllCache() {
 	memory.price_list_cache = {};
 	memory.item_details_cache = {};
 	memory.tax_template_cache = {};
+	memory.item_groups_cache = [];
 	memory.cache_version = CACHE_VERSION;
 	memory.tax_inclusive = false;
 	memory.manual_offline = false;

--- a/posawesome/public/js/offline/index.js
+++ b/posawesome/public/js/offline/index.js
@@ -92,9 +92,15 @@ export {
 	savePriceListItems,
 	getCachedPriceListItems,
 	clearPriceListCache,
-	saveItemDetailsCache,
-	getCachedItemDetails,
+        saveItemDetailsCache,
+        getCachedItemDetails,
 } from "./items.js";
+
+export {
+       saveItemGroups,
+       getCachedItemGroups,
+       clearItemGroups,
+} from "./item_groups.js";
 
 // Customers exports
 export {

--- a/posawesome/public/js/offline/item_groups.js
+++ b/posawesome/public/js/offline/item_groups.js
@@ -1,0 +1,36 @@
+import { memory } from "./cache.js";
+import { persist } from "./core.js";
+
+export function saveItemGroups(groups) {
+	try {
+		let clean;
+		try {
+			clean = JSON.parse(JSON.stringify(groups));
+		} catch (e) {
+			console.error("Failed to serialize item groups", e);
+			clean = [];
+		}
+		memory.item_groups_cache = clean;
+		persist("item_groups_cache", memory.item_groups_cache);
+	} catch (e) {
+		console.error("Failed to cache item groups", e);
+	}
+}
+
+export function getCachedItemGroups() {
+	try {
+		return memory.item_groups_cache || [];
+	} catch (e) {
+		console.error("Failed to get cached item groups", e);
+		return [];
+	}
+}
+
+export function clearItemGroups() {
+	try {
+		memory.item_groups_cache = [];
+		persist("item_groups_cache", memory.item_groups_cache);
+	} catch (e) {
+		console.error("Failed to clear item groups cache", e);
+	}
+}


### PR DESCRIPTION
## Summary
- extend offline cache with `item_groups_cache`
- expose new item group cache helpers
- persist item groups when items are loaded
- use cached item groups when offline and profile lacks groups