### PR TITLE
fix: reload items when cache empty

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -761,16 +761,21 @@ export default {
 				console.log("📝 Search:", search, "ItemGroup:", itemGroup);
 				
 				console.log("⏳ Calling searchStoredItems...");
-				const pageItems = await searchStoredItems({
-					search,
-					itemGroup,
-					limit: this.itemsPerPage,
-					offset: this.currentPage * this.itemsPerPage,
-				});
-				console.log("✅ searchStoredItems returned:", pageItems.length, "items");
-				
-				if (reset) this.items = pageItems;
-				else this.items = [...this.items, ...pageItems];
+                                const pageItems = await searchStoredItems({
+                                        search,
+                                        itemGroup,
+                                        limit: this.itemsPerPage,
+                                        offset: this.currentPage * this.itemsPerPage,
+                                });
+                                console.log("✅ searchStoredItems returned:", pageItems.length, "items");
+
+                                if (!pageItems.length && !isOffline()) {
+                                        await this.get_items(true);
+                                        return;
+                                }
+
+                                if (reset) this.items = pageItems;
+                                else this.items = [...this.items, ...pageItems];
 				
 				console.log("📊 Total items after update:", this.items.length);
 				


### PR DESCRIPTION
## Summary
- reload items from server when local cache returns no results

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm test` *(fails: Missing script "test")*
- `node --input-type=module` test script to simulate reload on empty cache

------
https://chatgpt.com/codex/tasks/task_e_68908401ccf08326856bfe787c66f58a