### PR TITLE
Increase network timeout in useNetwork.js

### DIFF
--- a/posawesome/public/js/posapp/composables/useNetwork.js
+++ b/posawesome/public/js/posapp/composables/useNetwork.js
@@ -7,9 +7,10 @@ let consecutiveFailures = 0;
 let consecutiveSuccesses = 0;
 const FAILURE_THRESHOLD = 2; // Number of failed checks before marking as disconnected
 const SUCCESS_THRESHOLD = 1; // Number of successful checks before marking as connected
-const DESK_TIMEOUT = 2500; // Reduced to ~2.5 seconds
-const STATIC_TIMEOUT = 2500; // Reduced to ~2.5 seconds
-const ORIGIN_TIMEOUT = 2500; // Reduced to ~2.5 seconds
+// Increase timeouts to avoid premature aborts on slower networks
+const DESK_TIMEOUT = 8000; // 8 seconds
+const STATIC_TIMEOUT = 8000; // 8 seconds
+const ORIGIN_TIMEOUT = 8000; // 8 seconds
 
 // Exponential backoff variables
 let checkInterval = 15000; // Start with 15s


### PR DESCRIPTION
## Summary
- raise DESK_TIMEOUT, STATIC_TIMEOUT and ORIGIN_TIMEOUT to 8 seconds
- keep connectivity checks using the new constants

## Testing
- `node --version`
- `grep -n "8000" posawesome/public/js/posapp/composables/useNetwork.js`

------
https://chatgpt.com/codex/tasks/task_e_6889ebe5ea0083268521d393713b1232