### PR TITLE
Fix DataCloneError when caching item details

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -200,8 +200,14 @@ export function getSalesPersonsStorage() {
 
 export function setSalesPersonsStorage(data) {
 	try {
-		memory.sales_persons_storage =
-			typeof structuredClone === "function" ? structuredClone(data) : JSON.parse(JSON.stringify(data));
+		let clean;
+		try {
+			clean = JSON.parse(JSON.stringify(data));
+		} catch (err) {
+			console.error("Failed to serialize sales persons", err);
+			clean = [];
+		}
+		memory.sales_persons_storage = clean;
 		persist("sales_persons_storage", memory.sales_persons_storage);
 	} catch (e) {
 		console.error("Failed to set sales persons storage", e);
@@ -214,8 +220,14 @@ export function getOpeningStorage() {
 
 export function setOpeningStorage(data) {
 	try {
-		memory.pos_opening_storage =
-			typeof structuredClone === "function" ? structuredClone(data) : JSON.parse(JSON.stringify(data));
+		let clean;
+		try {
+			clean = JSON.parse(JSON.stringify(data));
+		} catch (err) {
+			console.error("Failed to serialize opening storage", err);
+			clean = {};
+		}
+		memory.pos_opening_storage = clean;
 		persist("pos_opening_storage", memory.pos_opening_storage);
 	} catch (e) {
 		console.error("Failed to set opening storage", e);
@@ -237,8 +249,14 @@ export function getOpeningDialogStorage() {
 
 export function setOpeningDialogStorage(data) {
 	try {
-		memory.opening_dialog_storage =
-			typeof structuredClone === "function" ? structuredClone(data) : JSON.parse(JSON.stringify(data));
+		let clean;
+		try {
+			clean = JSON.parse(JSON.stringify(data));
+		} catch (err) {
+			console.error("Failed to serialize opening dialog", err);
+			clean = {};
+		}
+		memory.opening_dialog_storage = clean;
 		persist("opening_dialog_storage", memory.opening_dialog_storage);
 	} catch (e) {
 		console.error("Failed to set opening dialog storage", e);
@@ -258,8 +276,13 @@ export function getTaxTemplate(name) {
 export function setTaxTemplate(name, doc) {
 	try {
 		const cache = memory.tax_template_cache || {};
-		const cleanDoc =
-			typeof structuredClone === "function" ? structuredClone(doc) : JSON.parse(JSON.stringify(doc));
+		let cleanDoc;
+		try {
+			cleanDoc = JSON.parse(JSON.stringify(doc));
+		} catch (err) {
+			console.error("Failed to serialize tax template", err);
+			cleanDoc = doc ? { ...doc } : {};
+		}
 		cache[name] = cleanDoc;
 		memory.tax_template_cache = cache;
 		persist("tax_template_cache", memory.tax_template_cache);

--- a/posawesome/public/js/offline/items.js
+++ b/posawesome/public/js/offline/items.js
@@ -2,25 +2,22 @@ import { memory } from "./cache.js";
 import { persist, db, checkDbHealth } from "./core.js";
 
 export function saveItemUOMs(itemCode, uoms) {
-        try {
-                const cache = memory.uom_cache;
-                // Clone to avoid persisting reactive objects which cause
-                // DataCloneError when stored in IndexedDB
-                let cleanUoms;
-                try {
-                        cleanUoms =
-                                typeof structuredClone === "function"
-                                        ? structuredClone(uoms)
-                                        : JSON.parse(JSON.stringify(uoms));
-                } catch (err) {
-                        // Fallback to JSON serialization when structuredClone fails
-                        cleanUoms = JSON.parse(JSON.stringify(uoms));
-                }
-                cache[itemCode] = cleanUoms;
-                memory.uom_cache = cache;
-                persist("uom_cache", memory.uom_cache);
-        } catch (e) {
-                console.error("Failed to cache UOMs", e);
+	try {
+		const cache = memory.uom_cache;
+		// Clone to avoid persisting reactive objects which cause
+		// DataCloneError when stored in IndexedDB
+		let cleanUoms;
+		try {
+			cleanUoms = JSON.parse(JSON.stringify(uoms));
+		} catch (err) {
+			console.error("Failed to serialize UOMs", err);
+			cleanUoms = [];
+		}
+		cache[itemCode] = cleanUoms;
+		memory.uom_cache = cache;
+		persist("uom_cache", memory.uom_cache);
+	} catch (e) {
+		console.error("Failed to cache UOMs", e);
 	}
 }
 
@@ -52,10 +49,10 @@ export function getCachedOffers() {
 
 // Price list rate storage using dedicated table
 export async function savePriceListItems(priceList, items) {
-        try {
-                if (!priceList) return;
-                await checkDbHealth();
-                if (!db.isOpen()) await db.open();
+	try {
+		if (!priceList) return;
+		await checkDbHealth();
+		if (!db.isOpen()) await db.open();
 		const rates = items.map((it) => ({
 			price_list,
 			item_code: it.item_code,
@@ -70,10 +67,10 @@ export async function savePriceListItems(priceList, items) {
 }
 
 export async function getCachedPriceListItems(priceList, ttl = 24 * 60 * 60 * 1000) {
-        try {
-                if (!priceList) return null;
-                await checkDbHealth();
-                if (!db.isOpen()) await db.open();
+	try {
+		if (!priceList) return null;
+		await checkDbHealth();
+		if (!db.isOpen()) await db.open();
 		const now = Date.now();
 		const prices = await db.table("item_prices").where("price_list").equals(priceList).toArray();
 		if (!prices.length) return null;
@@ -116,25 +113,18 @@ export async function clearPriceListCache(priceList = null) {
 
 // Item details caching functions
 export function saveItemDetailsCache(profileName, priceList, items) {
-        try {
-                const cache = memory.item_details_cache || {};
-                const profileCache = cache[profileName] || {};
-                const priceCache = profileCache[priceList] || {};
+	try {
+		const cache = memory.item_details_cache || {};
+		const profileCache = cache[profileName] || {};
+		const priceCache = profileCache[priceList] || {};
 
-                let cleanItems;
-                try {
-                        cleanItems =
-                                typeof structuredClone === "function"
-                                        ? structuredClone(items)
-                                        : JSON.parse(JSON.stringify(items));
-                } catch (err) {
-                        console.error("Failed to serialize item details", err);
-                        try {
-                                cleanItems = JSON.parse(JSON.stringify(items));
-                        } catch (e2) {
-                                cleanItems = [];
-                        }
-                }
+		let cleanItems;
+		try {
+			cleanItems = JSON.parse(JSON.stringify(items));
+		} catch (err) {
+			console.error("Failed to serialize item details", err);
+			cleanItems = [];
+		}
 
 		cleanItems.forEach((item) => {
 			priceCache[item.item_code] = {


### PR DESCRIPTION
## Summary
- avoid `structuredClone` failures when caching

## Testing
- `npx --yes prettier --write posawesome/public/js/offline/items.js posawesome/public/js/offline/cache.js`
- `npm run format` *(fails: prettier not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889ca8611c883269ada607e1b9bbaad