### PR TITLE
fix: emit actual price list and improve caching

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1017,11 +1017,11 @@ export default {
 							vm.loading = false;
 						}
 					};
-					this.itemWorker.postMessage({
-						type: "parse_and_cache",
-						json: text,
-						priceList: vm.customer_price_list || "",
-					});
+                                               this.itemWorker.postMessage({
+                                                       type: "parse_and_cache",
+                                                       json: text,
+                                                       priceList: vm.customer_price_list || vm.pos_profile?.selling_price_list || "",
+                                               });
 				} catch (err) {
 					console.error("Failed to fetch items", err);
 					vm.loading = false;
@@ -1165,11 +1165,11 @@ export default {
 								resolve(0);
 							}
 						};
-						this.itemWorker.postMessage({
-							type: "parse_and_cache",
-							json: text,
-							priceList: this.customer_price_list || "",
-						});
+                                               this.itemWorker.postMessage({
+                                                       type: "parse_and_cache",
+                                                       json: text,
+                                                       priceList: this.customer_price_list || this.pos_profile?.selling_price_list || "",
+                                               });
 					});
 					if (count === limit) {
 						await this.backgroundLoadItems(offset + limit, syncSince, clearBefore);

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1,9 +1,10 @@
+/* global frappe, __, flt */
+
 import {
 	isOffline,
 	saveCustomerBalance,
 	getCachedCustomerBalance,
 	getCachedPriceListItems,
-	getItemUOMs,
 	getCustomerStorage,
 	getOfflineCustomers,
 	getTaxTemplate,
@@ -210,6 +211,7 @@ export default {
 	// Save and clear the current invoice (draft logic)
 	save_and_clear_invoice() {
 		const doc = this.get_invoice_doc();
+		let old_invoice;
 		if (doc.name) {
 			old_invoice = this.update_invoice(doc);
 		} else {
@@ -1573,7 +1575,7 @@ export default {
 		if (this.selected_price_list !== price_list) {
 			this.selected_price_list = price_list;
 			// Clear any customer specific price list to avoid reloading items
-			this.eventBus.emit("update_customer_price_list", null);
+			this.eventBus.emit("update_customer_price_list", price_list);
 		}
 	},
 

--- a/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
@@ -1,3 +1,5 @@
+/* global frappe */
+
 import { clearPriceListCache } from "../../../offline/index.js";
 
 export default {
@@ -32,7 +34,7 @@ export default {
 	// Watch for items array changes (deep) and re-handle offers
 	items: {
 		deep: true,
-		handler(items) {
+		handler() {
 			this.handelOffers();
 			this.$forceUpdate();
 		},
@@ -69,12 +71,13 @@ export default {
 	},
 
 	selected_price_list(newVal) {
-		// Clear cached price list items to avoid mixing rates
-		clearPriceListCache();
-
-		const price_list = newVal === this.pos_profile.selling_price_list ? null : newVal;
-		this.eventBus.emit("update_customer_price_list", price_list);
 		const applied = newVal || this.pos_profile.selling_price_list;
+
+		// Clear cached price list items to avoid mixing rates
+		clearPriceListCache(applied);
+
+		// Always emit the actual price list name
+		this.eventBus.emit("update_customer_price_list", applied);
 		this.apply_cached_price_list(applied);
 
 		// If multi-currency is enabled, sync currency with the price list currency
@@ -96,7 +99,7 @@ export default {
 
 	// Reactively update item prices when currency changes
 	selected_currency() {
-		clearPriceListCache();
+		clearPriceListCache(this.selected_price_list || this.pos_profile.selling_price_list);
 		if (this.items && this.items.length) {
 			this.update_item_rates();
 		}


### PR DESCRIPTION
## Summary
- ensure price list watcher emits default list name and clears only that cache
- map null price lists to POS profile default before reading/writing cache
- update ItemSelector and invoice methods to handle price lists without relying on null
- clear only the active price list cache when currency changes

## Testing
- `npx eslint posawesome/public/js/offline/items.js posawesome/public/js/posapp/components/pos/invoiceWatchers.js posawesome/public/js/posapp/components/pos/invoiceItemMethods.js`
- `npx prettier posawesome/public/js/offline/items.js posawesome/public/js/posapp/components/pos/invoiceWatchers.js posawesome/public/js/posapp/components/pos/invoiceItemMethods.js --check`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e4aa15f008326a1476a0af4720617