### PR TITLE
Fix item sync variable name

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -978,7 +978,7 @@ export default {
 						if (vm.items_request_token !== request_token) return;
 						if (r.message) {
 							const newItems = r.message;
-							if (lastSync && vm.items && vm.items.length) {
+							if (syncSince && vm.items && vm.items.length) {
 								const map = new Map(vm.items.map((it) => [it.item_code, it]));
 								newItems.forEach((it) => map.set(it.item_code, it));
 								vm.items = Array.from(map.values());


### PR DESCRIPTION
## Summary
- use `syncSince` within `get_items` server call callback

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_688a16dcaab4832693e7a926418d7460