### PR TITLE
Handle invalid offline cache for price list items

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -552,6 +552,11 @@ export default {
 			// Apply cached rates if available for immediate update
 			if (this.items_loaded && this.items && this.items.length > 0) {
 				const cached = await getCachedPriceListItems(this.customer_price_list);
+				if (cached === null) {
+					this.items_loaded = false;
+					this.get_items(true);
+					return;
+				}
 				if (cached && cached.length) {
 					const map = {};
 					cached.forEach((ci) => {
@@ -1231,6 +1236,9 @@ export default {
 				!this.pos_profile.pose_use_limit_search
 			) {
 				const cached = await getCachedPriceListItems(vm.customer_price_list);
+				if (cached === null) {
+					return await vm.get_items(true);
+				}
 				if (cached && cached.length) {
 					serverTimestamp = await vm.fetchServerItemsTimestamp();
 					if (serverTimestamp && syncSince && new Date(syncSince) < new Date(serverTimestamp)) {

--- a/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceItemMethods.js
@@ -1582,7 +1582,16 @@ export default {
 	// Apply cached price list rates to existing invoice items
 	async apply_cached_price_list(price_list) {
 		const cached = await getCachedPriceListItems(price_list);
+		if (cached === null) {
+			if (!isOffline()) {
+				await this.update_items_details(this.items);
+			}
+			return;
+		}
 		if (!Array.isArray(cached) || !cached.length) {
+			if (!isOffline()) {
+				await this.update_items_details(this.items);
+			}
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- handle DB health failures by returning null in `getCachedPriceListItems` and document that null signals server fetch
- adjust item selectors and invoice methods to detect null cache and retrieve price list data from the server

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689193d72d188326a5e8ca9b63f6e029