### PR TITLE
Fix cached price list and worker parsing

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1578,9 +1578,9 @@ export default {
 	},
 
 	// Apply cached price list rates to existing invoice items
-	apply_cached_price_list(price_list) {
-		const cached = getCachedPriceListItems(price_list);
-		if (!cached) {
+	async apply_cached_price_list(price_list) {
+		const cached = await getCachedPriceListItems(price_list);
+		if (!Array.isArray(cached) || !cached.length) {
 			return;
 		}
 

--- a/posawesome/public/js/posapp/workers/itemWorker.js
+++ b/posawesome/public/js/posapp/workers/itemWorker.js
@@ -91,7 +91,7 @@ self.onmessage = async (event) => {
 	const data = event.data || {};
 	if (data.type === "parse_and_cache") {
 		try {
-			const parsed = JSON.parse(data.json);
+			let parsed = JSON.parse(data.json);
 			let itemsRaw = parsed.message || parsed;
 			let items;
 			try {


### PR DESCRIPTION
## Summary
- fix parsing in item worker by not reassigning a const
- fetch cached price list asynchronously before iterating

## Testing
- `npx prettier -w posawesome/public/js/posapp/components/pos/invoiceItemMethods.js posawesome/public/js/posapp/workers/itemWorker.js`

------
https://chatgpt.com/codex/tasks/task_e_6889c0ad6af88326aa860572db60983e