### PR TITLE
Fix esbuild warning in StatusIndicator

### DIFF
--- a/posawesome/public/js/posapp/components/navbar/StatusIndicator.vue
+++ b/posawesome/public/js/posapp/components/navbar/StatusIndicator.vue
@@ -19,7 +19,10 @@
 </template>
 
 <script>
-const DEBUG = import.meta.env ? import.meta.env.DEV : false;
+// Avoid relying on `import.meta` so the file can be bundled with older
+// JavaScript targets without warnings from esbuild. Debug logging can be
+// toggled by changing this flag during development.
+const DEBUG = false;
 
 export default {
         name: "StatusIndicator",


### PR DESCRIPTION
## Summary
- remove `import.meta` usage from `StatusIndicator.vue` to avoid esbuild warning

## Testing
- `npx prettier --check posawesome/public/js/posapp/components/navbar/StatusIndicator.vue` *(fails: code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_688908d3c9848326a83ef47079263c34