### PR TITLE
Centralize Dark mode to Use data-theme attribute for dark mode

### DIFF
--- a/posawesome/public/css/responsive.css
+++ b/posawesome/public/css/responsive.css
@@ -71,7 +71,7 @@ body {
 	overflow: hidden;
 }
 
-:root.dark-theme {
+[data-theme="dark"] {
 	/* Dark mode colors */
 	--cancel-start: #cf6679;
 	--cancel-end: #e57373;
@@ -350,7 +350,7 @@ body {
 }
 
 /* Keep cards dark in dark theme */
-:root.dark-theme .cards,
+[data-theme="dark"] .cards,
 .v-theme--dark .cards {
 	background-color: #121212;
 }
@@ -434,7 +434,7 @@ body {
 	background-color: var(--surface-secondary) !important;
 }
 
-:root.dark-theme .dark-field,
+[data-theme="dark"] .dark-field,
 .v-theme--dark .dark-field {
 	background-color: #1e1e1e !important;
 }
@@ -517,32 +517,32 @@ body {
 
 /* ===== DARK MODE OVERRIDES ===== */
 /* These styles apply to all dark mode elements */
-:root.dark-theme .pos-card,
+[data-theme="dark"] .pos-card,
 .v-theme--dark .pos-card {
 	background-color: var(--surface-primary);
 	box-shadow: var(--shadow-lg);
 }
 
-:root.dark-theme .pos-table th:hover,
+[data-theme="dark"] .pos-table th:hover,
 .v-theme--dark .pos-table th:hover {
 	background-color: rgba(255, 255, 255, 0.05);
 }
 
-:root.dark-theme .pos-form-field,
+[data-theme="dark"] .pos-form-field,
 .v-theme--dark .pos-form-field {
 	background-color: var(--field-bg);
 }
 
-:root.dark-theme .pos-form-field input,
-:root.dark-theme .pos-form-field .v-field__input,
-:root.dark-theme .pos-form-field .v-label,
+[data-theme="dark"] .pos-form-field input,
+[data-theme="dark"] .pos-form-field .v-field__input,
+[data-theme="dark"] .pos-form-field .v-label,
 .v-theme--dark .pos-form-field input,
 .v-theme--dark .pos-form-field .v-field__input,
 .v-theme--dark .pos-form-field .v-label {
 	color: var(--text-primary);
 }
 
-:root.dark-theme .pos-form-field .v-field__overlay,
+[data-theme="dark"] .pos-form-field .v-field__overlay,
 .v-theme--dark .pos-form-field .v-field__overlay {
 	background-color: var(--field-bg);
 }

--- a/posawesome/public/js/posapp/components/Navbar.vue
+++ b/posawesome/public/js/posapp/components/Navbar.vue
@@ -31,10 +31,10 @@
 				/>
 			</template>
 
-      <!-- Slot for CPU gadget -->
-      <template #cpu-gadget>
-        <ServerUsageGadget />
-      </template>
+			<!-- Slot for CPU gadget -->
+			<template #cpu-gadget>
+				<ServerUsageGadget />
+			</template>
 
 			<!-- Slot for Database Usage Gadget -->
 			<template #db-usage-gadget>
@@ -349,7 +349,7 @@ nav {
 }
 
 /* Dark theme adjustments */
-:deep(.dark-theme) nav,
+:deep([data-theme="dark"]) nav,
 :deep(.v-theme--dark) nav {
 	background-color: var(--background) !important;
 }

--- a/posawesome/public/js/posapp/components/OfflineInvoices.vue
+++ b/posawesome/public/js/posapp/components/OfflineInvoices.vue
@@ -337,9 +337,9 @@ export default {
 }
 
 /* Dark theme adjustments for the offline invoices card */
-:deep(.dark-theme) .offline-invoices-card,
+:deep([data-theme="dark"]) .offline-invoices-card,
 :deep(.v-theme--dark) .offline-invoices-card,
-::v-deep(.dark-theme) .offline-invoices-card,
+::v-deep([data-theme="dark"]) .offline-invoices-card,
 ::v-deep(.v-theme--dark) .offline-invoices-card {
 	background-color: #1e1e1e !important;
 	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5) !important;
@@ -354,9 +354,9 @@ export default {
 }
 
 /* Dark theme adjustments for the header */
-:deep(.dark-theme) .offline-header,
+:deep([data-theme="dark"]) .offline-header,
 :deep(.v-theme--dark) .offline-header,
-::v-deep(.dark-theme) .offline-header,
+::v-deep([data-theme="dark"]) .offline-header,
 ::v-deep(.v-theme--dark) .offline-header {
 	background-color: #1e1e1e !important;
 	color: #fff !important;
@@ -443,9 +443,9 @@ export default {
 }
 
 /* Dark theme for the card content */
-:deep(.dark-theme) .white-background,
+:deep([data-theme="dark"]) .white-background,
 :deep(.v-theme--dark) .white-background,
-::v-deep(.dark-theme) .white-background,
+::v-deep([data-theme="dark"]) .white-background,
 ::v-deep(.v-theme--dark) .white-background {
 	background-color: #121212 !important;
 }
@@ -457,9 +457,9 @@ export default {
 }
 
 /* Dark theme for the empty state */
-:deep(.dark-theme) .empty-state,
+:deep([data-theme="dark"]) .empty-state,
 :deep(.v-theme--dark) .empty-state,
-::v-deep(.dark-theme) .empty-state,
+::v-deep([data-theme="dark"]) .empty-state,
 ::v-deep(.v-theme--dark) .empty-state {
 	background-color: #121212 !important;
 }
@@ -481,9 +481,9 @@ export default {
 }
 
 /* Dark theme for table container */
-:deep(.dark-theme) .table-container,
+:deep([data-theme="dark"]) .table-container,
 :deep(.v-theme--dark) .table-container,
-::v-deep(.dark-theme) .table-container,
+::v-deep([data-theme="dark"]) .table-container,
 ::v-deep(.v-theme--dark) .table-container {
 	background-color: #121212 !important;
 }
@@ -493,9 +493,9 @@ export default {
 }
 
 /* Dark theme for table header text */
-:deep(.dark-theme) .table-header,
+:deep([data-theme="dark"]) .table-header,
 :deep(.v-theme--dark) .table-header,
-::v-deep(.dark-theme) .table-header,
+::v-deep([data-theme="dark"]) .table-header,
 ::v-deep(.v-theme--dark) .table-header {
 	color: #e0e0e0 !important;
 }
@@ -509,20 +509,20 @@ export default {
 }
 
 /* Dark mode adjustments for invoice table */
-:deep(.dark-theme) .white-table,
+:deep([data-theme="dark"]) .white-table,
 :deep(.v-theme--dark) .white-table,
-::v-deep(.dark-theme) .white-table,
+::v-deep([data-theme="dark"]) .white-table,
 ::v-deep(.v-theme--dark) .white-table {
 	background-color: #121212 !important;
 }
 
-:deep(.dark-theme) .white-table :deep(th),
+:deep([data-theme="dark"]) .white-table :deep(th),
 :deep(.v-theme--dark) .white-table :deep(th),
-:deep(.dark-theme) .white-table :deep(td),
+:deep([data-theme="dark"]) .white-table :deep(td),
 :deep(.v-theme--dark) .white-table :deep(td),
-::v-deep(.dark-theme) .white-table th,
+::v-deep([data-theme="dark"]) .white-table th,
 ::v-deep(.v-theme--dark) .white-table th,
-::v-deep(.dark-theme) .white-table td,
+::v-deep([data-theme="dark"]) .white-table td,
 ::v-deep(.v-theme--dark) .white-table td {
 	color: #fff !important;
 	background-color: #1e1e1e !important;
@@ -530,26 +530,26 @@ export default {
 }
 
 /* Ensure table headings are dark themed */
-:deep(.dark-theme) .white-table :deep(thead th),
+:deep([data-theme="dark"]) .white-table :deep(thead th),
 :deep(.v-theme--dark) .white-table :deep(thead th),
-::v-deep(.dark-theme) .white-table thead th,
+::v-deep([data-theme="dark"]) .white-table thead th,
 ::v-deep(.v-theme--dark) .white-table thead th {
 	background-color: #121212 !important;
 	color: #fff !important;
 }
 
 /* Ensure internal header content is also dark */
-:deep(.dark-theme) .white-table :deep(.v-data-table-header__content),
+:deep([data-theme="dark"]) .white-table :deep(.v-data-table-header__content),
 :deep(.v-theme--dark) .white-table :deep(.v-data-table-header__content),
-::v-deep(.dark-theme) .white-table .v-data-table-header__content,
+::v-deep([data-theme="dark"]) .white-table .v-data-table-header__content,
 ::v-deep(.v-theme--dark) .white-table .v-data-table-header__content {
 	background-color: #121212 !important;
 }
 
 /* Ensure thead background is dark */
-:deep(.dark-theme) .white-table :deep(thead),
+:deep([data-theme="dark"]) .white-table :deep(thead),
 :deep(.v-theme--dark) .white-table :deep(thead),
-::v-deep(.dark-theme) .white-table thead,
+::v-deep([data-theme="dark"]) .white-table thead,
 ::v-deep(.v-theme--dark) .white-table thead {
 	background-color: #121212 !important;
 }
@@ -642,9 +642,9 @@ export default {
 }
 
 /* Dark theme for dialog footer */
-:deep(.dark-theme) .dialog-actions-container,
+:deep([data-theme="dark"]) .dialog-actions-container,
 :deep(.v-theme--dark) .dialog-actions-container,
-::v-deep(.dark-theme) .dialog-actions-container,
+::v-deep([data-theme="dark"]) .dialog-actions-container,
 ::v-deep(.v-theme--dark) .dialog-actions-container {
 	background: #1e1e1e !important;
 	border-top-color: #333 !important;

--- a/posawesome/public/js/posapp/components/navbar/CacheUsageMeter.vue
+++ b/posawesome/public/js/posapp/components/navbar/CacheUsageMeter.vue
@@ -16,44 +16,53 @@
 			</template>
 			<div class="cache-tooltip-content">
 				<div class="cache-tooltip-title">
-            <v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon>
-            {{ __("Cache Usage") }}
-          </div>
-        <v-divider class="my-2" />
-        <div class="cache-tooltip-section-title mb-1">{{ __("Usage") }}</div>
-        <div class="cache-tooltip-bar mb-2">
-          <div class="cache-bar-bg">
-            <div
-              class="cache-bar-fill"
-              :style="{ width: cacheUsage + '%', background: cacheBarGradient }"
-            >
-              <span class="cache-bar-label-inside">{{ cacheUsage }}%</span>
-            </div>
-            <span class="cache-bar-max">100%</span>
-          </div>
-        </div>
-        <div v-if="!cacheUsageLoading">
-            <div class="cache-tooltip-section-title mb-1">{{ __("Breakdown") }}</div>
-            <div class="cache-tooltip-detail"><v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon>{{ __("Total Size") }}: <b>{{ formatBytes(cacheUsageDetails.total) }}</b></div>
-            <div class="cache-tooltip-detail"><v-icon size="14" color="info" class="mr-1">mdi-database</v-icon>{{ __("IndexedDB") }}: <b>{{ formatBytes(cacheUsageDetails.indexedDB) }}</b></div>
-            <div class="cache-tooltip-detail"><v-icon size="14" color="info" class="mr-1">mdi-folder</v-icon>{{ __("localStorage") }}: <b>{{ formatBytes(cacheUsageDetails.localStorage) }}</b></div>
-        </div>
-        <div class="cache-tooltip-detail" v-else>
-          {{ __("Calculating...") }}
-        </div>
-        <v-divider class="my-2" />
-        <div v-if="cacheUsage >= 80" class="cache-tooltip-warning">
-          <v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
-          {{ __("Warning: High cache usage may affect performance.") }}
-        </div>
-        <div class="cache-tooltip-tip mt-2">
-          <v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
-          {{ __("Tip: Clear cache regularly to free up space and keep the app fast.") }}
-        </div>
-        <div class="cache-tooltip-explanation mt-2">
-          <v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon>
-          {{ __("The app stores data locally for offline use. This is called cache.") }}
-        </div>
+					<v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon>
+					{{ __("Cache Usage") }}
+				</div>
+				<v-divider class="my-2" />
+				<div class="cache-tooltip-section-title mb-1">{{ __("Usage") }}</div>
+				<div class="cache-tooltip-bar mb-2">
+					<div class="cache-bar-bg">
+						<div
+							class="cache-bar-fill"
+							:style="{ width: cacheUsage + '%', background: cacheBarGradient }"
+						>
+							<span class="cache-bar-label-inside">{{ cacheUsage }}%</span>
+						</div>
+						<span class="cache-bar-max">100%</span>
+					</div>
+				</div>
+				<div v-if="!cacheUsageLoading">
+					<div class="cache-tooltip-section-title mb-1">{{ __("Breakdown") }}</div>
+					<div class="cache-tooltip-detail">
+						<v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon
+						>{{ __("Total Size") }}: <b>{{ formatBytes(cacheUsageDetails.total) }}</b>
+					</div>
+					<div class="cache-tooltip-detail">
+						<v-icon size="14" color="info" class="mr-1">mdi-database</v-icon
+						>{{ __("IndexedDB") }}: <b>{{ formatBytes(cacheUsageDetails.indexedDB) }}</b>
+					</div>
+					<div class="cache-tooltip-detail">
+						<v-icon size="14" color="info" class="mr-1">mdi-folder</v-icon
+						>{{ __("localStorage") }}: <b>{{ formatBytes(cacheUsageDetails.localStorage) }}</b>
+					</div>
+				</div>
+				<div class="cache-tooltip-detail" v-else>
+					{{ __("Calculating...") }}
+				</div>
+				<v-divider class="my-2" />
+				<div v-if="cacheUsage >= 80" class="cache-tooltip-warning">
+					<v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
+					{{ __("Warning: High cache usage may affect performance.") }}
+				</div>
+				<div class="cache-tooltip-tip mt-2">
+					<v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
+					{{ __("Tip: Clear cache regularly to free up space and keep the app fast.") }}
+				</div>
+				<div class="cache-tooltip-explanation mt-2">
+					<v-icon size="14" color="info" class="mr-1">mdi-database-clock</v-icon>
+					{{ __("The app stores data locally for offline use. This is called cache.") }}
+				</div>
 				<div class="cache-tooltip-action mt-2">
 					<v-icon size="14" class="mr-1">mdi-refresh</v-icon>
 					{{ __("Click to refresh") }}
@@ -93,11 +102,11 @@ export default {
 		},
 		cacheBarGradient() {
 			if (this.cacheUsage < 50) {
-				return 'linear-gradient(90deg, #43e97b 0%, #38f9d7 100%)';
+				return "linear-gradient(90deg, #43e97b 0%, #38f9d7 100%)";
 			} else if (this.cacheUsage < 80) {
-				return 'linear-gradient(90deg, #f7971e 0%, #ffd200 100%)';
+				return "linear-gradient(90deg, #f7971e 0%, #ffd200 100%)";
 			} else {
-				return 'linear-gradient(90deg, #f953c6 0%, #b91d73 100%)';
+				return "linear-gradient(90deg, #f953c6 0%, #b91d73 100%)";
 			}
 		},
 	},
@@ -168,84 +177,84 @@ export default {
 	color: var(--primary);
 }
 .cache-tooltip-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
 }
 .cache-bar-bg {
-  width: 80px;
-  height: 8px;
-  background: #e3f2fd;
-  border-radius: 4px;
-  overflow: hidden;
-  margin-right: 6px;
+	width: 80px;
+	height: 8px;
+	background: #e3f2fd;
+	border-radius: 4px;
+	overflow: hidden;
+	margin-right: 6px;
 }
 .cache-bar-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #1976d2 0%, #42a5f5 100%);
-  border-radius: 4px;
-  transition: width 0.3s;
+	height: 100%;
+	background: linear-gradient(90deg, #1976d2 0%, #42a5f5 100%);
+	border-radius: 4px;
+	transition: width 0.3s;
 }
 .cache-bar-label {
-  font-size: 11px;
-  color: #1976d2;
-  font-weight: 600;
+	font-size: 11px;
+	color: #1976d2;
+	font-weight: 600;
 }
 .cache-tooltip-warning {
-  color: #d32f2f;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
-  margin-bottom: 4px;
+	color: #d32f2f;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
+	margin-bottom: 4px;
 }
 .cache-tooltip-tip {
-  color: #1976d2;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+	color: #1976d2;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
 }
 .cache-tooltip-explanation {
-  color: #0288d1;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+	color: #0288d1;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
 }
 .cache-tooltip-section-title {
-  font-weight: 600;
-  font-size: 13px;
-  margin-bottom: 4px;
-  color: var(--primary);
-  opacity: 0.85;
+	font-weight: 600;
+	font-size: 13px;
+	margin-bottom: 4px;
+	color: var(--primary);
+	opacity: 0.85;
 }
 
 /* Fix tooltip background and text color in light mode */
 :deep(.v-tooltip .v-overlay__content),
 :deep(.v-overlay__content) {
-  background: #e3f2fd !important;
-  color: #1a237e !important;
-  box-shadow: 0 4px 16px rgba(25, 118, 210, 0.10) !important;
-  border: 1px solid #90caf9 !important;
+	background: #e3f2fd !important;
+	color: #1a237e !important;
+	box-shadow: 0 4px 16px rgba(25, 118, 210, 0.1) !important;
+	border: 1px solid #90caf9 !important;
 }
 
 .cache-tooltip-title,
 .cache-tooltip-action {
-  color: #1a237e !important;
+	color: #1a237e !important;
 }
 
-:deep(.dark-theme) .v-tooltip .v-overlay__content,
+:deep([data-theme="dark"]) .v-tooltip .v-overlay__content,
 :deep(.v-theme--dark) .v-tooltip .v-overlay__content,
-:deep(.dark-theme) .v-overlay__content,
+:deep([data-theme="dark"]) .v-overlay__content,
 :deep(.v-theme--dark) .v-overlay__content {
-  background: #26344d !important;
-  color: #fff !important;
-  border: 1px solid #1976d2 !important;
+	background: #26344d !important;
+	color: #fff !important;
+	border: 1px solid #1976d2 !important;
 }
 
-:deep(.dark-theme) .cache-tooltip-title,
+:deep([data-theme="dark"]) .cache-tooltip-title,
 :deep(.v-theme--dark) .cache-tooltip-title,
-:deep(.dark-theme) .cache-tooltip-action,
+:deep([data-theme="dark"]) .cache-tooltip-action,
 :deep(.v-theme--dark) .cache-tooltip-action {
-  color: #fff !important;
+	color: #fff !important;
 }
 </style>

--- a/posawesome/public/js/posapp/components/navbar/CpuGadget.vue
+++ b/posawesome/public/js/posapp/components/navbar/CpuGadget.vue
@@ -1,90 +1,105 @@
 <template>
-  <div class="cpu-gadget-section mx-1">
-    <v-tooltip location="bottom">
-      <template #activator="{ props }">
-        <div v-bind="props" class="cpu-meter-container">
-          <v-icon size="22" color="success">mdi-chip</v-icon>
-          <span class="cpu-current-lag">{{ cpuLag.toFixed(1) }} ms</span>
-        </div>
-      </template>
-      <div class="cpu-tooltip-content">
-        <div class="cpu-tooltip-title">{{ __("CPU Load") }}</div>
-        <div class="cpu-tooltip-peak mb-1">
-          <v-icon size="14" color="success" class="mr-1">mdi-arrow-up-bold</v-icon>
-          {{ __("Peak:") }}
-          <b>{{ peakLag.toFixed(1) }} ms</b>
-          ({{ peakPercent }}%)
-        </div>
-        <div class="cpu-tooltip-sparkline mb-2">
-          <svg :width="180" :height="40" class="cpu-sparkline-large">
-            <defs>
-              <linearGradient id="cpuAreaGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stop-color="#4caf50" stop-opacity="0.35"/>
-                <stop offset="100%" stop-color="#4caf50" stop-opacity="0"/>
-              </linearGradient>
-            </defs>
-            <polyline
-              :points="sparklinePointsLarge"
-              fill="none"
-              stroke="#4caf50"
-              stroke-width="2"
-            />
-            <polygon
-              :points="areaPointsLarge"
-              fill="url(#cpuAreaGradient)"
-              stroke="none"
-            />
-          </svg>
-        </div>
-        <div class="cpu-tooltip-detail">
-          {{ __("Current Event Loop Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
-        </div>
-        <div v-if="cpuLag >= 80" class="cpu-tooltip-warning">
-          <v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
-          {{ __("Warning: High lag may indicate heavy processing or browser slowness.") }}
-        </div>
-        <div v-if="serverLoading" class="cpu-tooltip-detail">{{ __("Loading server CPU/memory usage...") }}</div>
-        <div v-else-if="serverError" class="cpu-tooltip-warning">{{ serverError }}</div>
-        <div v-else>
-          <div class="cpu-tooltip-detail">
-            {{ __("Server CPU Usage:") }} <b>{{ serverCpu !== null ? serverCpu.toFixed(1) + '%' : 'N/A' }}</b>
-            <span class="ml-2">{{ __("Peak Server:") }} <b>{{ serverPeak.toFixed(1) }}%</b></span>
-          </div>
-          <div class="cpu-tooltip-detail">
-            {{ __("Server Memory Usage:") }}
-            <b>{{ serverMemory !== null ? serverMemory.toFixed(1) + '%' : 'N/A' }}</b>
-            <span class="ml-2">{{ __("Peak Memory:") }} <b>{{ serverMemoryPeak.toFixed(1) }}%</b></span>
-          </div>
-          <div class="cpu-tooltip-bar">
-            <div class="cpu-bar-bg">
-              <div class="cpu-bar-fill" :style="{ width: (serverMemory || 0) + '%', background: 'linear-gradient(90deg,#1976d2 0%,#42a5f5 100%)' }"></div>
-            </div>
-            <span class="cpu-bar-label">{{ serverMemory !== null ? serverMemory.toFixed(1) + '%' : 'N/A' }}</span>
-          </div>
-          <div class="cpu-tooltip-detail">
-            {{ __("Total:") }} <b>{{ formatBytes(memoryTotal) }}</b>
-            <span class="ml-2">{{ __("Used:") }} <b>{{ formatBytes(memoryUsed) }}</b></span>
-            <span class="ml-2">{{ __("Available:") }} <b>{{ formatBytes(memoryAvailable) }}</b></span>
-          </div>
-          <div class="cpu-tooltip-detail">
-            {{ __("Server Uptime:") }} <b>{{ formatUptime(serverUptime) }}</b>
-          </div>
-        </div>
-        <div class="cpu-tooltip-tip mt-2">
-          <v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
-          {{ __("Tip: Close unused tabs or apps to reduce lag.") }}
-        </div>
-        <div class="cpu-tooltip-explanation mt-2">
-          <v-icon size="14" color="info" class="mr-1">mdi-chip</v-icon>
-          {{ __("Event-loop lag measures how busy your browser is. Lower is better.") }}
-        </div>
-        <div class="cpu-tooltip-action mt-2">
-          <v-icon size="14" class="mr-1">mdi-refresh</v-icon>
-          {{ __("Updates automatically") }}
-        </div>
-      </div>
-    </v-tooltip>
-  </div>
+	<div class="cpu-gadget-section mx-1">
+		<v-tooltip location="bottom">
+			<template #activator="{ props }">
+				<div v-bind="props" class="cpu-meter-container">
+					<v-icon size="22" color="success">mdi-chip</v-icon>
+					<span class="cpu-current-lag">{{ cpuLag.toFixed(1) }} ms</span>
+				</div>
+			</template>
+			<div class="cpu-tooltip-content">
+				<div class="cpu-tooltip-title">{{ __("CPU Load") }}</div>
+				<div class="cpu-tooltip-peak mb-1">
+					<v-icon size="14" color="success" class="mr-1">mdi-arrow-up-bold</v-icon>
+					{{ __("Peak:") }}
+					<b>{{ peakLag.toFixed(1) }} ms</b>
+					({{ peakPercent }}%)
+				</div>
+				<div class="cpu-tooltip-sparkline mb-2">
+					<svg :width="180" :height="40" class="cpu-sparkline-large">
+						<defs>
+							<linearGradient id="cpuAreaGradient" x1="0" y1="0" x2="0" y2="1">
+								<stop offset="0%" stop-color="#4caf50" stop-opacity="0.35" />
+								<stop offset="100%" stop-color="#4caf50" stop-opacity="0" />
+							</linearGradient>
+						</defs>
+						<polyline
+							:points="sparklinePointsLarge"
+							fill="none"
+							stroke="#4caf50"
+							stroke-width="2"
+						/>
+						<polygon :points="areaPointsLarge" fill="url(#cpuAreaGradient)" stroke="none" />
+					</svg>
+				</div>
+				<div class="cpu-tooltip-detail">
+					{{ __("Current Event Loop Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
+				</div>
+				<div v-if="cpuLag >= 80" class="cpu-tooltip-warning">
+					<v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
+					{{ __("Warning: High lag may indicate heavy processing or browser slowness.") }}
+				</div>
+				<div v-if="serverLoading" class="cpu-tooltip-detail">
+					{{ __("Loading server CPU/memory usage...") }}
+				</div>
+				<div v-else-if="serverError" class="cpu-tooltip-warning">{{ serverError }}</div>
+				<div v-else>
+					<div class="cpu-tooltip-detail">
+						{{ __("Server CPU Usage:") }}
+						<b>{{ serverCpu !== null ? serverCpu.toFixed(1) + "%" : "N/A" }}</b>
+						<span class="ml-2"
+							>{{ __("Peak Server:") }} <b>{{ serverPeak.toFixed(1) }}%</b></span
+						>
+					</div>
+					<div class="cpu-tooltip-detail">
+						{{ __("Server Memory Usage:") }}
+						<b>{{ serverMemory !== null ? serverMemory.toFixed(1) + "%" : "N/A" }}</b>
+						<span class="ml-2"
+							>{{ __("Peak Memory:") }} <b>{{ serverMemoryPeak.toFixed(1) }}%</b></span
+						>
+					</div>
+					<div class="cpu-tooltip-bar">
+						<div class="cpu-bar-bg">
+							<div
+								class="cpu-bar-fill"
+								:style="{
+									width: (serverMemory || 0) + '%',
+									background: 'linear-gradient(90deg,#1976d2 0%,#42a5f5 100%)',
+								}"
+							></div>
+						</div>
+						<span class="cpu-bar-label">{{
+							serverMemory !== null ? serverMemory.toFixed(1) + "%" : "N/A"
+						}}</span>
+					</div>
+					<div class="cpu-tooltip-detail">
+						{{ __("Total:") }} <b>{{ formatBytes(memoryTotal) }}</b>
+						<span class="ml-2"
+							>{{ __("Used:") }} <b>{{ formatBytes(memoryUsed) }}</b></span
+						>
+						<span class="ml-2"
+							>{{ __("Available:") }} <b>{{ formatBytes(memoryAvailable) }}</b></span
+						>
+					</div>
+					<div class="cpu-tooltip-detail">
+						{{ __("Server Uptime:") }} <b>{{ formatUptime(serverUptime) }}</b>
+					</div>
+				</div>
+				<div class="cpu-tooltip-tip mt-2">
+					<v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
+					{{ __("Tip: Close unused tabs or apps to reduce lag.") }}
+				</div>
+				<div class="cpu-tooltip-explanation mt-2">
+					<v-icon size="14" color="info" class="mr-1">mdi-chip</v-icon>
+					{{ __("Event-loop lag measures how busy your browser is. Lower is better.") }}
+				</div>
+				<div class="cpu-tooltip-action mt-2">
+					<v-icon size="14" class="mr-1">mdi-refresh</v-icon>
+					{{ __("Updates automatically") }}
+				</div>
+			</div>
+		</v-tooltip>
+	</div>
 </template>
 
 <script setup lang="ts">
@@ -97,69 +112,69 @@ const __ = inject("__", (txt: string) => txt);
 
 // Use the composable for server CPU and memory
 const {
-  cpu: serverCpu,
-  memory: serverMemory,
-  memoryTotal,
-  memoryUsed,
-  memoryAvailable,
-  history: serverHistory,
-  loading: serverLoading,
-  error: serverError
+	cpu: serverCpu,
+	memory: serverMemory,
+	memoryTotal,
+	memoryUsed,
+	memoryAvailable,
+	history: serverHistory,
+	loading: serverLoading,
+	error: serverError,
 } = useServerCpu(10000, 60);
 
-const serverPeak = computed(() => Math.max(...serverHistory.value.map(h => h.cpu ?? 0), 0));
-const serverMemoryPeak = computed(() => Math.max(...serverHistory.value.map(h => h.memory ?? 0), 0));
+const serverPeak = computed(() => Math.max(...serverHistory.value.map((h) => h.cpu ?? 0), 0));
+const serverMemoryPeak = computed(() => Math.max(...serverHistory.value.map((h) => h.memory ?? 0), 0));
 
 // Uptime formatting
 import { ref, watch } from "vue";
 const serverUptime = ref<number | null>(null);
-watch(serverHistory, (hist) => {
-  if (hist.length && hist[hist.length - 1].uptime != null) {
-    serverUptime.value = hist[hist.length - 1].uptime;
-  }
-}, { immediate: true, deep: true });
+watch(
+	serverHistory,
+	(hist) => {
+		if (hist.length && hist[hist.length - 1].uptime != null) {
+			serverUptime.value = hist[hist.length - 1].uptime;
+		}
+	},
+	{ immediate: true, deep: true },
+);
 
 function formatUptime(seconds: number | null) {
-  if (seconds == null) return 'N/A';
-  const d = Math.floor(seconds / (3600 * 24));
-  const h = Math.floor((seconds % (3600 * 24)) / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  let str = '';
-  if (d > 0) str += `${d}d `;
-  if (h > 0 || d > 0) str += `${h}h `;
-  str += `${m}m`;
-  return str.trim();
+	if (seconds == null) return "N/A";
+	const d = Math.floor(seconds / (3600 * 24));
+	const h = Math.floor((seconds % (3600 * 24)) / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	let str = "";
+	if (d > 0) str += `${d}d `;
+	if (h > 0 || d > 0) str += `${h}h `;
+	str += `${m}m`;
+	return str.trim();
 }
 
 function formatBytes(bytes: number | null) {
-  if (bytes == null) return 'N/A';
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+	if (bytes == null) return "N/A";
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
 function getSparklinePoints(arr: number[], w: number, h: number) {
-  if (!arr.length) return '';
-  const max = Math.max(...arr, 100);
-  const min = 0;
-  const step = arr.length > 1 ? w / (arr.length - 1) : w;
-  return arr
-    .map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`)
-    .join(' ');
+	if (!arr.length) return "";
+	const max = Math.max(...arr, 100);
+	const min = 0;
+	const step = arr.length > 1 ? w / (arr.length - 1) : w;
+	return arr.map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`).join(" ");
 }
 
 function getAreaPoints(arr: number[], w: number, h: number) {
-  if (!arr.length) return '';
-  const max = Math.max(...arr, 100);
-  const min = 0;
-  const step = arr.length > 1 ? w / (arr.length - 1) : w;
-  let points = arr
-    .map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`)
-    .join(' ');
-  // Close the area polygon
-  points += ` ${w},${h} 0,${h}`;
-  return points;
+	if (!arr.length) return "";
+	const max = Math.max(...arr, 100);
+	const min = 0;
+	const step = arr.length > 1 ? w / (arr.length - 1) : w;
+	let points = arr.map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`).join(" ");
+	// Close the area polygon
+	points += ` ${w},${h} 0,${h}`;
+	return points;
 }
 
 const sparklinePointsLarge = computed(() => getSparklinePoints(history.value, 180, 40));
@@ -172,173 +187,173 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 
 <style scoped>
 .cpu-gadget-section {
-  display: flex;
-  align-items: center;
-  margin: 0 8px;
+	display: flex;
+	align-items: center;
+	margin: 0 8px;
 }
 
 .cpu-meter-container {
-  cursor: pointer;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
+	cursor: pointer;
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: all 0.3s ease;
 }
 
 .cpu-meter-container:hover {
-  transform: scale(1.1);
+	transform: scale(1.1);
 }
 
 .cpu-meter {
-  transition: all 0.3s ease;
+	transition: all 0.3s ease;
 }
 
 .cpu-tooltip-content {
-  @apply p-3 min-w-[180px];
+	@apply p-3 min-w-[180px];
 }
 
 .cpu-tooltip-title {
-  font-weight: 600;
-  font-size: 14px;
-  margin-bottom: 8px;
-  color: var(--primary);
+	font-weight: 600;
+	font-size: 14px;
+	margin-bottom: 8px;
+	color: var(--primary);
 }
 
 .cpu-tooltip-detail {
-  font-size: 12px;
-  margin-bottom: 8px;
-  line-height: 1.5;
+	font-size: 12px;
+	margin-bottom: 8px;
+	line-height: 1.5;
 }
 
 .cpu-tooltip-action {
-  font-size: 11px;
-  opacity: 0.7;
-  display: flex;
-  align-items: center;
-  margin-top: 8px;
-  color: var(--primary);
+	font-size: 11px;
+	opacity: 0.7;
+	display: flex;
+	align-items: center;
+	margin-top: 8px;
+	color: var(--primary);
 }
 
 .cpu-tooltip-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
 }
 .cpu-bar-bg {
-  width: 80px;
-  height: 8px;
-  background: #e3f2fd;
-  border-radius: 4px;
-  overflow: hidden;
-  margin-right: 6px;
+	width: 80px;
+	height: 8px;
+	background: #e3f2fd;
+	border-radius: 4px;
+	overflow: hidden;
+	margin-right: 6px;
 }
 .cpu-bar-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #7b1fa2 0%, #42a5f5 100%);
-  border-radius: 4px;
-  transition: width 0.3s;
+	height: 100%;
+	background: linear-gradient(90deg, #7b1fa2 0%, #42a5f5 100%);
+	border-radius: 4px;
+	transition: width 0.3s;
 }
 .cpu-bar-label {
-  font-size: 11px;
-  color: #7b1fa2;
-  font-weight: 600;
+	font-size: 11px;
+	color: #7b1fa2;
+	font-weight: 600;
 }
 .cpu-tooltip-warning {
-  color: #d32f2f;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
-  margin-bottom: 4px;
+	color: #d32f2f;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
+	margin-bottom: 4px;
 }
 .cpu-tooltip-tip {
-  color: #1976d2;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+	color: #1976d2;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
 }
 .cpu-tooltip-explanation {
-  color: #0288d1;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+	color: #0288d1;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
 }
 
 .cpu-sparkline-wrapper {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
 }
 .cpu-sparkline {
-  display: block;
-  background: none;
+	display: block;
+	background: none;
 }
 .cpu-current-lag {
-  font-size: 13px;
-  font-weight: 600;
-  color: #4caf50;
-  min-width: 48px;
-  text-align: right;
+	font-size: 13px;
+	font-weight: 600;
+	color: #4caf50;
+	min-width: 48px;
+	text-align: right;
 }
 .cpu-tooltip-sparkline {
-  width: 180px;
-  height: 40px;
-  margin-bottom: 8px;
+	width: 180px;
+	height: 40px;
+	margin-bottom: 8px;
 }
 .cpu-sparkline-large {
-  display: block;
-  background: none;
+	display: block;
+	background: none;
 }
 
 .cpu-tooltip-legend {
-  font-size: 12px;
-  margin-bottom: 4px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
+	font-size: 12px;
+	margin-bottom: 4px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
 }
 .legend-dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  margin-right: 4px;
+	display: inline-block;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	margin-right: 4px;
 }
 .legend-dot.client {
-  background: #4caf50;
+	background: #4caf50;
 }
 .legend-dot.server {
-  background: #1976d2;
+	background: #1976d2;
 }
 
 /* Fix tooltip background and text color in light mode */
 :deep(.v-tooltip .v-overlay__content),
 :deep(.v-overlay__content) {
-  background: #e3f2fd !important;
-  color: #1a237e !important;
-  box-shadow: 0 4px 16px rgba(25, 118, 210, 0.10) !important;
-  border: 1px solid #90caf9 !important;
+	background: #e3f2fd !important;
+	color: #1a237e !important;
+	box-shadow: 0 4px 16px rgba(25, 118, 210, 0.1) !important;
+	border: 1px solid #90caf9 !important;
 }
 
 .cpu-tooltip-title,
 .cpu-tooltip-action {
-  color: #1a237e !important;
+	color: #1a237e !important;
 }
 
-:deep(.dark-theme) .v-tooltip .v-overlay__content,
+:deep([data-theme="dark"]) .v-tooltip .v-overlay__content,
 :deep(.v-theme--dark) .v-tooltip .v-overlay__content,
-:deep(.dark-theme) .v-overlay__content,
+:deep([data-theme="dark"]) .v-overlay__content,
 :deep(.v-theme--dark) .v-overlay__content {
-  background: #26344d !important;
-  color: #fff !important;
-  border: 1px solid #1976d2 !important;
+	background: #26344d !important;
+	color: #fff !important;
+	border: 1px solid #1976d2 !important;
 }
 
-:deep(.dark-theme) .cpu-tooltip-title,
+:deep([data-theme="dark"]) .cpu-tooltip-title,
 :deep(.v-theme--dark) .cpu-tooltip-title,
-:deep(.dark-theme) .cpu-tooltip-action,
+:deep([data-theme="dark"]) .cpu-tooltip-action,
 :deep(.v-theme--dark) .cpu-tooltip-action {
-  color: #fff !important;
+	color: #fff !important;
 }
-</style> 
+</style>

--- a/posawesome/public/js/posapp/components/navbar/DatabaseUsageGadget.vue
+++ b/posawesome/public/js/posapp/components/navbar/DatabaseUsageGadget.vue
@@ -1,76 +1,90 @@
 <template>
-  <div class="db-gadget-section mx-1">
-    <v-tooltip location="bottom">
-      <template #activator="{ props }">
-        <div v-bind="props" class="db-meter-container">
-          <v-icon size="22" color="info">mdi-database</v-icon>
-          <span class="db-current-size">{{ formattedDbSize }}</span>
-        </div>
-      </template>
-      <div class="db-tooltip-content p-3 min-w-[220px]">
-        <div class="db-tooltip-title flex items-center font-semibold text-[14px] mb-2">
-          <v-icon size="16" color="info" class="mr-1">mdi-database-settings</v-icon>
-          {{ __("Database Health") }}
-        </div>
-        <v-divider class="my-2" />
-        <div v-if="loading" class="db-tooltip-detail">{{ __("Loading database stats...") }}</div>
-        <div v-else-if="error" class="db-tooltip-warning">{{ error }}</div>
-        <div v-else>
-          <div class="db-tooltip-section-title mb-1">{{ __("Database Info") }}</div>
-          <div class="db-tooltip-sparkline mb-2">
-            <svg :width="120" :height="32" class="db-sparkline">
-              <polyline
-                :points="sparklinePoints"
-                fill="none"
-                stroke="#1976d2"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-          <div class="db-tooltip-detail flex items-center mb-1">
-            <v-icon size="14" color="info" class="mr-1">mdi-database-settings</v-icon>
-            <b>{{ dbStats.db_engine }}</b>
-            <span class="ml-2">{{ dbStats.db_version }}</span>
-          </div>
-          <v-divider class="my-2" />
-          <div class="db-tooltip-section-title mb-1">{{ __("Usage Stats") }}</div>
-          <div class="db-tooltip-detail flex items-center mb-1">
-            <v-icon size="14" color="info" class="mr-1">mdi-database</v-icon>
-            {{ __("Size:") }} <b>{{ formattedDbSize }}</b>
-            <span class="ml-2 flex items-center"><v-icon size="14" color="info" class="mr-1">mdi-table</v-icon>{{ __("Tables:") }} <b>{{ dbStats.db_table_count }}</b></span>
-            <span class="ml-2 flex items-center"><v-icon size="14" color="info" class="mr-1">mdi-format-list-numbered</v-icon>{{ __("Rows:") }} <b>{{ dbStats.db_total_rows }}</b></span>
-          </div>
-          <div class="db-tooltip-detail flex items-center mb-1">
-            <v-icon size="14" color="info" class="mr-1">mdi-connection</v-icon>
-            {{ __("Connections:") }} <b>{{ dbStats.db_connections }}</b>
-            <span class="ml-2 flex items-center"><v-icon size="14" color="warning" class="mr-1">mdi-timer-sand</v-icon>{{ __("Slow Queries:") }} <b>{{ dbStats.db_slow_queries }}</b></span>
-          </div>
-          <v-divider class="my-2" />
-          <div v-if="dbStats.db_top_tables && dbStats.db_top_tables.length">
-            <div class="db-tooltip-section-title mb-1 flex items-center">
-              <v-icon size="14" color="info" class="mr-1">mdi-database-outline</v-icon>
-              {{ __("Top Tables") }}
-            </div>
-            <ul class="db-top-tables ml-2">
-              <li v-for="t in dbStats.db_top_tables" :key="t.name" class="flex items-center mb-1">
-                <v-icon size="12" color="info" class="mr-1">mdi-table</v-icon>
-                <b>{{ t.name }}</b>: {{ formatBytes(t.size) }}
-              </li>
-            </ul>
-          </div>
-        </div>
-        <v-divider class="my-2" />
-        <div class="db-tooltip-tip mt-2 flex items-center">
-          <v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
-          {{ __("Tip: Monitor slow queries and table size for optimal performance.") }}
-        </div>
-        <div class="db-tooltip-explanation mt-2 flex items-center">
-          <v-icon size="14" color="info" class="mr-1">mdi-database</v-icon>
-          {{ __("Database health affects overall system speed and reliability.") }}
-        </div>
-      </div>
-    </v-tooltip>
-  </div>
+	<div class="db-gadget-section mx-1">
+		<v-tooltip location="bottom">
+			<template #activator="{ props }">
+				<div v-bind="props" class="db-meter-container">
+					<v-icon size="22" color="info">mdi-database</v-icon>
+					<span class="db-current-size">{{ formattedDbSize }}</span>
+				</div>
+			</template>
+			<div class="db-tooltip-content p-3 min-w-[220px]">
+				<div class="db-tooltip-title flex items-center font-semibold text-[14px] mb-2">
+					<v-icon size="16" color="info" class="mr-1">mdi-database-settings</v-icon>
+					{{ __("Database Health") }}
+				</div>
+				<v-divider class="my-2" />
+				<div v-if="loading" class="db-tooltip-detail">{{ __("Loading database stats...") }}</div>
+				<div v-else-if="error" class="db-tooltip-warning">{{ error }}</div>
+				<div v-else>
+					<div class="db-tooltip-section-title mb-1">{{ __("Database Info") }}</div>
+					<div class="db-tooltip-sparkline mb-2">
+						<svg :width="120" :height="32" class="db-sparkline">
+							<polyline
+								:points="sparklinePoints"
+								fill="none"
+								stroke="#1976d2"
+								stroke-width="2"
+							/>
+						</svg>
+					</div>
+					<div class="db-tooltip-detail flex items-center mb-1">
+						<v-icon size="14" color="info" class="mr-1">mdi-database-settings</v-icon>
+						<b>{{ dbStats.db_engine }}</b>
+						<span class="ml-2">{{ dbStats.db_version }}</span>
+					</div>
+					<v-divider class="my-2" />
+					<div class="db-tooltip-section-title mb-1">{{ __("Usage Stats") }}</div>
+					<div class="db-tooltip-detail flex items-center mb-1">
+						<v-icon size="14" color="info" class="mr-1">mdi-database</v-icon>
+						{{ __("Size:") }} <b>{{ formattedDbSize }}</b>
+						<span class="ml-2 flex items-center"
+							><v-icon size="14" color="info" class="mr-1">mdi-table</v-icon
+							>{{ __("Tables:") }} <b>{{ dbStats.db_table_count }}</b></span
+						>
+						<span class="ml-2 flex items-center"
+							><v-icon size="14" color="info" class="mr-1">mdi-format-list-numbered</v-icon
+							>{{ __("Rows:") }} <b>{{ dbStats.db_total_rows }}</b></span
+						>
+					</div>
+					<div class="db-tooltip-detail flex items-center mb-1">
+						<v-icon size="14" color="info" class="mr-1">mdi-connection</v-icon>
+						{{ __("Connections:") }} <b>{{ dbStats.db_connections }}</b>
+						<span class="ml-2 flex items-center"
+							><v-icon size="14" color="warning" class="mr-1">mdi-timer-sand</v-icon
+							>{{ __("Slow Queries:") }} <b>{{ dbStats.db_slow_queries }}</b></span
+						>
+					</div>
+					<v-divider class="my-2" />
+					<div v-if="dbStats.db_top_tables && dbStats.db_top_tables.length">
+						<div class="db-tooltip-section-title mb-1 flex items-center">
+							<v-icon size="14" color="info" class="mr-1">mdi-database-outline</v-icon>
+							{{ __("Top Tables") }}
+						</div>
+						<ul class="db-top-tables ml-2">
+							<li
+								v-for="t in dbStats.db_top_tables"
+								:key="t.name"
+								class="flex items-center mb-1"
+							>
+								<v-icon size="12" color="info" class="mr-1">mdi-table</v-icon>
+								<b>{{ t.name }}</b
+								>: {{ formatBytes(t.size) }}
+							</li>
+						</ul>
+					</div>
+				</div>
+				<v-divider class="my-2" />
+				<div class="db-tooltip-tip mt-2 flex items-center">
+					<v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
+					{{ __("Tip: Monitor slow queries and table size for optimal performance.") }}
+				</div>
+				<div class="db-tooltip-explanation mt-2 flex items-center">
+					<v-icon size="14" color="info" class="mr-1">mdi-database</v-icon>
+					{{ __("Database health affects overall system speed and reliability.") }}
+				</div>
+			</div>
+		</v-tooltip>
+	</div>
 </template>
 
 <script setup>
@@ -83,135 +97,136 @@ const __ = inject("__", (txt) => txt);
 const formattedDbSize = computed(() => formatBytes(dbStats.value?.db_size));
 
 function formatBytes(bytes) {
-  if (bytes == null) return 'N/A';
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+	if (bytes == null) return "N/A";
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
 const sparklinePoints = computed(() => {
-  const arr = history.value.map(h => h.db_size || 0);
-  const w = 120, h = 32;
-  if (!arr.length) return '';
-  const max = Math.max(...arr, 100);
-  const min = 0;
-  const step = arr.length > 1 ? w / (arr.length - 1) : w;
-  return arr.map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`).join(' ');
+	const arr = history.value.map((h) => h.db_size || 0);
+	const w = 120,
+		h = 32;
+	if (!arr.length) return "";
+	const max = Math.max(...arr, 100);
+	const min = 0;
+	const step = arr.length > 1 ? w / (arr.length - 1) : w;
+	return arr.map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`).join(" ");
 });
 </script>
 
 <style scoped>
 .db-gadget-section {
-  display: flex;
-  align-items: center;
-  margin: 0 8px;
+	display: flex;
+	align-items: center;
+	margin: 0 8px;
 }
 .db-meter-container {
-  cursor: pointer;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
+	cursor: pointer;
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: all 0.3s ease;
 }
 .db-meter-container:hover {
-  transform: scale(1.1);
+	transform: scale(1.1);
 }
 .db-current-size {
-  font-size: 13px;
-  font-weight: 600;
-  color: #1976d2;
-  min-width: 48px;
-  text-align: right;
+	font-size: 13px;
+	font-weight: 600;
+	color: #1976d2;
+	min-width: 48px;
+	text-align: right;
 }
 .db-tooltip-content {
-  padding: 14px;
-  min-width: 220px;
+	padding: 14px;
+	min-width: 220px;
 }
 .db-tooltip-title {
-  font-weight: 600;
-  font-size: 14px;
-  margin-bottom: 8px;
-  color: var(--primary);
+	font-weight: 600;
+	font-size: 14px;
+	margin-bottom: 8px;
+	color: var(--primary);
 }
 .db-tooltip-detail {
-  font-size: 12px;
-  margin-bottom: 8px;
-  line-height: 1.5;
+	font-size: 12px;
+	margin-bottom: 8px;
+	line-height: 1.5;
 }
 .db-tooltip-section-title {
-  font-weight: 600;
-  font-size: 13px;
-  margin-bottom: 4px;
-  color: var(--primary);
-  opacity: 0.85;
+	font-weight: 600;
+	font-size: 13px;
+	margin-bottom: 4px;
+	color: var(--primary);
+	opacity: 0.85;
 }
 .db-tooltip-subtitle {
-  font-size: 12px;
-  font-weight: 600;
-  color: #1976d2;
+	font-size: 12px;
+	font-weight: 600;
+	color: #1976d2;
 }
 .db-top-tables {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+	list-style: none;
+	padding: 0;
+	margin: 0;
 }
 .db-top-tables li {
-  font-size: 12px;
-  margin-bottom: 2px;
-  display: flex;
-  align-items: center;
+	font-size: 12px;
+	margin-bottom: 2px;
+	display: flex;
+	align-items: center;
 }
 .db-tooltip-warning {
-  color: #d32f2f;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
-  margin-bottom: 4px;
+	color: #d32f2f;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
+	margin-bottom: 4px;
 }
 .db-tooltip-tip {
-  color: #1976d2;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+	color: #1976d2;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
 }
 .db-tooltip-explanation {
-  color: #0288d1;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+	color: #0288d1;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
 }
 /* Match ServerUsageGadget tooltip background and text color */
 :deep(.v-tooltip .v-overlay__content),
 :deep(.v-overlay__content) {
-  background: #e3f2fd !important;
-  color: #1a237e !important;
-  box-shadow: 0 4px 16px rgba(25, 118, 210, 0.10) !important;
-  border: 1px solid #90caf9 !important;
+	background: #e3f2fd !important;
+	color: #1a237e !important;
+	box-shadow: 0 4px 16px rgba(25, 118, 210, 0.1) !important;
+	border: 1px solid #90caf9 !important;
 }
 
 .db-tooltip-title,
 .db-tooltip-tip,
 .db-tooltip-explanation {
-  color: #1a237e !important;
+	color: #1a237e !important;
 }
 
-:deep(.dark-theme) .v-tooltip .v-overlay__content,
+:deep([data-theme="dark"]) .v-tooltip .v-overlay__content,
 :deep(.v-theme--dark) .v-tooltip .v-overlay__content,
-:deep(.dark-theme) .v-overlay__content,
+:deep([data-theme="dark"]) .v-overlay__content,
 :deep(.v-theme--dark) .v-overlay__content {
-  background: #26344d !important;
-  color: #fff !important;
-  border: 1px solid #1976d2 !important;
+	background: #26344d !important;
+	color: #fff !important;
+	border: 1px solid #1976d2 !important;
 }
 
-:deep(.dark-theme) .db-tooltip-title,
+:deep([data-theme="dark"]) .db-tooltip-title,
 :deep(.v-theme--dark) .db-tooltip-title,
-:deep(.dark-theme) .db-tooltip-tip,
+:deep([data-theme="dark"]) .db-tooltip-tip,
 :deep(.v-theme--dark) .db-tooltip-tip,
-:deep(.dark-theme) .db-tooltip-explanation,
+:deep([data-theme="dark"]) .db-tooltip-explanation,
 :deep(.v-theme--dark) .db-tooltip-explanation {
-  color: #fff !important;
+	color: #fff !important;
 }
-</style> 
+</style>

--- a/posawesome/public/js/posapp/components/navbar/NavbarAppBar.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarAppBar.vue
@@ -32,11 +32,11 @@
 		<!-- Cache Usage Meter -->
 		<slot name="cache-usage-meter"></slot>
 
-    <!-- Database Usage Gadget -->
-    <slot name="db-usage-gadget"></slot>
+		<!-- Database Usage Gadget -->
+		<slot name="db-usage-gadget"></slot>
 
-    <!-- CPU Load Gadget -->
-    <slot name="cpu-gadget"></slot>
+		<!-- CPU Load Gadget -->
+		<slot name="cpu-gadget"></slot>
 
 		<div class="profile-section mx-1">
 			<v-chip color="primary" variant="outlined" class="profile-chip">
@@ -189,7 +189,7 @@ export default {
 }
 
 /* Dark theme adjustments */
-:deep(.dark-theme) .navbar-enhanced,
+:deep([data-theme="dark"]) .navbar-enhanced,
 :deep(.v-theme--dark) .navbar-enhanced {
 	background-image: linear-gradient(
 		135deg,
@@ -201,27 +201,27 @@ export default {
 	color: var(--text-primary, #ffffff) !important;
 }
 
-:deep(.dark-theme) .navbar-enhanced:hover,
+:deep([data-theme="dark"]) .navbar-enhanced:hover,
 :deep(.v-theme--dark) .navbar-enhanced:hover {
 	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3) !important;
 }
 
-:deep(.dark-theme) .nav-icon,
+:deep([data-theme="dark"]) .nav-icon,
 :deep(.v-theme--dark) .nav-icon {
 	color: var(--text-primary, #ffffff) !important;
 }
 
-:deep(.dark-theme) .nav-icon:hover,
+:deep([data-theme="dark"]) .nav-icon:hover,
 :deep(.v-theme--dark) .nav-icon:hover {
 	background-color: rgba(144, 202, 249, 0.1);
 }
 
-:deep(.dark-theme) .navbar-title,
+:deep([data-theme="dark"]) .navbar-title,
 :deep(.v-theme--dark) .navbar-title {
 	color: var(--text-primary, #ffffff) !important;
 }
 
-:deep(.dark-theme) .profile-chip,
+:deep([data-theme="dark"]) .profile-chip,
 :deep(.v-theme--dark) .profile-chip {
 	background-color: var(--surface-secondary, #2d2d2d) !important;
 	color: var(--text-primary, #ffffff) !important;

--- a/posawesome/public/js/posapp/components/navbar/NavbarDrawer.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarDrawer.vue
@@ -172,21 +172,21 @@ export default {
 }
 
 /* Dark Theme Adjustments */
-:deep(.dark-theme) .drawer-custom,
+:deep([data-theme="dark"]) .drawer-custom,
 :deep(.v-theme--dark) .drawer-custom {
 	background-color: var(--surface-primary, #1e1e1e) !important;
 	color: var(--text-primary, #ffffff) !important;
 }
 
-:deep(.dark-theme) .drawer-header,
-:deep(.dark-theme) .drawer-header-mini,
+:deep([data-theme="dark"]) .drawer-header,
+:deep([data-theme="dark"]) .drawer-header-mini,
 :deep(.v-theme--dark) .drawer-header,
 :deep(.v-theme--dark) .drawer-header-mini {
 	background: linear-gradient(135deg, #2d2d2d 0%, #1e1e1e 100%);
 	border-bottom: 1px solid rgba(255, 255, 255, 0.12);
 }
 
-:deep(.dark-theme) .drawer-item-title,
+:deep([data-theme="dark"]) .drawer-item-title,
 :deep(.v-theme--dark) .drawer-item-title {
 	color: #000000 !important;
 	font-weight: 500;
@@ -194,7 +194,7 @@ export default {
 	font-family: "Roboto", sans-serif;
 }
 
-:deep(.dark-theme) .drawer-company,
+:deep([data-theme="dark"]) .drawer-company,
 :deep(.v-theme--dark) .drawer-company {
 	color: var(--text-primary, #ffffff) !important;
 	font-weight: 500;
@@ -202,24 +202,24 @@ export default {
 	font-family: "Roboto", sans-serif;
 }
 
-:deep(.dark-theme) .drawer-icon,
+:deep([data-theme="dark"]) .drawer-icon,
 :deep(.v-theme--dark) .drawer-icon {
 	color: var(--primary-light, #90caf9) !important;
 	font-size: 24px;
 }
 
-:deep(.dark-theme) .v-list-item:hover,
+:deep([data-theme="dark"]) .v-list-item:hover,
 :deep(.v-theme--dark) .v-list-item:hover {
 	background-color: rgba(144, 202, 249, 0.08) !important;
 }
 
-:deep(.dark-theme) .active-item,
+:deep([data-theme="dark"]) .active-item,
 :deep(.v-theme--dark) .active-item {
 	background-color: rgba(144, 202, 249, 0.12) !important;
 	border-right: 3px solid #90caf9;
 }
 
-:deep(.dark-theme) .v-divider,
+:deep([data-theme="dark"]) .v-divider,
 :deep(.v-theme--dark) .v-divider {
 	border-color: rgba(255, 255, 255, 0.12) !important;
 }
@@ -252,7 +252,7 @@ export default {
 }
 
 @media (max-width: 1024px) {
-	:deep(.dark-theme) .drawer-custom.drawer-visible,
+	:deep([data-theme="dark"]) .drawer-custom.drawer-visible,
 	:deep(.v-theme--dark) .drawer-custom.drawer-visible {
 		background-color: var(--surface-primary, #1e1e1e) !important;
 	}

--- a/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarMenu.vue
@@ -492,19 +492,19 @@ export default {
 }
 
 /* Dark Theme Adjustments */
-:deep(.dark-theme) .menu-btn-compact,
+:deep([data-theme="dark"]) .menu-btn-compact,
 :deep(.v-theme--dark) .menu-btn-compact {
 	background: linear-gradient(135deg, #90caf9 0%, #42a5f5 100%);
 	color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .menu-btn-compact:hover,
+:deep([data-theme="dark"]) .menu-btn-compact:hover,
 :deep(.v-theme--dark) .menu-btn-compact:hover {
 	background: linear-gradient(135deg, #64b5f6 0%, #1976d2 100%);
 	box-shadow: 0 4px 12px rgba(144, 202, 249, 0.3);
 }
 
-:deep(.dark-theme) .menu-card-compact,
+:deep([data-theme="dark"]) .menu-card-compact,
 :deep(.v-theme--dark) .menu-card-compact {
 	background: var(--surface-primary, #1e1e1e) !important;
 	border: 1px solid rgba(255, 255, 255, 0.12);
@@ -513,38 +513,38 @@ export default {
 		0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
-:deep(.dark-theme) .menu-header-compact,
+:deep([data-theme="dark"]) .menu-header-compact,
 :deep(.v-theme--dark) .menu-header-compact {
 	background: linear-gradient(135deg, #2d2d2d 0%, #1e1e1e 100%) !important;
 	border-bottom: 1px solid rgba(255, 255, 255, 0.12);
 }
 
-:deep(.dark-theme) .menu-header-text-compact,
+:deep([data-theme="dark"]) .menu-header-text-compact,
 :deep(.v-theme--dark) .menu-header-text-compact {
 	color: var(--primary-light, #90caf9) !important;
 }
 
-:deep(.dark-theme) .menu-list-compact,
+:deep([data-theme="dark"]) .menu-list-compact,
 :deep(.v-theme--dark) .menu-list-compact {
 	background: var(--surface-primary, #1e1e1e) !important;
 }
 
-:deep(.dark-theme) .menu-item-title-compact,
+:deep([data-theme="dark"]) .menu-item-title-compact,
 :deep(.v-theme--dark) .menu-item-title-compact {
 	color: var(--text-primary, #ffffff) !important;
 }
 
-:deep(.dark-theme) .menu-item-subtitle-compact,
+:deep([data-theme="dark"]) .menu-item-subtitle-compact,
 :deep(.v-theme--dark) .menu-item-subtitle-compact {
 	color: var(--text-secondary, #b0b0b0) !important;
 }
 
-:deep(.dark-theme) .menu-section-divider-compact,
+:deep([data-theme="dark"]) .menu-section-divider-compact,
 :deep(.v-theme--dark) .menu-section-divider-compact {
 	border-color: rgba(255, 255, 255, 0.12) !important;
 }
 
-:deep(.dark-theme) .menu-item-compact:hover::before,
+:deep([data-theme="dark"]) .menu-item-compact:hover::before,
 :deep(.v-theme--dark) .menu-item-compact:hover::before {
 	background: linear-gradient(
 		135deg,
@@ -554,37 +554,37 @@ export default {
 }
 
 /* Dark mode icon adjustments */
-:deep(.dark-theme) .primary-icon,
+:deep([data-theme="dark"]) .primary-icon,
 :deep(.v-theme--dark) .primary-icon {
 	background: linear-gradient(135deg, #90caf9 0%, #42a5f5 100%);
 	box-shadow: 0 2px 6px rgba(144, 202, 249, 0.3);
 }
 
-:deep(.dark-theme) .secondary-icon,
+:deep([data-theme="dark"]) .secondary-icon,
 :deep(.v-theme--dark) .secondary-icon {
 	background: linear-gradient(135deg, #ce93d8 0%, #ba68c8 100%);
 	box-shadow: 0 2px 6px rgba(206, 147, 216, 0.3);
 }
 
-:deep(.dark-theme) .info-icon,
+:deep([data-theme="dark"]) .info-icon,
 :deep(.v-theme--dark) .info-icon {
 	background: linear-gradient(135deg, #81d4fa 0%, #4fc3f7 100%);
 	box-shadow: 0 2px 6px rgba(129, 212, 250, 0.3);
 }
 
-:deep(.dark-theme) .neutral-icon,
+:deep([data-theme="dark"]) .neutral-icon,
 :deep(.v-theme--dark) .neutral-icon {
 	background: linear-gradient(135deg, #bdbdbd 0%, #9e9e9e 100%);
 	box-shadow: 0 2px 6px rgba(189, 189, 189, 0.3);
 }
 
-:deep(.dark-theme) .danger-icon,
+:deep([data-theme="dark"]) .danger-icon,
 :deep(.v-theme--dark) .danger-icon {
 	background: linear-gradient(135deg, #ef5350 0%, #f44336 100%);
 	box-shadow: 0 2px 6px rgba(239, 83, 80, 0.3);
 }
 
-:deep(.dark-theme) .warning-icon,
+:deep([data-theme="dark"]) .warning-icon,
 :deep(.v-theme--dark) .warning-icon {
 	background: linear-gradient(135deg, #ffb74d 0%, #ffc107 100%);
 	box-shadow: 0 2px 6px rgba(255, 183, 77, 0.3);

--- a/posawesome/public/js/posapp/components/navbar/ServerUsageGadget.vue
+++ b/posawesome/public/js/posapp/components/navbar/ServerUsageGadget.vue
@@ -1,116 +1,133 @@
 <template>
-  <div class="cpu-gadget-section mx-1">
-    <v-tooltip location="bottom">
-      <template #activator="{ props }">
-        <div v-bind="props" class="cpu-meter-container">
-          <v-icon size="22" color="primary">mdi-server</v-icon>
-          <span class="cpu-current-lag">{{ cpuLag.toFixed(1) }} ms</span>
-        </div>
-      </template>
-      <div class="cpu-tooltip-content">
-        <div class="cpu-tooltip-title">
-          <v-icon size="16" color="primary" class="mr-1">mdi-server</v-icon>
-          {{ __("Server Health") }}
-        </div>
-        <v-divider class="my-2" />
-        <div class="cpu-tooltip-section-title mb-1">{{ __("Server Metrics") }}</div>
-        <div class="cpu-tooltip-peak mb-1">
-          <v-icon size="14" color="success" class="mr-1">mdi-arrow-up-bold</v-icon>
-          {{ __("Peak:") }}
-          <b>{{ peakLag.toFixed(1) }} ms</b>
-          ({{ peakPercent }}%)
-        </div>
-        <div class="cpu-tooltip-sparkline mb-2">
-          <svg :width="180" :height="40" class="cpu-sparkline-large">
-            <defs>
-              <linearGradient id="cpuAreaGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stop-color="#4caf50" stop-opacity="0.35"/>
-                <stop offset="100%" stop-color="#4caf50" stop-opacity="0"/>
-              </linearGradient>
-            </defs>
-            <polyline
-              :points="sparklinePointsLarge"
-              fill="none"
-              stroke="#4caf50"
-              stroke-width="2"
-            />
-            <polygon
-              :points="areaPointsLarge"
-              fill="url(#cpuAreaGradient)"
-              stroke="none"
-            />
-          </svg>
-        </div>
-        <div class="cpu-tooltip-detail">
-          <v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
-          {{ __("Current Event Loop Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
-        </div>
-        <div v-if="cpuLag >= 80" class="cpu-tooltip-warning">
-          <v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
-          {{ __("Warning: High lag may indicate heavy processing or browser slowness.") }}
-        </div>
-        <div v-if="serverLoading" class="cpu-tooltip-detail">{{ __("Loading server CPU/memory usage...") }}</div>
-        <div v-else-if="serverError" class="cpu-tooltip-warning">{{ serverError }}</div>
-        <div v-else>
-          <div class="cpu-tooltip-detail">
-            <v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
-            {{ __("Server CPU Usage:") }} <b>{{ serverCpu !== null ? serverCpu.toFixed(1) + '%' : 'N/A' }}</b>
-            <span class="ml-2">{{ __("Peak Server:") }} <b>{{ serverPeak.toFixed(1) }}%</b></span>
-          </div>
-          <div class="cpu-tooltip-detail">
-            <v-icon size="14" color="primary" class="mr-1">mdi-memory</v-icon>
-            {{ __("Server Memory Usage:") }}
-            <b>{{ serverMemory !== null ? serverMemory.toFixed(1) + '%' : 'N/A' }}</b>
-            <span class="ml-2">{{ __("Peak Memory:") }} <b>{{ serverMemoryPeak.toFixed(1) }}%</b></span>
-          </div>
-          <div class="cpu-tooltip-bar">
-            <div class="cpu-bar-bg">
-              <div class="cpu-bar-fill" :style="{ width: (serverMemory || 0) + '%', background: 'linear-gradient(90deg,#1976d2 0%,#42a5f5 100%)' }"></div>
-            </div>
-            <span class="cpu-bar-label">{{ serverMemory !== null ? serverMemory.toFixed(1) + '%' : 'N/A' }}</span>
-          </div>
-          <div class="cpu-tooltip-detail">
-            <v-icon size="14" color="primary" class="mr-1">mdi-database</v-icon>
-            {{ __("Total:") }} <b>{{ formatBytes(memoryTotal) }}</b>
-            <span class="ml-2">{{ __("Used:") }} <b>{{ formatBytes(memoryUsed) }}</b></span>
-            <span class="ml-2">{{ __("Available:") }} <b>{{ formatBytes(memoryAvailable) }}</b></span>
-          </div>
-          <div class="cpu-tooltip-detail">
-            <v-icon size="14" color="primary" class="mr-1">mdi-timer-outline</v-icon>
-            {{ __("Server Uptime:") }} <b>{{ formatUptime(serverUptime) }}</b>
-          </div>
-        </div>
-        <v-divider class="my-2" />
-        <div class="cpu-tooltip-section-title mb-1">{{ __("Client Metrics") }}</div>
-        <div class="cpu-tooltip-detail">
-          <v-icon size="14" color="primary" class="mr-1">mdi-monitor</v-icon>
-          {{ __("Client CPU Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
-        </div>
-        <div class="cpu-tooltip-detail">
-          <v-icon size="14" color="primary" class="mr-1">mdi-memory</v-icon>
-          {{ __("Client Memory Usage:") }} <b>{{ formatBytes(memoryUsage) }}</b>
-        </div>
-        <div class="cpu-tooltip-detail">
-          <v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
-          {{ __("CPU Cores:") }} <b>{{ device.cores }}</b>
-          <span v-if="device.gbMemory" class="ml-2">{{ __("Device Memory:") }} <b>{{ device.gbMemory }} GB</b></span>
-        </div>
-        <v-divider class="my-2" />
-        <div class="cpu-tooltip-tip mt-2">
-          <v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
-          {{ __("Tip: Close unused tabs or apps to reduce lag.") }}
-        </div>
-        <div class="cpu-tooltip-explanation mt-2">
-          <v-icon size="14" color="info" class="mr-1">mdi-chip</v-icon>
-          {{ __("Event-loop lag measures how busy your browser is. Lower is better.") }}
-        </div>
-        <div class="cpu-tooltip-action mt-2">
-          <v-icon size="14" class="mr-1">mdi-refresh</v-icon>
-          {{ __("Updates automatically") }}
-        </div>
-      </div>
-    </v-tooltip>
-  </div>
+	<div class="cpu-gadget-section mx-1">
+		<v-tooltip location="bottom">
+			<template #activator="{ props }">
+				<div v-bind="props" class="cpu-meter-container">
+					<v-icon size="22" color="primary">mdi-server</v-icon>
+					<span class="cpu-current-lag">{{ cpuLag.toFixed(1) }} ms</span>
+				</div>
+			</template>
+			<div class="cpu-tooltip-content">
+				<div class="cpu-tooltip-title">
+					<v-icon size="16" color="primary" class="mr-1">mdi-server</v-icon>
+					{{ __("Server Health") }}
+				</div>
+				<v-divider class="my-2" />
+				<div class="cpu-tooltip-section-title mb-1">{{ __("Server Metrics") }}</div>
+				<div class="cpu-tooltip-peak mb-1">
+					<v-icon size="14" color="success" class="mr-1">mdi-arrow-up-bold</v-icon>
+					{{ __("Peak:") }}
+					<b>{{ peakLag.toFixed(1) }} ms</b>
+					({{ peakPercent }}%)
+				</div>
+				<div class="cpu-tooltip-sparkline mb-2">
+					<svg :width="180" :height="40" class="cpu-sparkline-large">
+						<defs>
+							<linearGradient id="cpuAreaGradient" x1="0" y1="0" x2="0" y2="1">
+								<stop offset="0%" stop-color="#4caf50" stop-opacity="0.35" />
+								<stop offset="100%" stop-color="#4caf50" stop-opacity="0" />
+							</linearGradient>
+						</defs>
+						<polyline
+							:points="sparklinePointsLarge"
+							fill="none"
+							stroke="#4caf50"
+							stroke-width="2"
+						/>
+						<polygon :points="areaPointsLarge" fill="url(#cpuAreaGradient)" stroke="none" />
+					</svg>
+				</div>
+				<div class="cpu-tooltip-detail">
+					<v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
+					{{ __("Current Event Loop Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
+				</div>
+				<div v-if="cpuLag >= 80" class="cpu-tooltip-warning">
+					<v-icon size="14" color="error" class="mr-1">mdi-alert</v-icon>
+					{{ __("Warning: High lag may indicate heavy processing or browser slowness.") }}
+				</div>
+				<div v-if="serverLoading" class="cpu-tooltip-detail">
+					{{ __("Loading server CPU/memory usage...") }}
+				</div>
+				<div v-else-if="serverError" class="cpu-tooltip-warning">{{ serverError }}</div>
+				<div v-else>
+					<div class="cpu-tooltip-detail">
+						<v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
+						{{ __("Server CPU Usage:") }}
+						<b>{{ serverCpu !== null ? serverCpu.toFixed(1) + "%" : "N/A" }}</b>
+						<span class="ml-2"
+							>{{ __("Peak Server:") }} <b>{{ serverPeak.toFixed(1) }}%</b></span
+						>
+					</div>
+					<div class="cpu-tooltip-detail">
+						<v-icon size="14" color="primary" class="mr-1">mdi-memory</v-icon>
+						{{ __("Server Memory Usage:") }}
+						<b>{{ serverMemory !== null ? serverMemory.toFixed(1) + "%" : "N/A" }}</b>
+						<span class="ml-2"
+							>{{ __("Peak Memory:") }} <b>{{ serverMemoryPeak.toFixed(1) }}%</b></span
+						>
+					</div>
+					<div class="cpu-tooltip-bar">
+						<div class="cpu-bar-bg">
+							<div
+								class="cpu-bar-fill"
+								:style="{
+									width: (serverMemory || 0) + '%',
+									background: 'linear-gradient(90deg,#1976d2 0%,#42a5f5 100%)',
+								}"
+							></div>
+						</div>
+						<span class="cpu-bar-label">{{
+							serverMemory !== null ? serverMemory.toFixed(1) + "%" : "N/A"
+						}}</span>
+					</div>
+					<div class="cpu-tooltip-detail">
+						<v-icon size="14" color="primary" class="mr-1">mdi-database</v-icon>
+						{{ __("Total:") }} <b>{{ formatBytes(memoryTotal) }}</b>
+						<span class="ml-2"
+							>{{ __("Used:") }} <b>{{ formatBytes(memoryUsed) }}</b></span
+						>
+						<span class="ml-2"
+							>{{ __("Available:") }} <b>{{ formatBytes(memoryAvailable) }}</b></span
+						>
+					</div>
+					<div class="cpu-tooltip-detail">
+						<v-icon size="14" color="primary" class="mr-1">mdi-timer-outline</v-icon>
+						{{ __("Server Uptime:") }} <b>{{ formatUptime(serverUptime) }}</b>
+					</div>
+				</div>
+				<v-divider class="my-2" />
+				<div class="cpu-tooltip-section-title mb-1">{{ __("Client Metrics") }}</div>
+				<div class="cpu-tooltip-detail">
+					<v-icon size="14" color="primary" class="mr-1">mdi-monitor</v-icon>
+					{{ __("Client CPU Lag:") }} <b>{{ cpuLag.toFixed(1) }}</b> ms
+				</div>
+				<div class="cpu-tooltip-detail">
+					<v-icon size="14" color="primary" class="mr-1">mdi-memory</v-icon>
+					{{ __("Client Memory Usage:") }} <b>{{ formatBytes(memoryUsage) }}</b>
+				</div>
+				<div class="cpu-tooltip-detail">
+					<v-icon size="14" color="primary" class="mr-1">mdi-chip</v-icon>
+					{{ __("CPU Cores:") }} <b>{{ device.cores }}</b>
+					<span v-if="device.gbMemory" class="ml-2"
+						>{{ __("Device Memory:") }} <b>{{ device.gbMemory }} GB</b></span
+					>
+				</div>
+				<v-divider class="my-2" />
+				<div class="cpu-tooltip-tip mt-2">
+					<v-icon size="14" color="primary" class="mr-1">mdi-lightbulb-on-outline</v-icon>
+					{{ __("Tip: Close unused tabs or apps to reduce lag.") }}
+				</div>
+				<div class="cpu-tooltip-explanation mt-2">
+					<v-icon size="14" color="info" class="mr-1">mdi-chip</v-icon>
+					{{ __("Event-loop lag measures how busy your browser is. Lower is better.") }}
+				</div>
+				<div class="cpu-tooltip-action mt-2">
+					<v-icon size="14" class="mr-1">mdi-refresh</v-icon>
+					{{ __("Updates automatically") }}
+				</div>
+			</div>
+		</v-tooltip>
+	</div>
 </template>
 
 <script setup lang="ts">
@@ -123,69 +140,69 @@ const __ = inject("__", (txt: string) => txt);
 
 // Use the composable for server CPU and memory
 const {
-  cpu: serverCpu,
-  memory: serverMemory,
-  memoryTotal,
-  memoryUsed,
-  memoryAvailable,
-  history: serverHistory,
-  loading: serverLoading,
-  error: serverError
+	cpu: serverCpu,
+	memory: serverMemory,
+	memoryTotal,
+	memoryUsed,
+	memoryAvailable,
+	history: serverHistory,
+	loading: serverLoading,
+	error: serverError,
 } = useServerStats(10000, 60);
 
-const serverPeak = computed(() => Math.max(...serverHistory.value.map(h => h.cpu ?? 0), 0));
-const serverMemoryPeak = computed(() => Math.max(...serverHistory.value.map(h => h.memory ?? 0), 0));
+const serverPeak = computed(() => Math.max(...serverHistory.value.map((h) => h.cpu ?? 0), 0));
+const serverMemoryPeak = computed(() => Math.max(...serverHistory.value.map((h) => h.memory ?? 0), 0));
 
 // Uptime formatting
 import { ref, watch } from "vue";
 const serverUptime = ref<number | null>(null);
-watch(serverHistory, (hist) => {
-  if (hist.length && hist[hist.length - 1].uptime != null) {
-    serverUptime.value = hist[hist.length - 1].uptime;
-  }
-}, { immediate: true, deep: true });
+watch(
+	serverHistory,
+	(hist) => {
+		if (hist.length && hist[hist.length - 1].uptime != null) {
+			serverUptime.value = hist[hist.length - 1].uptime;
+		}
+	},
+	{ immediate: true, deep: true },
+);
 
 function formatUptime(seconds: number | null) {
-  if (seconds == null) return 'N/A';
-  const d = Math.floor(seconds / (3600 * 24));
-  const h = Math.floor((seconds % (3600 * 24)) / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  let str = '';
-  if (d > 0) str += `${d}d `;
-  if (h > 0 || d > 0) str += `${h}h `;
-  str += `${m}m`;
-  return str.trim();
+	if (seconds == null) return "N/A";
+	const d = Math.floor(seconds / (3600 * 24));
+	const h = Math.floor((seconds % (3600 * 24)) / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	let str = "";
+	if (d > 0) str += `${d}d `;
+	if (h > 0 || d > 0) str += `${h}h `;
+	str += `${m}m`;
+	return str.trim();
 }
 
 function formatBytes(bytes: number | null) {
-  if (bytes == null) return 'N/A';
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+	if (bytes == null) return "N/A";
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
 function getSparklinePoints(arr: number[], w: number, h: number) {
-  if (!arr.length) return '';
-  const max = Math.max(...arr, 100);
-  const min = 0;
-  const step = arr.length > 1 ? w / (arr.length - 1) : w;
-  return arr
-    .map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`)
-    .join(' ');
+	if (!arr.length) return "";
+	const max = Math.max(...arr, 100);
+	const min = 0;
+	const step = arr.length > 1 ? w / (arr.length - 1) : w;
+	return arr.map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`).join(" ");
 }
 
 function getAreaPoints(arr: number[], w: number, h: number) {
-  if (!arr.length) return '';
-  const max = Math.max(...arr, 100);
-  const min = 0;
-  const step = arr.length > 1 ? w / (arr.length - 1) : w;
-  let points = arr
-    .map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`)
-    .join(' ');
-  // Close the area polygon
-  points += ` ${w},${h} 0,${h}`;
-  return points;
+	if (!arr.length) return "";
+	const max = Math.max(...arr, 100);
+	const min = 0;
+	const step = arr.length > 1 ? w / (arr.length - 1) : w;
+	let points = arr.map((v, i) => `${i * step},${h - ((v - min) / (max - min || 1)) * h}`).join(" ");
+	// Close the area polygon
+	points += ` ${w},${h} 0,${h}`;
+	return points;
 }
 
 const sparklinePointsLarge = computed(() => getSparklinePoints(history.value, 180, 40));
@@ -198,180 +215,180 @@ const peakPercent = computed(() => Math.round(Math.min(peakLag.value, 100)));
 
 <style scoped>
 .cpu-gadget-section {
-  display: flex;
-  align-items: center;
-  margin: 0 8px;
+	display: flex;
+	align-items: center;
+	margin: 0 8px;
 }
 
 .cpu-meter-container {
-  cursor: pointer;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.3s ease;
+	cursor: pointer;
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: all 0.3s ease;
 }
 
 .cpu-meter-container:hover {
-  transform: scale(1.1);
+	transform: scale(1.1);
 }
 
 .cpu-meter {
-  transition: all 0.3s ease;
+	transition: all 0.3s ease;
 }
 
 .cpu-tooltip-content {
-  @apply p-3 min-w-[180px];
+	@apply p-3 min-w-[180px];
 }
 
 .cpu-tooltip-title {
-  font-weight: 600;
-  font-size: 14px;
-  margin-bottom: 8px;
-  color: var(--primary);
+	font-weight: 600;
+	font-size: 14px;
+	margin-bottom: 8px;
+	color: var(--primary);
 }
 
 .cpu-tooltip-detail {
-  font-size: 12px;
-  margin-bottom: 8px;
-  line-height: 1.5;
+	font-size: 12px;
+	margin-bottom: 8px;
+	line-height: 1.5;
 }
 
 .cpu-tooltip-action {
-  font-size: 11px;
-  opacity: 0.7;
-  display: flex;
-  align-items: center;
-  margin-top: 8px;
-  color: var(--primary);
+	font-size: 11px;
+	opacity: 0.7;
+	display: flex;
+	align-items: center;
+	margin-top: 8px;
+	color: var(--primary);
 }
 
 .cpu-tooltip-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 4px;
 }
 .cpu-bar-bg {
-  width: 80px;
-  height: 8px;
-  background: #e3f2fd;
-  border-radius: 4px;
-  overflow: hidden;
-  margin-right: 6px;
+	width: 80px;
+	height: 8px;
+	background: #e3f2fd;
+	border-radius: 4px;
+	overflow: hidden;
+	margin-right: 6px;
 }
 .cpu-bar-fill {
-  height: 100%;
-  background: linear-gradient(90deg, #7b1fa2 0%, #42a5f5 100%);
-  border-radius: 4px;
-  transition: width 0.3s;
+	height: 100%;
+	background: linear-gradient(90deg, #7b1fa2 0%, #42a5f5 100%);
+	border-radius: 4px;
+	transition: width 0.3s;
 }
 .cpu-bar-label {
-  font-size: 11px;
-  color: #7b1fa2;
-  font-weight: 600;
+	font-size: 11px;
+	color: #7b1fa2;
+	font-weight: 600;
 }
 .cpu-tooltip-warning {
-  color: #d32f2f;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
-  margin-bottom: 4px;
+	color: #d32f2f;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
+	margin-bottom: 4px;
 }
 .cpu-tooltip-tip {
-  color: #1976d2;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+	color: #1976d2;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
 }
 .cpu-tooltip-explanation {
-  color: #0288d1;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+	color: #0288d1;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
 }
 
 .cpu-sparkline-wrapper {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
 }
 .cpu-sparkline {
-  display: block;
-  background: none;
+	display: block;
+	background: none;
 }
 .cpu-current-lag {
-  font-size: 13px;
-  font-weight: 600;
-  color: #4caf50;
-  min-width: 48px;
-  text-align: right;
+	font-size: 13px;
+	font-weight: 600;
+	color: #4caf50;
+	min-width: 48px;
+	text-align: right;
 }
 .cpu-tooltip-sparkline {
-  width: 180px;
-  height: 40px;
-  margin-bottom: 8px;
+	width: 180px;
+	height: 40px;
+	margin-bottom: 8px;
 }
 .cpu-sparkline-large {
-  display: block;
-  background: none;
+	display: block;
+	background: none;
 }
 
 .cpu-tooltip-legend {
-  font-size: 12px;
-  margin-bottom: 4px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
+	font-size: 12px;
+	margin-bottom: 4px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
 }
 .legend-dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  margin-right: 4px;
+	display: inline-block;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	margin-right: 4px;
 }
 .legend-dot.client {
-  background: #4caf50;
+	background: #4caf50;
 }
 .legend-dot.server {
-  background: #1976d2;
+	background: #1976d2;
 }
 
 /* Fix tooltip background and text color in light mode */
 :deep(.v-tooltip .v-overlay__content),
 :deep(.v-overlay__content) {
-  background: #e3f2fd !important;
-  color: #1a237e !important;
-  box-shadow: 0 4px 16px rgba(25, 118, 210, 0.10) !important;
-  border: 1px solid #90caf9 !important;
+	background: #e3f2fd !important;
+	color: #1a237e !important;
+	box-shadow: 0 4px 16px rgba(25, 118, 210, 0.1) !important;
+	border: 1px solid #90caf9 !important;
 }
 
 .cpu-tooltip-title,
 .cpu-tooltip-action {
-  color: #1a237e !important;
+	color: #1a237e !important;
 }
 
-:deep(.dark-theme) .v-tooltip .v-overlay__content,
+:deep([data-theme="dark"]) .v-tooltip .v-overlay__content,
 :deep(.v-theme--dark) .v-tooltip .v-overlay__content,
-:deep(.dark-theme) .v-overlay__content,
+:deep([data-theme="dark"]) .v-overlay__content,
 :deep(.v-theme--dark) .v-overlay__content {
-  background: #26344d !important;
-  color: #fff !important;
-  border: 1px solid #1976d2 !important;
+	background: #26344d !important;
+	color: #fff !important;
+	border: 1px solid #1976d2 !important;
 }
 
-:deep(.dark-theme) .cpu-tooltip-title,
+:deep([data-theme="dark"]) .cpu-tooltip-title,
 :deep(.v-theme--dark) .cpu-tooltip-title,
-:deep(.dark-theme) .cpu-tooltip-action,
+:deep([data-theme="dark"]) .cpu-tooltip-action,
 :deep(.v-theme--dark) .cpu-tooltip-action {
-  color: #fff !important;
+	color: #fff !important;
 }
 .cpu-tooltip-section-title {
-  font-weight: 600;
-  font-size: 13px;
-  margin-bottom: 4px;
-  color: var(--primary);
-  opacity: 0.85;
+	font-weight: 600;
+	font-size: 13px;
+	margin-bottom: 4px;
+	color: var(--primary);
+	opacity: 0.85;
 }
-</style> 
+</style>

--- a/posawesome/public/js/posapp/components/payments/Pay.vue
+++ b/posawesome/public/js/posapp/components/payments/Pay.vue
@@ -1222,31 +1222,31 @@ export default {
 
 <style>
 /* Dark mode input styling */
-:deep(.dark-theme) .dark-field,
+:deep([data-theme="dark"]) .dark-field,
 :deep(.v-theme--dark) .dark-field,
-::v-deep(.dark-theme) .dark-field,
+::v-deep([data-theme="dark"]) .dark-field,
 ::v-deep(.v-theme--dark) .dark-field {
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep(.dark-theme) .dark-field :deep(input),
+:deep([data-theme="dark"]) .dark-field :deep(input),
 :deep(.v-theme--dark) .dark-field :deep(input),
-:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep([data-theme="dark"]) .dark-field :deep(.v-label),
 :deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep([data-theme="dark"]) .dark-field .v-field__input,
 ::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep(.dark-theme) .dark-field input,
+::v-deep([data-theme="dark"]) .dark-field input,
 ::v-deep(.v-theme--dark) .dark-field input,
-::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep([data-theme="dark"]) .dark-field .v-label,
 ::v-deep(.v-theme--dark) .dark-field .v-label {
 	color: #fff !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
 ::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
 	background-color: #1e1e1e !important;
 }

--- a/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
@@ -143,22 +143,22 @@ export default {
 	}),
 	watch: {},
 
-        methods: {
-                close_dialog() {
-                        this.closingDialog = false;
-                },
-                submit_dialog() {
-                        const invalid = (this.dialog_data.payments || []).some(
-                                (p) => isNaN(parseFloat(p.closing_amount))
-                        );
-                        if (invalid) {
-                                alert(this.__("Invalid closing amount"));
-                                return;
-                        }
-                        this.eventBus.emit("submit_closing_pos", this.dialog_data);
-                        this.closingDialog = false;
-                },
-        },
+	methods: {
+		close_dialog() {
+			this.closingDialog = false;
+		},
+		submit_dialog() {
+			const invalid = (this.dialog_data.payments || []).some((p) =>
+				isNaN(parseFloat(p.closing_amount)),
+			);
+			if (invalid) {
+				alert(this.__("Invalid closing amount"));
+				return;
+			}
+			this.eventBus.emit("submit_closing_pos", this.dialog_data);
+			this.closingDialog = false;
+		},
+	},
 
 	computed: {
 		isDarkTheme() {
@@ -319,39 +319,39 @@ export default {
 }
 
 /* Dark theme overrides */
-:deep(.dark-theme) .closing-dialog-card,
+:deep([data-theme="dark"]) .closing-dialog-card,
 :deep(.v-theme--dark) .closing-dialog-card,
-::v-deep(.dark-theme) .closing-dialog-card,
+::v-deep([data-theme="dark"]) .closing-dialog-card,
 ::v-deep(.v-theme--dark) .closing-dialog-card {
 	background: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .closing-header,
+:deep([data-theme="dark"]) .closing-header,
 :deep(.v-theme--dark) .closing-header,
-::v-deep(.dark-theme) .closing-header,
+::v-deep([data-theme="dark"]) .closing-header,
 ::v-deep(.v-theme--dark) .closing-header {
 	background: #1e1e1e !important;
 	color: #fff !important;
 	border-bottom: 1px solid #373737;
 }
 
-:deep(.dark-theme) .white-background,
+:deep([data-theme="dark"]) .white-background,
 :deep(.v-theme--dark) .white-background,
-::v-deep(.dark-theme) .white-background,
+::v-deep([data-theme="dark"]) .white-background,
 ::v-deep(.v-theme--dark) .white-background {
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .white-table,
+:deep([data-theme="dark"]) .white-table,
 :deep(.v-theme--dark) .white-table,
-::v-deep(.dark-theme) .white-table,
+::v-deep([data-theme="dark"]) .white-table,
 ::v-deep(.v-theme--dark) .white-table {
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .dialog-actions-container,
+:deep([data-theme="dark"]) .dialog-actions-container,
 :deep(.v-theme--dark) .dialog-actions-container,
-::v-deep(.dark-theme) .dialog-actions-container,
+::v-deep([data-theme="dark"]) .dialog-actions-container,
 ::v-deep(.v-theme--dark) .dialog-actions-container {
 	background: #1e1e1e !important;
 	border-top: 1px solid #373737;

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -112,32 +112,32 @@
 }
 
 /* Dark mode styling */
-:deep(.dark-theme) .customer-autocomplete,
+:deep([data-theme="dark"]) .customer-autocomplete,
 :deep(.v-theme--dark) .customer-autocomplete,
-::v-deep(.dark-theme) .customer-autocomplete,
+::v-deep([data-theme="dark"]) .customer-autocomplete,
 ::v-deep(.v-theme--dark) .customer-autocomplete {
 	/* Use surface color for dark mode */
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .customer-autocomplete :deep(.v-field__input),
+:deep([data-theme="dark"]) .customer-autocomplete :deep(.v-field__input),
 :deep(.v-theme--dark) .customer-autocomplete :deep(.v-field__input),
-:deep(.dark-theme) .customer-autocomplete :deep(input),
+:deep([data-theme="dark"]) .customer-autocomplete :deep(input),
 :deep(.v-theme--dark) .customer-autocomplete :deep(input),
-:deep(.dark-theme) .customer-autocomplete :deep(.v-label),
+:deep([data-theme="dark"]) .customer-autocomplete :deep(.v-label),
 :deep(.v-theme--dark) .customer-autocomplete :deep(.v-label),
-::v-deep(.dark-theme) .customer-autocomplete .v-field__input,
+::v-deep([data-theme="dark"]) .customer-autocomplete .v-field__input,
 ::v-deep(.v-theme--dark) .customer-autocomplete .v-field__input,
-::v-deep(.dark-theme) .customer-autocomplete input,
+::v-deep([data-theme="dark"]) .customer-autocomplete input,
 ::v-deep(.v-theme--dark) .customer-autocomplete input,
-::v-deep(.dark-theme) .customer-autocomplete .v-label,
+::v-deep([data-theme="dark"]) .customer-autocomplete .v-label,
 ::v-deep(.v-theme--dark) .customer-autocomplete .v-label {
 	color: #fff !important;
 }
 
-:deep(.dark-theme) .customer-autocomplete :deep(.v-field__overlay),
+:deep([data-theme="dark"]) .customer-autocomplete :deep(.v-field__overlay),
 :deep(.v-theme--dark) .customer-autocomplete :deep(.v-field__overlay),
-::v-deep(.dark-theme) .customer-autocomplete .v-field__overlay,
+::v-deep([data-theme="dark"]) .customer-autocomplete .v-field__overlay,
 ::v-deep(.v-theme--dark) .customer-autocomplete .v-field__overlay {
 	background-color: #1e1e1e !important;
 }

--- a/posawesome/public/js/posapp/components/pos/DeliveryCharges.vue
+++ b/posawesome/public/js/posapp/components/pos/DeliveryCharges.vue
@@ -85,31 +85,31 @@ export default {
 </script>
 
 <style scoped>
-:deep(.dark-theme) .dark-field,
+:deep([data-theme="dark"]) .dark-field,
 :deep(.v-theme--dark) .dark-field,
-::v-deep(.dark-theme) .dark-field,
+::v-deep([data-theme="dark"]) .dark-field,
 ::v-deep(.v-theme--dark) .dark-field {
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep(.dark-theme) .dark-field :deep(input),
+:deep([data-theme="dark"]) .dark-field :deep(input),
 :deep(.v-theme--dark) .dark-field :deep(input),
-:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep([data-theme="dark"]) .dark-field :deep(.v-label),
 :deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep([data-theme="dark"]) .dark-field .v-field__input,
 ::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep(.dark-theme) .dark-field input,
+::v-deep([data-theme="dark"]) .dark-field input,
 ::v-deep(.v-theme--dark) .dark-field input,
-::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep([data-theme="dark"]) .dark-field .v-label,
 ::v-deep(.v-theme--dark) .dark-field .v-label {
 	color: #fff !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
 ::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
 	background-color: #1e1e1e !important;
 }

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -1294,7 +1294,7 @@ export default {
 	transform: translateY(-100%);
 }
 
-:deep(.dark-theme) .column-selector-container,
+:deep([data-theme="dark"]) .column-selector-container,
 :deep(.v-theme--dark) .column-selector-container {
 	background-color: #1e1e1e;
 }

--- a/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
+++ b/posawesome/public/js/posapp/components/pos/InvoiceSummary.vue
@@ -233,14 +233,14 @@ export default {
 	background-color: #f5f5f5 !important;
 }
 
-:deep(.dark-theme) .cards,
-:deep(.dark-theme) .cards .v-card__underlay,
+:deep([data-theme="dark"]) .cards,
+:deep([data-theme="dark"]) .cards .v-card__underlay,
 :deep(.v-theme--dark) .cards,
 :deep(.v-theme--dark) .cards .v-card__underlay,
 :deep(.cards.v-theme--dark),
 :deep(.cards.v-theme--dark) .v-card__underlay,
-::v-deep(.dark-theme) .cards,
-::v-deep(.dark-theme) .cards .v-card__underlay,
+::v-deep([data-theme="dark"]) .cards,
+::v-deep([data-theme="dark"]) .cards .v-card__underlay,
 ::v-deep(.v-theme--dark) .cards,
 ::v-deep(.v-theme--dark) .cards .v-card__underlay,
 ::v-deep(.cards.v-theme--dark),

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -21,7 +21,13 @@
 			hide-default-footer
 			:single-expand="true"
 			:header-props="headerProps"
-                        @update:expanded="val => $emit('update:expanded', val.map(v => typeof v === 'object' ? v.posa_row_id : v))"
+			@update:expanded="
+				(val) =>
+					$emit(
+						'update:expanded',
+						val.map((v) => (typeof v === 'object' ? v.posa_row_id : v)),
+					)
+			"
 			:search="itemSearch"
 		>
 			<!-- Quantity column -->
@@ -513,7 +519,7 @@
 </template>
 
 <script>
-import _ from 'lodash';
+import _ from "lodash";
 export default {
 	name: "ItemsTable",
 	props: {
@@ -612,10 +618,10 @@ export default {
 		addItem(newItem) {
 			// Find a matching item (by item_code, uom, and rate)
 			const match = this.items.find(
-				item =>
+				(item) =>
 					item.item_code === newItem.item_code &&
 					item.uom === newItem.uom &&
-					item.rate === newItem.rate
+					item.rate === newItem.rate,
 			);
 			if (match) {
 				// If found, increment quantity
@@ -626,7 +632,7 @@ export default {
 				this.items.push({ ...newItem });
 			}
 		},
-		addItemDebounced: _.debounce(function(item) {
+		addItemDebounced: _.debounce(function (item) {
 			this.addItem(item);
 		}, 50),
 	},
@@ -727,7 +733,7 @@ export default {
 	border: 1px solid rgba(0, 0, 0, 0.05);
 }
 
-:deep(.dark-theme) .action-panel,
+:deep([data-theme="dark"]) .action-panel,
 :deep(.v-theme--dark) .action-panel {
 	background-color: rgba(255, 255, 255, 0.05);
 	border: 1px solid rgba(255, 255, 255, 0.1);
@@ -805,40 +811,40 @@ export default {
 }
 
 /* Dark theme button styles */
-:deep(.dark-theme) .item-action-btn.delete-btn,
+:deep([data-theme="dark"]) .item-action-btn.delete-btn,
 :deep(.v-theme--dark) .item-action-btn.delete-btn {
 	background: linear-gradient(145deg, #4a1515, #3a1010) !important;
 	color: #ff8a80 !important;
 }
 
-:deep(.dark-theme) .item-action-btn.delete-btn:hover,
+:deep([data-theme="dark"]) .item-action-btn.delete-btn:hover,
 :deep(.v-theme--dark) .item-action-btn.delete-btn:hover {
 	background: linear-gradient(145deg, #5a1a1a, #4a1515) !important;
 }
 
-:deep(.dark-theme) .item-action-btn.minus-btn,
+:deep([data-theme="dark"]) .item-action-btn.minus-btn,
 :deep(.v-theme--dark) .item-action-btn.minus-btn {
 	background: linear-gradient(145deg, #4a3c10, #3a2e0c) !important;
 	color: #ffe082 !important;
 }
 
-:deep(.dark-theme) .item-action-btn.minus-btn:hover,
+:deep([data-theme="dark"]) .item-action-btn.minus-btn:hover,
 :deep(.v-theme--dark) .item-action-btn.minus-btn:hover {
 	background: linear-gradient(145deg, #5a4a14, #4a3c10) !important;
 }
 
-:deep(.dark-theme) .item-action-btn.plus-btn,
+:deep([data-theme="dark"]) .item-action-btn.plus-btn,
 :deep(.v-theme--dark) .item-action-btn.plus-btn {
 	background: linear-gradient(145deg, #1b4620, #133419) !important;
 	color: #a5d6a7 !important;
 }
 
-:deep(.dark-theme) .item-action-btn.plus-btn:hover,
+:deep([data-theme="dark"]) .item-action-btn.plus-btn:hover,
 :deep(.v-theme--dark) .item-action-btn.plus-btn:hover {
 	background: linear-gradient(145deg, #235828, #1b4620) !important;
 }
 
-:deep(.dark-theme) .item-action-btn .v-icon,
+:deep([data-theme="dark"]) .item-action-btn .v-icon,
 :deep(.v-theme--dark) .item-action-btn .v-icon {
 	opacity: 0.9;
 }
@@ -870,7 +876,7 @@ export default {
 	border-top: 1px dashed rgba(0, 0, 0, 0.1);
 }
 
-:deep(.dark-theme) .form-section,
+:deep([data-theme="dark"]) .form-section,
 :deep(.v-theme--dark) .form-section {
 	border-top: 1px dashed rgba(255, 255, 255, 0.1);
 }
@@ -903,7 +909,7 @@ export default {
 	background-color: rgba(0, 0, 0, 0.02);
 }
 
-:deep(.dark-theme) .draggable-row:hover,
+:deep([data-theme="dark"]) .draggable-row:hover,
 :deep(.v-theme--dark) .draggable-row:hover {
 	background-color: rgba(255, 255, 255, 0.05);
 }
@@ -944,12 +950,12 @@ export default {
 }
 
 /* Dark theme drag styles */
-:deep(.dark-theme) .drag-source,
+:deep([data-theme="dark"]) .drag-source,
 :deep(.v-theme--dark) .drag-source {
 	background-color: rgba(144, 202, 249, 0.1) !important;
 }
 
-:deep(.dark-theme) .drag-over,
+:deep([data-theme="dark"]) .drag-over,
 :deep(.v-theme--dark) .drag-over {
 	background-color: rgba(144, 202, 249, 0.2) !important;
 	border-top: 2px solid #90caf9;

--- a/posawesome/public/js/posapp/components/pos/MultiCurrencyRow.vue
+++ b/posawesome/public/js/posapp/components/pos/MultiCurrencyRow.vue
@@ -94,31 +94,31 @@ export default {
 </script>
 
 <style scoped>
-:deep(.dark-theme) .dark-field,
+:deep([data-theme="dark"]) .dark-field,
 :deep(.v-theme--dark) .dark-field,
-::v-deep(.dark-theme) .dark-field,
+::v-deep([data-theme="dark"]) .dark-field,
 ::v-deep(.v-theme--dark) .dark-field {
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep(.dark-theme) .dark-field :deep(input),
+:deep([data-theme="dark"]) .dark-field :deep(input),
 :deep(.v-theme--dark) .dark-field :deep(input),
-:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep([data-theme="dark"]) .dark-field :deep(.v-label),
 :deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep([data-theme="dark"]) .dark-field .v-field__input,
 ::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep(.dark-theme) .dark-field input,
+::v-deep([data-theme="dark"]) .dark-field input,
 ::v-deep(.v-theme--dark) .dark-field input,
-::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep([data-theme="dark"]) .dark-field .v-label,
 ::v-deep(.v-theme--dark) .dark-field .v-label {
 	color: #fff !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
 ::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
 	background-color: #1e1e1e !important;
 }

--- a/posawesome/public/js/posapp/components/pos/NewAddress.vue
+++ b/posawesome/public/js/posapp/components/pos/NewAddress.vue
@@ -128,31 +128,31 @@ export default {
 
 <style scoped>
 /* Dark mode input styling */
-:deep(.dark-theme) .dark-field,
+:deep([data-theme="dark"]) .dark-field,
 :deep(.v-theme--dark) .dark-field,
-::v-deep(.dark-theme) .dark-field,
+::v-deep([data-theme="dark"]) .dark-field,
 ::v-deep(.v-theme--dark) .dark-field {
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep(.dark-theme) .dark-field :deep(input),
+:deep([data-theme="dark"]) .dark-field :deep(input),
 :deep(.v-theme--dark) .dark-field :deep(input),
-:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep([data-theme="dark"]) .dark-field :deep(.v-label),
 :deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep([data-theme="dark"]) .dark-field .v-field__input,
 ::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep(.dark-theme) .dark-field input,
+::v-deep([data-theme="dark"]) .dark-field input,
 ::v-deep(.v-theme--dark) .dark-field input,
-::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep([data-theme="dark"]) .dark-field .v-label,
 ::v-deep(.v-theme--dark) .dark-field .v-label {
 	color: #fff !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
 ::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
 	background-color: #1e1e1e !important;
 }

--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -665,32 +665,32 @@ export default {
 }
 
 /* Dark theme overrides */
-:deep(.dark-theme) .opening-dialog-card,
+:deep([data-theme="dark"]) .opening-dialog-card,
 :deep(.v-theme--dark) .opening-dialog-card,
-::v-deep(.dark-theme) .opening-dialog-card,
+::v-deep([data-theme="dark"]) .opening-dialog-card,
 ::v-deep(.v-theme--dark) .opening-dialog-card {
 	background: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .opening-dialog-header,
+:deep([data-theme="dark"]) .opening-dialog-header,
 :deep(.v-theme--dark) .opening-dialog-header,
-::v-deep(.dark-theme) .opening-dialog-header,
+::v-deep([data-theme="dark"]) .opening-dialog-header,
 ::v-deep(.v-theme--dark) .opening-dialog-header {
 	background: #1e1e1e !important;
 	color: #fff !important;
 	border-bottom: 1px solid #373737;
 }
 
-:deep(.dark-theme) .opening-dialog-content,
+:deep([data-theme="dark"]) .opening-dialog-content,
 :deep(.v-theme--dark) .opening-dialog-content,
-::v-deep(.dark-theme) .opening-dialog-content,
+::v-deep([data-theme="dark"]) .opening-dialog-content,
 ::v-deep(.v-theme--dark) .opening-dialog-content {
 	background: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .dialog-actions-container,
+:deep([data-theme="dark"]) .dialog-actions-container,
 :deep(.v-theme--dark) .dialog-actions-container,
-::v-deep(.dark-theme) .dialog-actions-container,
+::v-deep([data-theme="dark"]) .dialog-actions-container,
 ::v-deep(.v-theme--dark) .dialog-actions-container {
 	background: #1e1e1e !important;
 	border-top: 1px solid #373737;

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -2007,31 +2007,31 @@ export default {
 }
 
 /* Dark mode styling for input fields */
-:deep(.dark-theme) .dark-field,
+:deep([data-theme="dark"]) .dark-field,
 :deep(.v-theme--dark) .dark-field,
-::v-deep(.dark-theme) .dark-field,
+::v-deep([data-theme="dark"]) .dark-field,
 ::v-deep(.v-theme--dark) .dark-field {
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep(.dark-theme) .dark-field :deep(input),
+:deep([data-theme="dark"]) .dark-field :deep(input),
 :deep(.v-theme--dark) .dark-field :deep(input),
-:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep([data-theme="dark"]) .dark-field :deep(.v-label),
 :deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep([data-theme="dark"]) .dark-field .v-field__input,
 ::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep(.dark-theme) .dark-field input,
+::v-deep([data-theme="dark"]) .dark-field input,
 ::v-deep(.v-theme--dark) .dark-field input,
-::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep([data-theme="dark"]) .dark-field .v-label,
 ::v-deep(.v-theme--dark) .dark-field .v-label {
 	color: #fff !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
 ::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
 	background-color: #1e1e1e !important;
 }

--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -90,50 +90,50 @@ export default {
 
 <style scoped>
 /* Dark mode styling for input wrapper */
-:deep(.dark-theme) .dark-field,
+:deep([data-theme="dark"]) .dark-field,
 :deep(.v-theme--dark) .dark-field,
-::v-deep(.dark-theme) .dark-field,
+::v-deep([data-theme="dark"]) .dark-field,
 ::v-deep(.v-theme--dark) .dark-field {
 	background-color: #1e1e1e !important;
 }
 
 /* Ensure input text and label are readable */
-:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep(.dark-theme) .dark-field :deep(input),
+:deep([data-theme="dark"]) .dark-field :deep(input),
 :deep(.v-theme--dark) .dark-field :deep(input),
-:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep([data-theme="dark"]) .dark-field :deep(.v-label),
 :deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep([data-theme="dark"]) .dark-field .v-field__input,
 ::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep(.dark-theme) .dark-field input,
+::v-deep([data-theme="dark"]) .dark-field input,
 ::v-deep(.v-theme--dark) .dark-field input,
-::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep([data-theme="dark"]) .dark-field .v-label,
 ::v-deep(.v-theme--dark) .dark-field .v-label {
 	color: #fff !important;
 }
 
 /* Overlay background in dark mode */
-:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
 ::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
 	background-color: #1e1e1e !important;
 }
 
 /* Dark mode styling for date picker input */
-:deep(.dark-theme) .dp__input,
+:deep([data-theme="dark"]) .dp__input,
 :deep(.v-theme--dark) .dp__input,
-::v-deep(.dark-theme) .dp__input,
+::v-deep([data-theme="dark"]) .dp__input,
 ::v-deep(.v-theme--dark) .dp__input {
 	background-color: #1e1e1e !important;
 	color: #fff !important;
 }
 
 /* Dark mode styling for date picker calendar dropdown */
-:deep(.dark-theme) .dp__menu,
+:deep([data-theme="dark"]) .dp__menu,
 :deep(.v-theme--dark) .dp__menu,
-::v-deep(.dark-theme) .dp__menu,
+::v-deep([data-theme="dark"]) .dp__menu,
 ::v-deep(.v-theme--dark) .dp__menu {
 	background-color: #1e1e1e !important;
 	color: #fff !important;

--- a/posawesome/public/js/posapp/components/pos/UpdateCustomer.vue
+++ b/posawesome/public/js/posapp/components/pos/UpdateCustomer.vue
@@ -680,31 +680,31 @@ export default {
 
 <style scoped>
 /* Dark mode input styling */
-:deep(.dark-theme) .dark-field,
+:deep([data-theme="dark"]) .dark-field,
 :deep(.v-theme--dark) .dark-field,
-::v-deep(.dark-theme) .dark-field,
+::v-deep([data-theme="dark"]) .dark-field,
 ::v-deep(.v-theme--dark) .dark-field {
 	background-color: #1e1e1e !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__input),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep(.dark-theme) .dark-field :deep(input),
+:deep([data-theme="dark"]) .dark-field :deep(input),
 :deep(.v-theme--dark) .dark-field :deep(input),
-:deep(.dark-theme) .dark-field :deep(.v-label),
+:deep([data-theme="dark"]) .dark-field :deep(.v-label),
 :deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep(.dark-theme) .dark-field .v-field__input,
+::v-deep([data-theme="dark"]) .dark-field .v-field__input,
 ::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep(.dark-theme) .dark-field input,
+::v-deep([data-theme="dark"]) .dark-field input,
 ::v-deep(.v-theme--dark) .dark-field input,
-::v-deep(.dark-theme) .dark-field .v-label,
+::v-deep([data-theme="dark"]) .dark-field .v-label,
 ::v-deep(.v-theme--dark) .dark-field .v-label {
 	color: #fff !important;
 }
 
-:deep(.dark-theme) .dark-field :deep(.v-field__overlay),
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
 :deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep(.dark-theme) .dark-field .v-field__overlay,
+::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
 ::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
 	background-color: #1e1e1e !important;
 }


### PR DESCRIPTION
## Summary
- use `[data-theme="dark"]` selector instead of `.dark-theme` for root-level dark mode variables and styles
- update component styles to reference `[data-theme="dark"]` through `:deep`/`::v-deep` selectors for consistent theme overrides