### PR TITLE
feat: make items selector grid responsive

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2523,7 +2523,7 @@ export default {
 
 .items-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(180px, 180px));
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 	gap: var(--dynamic-sm);
 	align-items: start;
 	align-content: start;


### PR DESCRIPTION
## Summary
- make item selector grid responsive using `auto-fit` and flexible columns

## Testing
- `npx prettier -w posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_688dc8d9de448326ac6f6f57187a6033