### PR TITLE
refactor: theme-aware cancel button styling

### DIFF
--- a/posawesome/public/js/posapp/components/OfflineInvoices.vue
+++ b/posawesome/public/js/posapp/components/OfflineInvoices.vue
@@ -147,7 +147,8 @@
 					</v-btn>
 					<v-spacer></v-spacer>
 					<v-btn
-						theme="dark"
+						color="error"
+						variant="flat"
 						@click="dialog = false"
 						class="pos-action-btn cancel-action-btn"
 						size="large"
@@ -465,12 +466,12 @@ export default {
 	padding: var(--dynamic-md) var(--dynamic-xl) !important;
 	min-width: 120px !important;
 	transition: all 0.3s ease !important;
-	color: white !important;
+	color: var(--text-primary) !important;
 }
 
 .pos-action-btn .v-icon,
 .pos-action-btn span {
-	color: white !important;
+	color: var(--text-primary) !important;
 }
 
 .cancel-action-btn {
@@ -502,6 +503,6 @@ export default {
 
 .pos-action-btn:disabled .v-icon,
 .pos-action-btn:disabled span {
-	color: white !important;
+	color: var(--text-primary) !important;
 }
 </style>


### PR DESCRIPTION
## Summary
- use Vuetify color system for the Close button instead of forcing dark theme
- switch action button text/icon colors to `var(--text-primary)` for theme awareness