### PR TITLE
Handle item cache merges

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -953,9 +953,10 @@ export function getItemsStorage() {
 	return memory.items_storage || [];
 }
 
-export function setItemsStorage(items) {
+export function setItemsStorage(items, merge = true) {
+	let trimmed = [];
 	try {
-		memory.items_storage = items.map((it) => ({
+		trimmed = items.map((it) => ({
 			item_code: it.item_code,
 			item_name: it.item_name,
 			description: it.description,
@@ -973,8 +974,16 @@ export function setItemsStorage(items) {
 		}));
 	} catch (e) {
 		console.error("Failed to trim items for storage", e);
-		memory.items_storage = [];
 	}
+
+	if (merge && Array.isArray(memory.items_storage) && memory.items_storage.length) {
+		const map = new Map(memory.items_storage.map((it) => [it.item_code, it]));
+		trimmed.forEach((it) => map.set(it.item_code, it));
+		memory.items_storage = Array.from(map.values());
+	} else {
+		memory.items_storage = trimmed;
+	}
+
 	persist("items_storage");
 }
 

--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -129,9 +129,10 @@ export function getItemsStorage() {
 	return memory.items_storage || [];
 }
 
-export function setItemsStorage(items) {
+export function setItemsStorage(items, merge = true) {
+	let trimmed = [];
 	try {
-		memory.items_storage = items.map((it) => ({
+		trimmed = items.map((it) => ({
 			item_code: it.item_code,
 			item_name: it.item_name,
 			description: it.description,
@@ -150,8 +151,16 @@ export function setItemsStorage(items) {
 		}));
 	} catch (e) {
 		console.error("Failed to trim items for storage", e);
-		memory.items_storage = [];
 	}
+
+	if (merge && Array.isArray(memory.items_storage) && memory.items_storage.length) {
+		const map = new Map(memory.items_storage.map((it) => [it.item_code, it]));
+		trimmed.forEach((it) => map.set(it.item_code, it));
+		memory.items_storage = Array.from(map.values());
+	} else {
+		memory.items_storage = trimmed;
+	}
+
 	persist("items_storage", memory.items_storage);
 }
 

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -384,6 +384,7 @@ import {
 	getCachedItemGroups,
 	getItemsLastSync,
 	setItemsLastSync,
+	memory,
 } from "../../../offline/index.js";
 import { useResponsive } from "../../composables/useResponsive.js";
 
@@ -696,6 +697,7 @@ export default {
 
 			if (force_server && this.pos_profile.posa_local_storage) {
 				localStorage.setItem("items_storage", "");
+				memory.items_storage = [];
 			}
 
 			const vm = this;
@@ -877,7 +879,7 @@ export default {
 								!vm.pos_profile.pose_use_limit_search
 							) {
 								try {
-									setItemsStorage(vm.items);
+									setItemsStorage(vm.items, !force_server);
 									vm.items.forEach((it) => {
 										if (it.item_uoms && it.item_uoms.length > 0) {
 											saveItemUOMs(it.item_code, it.item_uoms);
@@ -991,7 +993,7 @@ export default {
 								!vm.pos_profile.pose_use_limit_search
 							) {
 								try {
-									setItemsStorage(vm.items);
+									setItemsStorage(vm.items, !force_server);
 									vm.items.forEach((it) => {
 										if (it.item_uoms && it.item_uoms.length > 0) {
 											saveItemUOMs(it.item_code, it.item_uoms);
@@ -1045,7 +1047,7 @@ export default {
 						this.pos_profile.posa_local_storage &&
 						!this.pos_profile.pose_use_limit_search
 					) {
-						setItemsStorage(this.items);
+						setItemsStorage(this.items, true);
 					}
 					if (parsed.length === limit) {
 						this.backgroundLoadItems(offset + limit, syncSince);
@@ -1081,7 +1083,7 @@ export default {
 							this.pos_profile.posa_local_storage &&
 							!this.pos_profile.pose_use_limit_search
 						) {
-							setItemsStorage(this.items);
+							setItemsStorage(this.items, true);
 						}
 						if (rows.length === limit) {
 							this.backgroundLoadItems(offset + limit, syncSince);


### PR DESCRIPTION
## Summary
- avoid overwriting item cache data in `setItemsStorage`
- merge new items on refresh and clear cache when forcing reload

## Testing
- `npx prettier --write posawesome/public/js/offline.js posawesome/public/js/offline/cache.js posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npx eslint posawesome/public/js/offline.js posawesome/public/js/offline/cache.js posawesome/public/js/posapp/components/pos/ItemsSelector.vue` *(fails: 'frappe' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6888a6c74d7083268ee30f69ea3af067