### PR TITLE
Handle full stock cache initialization

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -809,9 +809,6 @@ export default {
 					vm.items_loaded = true;
 
 					if (vm.items && vm.items.length > 0) {
-						if (vm.items.length <= 500) {
-							vm.prePopulateStockCache(vm.items);
-						}
 						vm.update_items_details(vm.items);
 					}
 					return;
@@ -848,9 +845,6 @@ export default {
 					vm.items_loaded = true;
 
 					if (vm.items && vm.items.length > 0) {
-						if (vm.items.length <= 500) {
-							await vm.prePopulateStockCache(vm.items);
-						}
 						vm.update_items_details(vm.items);
 					}
 					return;
@@ -928,11 +922,6 @@ export default {
 								),
 							);
 							saveItemGroups(groups);
-
-							// Pre-populate stock cache when items are freshly loaded
-							if (vm.items.length <= 500) {
-								vm.prePopulateStockCache(vm.items);
-							}
 
 							vm.$nextTick(() => {
 								if (vm.search && vm.pos_profile && !vm.pos_profile.pose_use_limit_search) {
@@ -1019,9 +1008,6 @@ export default {
 							saveItemGroups(groups);
 
 							// Pre-populate stock cache when items are freshly loaded
-							if (vm.items.length <= 500) {
-								vm.prePopulateStockCache(vm.items);
-							}
 
 							vm.$nextTick(() => {
 								if (vm.search && vm.pos_profile && !vm.pos_profile.pose_use_limit_search) {
@@ -1105,6 +1091,7 @@ export default {
 							this.itemWorker.terminate();
 							this.itemWorker = null;
 						}
+						await this.prePopulateStockCache(this.items);
 					}
 				} catch (err) {
 					console.error("Failed to background load items", err);
@@ -1141,6 +1128,7 @@ export default {
 							this.backgroundLoadItems(offset + limit, syncSince);
 						} else {
 							setItemsLastSync(new Date().toISOString());
+							await this.prePopulateStockCache(this.items);
 						}
 					},
 					error: (err) => {
@@ -1617,10 +1605,6 @@ export default {
 				return;
 			}
 			if (!Array.isArray(items) || items.length === 0) {
-				return;
-			}
-			if (items.length > 500) {
-				console.info("Skipping stock pre-population for", items.length, "items");
 				return;
 			}
 			this.prePopulateInProgress = true;


### PR DESCRIPTION
## Summary
- populate stock cache after background loading finishes
- remove 500 item limit check from `prePopulateStockCache`
- update item load handlers

## Testing
- `npx prettier posawesome/public/js/posapp/components/pos/ItemsSelector.vue -w`

------
https://chatgpt.com/codex/tasks/task_e_688a1925c8d483269485267f915016d9