### PR TITLE
refactor origin connectivity check to use frappe.call

### DIFF
--- a/posawesome/public/js/posapp/composables/useNetwork.js
+++ b/posawesome/public/js/posapp/composables/useNetwork.js
@@ -270,27 +270,23 @@ export async function checkFrappePing() {
 	}
 }
 
-export async function checkCurrentOrigin(protocol, hostname, port) {
-	try {
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), 5000);
-		const baseUrl = `${protocol}//${hostname}${port ? ":" + port : ""}`;
-		const response = await fetch(`${baseUrl}/api/method/frappe.auth.get_logged_user`, {
-			method: "HEAD",
-			cache: "no-cache",
-			signal: controller.signal,
-			headers: {
-				"Cache-Control": "no-cache, no-store, must-revalidate",
-			},
-		});
-		clearTimeout(timeoutId);
-		return response.status < 500;
-	} catch (error) {
-		if (error.name !== "AbortError") {
-			console.warn("Current origin check failed:", error);
-		}
-		return false;
-	}
+export async function checkCurrentOrigin(_protocol, _hostname, _port) {
+        try {
+                return await new Promise((resolve) => {
+                        frappe.call({
+                                method: "frappe.auth.get_logged_user",
+                                callback: (res) => {
+                                        resolve(Boolean(res.message));
+                                },
+                                error: () => {
+                                        resolve(false);
+                                },
+                        });
+                });
+        } catch (error) {
+                console.warn("Current origin check failed:", error);
+                return false;
+        }
 }
 
 export async function checkExternalConnectivity() {


### PR DESCRIPTION
## Summary
- replace fetch-based logged user check with frappe.call in network origin logic
- drop manual headers and timeout handling

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68918a03b23c83269ea6e8e348f4f9a5