### PR TITLE
Reset items sync after clearing stored data

### DIFF
--- a/posawesome/public/js/offline.js
+++ b/posawesome/public/js/offline.js
@@ -30,12 +30,13 @@ const memory = {
 	customer_storage: [],
 	pos_opening_storage: null,
 	opening_dialog_storage: null,
-	sales_persons_storage: [],
-	price_list_cache: {},
-	item_details_cache: {},
-	tax_template_cache: {},
-	tax_inclusive: false,
-	manual_offline: false,
+        sales_persons_storage: [],
+        price_list_cache: {},
+        item_details_cache: {},
+        items_last_sync: null,
+        tax_template_cache: {},
+        tax_inclusive: false,
+        manual_offline: false,
 };
 
 // Flag to avoid concurrent invoice syncs which can cause duplicate submissions
@@ -1001,13 +1002,15 @@ export async function saveItems(items) {
 }
 
 export async function clearStoredItems() {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		await db.table("items").clear();
-	} catch (e) {
-		console.error("Failed to clear stored items", e);
-	}
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) await db.open();
+                await db.table("items").clear();
+                memory.items_last_sync = null;
+                persist("items_last_sync");
+        } catch (e) {
+                console.error("Failed to clear stored items", e);
+        }
 }
 
 export function getCustomerStorage() {

--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -157,13 +157,14 @@ export async function saveItems(items) {
 }
 
 export async function clearStoredItems() {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		await db.table("items").clear();
-	} catch (e) {
-		console.error("Failed to clear stored items", e);
-	}
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) await db.open();
+                await db.table("items").clear();
+                setItemsLastSync(null);
+        } catch (e) {
+                console.error("Failed to clear stored items", e);
+        }
 }
 
 export function getCustomerStorage() {

--- a/posawesome/public/js/offline/items.js
+++ b/posawesome/public/js/offline/items.js
@@ -222,11 +222,13 @@ export async function searchStoredItems({ search = "", itemGroup = "", limit = 1
 }
 
 export async function clearStoredItems() {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		await db.table("items").clear();
-	} catch (e) {
-		console.error("Failed to clear stored items", e);
-	}
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) await db.open();
+                await db.table("items").clear();
+                memory.items_last_sync = null;
+                persist("items_last_sync", null);
+        } catch (e) {
+                console.error("Failed to clear stored items", e);
+        }
 }


### PR DESCRIPTION
## Summary
- reset `items_last_sync` when IndexedDB items table is cleared
- expose new `items_last_sync` field in offline memory cache

## Testing
- `npx eslint posawesome/public/js/offline.js posawesome/public/js/offline/cache.js posawesome/public/js/offline/items.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e0f67a0cc8326b7a99800a67458f5