### PR TITLE
feat: honor theme in drafts dialog

### DIFF
--- a/posawesome/public/js/posapp/components/pos/Drafts.vue
+++ b/posawesome/public/js/posapp/components/pos/Drafts.vue
@@ -4,7 +4,7 @@
 			<!-- <template v-slot:activator="{ on, attrs }">
         <v-btn color="primary" theme="dark" v-bind="attrs" v-on="on">Open Dialog</v-btn>
       </template>-->
-			<v-card variant="flat" color="white">
+			<v-card variant="flat" :color="isDarkTheme ? $vuetify.theme.themes.dark.colors.surface : 'white'">
 				<v-card-title>
 					<span class="text-h5 text-primary">{{ __("Load Sales Invoice") }}</span>
 				</v-card-title>
@@ -20,6 +20,7 @@
 									:items="dialog_data"
 									item-value="name"
 									class="elevation-1"
+									:theme="isDarkTheme ? 'dark' : 'light'"
 									show-select
 									v-model="selected"
 									select-strategy="single"
@@ -48,6 +49,7 @@
 </template>
 
 <script>
+/* global __ */
 import format from "../../format";
 export default {
 	// props: ["draftsDialog"],
@@ -90,6 +92,11 @@ export default {
 			},
 		],
 	}),
+	computed: {
+		isDarkTheme() {
+			return this.$vuetify.theme.current.value.dark;
+		},
+	},
 	watch: {},
 	methods: {
 		close_dialog() {


### PR DESCRIPTION
## Summary
- use Vuetify theme for drafts card color
- add `isDarkTheme` and theme binding to data table
- compute dark mode via `$vuetify.theme.current.value.dark` for reactive updates