### PR TITLE
refactor: centralize item storage helpers

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -127,46 +127,6 @@ export function reduceCacheUsage() {
 
 // --- Generic getters and setters for cached data ----------------------------
 
-export async function getStoredItems() {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		const items = await db.table("items").toArray();
-               return items;
-	} catch (e) {
-		console.error("Failed to get stored items", e);
-		return [];
-	}
-}
-
-export async function saveItems(items) {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		let cleanItems;
-		try {
-			cleanItems = JSON.parse(JSON.stringify(items));
-		} catch (err) {
-			console.error("Failed to serialize items", err);
-			cleanItems = [];
-		}
-		await db.table("items").bulkPut(cleanItems);
-	} catch (e) {
-		console.error("Failed to save items", e);
-	}
-}
-
-export async function clearStoredItems() {
-        try {
-                await checkDbHealth();
-                if (!db.isOpen()) await db.open();
-                await db.table("items").clear();
-                setItemsLastSync(null);
-        } catch (e) {
-                console.error("Failed to clear stored items", e);
-        }
-}
-
 export function getCustomerStorage() {
 	return memory.customer_storage || [];
 }

--- a/posawesome/public/js/offline/index.js
+++ b/posawesome/public/js/offline/index.js
@@ -15,9 +15,6 @@ export {
 export {
 	memory,
 	memoryInitPromise,
-	getStoredItems,
-	saveItems,
-	clearStoredItems,
 	getCustomerStorage,
 	setCustomerStorage,
 	getItemsLastSync,
@@ -100,9 +97,10 @@ export {
 	clearPriceListCache,
 	saveItemDetailsCache,
 	getCachedItemDetails,
-	saveItemsBulk,
-	getAllStoredItems,
+	saveItems,
+	getStoredItems,
 	searchStoredItems,
+	clearStoredItems,
 } from "./items.js";
 
 export { saveItemGroups, getCachedItemGroups, clearItemGroups } from "./item_groups.js";

--- a/posawesome/public/js/offline/items.js
+++ b/posawesome/public/js/offline/items.js
@@ -170,7 +170,7 @@ export function getCachedItemDetails(profileName, priceList, itemCodes, ttl = 15
 
 // Persistent item storage helpers
 
-export async function saveItemsBulk(items) {
+export async function saveItems(items) {
 	try {
 		await checkDbHealth();
 		if (!db.isOpen()) await db.open();
@@ -187,7 +187,7 @@ export async function saveItemsBulk(items) {
 	}
 }
 
-export async function getAllStoredItems() {
+export async function getStoredItems() {
 	try {
 		await checkDbHealth();
 		if (!db.isOpen()) await db.open();


### PR DESCRIPTION
## Summary
- consolidate `searchStoredItems` and related helpers into `offline/items.js`
- re-export item helpers from `offline/index.js` and `offline.js`
- drop obsolete item storage helpers from cache

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint posawesome/public/js/offline/items.js posawesome/public/js/offline/index.js posawesome/public/js/offline.js posawesome/public/js/offline/cache.js`
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`


------
https://chatgpt.com/codex/tasks/task_e_689083e6bdb083269f28130e55b92bfc