### PR TITLE
Fix local cache fallback

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -66,6 +66,17 @@ export const memoryInitPromise = (async () => {
 					}
 				}
 			}
+			if (typeof sessionStorage !== "undefined") {
+				const ss = sessionStorage.getItem(`posa_${key}`);
+				if (ss) {
+					try {
+						memory[key] = JSON.parse(ss);
+						continue;
+					} catch (err) {
+						console.error("Failed to parse sessionStorage for", key, err);
+					}
+				}
+			}
 		}
 
 		// Verify cache version and clear outdated caches
@@ -73,6 +84,10 @@ export const memoryInitPromise = (async () => {
 		let storedVersion = versionEntry ? versionEntry.value : null;
 		if (!storedVersion && typeof localStorage !== "undefined") {
 			const v = localStorage.getItem("posa_cache_version");
+			if (v) storedVersion = parseInt(v, 10);
+		}
+		if (!storedVersion && typeof sessionStorage !== "undefined") {
+			const v = sessionStorage.getItem("posa_cache_version");
 			if (v) storedVersion = parseInt(v, 10);
 		}
 		if (storedVersion !== CACHE_VERSION) {
@@ -399,6 +414,13 @@ export async function forceClearAllCache() {
 		Object.keys(localStorage).forEach((key) => {
 			if (key.startsWith("posa_")) {
 				localStorage.removeItem(key);
+			}
+		});
+	}
+	if (typeof sessionStorage !== "undefined") {
+		Object.keys(sessionStorage).forEach((key) => {
+			if (key.startsWith("posa_")) {
+				sessionStorage.removeItem(key);
 			}
 		});
 	}

--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -129,6 +129,13 @@ export function persist(key, value) {
 			localStorage.setItem(`posa_${key}`, JSON.stringify(value));
 		} catch (err) {
 			console.error("Failed to persist", key, "to localStorage", err);
+			if (typeof sessionStorage !== "undefined") {
+				try {
+					sessionStorage.setItem(`posa_${key}`, JSON.stringify(value));
+				} catch (sesErr) {
+					console.error("Failed to persist", key, "to sessionStorage", sesErr);
+				}
+			}
 		}
 	}
 }

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -695,7 +695,12 @@ export default {
 			}
 
 			if (force_server && this.pos_profile.posa_local_storage) {
-				localStorage.setItem("items_storage", "");
+				if (typeof localStorage !== "undefined") {
+					localStorage.removeItem("posa_items_storage");
+				}
+				if (typeof sessionStorage !== "undefined") {
+					sessionStorage.removeItem("posa_items_storage");
+				}
 			}
 
 			const vm = this;
@@ -877,7 +882,9 @@ export default {
 								!vm.pos_profile.pose_use_limit_search
 							) {
 								try {
-									setItemsStorage(vm.items);
+									if (!sr) {
+										setItemsStorage(vm.items);
+									}
 									vm.items.forEach((it) => {
 										if (it.item_uoms && it.item_uoms.length > 0) {
 											saveItemUOMs(it.item_code, it.item_uoms);
@@ -991,7 +998,9 @@ export default {
 								!vm.pos_profile.pose_use_limit_search
 							) {
 								try {
-									setItemsStorage(vm.items);
+									if (!sr) {
+										setItemsStorage(vm.items);
+									}
 									vm.items.forEach((it) => {
 										if (it.item_uoms && it.item_uoms.length > 0) {
 											saveItemUOMs(it.item_code, it.item_uoms);
@@ -1045,7 +1054,9 @@ export default {
 						this.pos_profile.posa_local_storage &&
 						!this.pos_profile.pose_use_limit_search
 					) {
-						setItemsStorage(this.items);
+						if (!this.search) {
+							setItemsStorage(this.items);
+						}
 					}
 					if (parsed.length === limit) {
 						this.backgroundLoadItems(offset + limit, syncSince);
@@ -1081,7 +1092,9 @@ export default {
 							this.pos_profile.posa_local_storage &&
 							!this.pos_profile.pose_use_limit_search
 						) {
-							setItemsStorage(this.items);
+							if (!this.search) {
+								setItemsStorage(this.items);
+							}
 						}
 						if (rows.length === limit) {
 							this.backgroundLoadItems(offset + limit, syncSince);


### PR DESCRIPTION
## Summary
- use sessionStorage when localStorage writes fail
- load cached data from sessionStorage if localStorage unavailable
- clear sessionStorage in forceClearAllCache

## Testing
- `npx prettier -w posawesome/public/js/offline/core.js posawesome/public/js/offline/cache.js`

------
https://chatgpt.com/codex/tasks/task_e_68887c241e7c8326aa5ba221da66695c