### PR TITLE
feat: add dark theme support for sales order search

### DIFF
--- a/posawesome/public/js/posapp/components/pos/SalesOrders.vue
+++ b/posawesome/public/js/posapp/components/pos/SalesOrders.vue
@@ -11,16 +11,16 @@
 				<v-card-text class="pa-0">
 					<v-container>
 						<v-row class="mb-4">
-							<v-text-field
-								color="primary"
-								:label="frappe._('Order ID')"
-								bg-color="white"
-								hide-details
-								v-model="order_name"
-								density="compact"
-								clearable
-								class="mx-4"
-							></v-text-field>
+                                                        <v-text-field
+                                                                color="primary"
+                                                                :label="frappe._('Order ID')"
+                                                                :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+                                                                hide-details
+                                                                v-model="order_name"
+                                                                density="compact"
+                                                                clearable
+                                                                class="mx-4"
+                                                        ></v-text-field>
 							<v-btn
 								variant="text"
 								class="ml-2"
@@ -71,11 +71,11 @@ import format from "../../format";
 export default {
 	// props: ["draftsDialog"],
 	mixins: [format],
-	data: () => ({
-		draftsDialog: false,
-		singleSelect: true,
-		pos_profile: {},
-		selected: [],
+        data: () => ({
+                draftsDialog: false,
+                singleSelect: true,
+                pos_profile: {},
+                selected: [],
 		dialog_data: {},
 		order_name: "",
 		headers: [
@@ -109,13 +109,18 @@ export default {
 				align: "end",
 				sortable: false,
 			},
-		],
-	}),
-	watch: {},
-	methods: {
-		close_dialog() {
-			this.draftsDialog = false;
-		},
+                ],
+        }),
+        computed: {
+                isDarkTheme() {
+                        return this.$theme.current === "dark";
+                },
+        },
+        watch: {},
+        methods: {
+                close_dialog() {
+                        this.draftsDialog = false;
+                },
 
 		clearSelected() {
 			this.selected = [];


### PR DESCRIPTION
## Summary
- make sales order search field respond to dark theme
- add isDarkTheme computed property to SalesOrders