### PR TITLE
Use responsive card height for item cards

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2531,14 +2531,14 @@ export default {
 }
 
 .dynamic-item-card {
-	margin: var(--dynamic-xs);
-	transition: var(--transition-normal);
-	background-color: var(--surface-secondary);
-	display: flex;
-	flex-direction: column;
-	height: auto;
-	max-width: 180px;
-	box-sizing: border-box;
+        margin: var(--dynamic-xs);
+        transition: var(--transition-normal);
+        background-color: var(--surface-secondary);
+        display: flex;
+        flex-direction: column;
+        height: var(--card-height);
+        max-width: 180px;
+        box-sizing: border-box;
 }
 
 .dynamic-item-card .v-img {


### PR DESCRIPTION
## Summary
- Bind item cards to the `--card-height` variable for consistent sizing across layouts.
- Verify responsive helper continues to calculate `--card-height` based on viewport size.

## Testing
- `node` script verifying `--card-height` computation for several resolutions
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue posawesome/public/js/posapp/composables/useResponsive.js`
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_688dc8dbd59c8326b53bfe3f077f0b98