### PR TITLE
Fix local cache fallback

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -66,6 +66,17 @@ export const memoryInitPromise = (async () => {
 					}
 				}
 			}
+			if (typeof sessionStorage !== "undefined") {
+				const ss = sessionStorage.getItem(`posa_${key}`);
+				if (ss) {
+					try {
+						memory[key] = JSON.parse(ss);
+						continue;
+					} catch (err) {
+						console.error("Failed to parse sessionStorage for", key, err);
+					}
+				}
+			}
 		}
 
 		// Verify cache version and clear outdated caches
@@ -73,6 +84,10 @@ export const memoryInitPromise = (async () => {
 		let storedVersion = versionEntry ? versionEntry.value : null;
 		if (!storedVersion && typeof localStorage !== "undefined") {
 			const v = localStorage.getItem("posa_cache_version");
+			if (v) storedVersion = parseInt(v, 10);
+		}
+		if (!storedVersion && typeof sessionStorage !== "undefined") {
+			const v = sessionStorage.getItem("posa_cache_version");
 			if (v) storedVersion = parseInt(v, 10);
 		}
 		if (storedVersion !== CACHE_VERSION) {
@@ -399,6 +414,13 @@ export async function forceClearAllCache() {
 		Object.keys(localStorage).forEach((key) => {
 			if (key.startsWith("posa_")) {
 				localStorage.removeItem(key);
+			}
+		});
+	}
+	if (typeof sessionStorage !== "undefined") {
+		Object.keys(sessionStorage).forEach((key) => {
+			if (key.startsWith("posa_")) {
+				sessionStorage.removeItem(key);
 			}
 		});
 	}

--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -129,6 +129,13 @@ export function persist(key, value) {
 			localStorage.setItem(`posa_${key}`, JSON.stringify(value));
 		} catch (err) {
 			console.error("Failed to persist", key, "to localStorage", err);
+			if (typeof sessionStorage !== "undefined") {
+				try {
+					sessionStorage.setItem(`posa_${key}`, JSON.stringify(value));
+				} catch (sesErr) {
+					console.error("Failed to persist", key, "to sessionStorage", sesErr);
+				}
+			}
 		}
 	}
 }

--- a/posawesome/public/js/posapp/workers/itemWorker.js
+++ b/posawesome/public/js/posapp/workers/itemWorker.js
@@ -51,6 +51,19 @@ async function persist(key, value) {
 			localStorage.setItem(`posa_${key}`, JSON.stringify(value));
 		} catch (err) {
 			console.error("Worker localStorage failed", err);
+			if (typeof sessionStorage !== "undefined") {
+				try {
+					sessionStorage.setItem(`posa_${key}`, JSON.stringify(value));
+				} catch (ssErr) {
+					console.error("Worker sessionStorage failed", ssErr);
+				}
+			}
+		}
+	} else if (typeof sessionStorage !== "undefined" && key !== "price_list_cache") {
+		try {
+			sessionStorage.setItem(`posa_${key}`, JSON.stringify(value));
+		} catch (err) {
+			console.error("Worker sessionStorage failed", err);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- use sessionStorage when localStorage writes fail
- load cached data from sessionStorage if localStorage unavailable
- clear sessionStorage in forceClearAllCache
- fall back to sessionStorage in persist worker

## Testing
- `npx prettier -w posawesome/public/js/offline/core.js posawesome/public/js/offline/cache.js posawesome/public/js/posapp/workers/itemWorker.js`

------
https://chatgpt.com/codex/tasks/task_e_68887c241e7c8326aa5ba221da66695c