### PR TITLE
fix: import clearStoredItems from index

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -399,8 +399,9 @@ import {
         getCachedItemGroups,
         getItemsLastSync,
         forceClearAllCache,
+        clearStoredItems,
+        setItemsLastSync,
 } from "../../../offline/index.js";
-import { clearStoredItems, setItemsLastSync } from "../../../offline/cache.js";
 import { useResponsive } from "../../composables/useResponsive.js";
 
 export default {


### PR DESCRIPTION
## Summary
- use central offline index for clearStoredItems and setItemsLastSync import in ItemsSelector

## Testing
- `node esbuild --production --apps posawesome --run-build-command` *(fails: Cannot find module '/workspace/POS-Awesome-V15/esbuild')*
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`

------
https://chatgpt.com/codex/tasks/task_e_689091a412c88326b519631a1924917d