### PR TITLE
Fix items list when local storage disabled

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2262,8 +2262,11 @@ export default {
 	},
 
 	created() {
-		memoryInitPromise.then(() => {
-			this.loadVisibleItems(true);
+		memoryInitPromise.then(async () => {
+			const profile = await ensurePosProfile();
+			if (profile && profile.posa_local_storage) {
+				this.loadVisibleItems(true);
+			}
 		});
 
 		this.loadItemSettings();
@@ -2293,7 +2296,9 @@ export default {
 			await memoryInitPromise;
 			await checkDbHealth();
 			this.pos_profile = data.pos_profile;
-			if (this.pos_profile.posa_force_reload_items && !this.pos_profile.posa_smart_reload_mode) {
+			if (!this.pos_profile.posa_local_storage) {
+				await this.get_items(true);
+			} else if (this.pos_profile.posa_force_reload_items && !this.pos_profile.posa_smart_reload_mode) {
 				if (!isOffline()) {
 					await this.get_items(true);
 				} else {


### PR DESCRIPTION
## Summary
- avoid reading cached items on load when POS profile has local storage disabled
- fetch from server immediately if caching is turned off