### PR TITLE
Update frappe logo path

### DIFF
--- a/posawesome/public/js/posapp/composables/useNetwork.js
+++ b/posawesome/public/js/posapp/composables/useNetwork.js
@@ -125,7 +125,7 @@ export async function checkNetworkConnectivity() {
 			signal: AbortSignal.timeout(DESK_TIMEOUT),
 		}).then((r) => r.status < 500);
 
-		const staticRequest = fetch("/assets/frappe/images/frappe-logo.svg", {
+               const staticRequest = fetch("/assets/frappe/images/frappe-logo.png", {
 			method: "HEAD",
 			cache: "no-cache",
 			signal: AbortSignal.timeout(STATIC_TIMEOUT),


### PR DESCRIPTION
## Summary
- use PNG frappe logo in network checker

## Testing
- `bench build --app posawesome` *(fails: command not runnable as root)*

------
https://chatgpt.com/codex/tasks/task_e_6888bd5a0efc83269e2aaa4ad1a0b885