### PR TITLE
Fix item selector card width

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2523,10 +2523,11 @@ export default {
 
 .items-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(180px, 180px));
 	gap: var(--dynamic-sm);
 	align-items: start;
 	align-content: start;
+	justify-content: flex-start;
 }
 
 .dynamic-item-card {
@@ -2536,6 +2537,7 @@ export default {
 	display: flex;
 	flex-direction: column;
 	height: auto;
+	max-width: 180px;
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- keep item selector grid columns at fixed width and left aligned
- prevent single item cards from stretching across selector

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- Manual: searched for an item returning a single result and verified card width remained fixed

------
https://chatgpt.com/codex/tasks/task_e_688dbd34e86083268fc58966d90420c8