### PR TITLE
Fix mobile item selector page limit

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -531,7 +531,8 @@ export default {
 			const containerHeight = height * 0.68; // card container is ~68% of viewport
 			const columns = Math.max(1, Math.floor(width / cardWidth));
 			const rows = Math.max(1, Math.floor(containerHeight / cardHeight));
-			this.itemsPerPage = columns * rows;
+			// Ensure at least 50 items are shown regardless of device size
+			this.itemsPerPage = Math.max(50, columns * rows);
 		},
 		refreshPricesForVisibleItems() {
 			const vm = this;


### PR DESCRIPTION
## Summary
- ensure at least 50 items show per page regardless of screen size

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68845731ae8c83268137ee2b7f0f993d