### PR TITLE
Fix customer switch after cancelling payment

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -1063,6 +1063,11 @@ export default {
 		back_to_invoice() {
 			this.eventBus.emit("show_payment", "false");
 			this.eventBus.emit("set_customer_readonly", false);
+			// Clear invoice name so a new invoice is created if
+			// customer changes before paying again
+			if (this.invoice_doc && this.invoice_doc.name) {
+				delete this.invoice_doc.name;
+			}
 		},
 		// Reset all cash payments to zero
 		reset_cash_payments() {
@@ -1946,6 +1951,11 @@ export default {
 					this.redeem_customer_credit = false;
 					this.is_cashback = true;
 					this.is_credit_return = false;
+				}
+				// keep invoice_doc in sync with changed customer
+				if (this.invoice_doc) {
+					this.invoice_doc.customer = customer;
+					this.invoice_doc.customer_name = customer;
 				}
 			});
 			this.eventBus.on("set_pos_settings", (data) => {

--- a/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
@@ -4,6 +4,15 @@ export default {
 	// Watch for customer change and update related data
 	customer() {
 		this.close_payments();
+
+		// If an invoice doc already exists, clear its name so a new one is
+		// created when paying again and update the customer field
+		if (this.invoice_doc) {
+			if (this.invoice_doc.name) delete this.invoice_doc.name;
+			this.invoice_doc.customer = this.customer;
+			this.invoice_doc.customer_name = this.customer;
+		}
+
 		this.eventBus.emit("set_customer", this.customer);
 		this.fetch_customer_details();
 		this.fetch_customer_balance();


### PR DESCRIPTION
## Summary
- ensure invoice name resets if customer changes
- keep invoice's customer in sync when cancelling payment

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6887b583cd7c8326b062659701c8fb7d