### PR TITLE
fix: hide outer card overflow in card view

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -8,11 +8,11 @@
 			:style="{
 				height: responsiveStyles['--container-height'],
 				maxHeight: responsiveStyles['--container-height'],
-				backgroundColor: isDarkTheme ? '#121212' : '',
-				resize: 'vertical',
-				overflow: 'auto',
-			}"
-		>
+                               backgroundColor: isDarkTheme ? '#121212' : '',
+                               resize: 'vertical',
+                                overflow: items_view === 'card' ? 'hidden' : 'auto',
+                        }"
+                >
 			<v-progress-linear
 				:active="loading"
 				:indeterminate="loading"


### PR DESCRIPTION
## Summary
- hide outer item selector overflow for card view
- rely on inner container for card view scrolling

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688df8ca38a88326ad46970c1432e4e9