### PR TITLE
Add console message on item and customer load

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -181,6 +181,7 @@ export default {
 		effectiveReadonly: false,
 		customer_info: {}, // Used for edit modal
 		loadingCustomers: false, // ? New state to track loading status
+		customers_loaded: false,
 		customerSearch: "", // Search text
 		customersPageLimit: 500,
 	}),
@@ -215,6 +216,11 @@ export default {
 	watch: {
 		readonly(val) {
 			this.effectiveReadonly = val && navigator.onLine;
+		},
+		customers_loaded(val) {
+			if (val) {
+				this.eventBus.emit("customers_loaded");
+			}
 		},
 	},
 
@@ -320,7 +326,10 @@ export default {
 		// Fetch customers list
 		get_customer_names() {
 			var vm = this;
-			if (this.customers.length > 0) return;
+			if (this.customers.length > 0) {
+				this.customers_loaded = true;
+				return;
+			}
 
 			const syncSince = getCustomersLastSync();
 
@@ -366,6 +375,7 @@ export default {
 						}
 					}
 					vm.loadingCustomers = false; // ? Stop loading
+					vm.customers_loaded = true;
 				},
 				error: function (err) {
 					console.error("Failed to fetch customers:", err);
@@ -378,6 +388,7 @@ export default {
 						}
 					}
 					vm.loadingCustomers = false;
+					vm.customers_loaded = true;
 				},
 			});
 		},

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -555,6 +555,11 @@ export default {
 			// Maintain the configured items per page on resize
 			this.itemsPerPage = this.items_per_page;
 		},
+		items_loaded(val) {
+			if (val) {
+				this.eventBus.emit("items_loaded");
+			}
+		},
 	},
 
 	methods: {

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -85,6 +85,8 @@ export default {
 			payment: false,
 			showOffers: false,
 			coupons: false,
+			itemsLoaded: false,
+			customersLoaded: false,
 		};
 	},
 
@@ -113,6 +115,11 @@ export default {
 			frappe.db.get_doc("POS Settings", undefined).then((doc) => {
 				this.eventBus.emit("set_pos_settings", doc);
 			});
+		},
+		checkLoadingComplete() {
+			if (this.itemsLoaded && this.customersLoaded) {
+				console.info("Loading completed");
+			}
 		},
 	},
 
@@ -158,6 +165,15 @@ export default {
 			this.eventBus.on("submit_closing_pos", (data) => {
 				this.submit_closing_pos(data);
 			});
+
+			this.eventBus.on("items_loaded", () => {
+				this.itemsLoaded = true;
+				this.checkLoadingComplete();
+			});
+			this.eventBus.on("customers_loaded", () => {
+				this.customersLoaded = true;
+				this.checkLoadingComplete();
+			});
 		});
 	},
 	beforeUnmount() {
@@ -169,6 +185,8 @@ export default {
 		this.eventBus.off("show_coupons");
 		this.eventBus.off("open_closing_dialog");
 		this.eventBus.off("submit_closing_pos");
+		this.eventBus.off("items_loaded");
+		this.eventBus.off("customers_loaded");
 	},
 	// In the created() or mounted() lifecycle hook
 	created() {


### PR DESCRIPTION
## Summary
- emit `items_loaded` and `customers_loaded` events in ItemsSelector and Customer components
- listen for those events in Pos.vue and log when both are completed

## Testing
- `npx prettier --write posawesome/public/js/posapp/components/pos/Customer.vue posawesome/public/js/posapp/components/pos/ItemsSelector.vue posawesome/public/js/posapp/components/pos/Pos.vue`

------
https://chatgpt.com/codex/tasks/task_e_6887ae501ec883268d800890f64c6914