### PR TITLE
style: adjust item card spacing

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2524,14 +2524,13 @@ export default {
 .items-grid {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(180px, 180px));
-	gap: var(--dynamic-sm);
+	gap: var(--dynamic-md);
 	align-items: start;
 	align-content: start;
 	justify-content: flex-start;
 }
 
 .dynamic-item-card {
-	margin: var(--dynamic-xs);
 	transition: var(--transition-normal);
 	background-color: var(--surface-secondary);
 	display: flex;


### PR DESCRIPTION
## Summary
- remove margin from item cards and rely on grid gap for spacing
- widen the items grid gap to maintain consistent layout

## Testing
- `npx prettier -w posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_688dc8d9d3208326b852b4e6571d4deb