### PR TITLE
fix(items): prevent double vertical scrollbar

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2,7 +2,7 @@
 	<div :style="responsiveStyles">
 		<v-card
 			:class="[
-                               'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
+				'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
 				isDarkTheme ? '' : 'bg-grey-lighten-5',
 			]"
 			:style="{
@@ -10,7 +10,7 @@
 				maxHeight: responsiveStyles['--container-height'],
 				backgroundColor: isDarkTheme ? '#121212' : '',
 				resize: 'vertical',
-				overflow: 'auto',
+				overflow: 'hidden',
 			}"
 		>
 			<v-progress-linear
@@ -179,14 +179,13 @@
 				</div>
 				<v-row class="items">
 					<v-col cols="12" class="pt-0 mt-0">
-                                               <div
-                                                       fluid
-                                                       class="items-grid dynamic-scroll"
-                                                       ref="itemsContainer"
-                                                       v-if="items_view == 'card'"
-                                                       :class="{ 'item-container': isOverflowing }"
-                                                       @scroll.passive="onCardScroll"
-                                               >
+						<div
+							fluid
+							class="items-grid item-container dynamic-scroll"
+							ref="itemsContainer"
+							v-if="items_view == 'card'"
+							@scroll.passive="onCardScroll"
+						>
 							<v-card
 								v-for="item in filtered_items"
 								:key="item.item_code"
@@ -458,10 +457,10 @@ export default {
 		// effectively disables incremental loading.
 		itemsPageLimit: 10000,
 		// Track if the current search was triggered by a scanner
-                search_from_scanner: false,
-                currentPage: 0,
-                isOverflowing: false,
-        }),
+		search_from_scanner: false,
+		currentPage: 0,
+		isOverflowing: false,
+	}),
 
 	watch: {
 		customer: _.debounce(function () {
@@ -584,17 +583,17 @@ export default {
 				this.loadVisibleItems(true);
 			}
 		},
-                filtered_items(new_value, old_value) {
-                        // Update item details if items changed
-                        if (
-                                this.pos_profile &&
-                                !this.pos_profile.pose_use_limit_search &&
-                                new_value.length !== old_value.length
-                        ) {
-                                this.update_items_details(new_value);
-                        }
-                        this.$nextTick(this.checkItemContainerOverflow);
-                },
+		filtered_items(new_value, old_value) {
+			// Update item details if items changed
+			if (
+				this.pos_profile &&
+				!this.pos_profile.pose_use_limit_search &&
+				new_value.length !== old_value.length
+			) {
+				this.update_items_details(new_value);
+			}
+			this.$nextTick(this.checkItemContainerOverflow);
+		},
 		// Automatically search and add item whenever the query changes
 		first_search: _.debounce(function (val) {
 			// Call without arguments so search_onchange treats it like an Enter key
@@ -618,21 +617,21 @@ export default {
 			// Maintain the configured items per page on resize
 			this.itemsPerPage = this.items_per_page;
 		},
-                items_loaded(val) {
-                        if (val) {
-                                this.eventBus.emit("items_loaded");
-                        }
-                },
-                items_view() {
-                        this.$nextTick(() => {
-                                if (this.items_view === "card") {
-                                        this.checkItemContainerOverflow();
-                                } else {
-                                        this.isOverflowing = false;
-                                }
-                        });
-                },
-        },
+		items_loaded(val) {
+			if (val) {
+				this.eventBus.emit("items_loaded");
+			}
+		},
+		items_view() {
+			this.$nextTick(() => {
+				if (this.items_view === "card") {
+					this.checkItemContainerOverflow();
+				} else {
+					this.isOverflowing = false;
+				}
+			});
+		},
+	},
 
 	methods: {
 		async loadVisibleItems(reset = false) {
@@ -663,31 +662,29 @@ export default {
 				this.loadVisibleItems();
 			}
 		},
-                onListScroll(event) {
-                        const el = event.target;
-                        if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
-                                this.currentPage += 1;
-                                this.loadVisibleItems();
-                        }
-                },
-                checkItemContainerOverflow() {
-                        const el = this.$refs.itemsContainer;
-                        if (!el) {
-                                this.isOverflowing = false;
-                                return;
-                        }
-                        const maxHeight = parseFloat(
-                                getComputedStyle(el).getPropertyValue("--container-height")
-                        );
-                        if (isNaN(maxHeight)) {
-                                this.isOverflowing = false;
-                                return;
-                        }
-                        this.isOverflowing = el.scrollHeight > maxHeight;
-                },
-                refreshPricesForVisibleItems() {
-                        const vm = this;
-                        if (!vm.filtered_items || vm.filtered_items.length === 0) return;
+		onListScroll(event) {
+			const el = event.target;
+			if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+				this.currentPage += 1;
+				this.loadVisibleItems();
+			}
+		},
+		checkItemContainerOverflow() {
+			const el = this.$refs.itemsContainer;
+			if (!el) {
+				this.isOverflowing = false;
+				return;
+			}
+			const maxHeight = parseFloat(getComputedStyle(el).getPropertyValue("--container-height"));
+			if (isNaN(maxHeight)) {
+				this.isOverflowing = false;
+				return;
+			}
+			this.isOverflowing = el.scrollHeight > maxHeight;
+		},
+		refreshPricesForVisibleItems() {
+			const vm = this;
+			if (!vm.filtered_items || vm.filtered_items.length === 0) return;
 
 			vm.loading = true;
 
@@ -2470,12 +2467,12 @@ export default {
 			await forceClearAllCache();
 			await this.get_items(true);
 		}
-                this.scan_barcoud();
-                // Apply the configured items per page on mount
-                this.itemsPerPage = this.items_per_page;
-                window.addEventListener("resize", this.checkItemContainerOverflow);
-                this.$nextTick(this.checkItemContainerOverflow);
-        },
+		this.scan_barcoud();
+		// Apply the configured items per page on mount
+		this.itemsPerPage = this.items_per_page;
+		window.addEventListener("resize", this.checkItemContainerOverflow);
+		this.$nextTick(this.checkItemContainerOverflow);
+	},
 
 	beforeUnmount() {
 		// Clear interval when component is destroyed
@@ -2513,11 +2510,11 @@ export default {
 		this.eventBus.off("update_cur_items_details");
 		this.eventBus.off("update_offers_counters");
 		this.eventBus.off("update_coupons_counters");
-                this.eventBus.off("update_customer_price_list");
-                this.eventBus.off("update_customer");
-                this.eventBus.off("force_reload_items");
-                window.removeEventListener("resize", this.checkItemContainerOverflow);
-        },
+		this.eventBus.off("update_customer_price_list");
+		this.eventBus.off("update_customer");
+		this.eventBus.off("force_reload_items");
+		window.removeEventListener("resize", this.checkItemContainerOverflow);
+	},
 };
 </script>
 
@@ -2541,14 +2538,14 @@ export default {
 }
 
 .dynamic-scroll {
-       transition: max-height var(--transition-normal);
-       padding-bottom: var(--dynamic-xs);
+	transition: max-height var(--transition-normal);
+	padding-bottom: var(--dynamic-xs);
 }
 
 .item-container {
-       max-height: var(--container-height);
-       overflow-y: auto;
-       scrollbar-gutter: stable;
+	max-height: var(--container-height);
+	overflow-y: auto;
+	scrollbar-gutter: stable;
 }
 
 .items-grid {


### PR DESCRIPTION
## Summary
- avoid vertical scrolling on the container card
- ensure items grid handles scrolling

## Testing
- `npx prettier posawesome/public/js/posapp/components/pos/ItemsSelector.vue -w`
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688de5fbb49883269dc7d9c8774c2b94