### PR TITLE
feat: enable item selector scrolling

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -10,7 +10,7 @@
 				maxHeight: responsiveStyles['--container-height'],
 				backgroundColor: isDarkTheme ? '#121212' : '',
 				resize: 'vertical',
-				overflow: 'hidden',
+				overflow: 'auto',
 			}"
 		>
 			<v-progress-linear


### PR DESCRIPTION
## Summary
- allow root item selector card to scroll

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npx prettier -c posawesome/public/js/posapp/components/pos/ItemsSelector.vue`


------
https://chatgpt.com/codex/tasks/task_e_688dbd2a4ad083269c719073e615cf3b