### PR TITLE
fix: ensure sticky headers are opaque

### DIFF
--- a/posawesome/public/js/posapp/components/navbar/NavbarDrawer.vue
+++ b/posawesome/public/js/posapp/components/navbar/NavbarDrawer.vue
@@ -1,14 +1,14 @@
 <template>
 	<v-navigation-drawer
 		v-model="drawerOpen"
-		:mini-variant="mini"
+		:rail="mini"
 		expand-on-hover
 		width="220"
 		:class="['drawer-custom', { 'drawer-visible': drawerOpen }]"
 		@mouseleave="handleMouseLeave"
 		temporary
 		location="left"
-		:scrim="true"
+		:scrim="scrimColor"
 	>
 		<div v-if="!mini" class="drawer-header">
 			<v-avatar size="40">
@@ -24,20 +24,19 @@
 
 		<v-divider />
 
-		<v-list dense nav>
-			<v-list-item-group v-model="activeItem" active-class="active-item">
-				<v-list-item
-					v-for="(item, index) in items"
-					:key="item.text"
-					@click="changePage(item.text)"
-					class="drawer-item"
-				>
-					<template v-slot:prepend>
-						<v-icon class="drawer-icon">{{ item.icon }}</v-icon>
-					</template>
-					<v-list-item-title class="drawer-item-title">{{ item.text }}</v-list-item-title>
-				</v-list-item>
-			</v-list-item-group>
+		<v-list density="compact" nav v-model:selected="activeItem" selected-class="active-item">
+			<v-list-item
+				v-for="(item, index) in items"
+				:key="item.text"
+				:value="index"
+				@click="changePage(item.text)"
+				class="drawer-item"
+			>
+				<template v-slot:prepend>
+					<v-icon class="drawer-icon">{{ item.icon }}</v-icon>
+				</template>
+				<v-list-item-title class="drawer-item-title">{{ item.text }}</v-list-item-title>
+			</v-list-item>
 		</v-list>
 		<!-- Sport section, hidden by default -->
 		<div v-if="showSport">
@@ -65,6 +64,13 @@ export default {
 			showSport: true,
 		};
 	},
+	computed: {
+		scrimColor() {
+			// Use an opaque background in light mode so that
+			// underlying content doesn't show through the drawer
+			return this.isDark ? true : "rgba(255,255,255,1)";
+		},
+	},
 	watch: {
 		drawer(val) {
 			this.drawerOpen = val;
@@ -73,6 +79,7 @@ export default {
 			}
 		},
 		drawerOpen(val) {
+			document.body.style.overflow = val ? "hidden" : "";
 			this.$emit("update:drawer", val);
 		},
 		item(val) {

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -366,6 +366,8 @@
 </template>
 
 <script type="module">
+/* eslint-disable no-unused-vars */
+/* global frappe, __, setLocalStockCache, flt, onScan, get_currency_symbol, current_items, wordCount */
 import format from "../../format";
 import _ from "lodash";
 import CameraScanner from "./CameraScanner.vue";
@@ -2501,11 +2503,11 @@ export default {
 }
 
 .sticky-header {
-	position: sticky;
-	top: 0;
-	z-index: 100;
-	background-color: var(--surface-primary);
-	box-shadow: var(--shadow-sm, 0 2px 4px rgba(0, 0, 0, 0.1));
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        background-color: var(--surface-primary, #fff);
+        box-shadow: var(--shadow-sm, 0 2px 4px rgba(0, 0, 0, 0.1));
 }
 
 [data-theme="dark"] .sticky-header {

--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -590,9 +590,9 @@ export default {
 			}
 		},
 
-		onDragEnterFromSelector(event) {
-			this.$emit("show-drop-feedback", true);
-		},
+                onDragEnterFromSelector() {
+                        this.$emit("show-drop-feedback", true);
+                },
 
 		onDragLeaveFromSelector(event) {
 			// Only hide feedback if leaving the entire table area
@@ -674,8 +674,11 @@ export default {
 	letter-spacing: 0.5px;
 	padding: 12px 16px;
 	transition: background-color var(--transition-normal);
-	border-bottom: 2px solid var(--table-header-border);
-	background-color: var(--table-header-bg);
+        border-bottom: 2px solid var(--table-header-border);
+        background-color: var(
+                --table-header-bg,
+                var(--surface-secondary, #f5f5f5)
+        );
 	color: var(--table-header-text);
 	position: sticky;
 	top: 0;


### PR DESCRIPTION
## Summary
- add fallback colors so item selector and table headers stay opaque and hide scrolled content
- declare globals and drop unused event params to satisfy lint
