### PR TITLE
feat: add price list dropdown toggle

### DIFF
--- a/posawesome/fixtures/custom_field.json
+++ b/posawesome/fixtures/custom_field.json
@@ -5487,6 +5487,16 @@
   {
     "doctype": "Custom Field",
     "dt": "POS Profile",
+    "fieldname": "posa_enable_price_list_dropdown",
+    "fieldtype": "Check",
+    "insert_after": "posa_allow_price_list_rate_change",
+    "label": "Enable Price List Dropdown",
+    "default": "0",
+    "name": "POS Profile-posa_enable_price_list_dropdown"
+  },
+  {
+    "doctype": "Custom Field",
+    "dt": "POS Profile",
     "fieldname": "posa_decimal_precision",
     "fieldtype": "Select",
     "insert_after": "hide_expected_amount",

--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -281,11 +281,12 @@ fixtures = [
 			[
 				"name",
 				"in",
-				[
-					"POS Profile-posa_allow_multi_currency",
-					"POS Profile-posa_decimal_precision",
-				],
-			]
-		],
-	},
+                                [
+                                        "POS Profile-posa_allow_multi_currency",
+                                        "POS Profile-posa_decimal_precision",
+                                        "POS Profile-posa_enable_price_list_dropdown",
+                                ],
+                        ]
+                ],
+        },
 ]

--- a/posawesome/public/js/posapp/components/pos/Invoice.vue
+++ b/posawesome/public/js/posapp/components/pos/Invoice.vue
@@ -627,7 +627,7 @@ export default {
 		},
 
 		async fetch_price_lists() {
-			if (this.pos_profile.posa_enable_price_list_dropdown) {
+			if (this.pos_profile.posa_enable_price_list_dropdown !== false) {
 				try {
 					const r = await frappe.call({
 						method: "posawesome.posawesome.api.posapp.get_selling_price_lists",

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2,17 +2,17 @@
 	<div :style="responsiveStyles">
 		<v-card
 			:class="[
-                               'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
+				'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
 				isDarkTheme ? '' : 'bg-grey-lighten-5',
 			]"
 			:style="{
 				height: responsiveStyles['--container-height'],
 				maxHeight: responsiveStyles['--container-height'],
-                               backgroundColor: isDarkTheme ? '#121212' : '',
-                               resize: 'vertical',
-                                overflow: items_view === 'card' ? 'hidden' : 'auto',
-                        }"
-                >
+				backgroundColor: isDarkTheme ? '#121212' : '',
+				resize: 'vertical',
+				overflow: items_view === 'card' ? 'hidden' : 'auto',
+			}"
+		>
 			<v-progress-linear
 				:active="loading"
 				:indeterminate="loading"
@@ -179,14 +179,14 @@
 				</div>
 				<v-row class="items">
 					<v-col cols="12" class="pt-0 mt-0">
-                                               <div
-                                                       fluid
-                                                       class="items-grid dynamic-scroll"
-                                                       ref="itemsContainer"
-                                                       v-if="items_view == 'card'"
-                                                       :class="{ 'item-container': isOverflowing }"
-                                                       @scroll.passive="onCardScroll"
-                                               >
+						<div
+							fluid
+							class="items-grid dynamic-scroll"
+							ref="itemsContainer"
+							v-if="items_view == 'card'"
+							:class="{ 'item-container': isOverflowing }"
+							@scroll.passive="onCardScroll"
+						>
 							<v-card
 								v-for="item in filtered_items"
 								:key="item.item_code"
@@ -312,7 +312,7 @@
 						v-model="item_group"
 					></v-select>
 				</v-col>
-				<v-col cols="12" class="mb-2" v-if="pos_profile.posa_enable_price_list_dropdown">
+				<v-col cols="12" class="mb-2" v-if="pos_profile.posa_enable_price_list_dropdown !== false">
 					<v-text-field
 						density="compact"
 						variant="solo"
@@ -458,10 +458,10 @@ export default {
 		// effectively disables incremental loading.
 		itemsPageLimit: 10000,
 		// Track if the current search was triggered by a scanner
-                search_from_scanner: false,
-                currentPage: 0,
-                isOverflowing: false,
-        }),
+		search_from_scanner: false,
+		currentPage: 0,
+		isOverflowing: false,
+	}),
 
 	watch: {
 		customer: _.debounce(function () {
@@ -584,17 +584,17 @@ export default {
 				this.loadVisibleItems(true);
 			}
 		},
-                filtered_items(new_value, old_value) {
-                        // Update item details if items changed
-                        if (
-                                this.pos_profile &&
-                                !this.pos_profile.pose_use_limit_search &&
-                                new_value.length !== old_value.length
-                        ) {
-                                this.update_items_details(new_value);
-                        }
-                        this.$nextTick(this.checkItemContainerOverflow);
-                },
+		filtered_items(new_value, old_value) {
+			// Update item details if items changed
+			if (
+				this.pos_profile &&
+				!this.pos_profile.pose_use_limit_search &&
+				new_value.length !== old_value.length
+			) {
+				this.update_items_details(new_value);
+			}
+			this.$nextTick(this.checkItemContainerOverflow);
+		},
 		// Automatically search and add item whenever the query changes
 		first_search: _.debounce(function (val) {
 			// Call without arguments so search_onchange treats it like an Enter key
@@ -618,21 +618,21 @@ export default {
 			// Maintain the configured items per page on resize
 			this.itemsPerPage = this.items_per_page;
 		},
-                items_loaded(val) {
-                        if (val) {
-                                this.eventBus.emit("items_loaded");
-                        }
-                },
-                items_view() {
-                        this.$nextTick(() => {
-                                if (this.items_view === "card") {
-                                        this.checkItemContainerOverflow();
-                                } else {
-                                        this.isOverflowing = false;
-                                }
-                        });
-                },
-        },
+		items_loaded(val) {
+			if (val) {
+				this.eventBus.emit("items_loaded");
+			}
+		},
+		items_view() {
+			this.$nextTick(() => {
+				if (this.items_view === "card") {
+					this.checkItemContainerOverflow();
+				} else {
+					this.isOverflowing = false;
+				}
+			});
+		},
+	},
 
 	methods: {
 		async loadVisibleItems(reset = false) {
@@ -663,31 +663,29 @@ export default {
 				this.loadVisibleItems();
 			}
 		},
-                onListScroll(event) {
-                        const el = event.target;
-                        if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
-                                this.currentPage += 1;
-                                this.loadVisibleItems();
-                        }
-                },
-                checkItemContainerOverflow() {
-                        const el = this.$refs.itemsContainer;
-                        if (!el) {
-                                this.isOverflowing = false;
-                                return;
-                        }
-                        const maxHeight = parseFloat(
-                                getComputedStyle(el).getPropertyValue("--container-height")
-                        );
-                        if (isNaN(maxHeight)) {
-                                this.isOverflowing = false;
-                                return;
-                        }
-                        this.isOverflowing = el.scrollHeight > maxHeight;
-                },
-                refreshPricesForVisibleItems() {
-                        const vm = this;
-                        if (!vm.filtered_items || vm.filtered_items.length === 0) return;
+		onListScroll(event) {
+			const el = event.target;
+			if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+				this.currentPage += 1;
+				this.loadVisibleItems();
+			}
+		},
+		checkItemContainerOverflow() {
+			const el = this.$refs.itemsContainer;
+			if (!el) {
+				this.isOverflowing = false;
+				return;
+			}
+			const maxHeight = parseFloat(getComputedStyle(el).getPropertyValue("--container-height"));
+			if (isNaN(maxHeight)) {
+				this.isOverflowing = false;
+				return;
+			}
+			this.isOverflowing = el.scrollHeight > maxHeight;
+		},
+		refreshPricesForVisibleItems() {
+			const vm = this;
+			if (!vm.filtered_items || vm.filtered_items.length === 0) return;
 
 			vm.loading = true;
 
@@ -818,14 +816,13 @@ export default {
 				return;
 			}
 
-                        const shouldClear =
-                                force_server && this.pos_profile.posa_local_storage && !isOffline();
-                        let cleared = false;
+			const shouldClear = force_server && this.pos_profile.posa_local_storage && !isOffline();
+			let cleared = false;
 
-                        const vm = this;
-                        this.loading = true;
-                        const syncSince = shouldClear ? null : getItemsLastSync();
-                        if (shouldClear) setItemsLastSync(null);
+			const vm = this;
+			this.loading = true;
+			const syncSince = shouldClear ? null : getItemsLastSync();
+			if (shouldClear) setItemsLastSync(null);
 
 			// Removed noisy debug log
 			let search = this.get_search(this.first_search);
@@ -951,7 +948,7 @@ export default {
 						if (ev.data.type === "parsed") {
 							const parsed = ev.data.items;
 							const newItems = parsed.message || parsed;
-                                                        if (syncSince !== null && vm.items && vm.items.length) {
+							if (syncSince !== null && vm.items && vm.items.length) {
 								const map = new Map(vm.items.map((it) => [it.item_code, it]));
 								newItems.forEach((it) => map.set(it.item_code, it));
 								vm.items = Array.from(map.values());
@@ -1017,11 +1014,11 @@ export default {
 							vm.loading = false;
 						}
 					};
-                                               this.itemWorker.postMessage({
-                                                       type: "parse_and_cache",
-                                                       json: text,
-                                                       priceList: vm.customer_price_list || vm.pos_profile?.selling_price_list || "",
-                                               });
+					this.itemWorker.postMessage({
+						type: "parse_and_cache",
+						json: text,
+						priceList: vm.customer_price_list || vm.pos_profile?.selling_price_list || "",
+					});
 				} catch (err) {
 					console.error("Failed to fetch items", err);
 					vm.loading = false;
@@ -1043,7 +1040,7 @@ export default {
 						if (vm.items_request_token !== request_token) return;
 						if (r.message) {
 							const newItems = r.message;
-                                                        if (syncSince !== null && vm.items && vm.items.length) {
+							if (syncSince !== null && vm.items && vm.items.length) {
 								const map = new Map(vm.items.map((it) => [it.item_code, it]));
 								newItems.forEach((it) => map.set(it.item_code, it));
 								vm.items = Array.from(map.values());
@@ -1165,11 +1162,11 @@ export default {
 								resolve(0);
 							}
 						};
-                                               this.itemWorker.postMessage({
-                                                       type: "parse_and_cache",
-                                                       json: text,
-                                                       priceList: this.customer_price_list || this.pos_profile?.selling_price_list || "",
-                                               });
+						this.itemWorker.postMessage({
+							type: "parse_and_cache",
+							json: text,
+							priceList: this.customer_price_list || this.pos_profile?.selling_price_list || "",
+						});
 					});
 					if (count === limit) {
 						await this.backgroundLoadItems(offset + limit, syncSince, clearBefore);
@@ -2472,12 +2469,12 @@ export default {
 			await forceClearAllCache();
 			await this.get_items(true);
 		}
-                this.scan_barcoud();
-                // Apply the configured items per page on mount
-                this.itemsPerPage = this.items_per_page;
-                window.addEventListener("resize", this.checkItemContainerOverflow);
-                this.$nextTick(this.checkItemContainerOverflow);
-        },
+		this.scan_barcoud();
+		// Apply the configured items per page on mount
+		this.itemsPerPage = this.items_per_page;
+		window.addEventListener("resize", this.checkItemContainerOverflow);
+		this.$nextTick(this.checkItemContainerOverflow);
+	},
 
 	beforeUnmount() {
 		// Clear interval when component is destroyed
@@ -2515,11 +2512,11 @@ export default {
 		this.eventBus.off("update_cur_items_details");
 		this.eventBus.off("update_offers_counters");
 		this.eventBus.off("update_coupons_counters");
-                this.eventBus.off("update_customer_price_list");
-                this.eventBus.off("update_customer");
-                this.eventBus.off("force_reload_items");
-                window.removeEventListener("resize", this.checkItemContainerOverflow);
-        },
+		this.eventBus.off("update_customer_price_list");
+		this.eventBus.off("update_customer");
+		this.eventBus.off("force_reload_items");
+		window.removeEventListener("resize", this.checkItemContainerOverflow);
+	},
 };
 </script>
 
@@ -2543,14 +2540,14 @@ export default {
 }
 
 .dynamic-scroll {
-       transition: max-height var(--transition-normal);
-       padding-bottom: var(--dynamic-xs);
+	transition: max-height var(--transition-normal);
+	padding-bottom: var(--dynamic-xs);
 }
 
 .item-container {
-       max-height: var(--container-height);
-       overflow-y: auto;
-       scrollbar-gutter: stable;
+	max-height: var(--container-height);
+	overflow-y: auto;
+	scrollbar-gutter: stable;
 }
 
 .items-grid {

--- a/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
+++ b/posawesome/public/js/posapp/components/pos/PostingDateRow.vue
@@ -13,7 +13,7 @@
 			/>
 		</v-col>
 		<v-col
-			v-if="pos_profile.posa_enable_price_list_dropdown"
+			v-if="pos_profile.posa_enable_price_list_dropdown !== false"
 			cols="12"
 			sm="6"
 			class="pb-2 d-flex align-center"


### PR DESCRIPTION
## Summary
- add `posa_enable_price_list_dropdown` custom field for POS Profile and export it
- default price list dropdown to visible unless profile disables it

## Testing
- `python -m py_compile posawesome/hooks.py`
- `npx eslint posawesome/public/js/posapp/components/pos/Invoice.vue posawesome/public/js/posapp/components/pos/ItemsSelector.vue posawesome/public/js/posapp/components/pos/PostingDateRow.vue` *(fails: '__' is not defined, 'frappe' is not defined, no-unused-vars)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5798bb948326825ff5d3f7883dac