### PR TITLE
Fix cache load for items and customers

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -402,7 +402,8 @@ export default {
 		},
 	},
 
-	created() {
+	async created() {
+		await memoryInitPromise;
 		// Load cached customers immediately for offline use
 		if (getCustomerStorage().length) {
 			try {
@@ -413,31 +414,20 @@ export default {
 			}
 		}
 
-		memoryInitPromise.then(() => {
-			if (getCustomerStorage().length) {
-				try {
-					this.customers = getCustomerStorage();
-				} catch (e) {
-					console.error("Failed to load cached customers", e);
-				}
-			}
-			this.effectiveReadonly = this.readonly && navigator.onLine;
-		});
-
 		this.effectiveReadonly = this.readonly && navigator.onLine;
 
 		this.$nextTick(() => {
-                        this.eventBus.on("register_pos_profile", async (pos_profile) => {
-                                await memoryInitPromise;
-                                this.pos_profile = pos_profile;
-                                this.get_customer_names();
-                        });
+			this.eventBus.on("register_pos_profile", async (pos_profile) => {
+				await memoryInitPromise;
+				this.pos_profile = pos_profile;
+				this.get_customer_names();
+			});
 
-                        this.eventBus.on("payments_register_pos_profile", async (pos_profile) => {
-                                await memoryInitPromise;
-                                this.pos_profile = pos_profile;
-                                this.get_customer_names();
-                        });
+			this.eventBus.on("payments_register_pos_profile", async (pos_profile) => {
+				await memoryInitPromise;
+				this.pos_profile = pos_profile;
+				this.get_customer_names();
+			});
 
 			this.eventBus.on("set_customer", (customer) => {
 				this.customer = customer;

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -427,15 +427,17 @@ export default {
 		this.effectiveReadonly = this.readonly && navigator.onLine;
 
 		this.$nextTick(() => {
-			this.eventBus.on("register_pos_profile", (pos_profile) => {
-				this.pos_profile = pos_profile;
-				this.get_customer_names();
-			});
+                        this.eventBus.on("register_pos_profile", async (pos_profile) => {
+                                await memoryInitPromise;
+                                this.pos_profile = pos_profile;
+                                this.get_customer_names();
+                        });
 
-			this.eventBus.on("payments_register_pos_profile", (pos_profile) => {
-				this.pos_profile = pos_profile;
-				this.get_customer_names();
-			});
+                        this.eventBus.on("payments_register_pos_profile", async (pos_profile) => {
+                                await memoryInitPromise;
+                                this.pos_profile = pos_profile;
+                                this.get_customer_names();
+                        });
 
 			this.eventBus.on("set_customer", (customer) => {
 				this.customer = customer;

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -402,17 +402,18 @@ export default {
 		},
 	},
 
-	async created() {
-		await memoryInitPromise;
-		// Load cached customers immediately for offline use
-		if (getCustomerStorage().length) {
-			try {
-				this.customers = getCustomerStorage();
-			} catch (e) {
-				console.error("Failed to parse customer cache:", e);
-				this.customers = [];
+	created() {
+		memoryInitPromise.then(() => {
+			if (getCustomerStorage().length) {
+				try {
+					this.customers = getCustomerStorage();
+				} catch (e) {
+					console.error("Failed to parse customer cache:", e);
+					this.customers = [];
+				}
 			}
-		}
+			this.effectiveReadonly = this.readonly && navigator.onLine;
+		});
 
 		this.effectiveReadonly = this.readonly && navigator.onLine;
 

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -444,19 +444,6 @@ export default {
 		search_from_scanner: false,
 	}),
 
-	async created() {
-		await memoryInitPromise;
-		if (getItemsStorage().length) {
-			try {
-				this.items = getItemsStorage();
-				this.eventBus.emit("set_all_items", this.items);
-				this.items_loaded = true;
-			} catch (e) {
-				console.error("Failed to load cached items", e);
-			}
-		}
-	},
-
 	watch: {
 		customer: _.debounce(function () {
 			if (this.pos_profile.posa_force_reload_items) {
@@ -2188,7 +2175,18 @@ export default {
 		},
 	},
 
-	created: function () {
+	async created() {
+		await memoryInitPromise;
+		if (getItemsStorage().length) {
+			try {
+				this.items = getItemsStorage();
+				this.eventBus.emit("set_all_items", this.items);
+				this.items_loaded = true;
+			} catch (e) {
+				console.error("Failed to load cached items", e);
+			}
+		}
+
 		this.loadItemSettings();
 		if (typeof Worker !== "undefined") {
 			try {

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -371,9 +371,9 @@ import {
 	setItemsStorage,
 	getLocalStockCache,
 	setLocalStockCache,
-        initPromise,
-        memoryInitPromise,
-        checkDbHealth,
+	initPromise,
+	memoryInitPromise,
+	checkDbHealth,
 	getCachedPriceListItems,
 	savePriceListItems,
 	updateLocalStockCache,
@@ -443,6 +443,19 @@ export default {
 		// Track if the current search was triggered by a scanner
 		search_from_scanner: false,
 	}),
+
+	async created() {
+		await memoryInitPromise;
+		if (getItemsStorage().length) {
+			try {
+				this.items = getItemsStorage();
+				this.eventBus.emit("set_all_items", this.items);
+				this.items_loaded = true;
+			} catch (e) {
+				console.error("Failed to load cached items", e);
+			}
+		}
+	},
 
 	watch: {
 		customer: _.debounce(function () {
@@ -2198,10 +2211,10 @@ export default {
 			}
 		}
 		this.$nextTick(function () {});
-                this.eventBus.on("register_pos_profile", async (data) => {
-                        await initPromise;
-                        await memoryInitPromise;
-                        await checkDbHealth();
+		this.eventBus.on("register_pos_profile", async (data) => {
+			await initPromise;
+			await memoryInitPromise;
+			await checkDbHealth();
 			this.pos_profile = data.pos_profile;
 			if (this.pos_profile.posa_force_reload_items && !this.pos_profile.posa_smart_reload_mode) {
 				await this.get_items(true);

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2175,17 +2175,18 @@ export default {
 		},
 	},
 
-	async created() {
-		await memoryInitPromise;
-		if (getItemsStorage().length) {
-			try {
-				this.items = getItemsStorage();
-				this.eventBus.emit("set_all_items", this.items);
-				this.items_loaded = true;
-			} catch (e) {
-				console.error("Failed to load cached items", e);
+	created() {
+		memoryInitPromise.then(() => {
+			if (getItemsStorage().length) {
+				try {
+					this.items = getItemsStorage();
+					this.eventBus.emit("set_all_items", this.items);
+					this.items_loaded = true;
+				} catch (e) {
+					console.error("Failed to load cached items", e);
+				}
 			}
-		}
+		});
 
 		this.loadItemSettings();
 		if (typeof Worker !== "undefined") {

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -371,8 +371,9 @@ import {
 	setItemsStorage,
 	getLocalStockCache,
 	setLocalStockCache,
-	initPromise,
-	checkDbHealth,
+        initPromise,
+        memoryInitPromise,
+        checkDbHealth,
 	getCachedPriceListItems,
 	savePriceListItems,
 	updateLocalStockCache,
@@ -2197,9 +2198,10 @@ export default {
 			}
 		}
 		this.$nextTick(function () {});
-		this.eventBus.on("register_pos_profile", async (data) => {
-			await initPromise;
-			await checkDbHealth();
+                this.eventBus.on("register_pos_profile", async (data) => {
+                        await initPromise;
+                        await memoryInitPromise;
+                        await checkDbHealth();
 			this.pos_profile = data.pos_profile;
 			if (this.pos_profile.posa_force_reload_items && !this.pos_profile.posa_smart_reload_mode) {
 				await this.get_items(true);

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -991,8 +991,8 @@ export default {
 								!vm.pos_profile.pose_use_limit_search
 							) {
 								try {
-									setItemsStorage(r.message);
-									r.message.forEach((it) => {
+									setItemsStorage(vm.items);
+									vm.items.forEach((it) => {
 										if (it.item_uoms && it.item_uoms.length > 0) {
 											saveItemUOMs(it.item_code, it.item_uoms);
 										}
@@ -1040,6 +1040,13 @@ export default {
 						else this.items.push(it);
 					});
 					this.eventBus.emit("set_all_items", this.items);
+					if (
+						this.pos_profile &&
+						this.pos_profile.posa_local_storage &&
+						!this.pos_profile.pose_use_limit_search
+					) {
+						setItemsStorage(this.items);
+					}
 					if (parsed.length === limit) {
 						this.backgroundLoadItems(offset + limit, syncSince);
 					} else {
@@ -1069,6 +1076,13 @@ export default {
 							else this.items.push(it);
 						});
 						this.eventBus.emit("set_all_items", this.items);
+						if (
+							this.pos_profile &&
+							this.pos_profile.posa_local_storage &&
+							!this.pos_profile.pose_use_limit_search
+						) {
+							setItemsStorage(this.items);
+						}
 						if (rows.length === limit) {
 							this.backgroundLoadItems(offset + limit, syncSince);
 						} else {


### PR DESCRIPTION
## Summary
- await offline cache initialization before loading items
- await offline cache initialization before loading customers

## Testing
- `npm run format` *(fails: prettier not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68884c34bec083268eb0e230e726e5a6