### PR TITLE
Implement server-only reload for items

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -376,6 +376,7 @@ import {
 	checkDbHealth,
 	getCachedPriceListItems,
 	savePriceListItems,
+	clearPriceListCache,
 	updateLocalStockCache,
 	isStockCacheReady,
 	getCachedItemDetails,
@@ -671,6 +672,9 @@ export default {
 			this.eventBus.emit("show_coupons", "true");
 		},
 		forceReloadItems() {
+			// Clear cached price list items so the reload always
+			// fetches the latest data from the server
+			clearPriceListCache();
 			// Always recreate the worker when forcing a reload so
 			// subsequent reloads fetch fresh data from the server.
 			if (!this.itemWorker && typeof Worker !== "undefined") {


### PR DESCRIPTION
## Summary
- clear price list cache before forcing item reloads

## Testing
- `npx prettier --write posawesome/public/js/posapp/components/pos/ItemsSelector.vue`

------
https://chatgpt.com/codex/tasks/task_e_68890b4769948326a639af577114cfbe