### PR TITLE
Fix stock cache init with all items

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -44,33 +44,38 @@ let invoiceSyncInProgress = false;
 // Modify initializeStockCache function to set the flag
 export async function initializeStockCache(items, pos_profile) {
 	try {
-		// If stock cache is already initialized, skip
-		if (memory.stock_cache_ready && Object.keys(memory.local_stock_cache || {}).length > 0) {
-			console.debug("Stock cache already initialized, skipping");
+		const existingCache = memory.local_stock_cache || {};
+		const missingItems = Array.isArray(items) ? items.filter((it) => !existingCache[it.item_code]) : [];
+
+		if (missingItems.length === 0) {
+			if (!memory.stock_cache_ready) {
+				memory.stock_cache_ready = true;
+				persist("stock_cache_ready");
+			}
+			console.debug("Stock cache already initialized");
+			console.info("Stock cache initialized with", Object.keys(existingCache).length, "items");
 			return true;
 		}
 
-		console.info("Initializing stock cache for", items.length, "items");
+		console.info("Initializing stock cache for", missingItems.length, "new items");
 
-		const updatedItems = await fetchItemStockQuantities(items, pos_profile);
+		const updatedItems = await fetchItemStockQuantities(missingItems, pos_profile);
 
 		if (updatedItems && updatedItems.length > 0) {
-			const stockCache = {};
-
 			updatedItems.forEach((item) => {
 				if (item.actual_qty !== undefined) {
-					stockCache[item.item_code] = {
+					existingCache[item.item_code] = {
 						actual_qty: item.actual_qty,
 						last_updated: new Date().toISOString(),
 					};
 				}
 			});
 
-			memory.local_stock_cache = stockCache;
-			memory.stock_cache_ready = true; // Set flag to true
+			memory.local_stock_cache = existingCache;
+			memory.stock_cache_ready = true;
 			persist("local_stock_cache");
-			persist("stock_cache_ready"); // Persist the flag
-			console.info("Stock cache initialized with", Object.keys(stockCache).length, "items");
+			persist("stock_cache_ready");
+			console.info("Stock cache initialized with", Object.keys(existingCache).length, "items");
 			return true;
 		}
 		return false;

--- a/posawesome/public/js/offline/stock.js
+++ b/posawesome/public/js/offline/stock.js
@@ -4,33 +4,38 @@ import { persist } from "./core.js";
 // Modify initializeStockCache function to set the flag
 export async function initializeStockCache(items, pos_profile) {
 	try {
-		// If stock cache is already initialized, skip
-		if (memory.stock_cache_ready && Object.keys(memory.local_stock_cache || {}).length > 0) {
-			console.debug("Stock cache already initialized, skipping");
+		const existingCache = memory.local_stock_cache || {};
+		const missingItems = Array.isArray(items) ? items.filter((it) => !existingCache[it.item_code]) : [];
+
+		if (missingItems.length === 0) {
+			if (!memory.stock_cache_ready) {
+				memory.stock_cache_ready = true;
+				persist("stock_cache_ready", memory.stock_cache_ready);
+			}
+			console.debug("Stock cache already initialized");
+			console.info("Stock cache initialized with", Object.keys(existingCache).length, "items");
 			return true;
 		}
 
-		console.info("Initializing stock cache for", items.length, "items");
+		console.info("Initializing stock cache for", missingItems.length, "new items");
 
-		const updatedItems = await fetchItemStockQuantities(items, pos_profile);
+		const updatedItems = await fetchItemStockQuantities(missingItems, pos_profile);
 
 		if (updatedItems && updatedItems.length > 0) {
-			const stockCache = {};
-
 			updatedItems.forEach((item) => {
 				if (item.actual_qty !== undefined) {
-					stockCache[item.item_code] = {
+					existingCache[item.item_code] = {
 						actual_qty: item.actual_qty,
 						last_updated: new Date().toISOString(),
 					};
 				}
 			});
 
-			memory.local_stock_cache = stockCache;
-			memory.stock_cache_ready = true; // Set flag to true
+			memory.local_stock_cache = existingCache;
+			memory.stock_cache_ready = true;
 			persist("local_stock_cache", memory.local_stock_cache);
-			persist("stock_cache_ready", memory.stock_cache_ready); // Persist the flag
-			console.info("Stock cache initialized with", Object.keys(stockCache).length, "items");
+			persist("stock_cache_ready", memory.stock_cache_ready);
+			console.info("Stock cache initialized with", Object.keys(existingCache).length, "items");
 			return true;
 		}
 		return false;


### PR DESCRIPTION
## Summary
- ensure stock cache initialization fetches missing items rather than skipping when cache exists
- log total cached items after initialization

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_688a66e46a508326976f34ec42fb466a