### PR TITLE
Gate console logs in StatusIndicator

### DIFF
--- a/posawesome/public/js/posapp/components/navbar/StatusIndicator.vue
+++ b/posawesome/public/js/posapp/components/navbar/StatusIndicator.vue
@@ -19,8 +19,10 @@
 </template>
 
 <script>
+const DEBUG = import.meta.env ? import.meta.env.DEV : false;
+
 export default {
-	name: "StatusIndicator",
+        name: "StatusIndicator",
 	props: {
 		networkOnline: Boolean,
 		serverOnline: Boolean,
@@ -35,19 +37,21 @@ export default {
 		 * @returns {string} A Vuetify color string ('green', 'red').
 		 */
 		statusColor() {
-			// Enhanced debugging with more context
-			console.log(
-				"StatusIndicator - Network:",
-				this.networkOnline,
-				"Server:",
-				this.serverOnline,
-				"Connecting:",
-				this.serverConnecting,
-				"IP Host:",
-				this.isIpHost,
-				"Host:",
-				window.location.hostname,
-			);
+                        // Enhanced debugging with more context
+                        if (DEBUG) {
+                                console.log(
+                                        "StatusIndicator - Network:",
+                                        this.networkOnline,
+                                        "Server:",
+                                        this.serverOnline,
+                                        "Connecting:",
+                                        this.serverConnecting,
+                                        "IP Host:",
+                                        this.isIpHost,
+                                        "Host:",
+                                        window.location.hostname,
+                                );
+                        }
 
 			// Show yellow/orange when connecting
 			if (this.serverConnecting) {
@@ -77,14 +81,16 @@ export default {
 		 * @returns {string} A Material Design Icon class string.
 		 */
 		statusIcon() {
-			console.log(
-				"StatusIndicator - Determining icon for network:",
-				this.networkOnline,
-				"server:",
-				this.serverOnline,
-				"connecting:",
-				this.serverConnecting,
-			);
+                        if (DEBUG) {
+                                console.log(
+                                        "StatusIndicator - Determining icon for network:",
+                                        this.networkOnline,
+                                        "server:",
+                                        this.serverOnline,
+                                        "connecting:",
+                                        this.serverConnecting,
+                                );
+                        }
 
 			// Show loading icon when connecting
 			if (this.serverConnecting) {


### PR DESCRIPTION
## Summary
- guard StatusIndicator debug logs behind a `DEBUG` flag
- rebuild assets with Vite to verify the flag resolves to `false` in production

## Testing
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_e_6888bd67ff348326bc5acb8035de1c08