### PR TITLE
Add incremental loading for items and customers

### DIFF
--- a/posawesome/posawesome/api/customers.py
+++ b/posawesome/posawesome/api/customers.py
@@ -54,25 +54,25 @@ def get_customer_names(pos_profile, limit=None, offset=None, modified_after=None
 	if ttl:
 		ttl = int(ttl) * 60
 
-        @redis_cache(ttl=ttl or 1800)
-        def __get_customer_names(pos_profile, limit=None, offset=None, modified_after=None):
-                return _get_customer_names(pos_profile, limit, offset, modified_after)
+	@redis_cache(ttl=ttl or 1800)
+	def __get_customer_names(pos_profile, limit=None, offset=None, modified_after=None):
+		return _get_customer_names(pos_profile, limit, offset, modified_after)
 
-        def _get_customer_names(pos_profile, limit=None, offset=None, modified_after=None):
-                pos_profile = json.loads(pos_profile)
-                filters = {"disabled": 0}
+	def _get_customer_names(pos_profile, limit=None, offset=None, modified_after=None):
+		pos_profile = json.loads(pos_profile)
+		filters = {"disabled": 0}
 
 		customer_groups = get_customer_groups(pos_profile)
 		if customer_groups:
 			filters["customer_group"] = ["in", customer_groups]
 
-                if modified_after:
-                        filters["modified"] = [">", modified_after]
+		if modified_after:
+		        filters["modified"] = [">", modified_after]
 
-                customers = frappe.get_all(
-                        "Customer",
-                        filters=filters,
-                        fields=[
+		customers = frappe.get_all(
+		        "Customer",
+		        filters=filters,
+		        fields=[
 				"name",
 				"mobile_no",
 				"email_id",
@@ -80,16 +80,16 @@ def get_customer_names(pos_profile, limit=None, offset=None, modified_after=None
 				"customer_name",
 				"primary_address",
 			],
-                        order_by="name",
-                        limit_start=offset,
-                        limit_page_length=limit,
-                )
-                return customers
+		        order_by="name",
+		        limit_start=offset,
+		        limit_page_length=limit,
+		)
+		return customers
 
-        if _pos_profile.get("posa_use_server_cache") and not (limit or offset or modified_after):
-                return __get_customer_names(pos_profile, limit, offset, modified_after)
-        else:
-                return _get_customer_names(pos_profile, limit, offset, modified_after)
+	if _pos_profile.get("posa_use_server_cache") and not (limit or offset or modified_after):
+		return __get_customer_names(pos_profile, limit, offset, modified_after)
+	else:
+		return _get_customer_names(pos_profile, limit, offset, modified_after)
 
 
 @frappe.whitelist()
@@ -128,25 +128,25 @@ def get_customer_info(customer):
 
 	addresses = frappe.db.sql(
 		"""
-        SELECT
-            address.name as address_name,
-            address.address_line1,
-            address.address_line2,
-            address.city,
-            address.state,
-            address.country,
-            address.address_type
-        FROM `tabAddress` address
-        INNER JOIN `tabDynamic Link` link
-            ON (address.name = link.parent)
-        WHERE
-            link.link_doctype = 'Customer'
-            AND link.link_name = %s
-            AND address.disabled = 0
-            AND address.address_type = 'Shipping'
-        ORDER BY address.creation DESC
-        LIMIT 1
-        """,
+	SELECT
+	    address.name as address_name,
+	    address.address_line1,
+	    address.address_line2,
+	    address.city,
+	    address.state,
+	    address.country,
+	    address.address_type
+	FROM `tabAddress` address
+	INNER JOIN `tabDynamic Link` link
+	    ON (address.name = link.parent)
+	WHERE
+	    link.link_doctype = 'Customer'
+	    AND link.link_name = %s
+	    AND address.disabled = 0
+	    AND address.address_type = 'Shipping'
+	ORDER BY address.creation DESC
+	LIMIT 1
+	""",
 		(customer.name,),
 		as_dict=True,
 	)
@@ -337,23 +337,23 @@ def set_customer_info(customer, fieldname, value=""):
 def get_customer_addresses(customer):
 	return frappe.db.sql(
 		"""
-        SELECT 
-            address.name,
-            address.address_line1,
-            address.address_line2,
-            address.address_title,
-            address.city,
-            address.state,
-            address.country,
-            address.address_type
-        FROM `tabAddress` as address
-        INNER JOIN `tabDynamic Link` AS link
+	SELECT 
+	    address.name,
+	    address.address_line1,
+	    address.address_line2,
+	    address.address_title,
+	    address.city,
+	    address.state,
+	    address.country,
+	    address.address_type
+	FROM `tabAddress` as address
+	INNER JOIN `tabDynamic Link` AS link
 				ON address.name = link.parent
-        WHERE link.link_doctype = 'Customer'
-            AND link.link_name = '{0}'
-            AND address.disabled = 0
-        ORDER BY address.name
-        """.format(customer),
+	WHERE link.link_doctype = 'Customer'
+	    AND link.link_name = '{0}'
+	    AND address.disabled = 0
+	ORDER BY address.name
+	""".format(customer),
 		as_dict=1,
 	)
 

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -489,18 +489,18 @@ def get_items_details(pos_profile, items_data, price_list=None):
 	if items_data:
 		for item in items_data:
 			item_code = item.get("item_code")
-				if item_code:
-					if item.get("has_variants"):
-						# Skip template items to avoid ValidationError
-						continue
-					item_detail = get_item_detail(
-						json.dumps(item),
-							warehouse=warehouse,
-							price_list=price_list or pos_profile.get("selling_price_list"),
-							company=company,
-						)
-					if item_detail:
-				result.append(item_detail)
+			if item_code:
+				if item.get("has_variants"):
+					# Skip template items to avoid ValidationError
+					continue
+				item_detail = get_item_detail(
+					json.dumps(item),
+						warehouse=warehouse,
+						price_list=price_list or pos_profile.get("selling_price_list"),
+						company=company,
+					)
+				if item_detail:
+			result.append(item_detail)
 
 	return result
 

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -61,10 +61,10 @@ def get_items(
 	price_list=None,
 	item_group="",
 	search_value="",
-        customer=None,
-        limit=None,
-        offset=None,
-        modified_after=None,
+	customer=None,
+	limit=None,
+	offset=None,
+	modified_after=None,
 ):
 	_pos_profile = json.loads(pos_profile)
 	use_price_list = _pos_profile.get("posa_use_server_cache")
@@ -75,32 +75,32 @@ def get_items(
 		price_list,
 		item_group,
 		search_value,
-                customer=None,
-                limit=None,
-                offset=None,
-                modified_after=None,
-        ):
-                return _get_items(
-                        pos_profile,
-                        price_list,
-                        item_group,
-                        search_value,
-                        customer,
-                        limit,
-                        offset,
-                        modified_after,
-                )
+		customer=None,
+		limit=None,
+		offset=None,
+		modified_after=None,
+	):
+		return _get_items(
+		        pos_profile,
+		        price_list,
+		        item_group,
+		        search_value,
+		        customer,
+		        limit,
+		        offset,
+		        modified_after,
+		)
 
 	def _get_items(
 		pos_profile,
 		price_list,
 		item_group,
 		search_value,
-                customer=None,
-                limit=None,
-                offset=None,
-                modified_after=None,
-        ):
+		customer=None,
+		limit=None,
+		offset=None,
+		modified_after=None,
+	):
 		pos_profile = json.loads(pos_profile)
 		condition = ""
 
@@ -176,9 +176,9 @@ def get_items(
 		result = []
 
 		# Build ORM filters
-                filters = {"disabled": 0, "is_sales_item": 1, "is_fixed_asset": 0}
-                if modified_after:
-                        filters["modified"] = [">", modified_after]
+		filters = {"disabled": 0, "is_sales_item": 1, "is_fixed_asset": 0}
+		if modified_after:
+		        filters["modified"] = [">", modified_after]
 
 		# Add item group filter
 		item_groups = get_item_groups(pos_profile.get("name"))
@@ -362,28 +362,28 @@ def get_items(
 					result.append(row)
 		return result
 
-        if use_price_list:
-                return __get_items(
-                        pos_profile,
-                        price_list,
-                        item_group,
-                        search_value,
-                        customer,
-                        limit,
-                        offset,
-                        modified_after,
-                )
-        else:
-                return _get_items(
-                        pos_profile,
-                        price_list,
-                        item_group,
-                        search_value,
-                        customer,
-                        limit,
-                        offset,
-                        modified_after,
-                )
+	if use_price_list:
+		return __get_items(
+		        pos_profile,
+		        price_list,
+		        item_group,
+		        search_value,
+		        customer,
+		        limit,
+		        offset,
+		        modified_after,
+		)
+	else:
+		return _get_items(
+		        pos_profile,
+		        price_list,
+		        item_group,
+		        search_value,
+		        customer,
+		        limit,
+		        offset,
+		        modified_after,
+		)
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -486,21 +486,21 @@ def get_items_details(pos_profile, items_data, price_list=None):
 	)
 	result = []
 
-        if items_data:
-                for item in items_data:
-                        item_code = item.get("item_code")
-                        if item_code:
-                                if item.get("has_variants"):
-                                        # Skip template items to avoid ValidationError
-                                        continue
-                                item_detail = get_item_detail(
-                                        json.dumps(item),
-                                        warehouse=warehouse,
-                                        price_list=price_list or pos_profile.get("selling_price_list"),
-                                        company=company,
-				)
-				if item_detail:
-					result.append(item_detail)
+	if items_data:
+		for item in items_data:
+			item_code = item.get("item_code")
+				if item_code:
+					if item.get("has_variants"):
+						# Skip template items to avoid ValidationError
+						continue
+					item_detail = get_item_detail(
+						json.dumps(item),
+							warehouse=warehouse,
+							price_list=price_list or pos_profile.get("selling_price_list"),
+							company=company,
+						)
+					if item_detail:
+				result.append(item_detail)
 
 	return result
 

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -61,9 +61,10 @@ def get_items(
 	price_list=None,
 	item_group="",
 	search_value="",
-	customer=None,
-	limit=None,
-	offset=None,
+        customer=None,
+        limit=None,
+        offset=None,
+        modified_after=None,
 ):
 	_pos_profile = json.loads(pos_profile)
 	use_price_list = _pos_profile.get("posa_use_server_cache")
@@ -74,29 +75,32 @@ def get_items(
 		price_list,
 		item_group,
 		search_value,
-		customer=None,
-		limit=None,
-		offset=None,
-	):
-		return _get_items(
-			pos_profile,
-			price_list,
-			item_group,
-			search_value,
-			customer,
-			limit,
-			offset,
-		)
+                customer=None,
+                limit=None,
+                offset=None,
+                modified_after=None,
+        ):
+                return _get_items(
+                        pos_profile,
+                        price_list,
+                        item_group,
+                        search_value,
+                        customer,
+                        limit,
+                        offset,
+                        modified_after,
+                )
 
 	def _get_items(
 		pos_profile,
 		price_list,
 		item_group,
 		search_value,
-		customer=None,
-		limit=None,
-		offset=None,
-	):
+                customer=None,
+                limit=None,
+                offset=None,
+                modified_after=None,
+        ):
 		pos_profile = json.loads(pos_profile)
 		condition = ""
 
@@ -172,7 +176,9 @@ def get_items(
 		result = []
 
 		# Build ORM filters
-		filters = {"disabled": 0, "is_sales_item": 1, "is_fixed_asset": 0}
+                filters = {"disabled": 0, "is_sales_item": 1, "is_fixed_asset": 0}
+                if modified_after:
+                        filters["modified"] = [">", modified_after]
 
 		# Add item group filter
 		item_groups = get_item_groups(pos_profile.get("name"))
@@ -356,26 +362,28 @@ def get_items(
 					result.append(row)
 		return result
 
-	if use_price_list:
-		return __get_items(
-			pos_profile,
-			price_list,
-			item_group,
-			search_value,
-			customer,
-			limit,
-			offset,
-		)
-	else:
-		return _get_items(
-			pos_profile,
-			price_list,
-			item_group,
-			search_value,
-			customer,
-			limit,
-			offset,
-		)
+        if use_price_list:
+                return __get_items(
+                        pos_profile,
+                        price_list,
+                        item_group,
+                        search_value,
+                        customer,
+                        limit,
+                        offset,
+                        modified_after,
+                )
+        else:
+                return _get_items(
+                        pos_profile,
+                        price_list,
+                        item_group,
+                        search_value,
+                        customer,
+                        limit,
+                        offset,
+                        modified_after,
+                )
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -486,15 +486,18 @@ def get_items_details(pos_profile, items_data, price_list=None):
 	)
 	result = []
 
-	if items_data:
-		for item in items_data:
-			item_code = item.get("item_code")
-			if item_code:
-				item_detail = get_item_detail(
-					json.dumps(item),
-					warehouse=warehouse,
-					price_list=price_list or pos_profile.get("selling_price_list"),
-					company=company,
+        if items_data:
+                for item in items_data:
+                        item_code = item.get("item_code")
+                        if item_code:
+                                if item.get("has_variants"):
+                                        # Skip template items to avoid ValidationError
+                                        continue
+                                item_detail = get_item_detail(
+                                        json.dumps(item),
+                                        warehouse=warehouse,
+                                        price_list=price_list or pos_profile.get("selling_price_list"),
+                                        company=company,
 				)
 				if item_detail:
 					result.append(item_detail)

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -500,7 +500,7 @@ def get_items_details(pos_profile, items_data, price_list=None):
 						company=company,
 					)
 				if item_detail:
-			result.append(item_detail)
+					result.append(item_detail)
 
 	return result
 

--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -146,6 +146,7 @@ export function setItemsStorage(items) {
 			actual_qty: it.actual_qty,
 			has_batch_no: it.has_batch_no,
 			has_serial_no: it.has_serial_no,
+			has_variants: !!it.has_variants,
 		}));
 	} catch (e) {
 		console.error("Failed to trim items for storage", e);

--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -1,4 +1,11 @@
-import { db, persist, checkDbHealth, terminatePersistWorker, initPersistWorker } from "./core.js";
+import {
+	db,
+	persist,
+	checkDbHealth,
+	terminatePersistWorker,
+	initPersistWorker,
+	tableForKey,
+} from "./core.js";
 import { getAllByCursor } from "./db-utils.js";
 import Dexie from "dexie/dist/dexie.mjs";
 
@@ -29,6 +36,8 @@ export const memory = {
 	translation_cache: {},
 	coupons_cache: {},
 	item_groups_cache: [],
+	items_last_sync: null,
+	customers_last_sync: null,
 	// Track the current cache schema version
 	cache_version: CACHE_VERSION,
 	cache_ready: false,
@@ -41,7 +50,7 @@ export const memoryInitPromise = (async () => {
 	try {
 		await checkDbHealth();
 		for (const key of Object.keys(memory)) {
-			const stored = await db.table("keyval").get(key);
+			const stored = await db.table(tableForKey(key)).get(key);
 			if (stored && stored.value !== undefined) {
 				memory[key] = stored.value;
 				continue;
@@ -60,7 +69,7 @@ export const memoryInitPromise = (async () => {
 		}
 
 		// Verify cache version and clear outdated caches
-		const versionEntry = await db.table("keyval").get("cache_version");
+		const versionEntry = await db.table(tableForKey("cache_version")).get("cache_version");
 		let storedVersion = versionEntry ? versionEntry.value : null;
 		if (!storedVersion && typeof localStorage !== "undefined") {
 			const v = localStorage.getItem("posa_cache_version");
@@ -94,6 +103,27 @@ export function resetOfflineState() {
 	persist("pos_last_sync_totals", memory.pos_last_sync_totals);
 }
 
+export function reduceCacheUsage() {
+	memory.price_list_cache = {};
+	memory.item_details_cache = {};
+	memory.uom_cache = {};
+	memory.offers_cache = [];
+	memory.customer_balance_cache = {};
+	memory.local_stock_cache = {};
+	memory.stock_cache_ready = false;
+	memory.coupons_cache = {};
+	memory.item_groups_cache = [];
+	persist("price_list_cache", memory.price_list_cache);
+	persist("item_details_cache", memory.item_details_cache);
+	persist("uom_cache", memory.uom_cache);
+	persist("offers_cache", memory.offers_cache);
+	persist("customer_balance_cache", memory.customer_balance_cache);
+	persist("local_stock_cache", memory.local_stock_cache);
+	persist("stock_cache_ready", memory.stock_cache_ready);
+	persist("coupons_cache", memory.coupons_cache);
+	persist("item_groups_cache", memory.item_groups_cache);
+}
+
 // --- Generic getters and setters for cached data ----------------------------
 export function getItemsStorage() {
 	return memory.items_storage || [];
@@ -101,9 +131,24 @@ export function getItemsStorage() {
 
 export function setItemsStorage(items) {
 	try {
-		memory.items_storage = JSON.parse(JSON.stringify(items));
+		memory.items_storage = items.map((it) => ({
+			item_code: it.item_code,
+			item_name: it.item_name,
+			description: it.description,
+			stock_uom: it.stock_uom,
+			image: it.image,
+			item_group: it.item_group,
+			rate: it.rate,
+			price_list_rate: it.price_list_rate,
+			currency: it.currency,
+			item_barcode: it.item_barcode,
+			item_uoms: it.item_uoms,
+			actual_qty: it.actual_qty,
+			has_batch_no: it.has_batch_no,
+			has_serial_no: it.has_serial_no,
+		}));
 	} catch (e) {
-		console.error("Failed to serialize items for storage", e);
+		console.error("Failed to trim items for storage", e);
 		memory.items_storage = [];
 	}
 	persist("items_storage", memory.items_storage);
@@ -114,8 +159,38 @@ export function getCustomerStorage() {
 }
 
 export function setCustomerStorage(customers) {
-	memory.customer_storage = customers;
+	try {
+		memory.customer_storage = customers.map((c) => ({
+			name: c.name,
+			customer_name: c.customer_name,
+			mobile_no: c.mobile_no,
+			email_id: c.email_id,
+			primary_address: c.primary_address,
+			tax_id: c.tax_id,
+		}));
+	} catch (e) {
+		console.error("Failed to trim customers for storage", e);
+		memory.customer_storage = [];
+	}
 	persist("customer_storage", memory.customer_storage);
+}
+
+export function getItemsLastSync() {
+	return memory.items_last_sync || null;
+}
+
+export function setItemsLastSync(ts) {
+	memory.items_last_sync = ts;
+	persist("items_last_sync", memory.items_last_sync);
+}
+
+export function getCustomersLastSync() {
+	return memory.customers_last_sync || null;
+}
+
+export function setCustomersLastSync(ts) {
+	memory.customers_last_sync = ts;
+	persist("customers_last_sync", memory.customers_last_sync);
 }
 
 export function getSalesPersonsStorage() {
@@ -300,6 +375,8 @@ export async function clearAllCache() {
 	memory.stock_cache_ready = false;
 	memory.items_storage = [];
 	memory.customer_storage = [];
+	memory.items_last_sync = null;
+	memory.customers_last_sync = null;
 	memory.pos_opening_storage = null;
 	memory.opening_dialog_storage = null;
 	memory.sales_persons_storage = [];
@@ -337,6 +414,8 @@ export async function forceClearAllCache() {
 	memory.stock_cache_ready = false;
 	memory.items_storage = [];
 	memory.customer_storage = [];
+	memory.items_last_sync = null;
+	memory.customers_last_sync = null;
 	memory.pos_opening_storage = null;
 	memory.opening_dialog_storage = null;
 	memory.sales_persons_storage = [];
@@ -382,11 +461,13 @@ export async function getCacheUsageEstimate() {
 		let indexedDBSize = 0;
 		try {
 			if (db.isOpen()) {
-				const entries = await getAllByCursor("keyval");
-				indexedDBSize = entries.reduce((size, item) => {
-					const itemSize = JSON.stringify(item).length * 2; // UTF-16 characters are 2 bytes each
-					return size + itemSize;
-				}, 0);
+				for (const table of db.tables) {
+					const entries = await getAllByCursor(table.name);
+					indexedDBSize += entries.reduce((size, item) => {
+						const itemSize = JSON.stringify(item).length * 2; // UTF-16 characters
+						return size + itemSize;
+					}, 0);
+				}
 			}
 		} catch (e) {
 			console.error("Failed to calculate IndexedDB size", e);

--- a/posawesome/public/js/offline/index.js
+++ b/posawesome/public/js/offline/index.js
@@ -19,6 +19,10 @@ export {
 	setItemsStorage,
 	getCustomerStorage,
 	setCustomerStorage,
+	getItemsLastSync,
+	setItemsLastSync,
+	getCustomersLastSync,
+	setCustomersLastSync,
 	getSalesPersonsStorage,
 	setSalesPersonsStorage,
 	getOpeningStorage,
@@ -39,6 +43,7 @@ export {
 	purgeOldQueueEntries,
 	MAX_QUEUE_ITEMS,
 	resetOfflineState,
+	reduceCacheUsage,
 	clearAllCache,
 	forceClearAllCache,
 	getCacheUsageEstimate,
@@ -92,30 +97,22 @@ export {
 	savePriceListItems,
 	getCachedPriceListItems,
 	clearPriceListCache,
-        saveItemDetailsCache,
-        getCachedItemDetails,
+	saveItemDetailsCache,
+	getCachedItemDetails,
 } from "./items.js";
 
-export {
-       saveItemGroups,
-       getCachedItemGroups,
-       clearItemGroups,
-} from "./item_groups.js";
+export { saveItemGroups, getCachedItemGroups, clearItemGroups } from "./item_groups.js";
 
 // Customers exports
 export {
-        saveCustomerBalance,
-        getCachedCustomerBalance,
-        clearCustomerBalanceCache,
-        clearExpiredCustomerBalances,
+	saveCustomerBalance,
+	getCachedCustomerBalance,
+	clearCustomerBalanceCache,
+	clearExpiredCustomerBalances,
 } from "./customers.js";
 
 // Coupons exports
-export {
-        saveCoupons,
-        getCachedCoupons,
-        clearCoupons,
-} from "./coupons.js";
+export { saveCoupons, getCachedCoupons, clearCoupons } from "./coupons.js";
 
 // Translation cache exports
 export { getTranslationsCache, saveTranslationsCache } from "./cache.js";

--- a/posawesome/public/js/offline/sync.js
+++ b/posawesome/public/js/offline/sync.js
@@ -1,4 +1,4 @@
-import { memory, resetOfflineState, setLastSyncTotals, MAX_QUEUE_ITEMS } from "./cache.js";
+import { memory, resetOfflineState, setLastSyncTotals, MAX_QUEUE_ITEMS, reduceCacheUsage } from "./cache.js";
 import { persist } from "./core.js";
 import { updateLocalStock } from "./stock.js";
 
@@ -249,6 +249,9 @@ export async function syncOfflineInvoices() {
 			persist("offline_invoices", memory.offline_invoices);
 		} else {
 			clearOfflineInvoices();
+			if (synced > 0 && drafted === 0) {
+				reduceCacheUsage();
+			}
 		}
 
 		const totals = { pending: pendingLeft, synced, drafted };

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -17,7 +17,7 @@
 			:no-data-text="__('Customers not found')"
 			hide-details
 			:customFilter="() => true"
-                        :disabled="effectiveReadonly || loadingCustomers"
+			:disabled="effectiveReadonly || loadingCustomers"
 			:menu-props="{ closeOnContentClick: false }"
 			@update:menu="onCustomerMenuToggle"
 			@update:modelValue="onCustomerChange"
@@ -157,7 +157,13 @@
 
 <script>
 import UpdateCustomer from "./UpdateCustomer.vue";
-import { getCustomerStorage, setCustomerStorage, memoryInitPromise } from "../../../offline/index.js";
+import {
+	getCustomerStorage,
+	setCustomerStorage,
+	memoryInitPromise,
+	getCustomersLastSync,
+	setCustomersLastSync,
+} from "../../../offline/index.js";
 
 export default {
 	props: {
@@ -171,8 +177,8 @@ export default {
 		internalCustomer: null, // Model bound to the dropdown
 		tempSelectedCustomer: null, // Temporarily holds customer selected from dropdown
 		isMenuOpen: false, // Tracks whether dropdown menu is open
-                readonly: false,
-                effectiveReadonly: false,
+		readonly: false,
+		effectiveReadonly: false,
 		customer_info: {}, // Used for edit modal
 		loadingCustomers: false, // ? New state to track loading status
 		customerSearch: "", // Search text
@@ -182,14 +188,14 @@ export default {
 		UpdateCustomer,
 	},
 
-        computed: {
+	computed: {
 		isDarkTheme() {
 			return this.$theme.current === "dark";
 		},
 
-                filteredCustomers() {
-                        const search = this.customerSearch.toLowerCase();
-                        let results = this.customers;
+		filteredCustomers() {
+			const search = this.customerSearch.toLowerCase();
+			let results = this.customers;
 			if (search) {
 				results = results.filter((cust) => {
 					return (
@@ -201,15 +207,15 @@ export default {
 					);
 				});
 			}
-                        return results;
-                },
-        },
+			return results;
+		},
+	},
 
-        watch: {
-                readonly(val) {
-                        this.effectiveReadonly = val && navigator.onLine;
-                },
-        },
+	watch: {
+		readonly(val) {
+			this.effectiveReadonly = val && navigator.onLine;
+		},
+	},
 
 	methods: {
 		// Called when dropdown opens or closes
@@ -282,7 +288,9 @@ export default {
 			var vm = this;
 			if (this.customers.length > 0) return;
 
-                        if (getCustomerStorage().length) {
+			const lastSync = getCustomersLastSync();
+
+			if (getCustomerStorage().length) {
 				try {
 					vm.customers = getCustomerStorage();
 				} catch (e) {
@@ -296,29 +304,43 @@ export default {
 				method: "posawesome.posawesome.api.customers.get_customer_names",
 				args: {
 					pos_profile: this.pos_profile.pos_profile,
+					modified_after: lastSync,
 				},
 				callback: function (r) {
 					if (r.message) {
-						vm.customers = r.message;
+						const newCust = r.message;
+						if (lastSync && vm.customers.length) {
+							newCust.forEach((c) => {
+								const idx = vm.customers.findIndex((x) => x.name === c.name);
+								if (idx !== -1) {
+									vm.customers.splice(idx, 1, c);
+								} else {
+									vm.customers.push(c);
+								}
+							});
+						} else {
+							vm.customers = newCust;
+						}
 
-                                                setCustomerStorage(r.message);
+						setCustomerStorage(vm.customers);
+						setCustomersLastSync(new Date().toISOString());
 					}
 					vm.loadingCustomers = false; // ? Stop loading
 				},
-                                error: function (err) {
-                                        console.error("Failed to fetch customers:", err);
-                                        if (getCustomerStorage().length) {
-                                                try {
-                                                        vm.customers = getCustomerStorage();
-                                                } catch (e) {
-                                                        console.error("Failed to load cached customers", e);
-                                                        vm.customers = [];
-                                                }
-                                        }
-                                        vm.loadingCustomers = false;
-                                },
-                        });
-                },
+				error: function (err) {
+					console.error("Failed to fetch customers:", err);
+					if (getCustomerStorage().length) {
+						try {
+							vm.customers = getCustomerStorage();
+						} catch (e) {
+							console.error("Failed to load cached customers", e);
+							vm.customers = [];
+						}
+					}
+					vm.loadingCustomers = false;
+				},
+			});
+		},
 
 		new_customer() {
 			this.eventBus.emit("open_update_customer", null);
@@ -329,29 +351,29 @@ export default {
 		},
 	},
 
-        created() {
-                // Load cached customers immediately for offline use
-                if (getCustomerStorage().length) {
-                        try {
-                                this.customers = getCustomerStorage();
-                        } catch (e) {
-                                console.error("Failed to parse customer cache:", e);
-                                this.customers = [];
-                        }
-                }
+	created() {
+		// Load cached customers immediately for offline use
+		if (getCustomerStorage().length) {
+			try {
+				this.customers = getCustomerStorage();
+			} catch (e) {
+				console.error("Failed to parse customer cache:", e);
+				this.customers = [];
+			}
+		}
 
-                memoryInitPromise.then(() => {
-                        if (getCustomerStorage().length) {
-                                try {
-                                        this.customers = getCustomerStorage();
-                                } catch (e) {
-                                        console.error("Failed to load cached customers", e);
-                                }
-                        }
-                        this.effectiveReadonly = this.readonly && navigator.onLine;
-                });
+		memoryInitPromise.then(() => {
+			if (getCustomerStorage().length) {
+				try {
+					this.customers = getCustomerStorage();
+				} catch (e) {
+					console.error("Failed to load cached customers", e);
+				}
+			}
+			this.effectiveReadonly = this.readonly && navigator.onLine;
+		});
 
-                this.effectiveReadonly = this.readonly && navigator.onLine;
+		this.effectiveReadonly = this.readonly && navigator.onLine;
 
 		this.$nextTick(() => {
 			this.eventBus.on("register_pos_profile", (pos_profile) => {
@@ -364,10 +386,10 @@ export default {
 				this.get_customer_names();
 			});
 
-                        this.eventBus.on("set_customer", (customer) => {
-                                this.customer = customer;
-                                this.internalCustomer = customer;
-                        });
+			this.eventBus.on("set_customer", (customer) => {
+				this.customer = customer;
+				this.internalCustomer = customer;
+			});
 
 			this.eventBus.on("add_customer_to_list", (customer) => {
 				const index = this.customers.findIndex((c) => c.name === customer.name);
@@ -377,7 +399,7 @@ export default {
 				} else {
 					this.customers.push(customer);
 				}
-                                setCustomerStorage(this.customers);
+				setCustomerStorage(this.customers);
 				this.customer = customer.name;
 				this.internalCustomer = customer.name;
 				this.eventBus.emit("update_customer", customer.name);

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -736,7 +736,9 @@ export default {
 					vm.items_loaded = true;
 
 					if (vm.items && vm.items.length > 0) {
-						vm.prePopulateStockCache(vm.items);
+						if (vm.items.length <= 500) {
+							vm.prePopulateStockCache(vm.items);
+						}
 						vm.update_items_details(vm.items);
 					}
 					return;
@@ -768,7 +770,9 @@ export default {
 				vm.items_loaded = true;
 
 				if (vm.items && vm.items.length > 0) {
-					await vm.prePopulateStockCache(vm.items);
+					if (vm.items.length <= 500) {
+						await vm.prePopulateStockCache(vm.items);
+					}
 					vm.update_items_details(vm.items);
 				}
 				return;
@@ -838,7 +842,9 @@ export default {
 							saveItemGroups(groups);
 
 							// Pre-populate stock cache when items are freshly loaded
-							vm.prePopulateStockCache(vm.items);
+							if (vm.items.length <= 500) {
+								vm.prePopulateStockCache(vm.items);
+							}
 
 							vm.$nextTick(() => {
 								if (vm.search && vm.pos_profile && !vm.pos_profile.pose_use_limit_search) {
@@ -944,7 +950,9 @@ export default {
 							saveItemGroups(groups);
 
 							// Pre-populate stock cache when items are freshly loaded
-							vm.prePopulateStockCache(vm.items);
+							if (vm.items.length <= 500) {
+								vm.prePopulateStockCache(vm.items);
+							}
 
 							vm.$nextTick(() => {
 								if (vm.search && vm.pos_profile && !vm.pos_profile.pose_use_limit_search) {
@@ -1444,6 +1452,13 @@ export default {
 		},
 		async prePopulateStockCache(items) {
 			if (this.prePopulateInProgress) {
+				return;
+			}
+			if (!Array.isArray(items) || items.length === 0) {
+				return;
+			}
+			if (items.length > 500) {
+				console.info("Skipping stock pre-population for", items.length, "items");
 				return;
 			}
 			this.prePopulateInProgress = true;

--- a/posawesome/public/js/posapp/workers/itemWorker.js
+++ b/posawesome/public/js/posapp/workers/itemWorker.js
@@ -92,6 +92,7 @@ self.onmessage = async (event) => {
 				actual_qty: it.actual_qty,
 				has_batch_no: it.has_batch_no,
 				has_serial_no: it.has_serial_no,
+				has_variants: !!it.has_variants,
 			}));
 			let cache = {};
 			try {

--- a/posawesome/public/js/posapp/workers/itemWorker.js
+++ b/posawesome/public/js/posapp/workers/itemWorker.js
@@ -9,7 +9,11 @@ let db;
 		DexieLib = await import("/assets/posawesome/js/libs/dexie.min.js?v=1");
 	}
 	db = new DexieLib.default("posawesome_offline");
-	db.version(1).stores({ keyval: "&key" });
+	db.version(2).stores({
+		keyval: "&key",
+		queue: "&key",
+		cache: "&key",
+	});
 	try {
 		await db.open();
 	} catch (err) {
@@ -17,12 +21,27 @@ let db;
 	}
 })();
 
+const KEY_TABLE_MAP = {
+	offline_invoices: "queue",
+	offline_customers: "queue",
+	offline_payments: "queue",
+	price_list_cache: "cache",
+	item_details_cache: "cache",
+	items_storage: "cache",
+	customer_storage: "cache",
+};
+
+function tableForKey(key) {
+	return KEY_TABLE_MAP[key] || "keyval";
+}
+
 async function persist(key, value) {
 	try {
 		if (!db.isOpen()) {
 			await db.open();
 		}
-		await db.table("keyval").put({ key, value });
+		const table = tableForKey(key);
+		await db.table(table).put({ key, value });
 	} catch (e) {
 		console.error("Worker persist failed", e);
 	}
@@ -58,19 +77,35 @@ self.onmessage = async (event) => {
 				self.postMessage({ type: "error", error: e.message });
 				return;
 			}
+			const trimmed = items.map((it) => ({
+				item_code: it.item_code,
+				item_name: it.item_name,
+				description: it.description,
+				stock_uom: it.stock_uom,
+				image: it.image,
+				item_group: it.item_group,
+				rate: it.rate,
+				price_list_rate: it.price_list_rate,
+				currency: it.currency,
+				item_barcode: it.item_barcode,
+				item_uoms: it.item_uoms,
+				actual_qty: it.actual_qty,
+				has_batch_no: it.has_batch_no,
+				has_serial_no: it.has_serial_no,
+			}));
 			let cache = {};
 			try {
 				if (!db.isOpen()) {
 					await db.open();
 				}
-				const stored = await db.table("keyval").get("price_list_cache");
+				const stored = await db.table(tableForKey("price_list_cache")).get("price_list_cache");
 				if (stored && stored.value) cache = stored.value;
 			} catch (e) {
 				console.error("Failed to read cache in worker", e);
 			}
-			cache[data.priceList] = { items, timestamp: Date.now() };
+			cache[data.priceList] = { items: trimmed, timestamp: Date.now() };
 			await persist("price_list_cache", cache);
-			self.postMessage({ type: "parsed", items });
+			self.postMessage({ type: "parsed", items: trimmed });
 		} catch (err) {
 			console.log(err);
 			self.postMessage({ type: "error", error: err.message });


### PR DESCRIPTION
## Summary
- support delta retrieval of customers and items
- track last sync timestamps in offline cache
- merge newly fetched records with cached data
- trim stored item and customer records before persisting offline
- add dedicated Dexie stores to keep large caches in separate tables
- reduce caches after successful sync

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6887344231d883269b82b0a0c9a7dd54