### PR TITLE
refactor: use frappe.call in item worker

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1332,14 +1332,10 @@ export default {
 
 			if (this.itemWorker) {
 				try {
-					const res = await fetch("/api/method/posawesome.posawesome.api.items.get_items", {
-						method: "POST",
-						headers: {
-							"Content-Type": "application/json",
-							"X-Frappe-CSRF-Token": frappe.csrf_token,
-						},
-						credentials: "same-origin",
-						body: JSON.stringify({
+					frappe.freeze();
+					const res = await frappe.call({
+						method: "posawesome.posawesome.api.items.get_items",
+						args: {
 							pos_profile: JSON.stringify(vm.pos_profile),
 							price_list: vm.customer_price_list,
 							item_group: gr,
@@ -1348,11 +1344,9 @@ export default {
 							modified_after: syncSince,
 							limit: this.itemsPageLimit,
 							offset: 0,
-						}),
+						},
 					});
-
-					const text = await res.text();
-					// console.log(text)
+					const text = JSON.stringify(res);
 					this.itemWorker.onmessage = async (ev) => {
 						if (this.items_request_token !== request_token) return;
 						if (ev.data.type === "parsed") {
@@ -1441,6 +1435,8 @@ export default {
 				} catch (err) {
 					console.error("Failed to fetch items", err);
 					vm.loading = false;
+				} finally {
+					frappe.unfreeze();
 				}
 			} else {
 				frappe.call({


### PR DESCRIPTION
## Summary
- use `frappe.call` instead of `fetch` for worker item retrieval
- add `frappe.freeze`/`frappe.unfreeze` around worker request

## Testing
- `npx prettier posawesome/public/js/posapp/components/pos/ItemsSelector.vue --write`
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`


------
https://chatgpt.com/codex/tasks/task_e_68918a435f848326a063c9ba20d9d0cd