### PR TITLE
fix: remove unsupported CSS composes usage

### DIFF
--- a/posawesome/public/js/posapp/components/OfflineInvoices.vue
+++ b/posawesome/public/js/posapp/components/OfflineInvoices.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-row justify="center">
 		<v-dialog v-model="dialog" max-width="1000px" persistent>
-			<v-card class="offline-invoices-card">
+                       <v-card class="pos-card offline-invoices-card">
 				<!-- Enhanced White Header -->
 				<v-card-title class="offline-header pa-6">
 					<div class="header-content">
@@ -243,11 +243,10 @@ export default {
 </script>
 
 <style>
-/* Replace with standardized pos-card class */
+/* Uses standardized pos-card class directly in the template */
 .offline-invoices-card {
-	composes: pos-card;
-	border-radius: var(--border-radius-xl) !important;
-	overflow: hidden;
+       border-radius: var(--border-radius-xl) !important;
+       overflow: hidden;
 }
 
 /* Header styling */

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2,7 +2,7 @@
 	<div :style="responsiveStyles">
 		<v-card
 			:class="[
-				'selection mx-auto my-0 py-0 mt-3 dynamic-card resizable',
+                               'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
 				isDarkTheme ? '' : 'bg-grey-lighten-5',
 			]"
 			:style="{
@@ -2493,10 +2493,7 @@ export default {
 </script>
 
 <style scoped>
-.dynamic-card {
-	composes: pos-card;
-}
-
+/* "dynamic-card" no longer composes from pos-card; the pos-card class is added directly in the template */
 .dynamic-padding {
 	/* Equal spacing on all sides for consistent alignment */
 	padding: var(--dynamic-sm);


### PR DESCRIPTION
## Summary
- replace `composes: pos-card` in ItemsSelector and OfflineInvoices with direct `pos-card` classes
- drop unused `composes` style blocks that were ignored by the build chain

## Testing
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_688dc8dc17c08326b4d34bece02090c3