### PR TITLE
defer memory cache initialization

### DIFF
--- a/posawesome/public/js/offline/index.js
+++ b/posawesome/public/js/offline/index.js
@@ -15,6 +15,7 @@ export {
 export {
 	memory,
 	memoryInitPromise,
+	initMemoryCache,
 	getCustomerStorage,
 	setCustomerStorage,
 	getItemsLastSync,

--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -46,7 +46,7 @@ import {
 	purgeOldQueueEntries,
 	MAX_QUEUE_ITEMS,
 	initPromise,
-	memoryInitPromise,
+	initMemoryCache,
 	isCacheReady,
 	toggleManualOffline,
 	isManualOffline,
@@ -143,7 +143,7 @@ export default {
 
 		async initializeData() {
 			await initPromise;
-			await memoryInitPromise;
+			await initMemoryCache();
 			this.cacheReady = true;
 			checkDbHealth().catch(() => {});
 			// Load POS profile from cache or storage

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -160,7 +160,7 @@ import UpdateCustomer from "./UpdateCustomer.vue";
 import {
 	getCustomerStorage,
 	setCustomerStorage,
-	memoryInitPromise,
+	initMemoryCache,
 	getCustomersLastSync,
 	setCustomersLastSync,
 } from "../../../offline/index.js";
@@ -403,7 +403,7 @@ export default {
 	},
 
 	created() {
-		memoryInitPromise.then(() => {
+		initMemoryCache().then(() => {
 			if (getCustomerStorage().length) {
 				try {
 					this.customers = getCustomerStorage();
@@ -419,13 +419,13 @@ export default {
 
 		this.$nextTick(() => {
 			this.eventBus.on("register_pos_profile", async (pos_profile) => {
-				await memoryInitPromise;
+				await initMemoryCache();
 				this.pos_profile = pos_profile;
 				this.get_customer_names();
 			});
 
 			this.eventBus.on("payments_register_pos_profile", async (pos_profile) => {
-				await memoryInitPromise;
+				await initMemoryCache();
 				this.pos_profile = pos_profile;
 				this.get_customer_names();
 			});

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -41,8 +41,8 @@
 								@keydown.esc="esc_event"
 								@keydown.enter="search_onchange"
 								@click:clear="clearSearch"
-                                                                prepend-inner-icon="mdi-magnify"
-                                                                @click:prepend-inner="search_onchange"
+								prepend-inner-icon="mdi-magnify"
+								@click:prepend-inner="search_onchange"
 								@focus="handleItemSearchFocus"
 								ref="debounce_search"
 							>
@@ -387,7 +387,7 @@ import {
 	getLocalStockCache,
 	setLocalStockCache,
 	initPromise,
-	memoryInitPromise,
+	initMemoryCache,
 	checkDbHealth,
 	getCachedPriceListItems,
 	savePriceListItems,
@@ -471,7 +471,7 @@ export default {
 		renderBuffer: 10,
 		lastScrollTop: 0,
 		scrollThrottle: null,
-                searchDebounce: null,
+		searchDebounce: null,
 		// Prevent repeated server fetches when local storage is empty
 		fallbackAttempted: false,
 	}),
@@ -614,9 +614,9 @@ export default {
 			this.$nextTick(this.checkItemContainerOverflow);
 		},
 		// Automatically trigger search when input is idle
-                first_search() {
-                        this.searchDebounce();
-                },
+		first_search() {
+			this.searchDebounce();
+		},
 
 		// Refresh item prices whenever the user changes currency
 		selected_currency() {
@@ -1897,58 +1897,58 @@ export default {
 			}
 		},
 		async search_onchange(newSearchTerm) {
-                        if (this.searchDebounce && this.searchDebounce.cancel) {
-                                this.searchDebounce.cancel();
-                        }
-                        const vm = this;
+			if (this.searchDebounce && this.searchDebounce.cancel) {
+				this.searchDebounce.cancel();
+			}
+			const vm = this;
 
-                        // Determine the actual query string and trim whitespace
-                        const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
-                        const searchTerm = (query || "").trim();
+			// Determine the actual query string and trim whitespace
+			const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
+			const searchTerm = (query || "").trim();
 
-                        if (!searchTerm) {
-                                vm.search_from_scanner = false;
-                                return;
-                        }
+			if (!searchTerm) {
+				vm.search_from_scanner = false;
+				return;
+			}
 
-                        const fromScanner = vm.search_from_scanner;
+			const fromScanner = vm.search_from_scanner;
 
-                        if (vm.pos_profile && vm.pos_profile.pose_use_limit_search) {
-                                // Only trigger search when query length meets minimum threshold
-                                if (searchTerm.length >= 3) {
-                                        if (vm.pos_profile && !vm.pos_profile.posa_local_storage) {
-                                                vm.get_items(true);
-                                        } else {
-                                                vm.get_items();
-                                        }
-                                }
-                        } else if (vm.pos_profile && vm.pos_profile.posa_local_storage) {
-                                await vm.loadVisibleItems(true);
-                                if (searchTerm.length >= 3) {
-                                        vm.enter_event();
-                                }
-                        } else {
-                                // Save the current filtered items before search to maintain quantity data
-                                const current_items = [...vm.filtered_items];
-                                if (searchTerm.length >= 3) {
-                                        vm.enter_event();
-                                }
+			if (vm.pos_profile && vm.pos_profile.pose_use_limit_search) {
+				// Only trigger search when query length meets minimum threshold
+				if (searchTerm.length >= 3) {
+					if (vm.pos_profile && !vm.pos_profile.posa_local_storage) {
+						vm.get_items(true);
+					} else {
+						vm.get_items();
+					}
+				}
+			} else if (vm.pos_profile && vm.pos_profile.posa_local_storage) {
+				await vm.loadVisibleItems(true);
+				if (searchTerm.length >= 3) {
+					vm.enter_event();
+				}
+			} else {
+				// Save the current filtered items before search to maintain quantity data
+				const current_items = [...vm.filtered_items];
+				if (searchTerm.length >= 3) {
+					vm.enter_event();
+				}
 
-                                // After search, update quantities for newly filtered items
-                                if (vm.filtered_items && vm.filtered_items.length > 0) {
-                                        setTimeout(() => {
-                                                vm.update_items_details(vm.filtered_items);
-                                        }, 300);
-                                }
-                        }
+				// After search, update quantities for newly filtered items
+				if (vm.filtered_items && vm.filtered_items.length > 0) {
+					setTimeout(() => {
+						vm.update_items_details(vm.filtered_items);
+					}, 300);
+				}
+			}
 
-                        // Clear the input only when triggered via scanner
-                        if (fromScanner) {
-                                vm.clearSearch();
-                                vm.$refs.debounce_search && vm.$refs.debounce_search.focus();
-                                vm.search_from_scanner = false;
-                        }
-                },
+			// Clear the input only when triggered via scanner
+			if (fromScanner) {
+				vm.clearSearch();
+				vm.$refs.debounce_search && vm.$refs.debounce_search.focus();
+				vm.search_from_scanner = false;
+			}
+		},
 		get_item_qty(first_search) {
 			const qtyVal = this.qty != null ? this.qty : 1;
 			let scal_qty = Math.abs(qtyVal);
@@ -2804,11 +2804,11 @@ export default {
 	},
 
 	created() {
-                console.log("ItemsSelector created - starting initialization");
-                this.searchDebounce = _.debounce(() => {
-                        this.search_onchange();
-                }, 800);
-		memoryInitPromise.then(async () => {
+		console.log("ItemsSelector created - starting initialization");
+		this.searchDebounce = _.debounce(() => {
+			this.search_onchange();
+		}, 800);
+		initMemoryCache().then(async () => {
 			try {
 				const profile = await ensurePosProfile();
 				console.log("POS Profile loaded:", profile ? "success" : "failed");
@@ -2928,7 +2928,7 @@ export default {
 			try {
 				console.log("POS Profile registered:", data.pos_profile.name);
 				await initPromise;
-				await memoryInitPromise;
+				await initMemoryCache();
 				try {
 					await checkDbHealth();
 				} catch (err) {

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -8,6 +8,7 @@ import themePlugin from "./plugins/theme.js";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import Home from "./Home.vue";
+import { initMemoryCache } from "../offline/index.js";
 
 // Expose Dexie globally for libraries that expect a global Dexie instance
 if (typeof window !== "undefined" && !window.Dexie) {
@@ -96,6 +97,12 @@ frappe.PosApp.posapp = class {
 			navigator.serviceWorker
 				.register("/sw.js")
 				.catch((err) => console.error("SW registration failed", err));
+		}
+
+		if (typeof requestIdleCallback === "function") {
+			requestIdleCallback(() => initMemoryCache());
+		} else {
+			setTimeout(() => initMemoryCache(), 0);
 		}
 	}
 	setup_header() {}


### PR DESCRIPTION
## Summary
- wrap memory cache initialization in initMemoryCache
- schedule initMemoryCache in requestIdleCallback
- update components to use initMemoryCache for cache readiness

## Testing
- `npx prettier --write posawesome/public/js/offline/cache.js posawesome/public/js/offline/index.js posawesome/public/js/posapp/posapp.js posawesome/public/js/posapp/Home.vue posawesome/public/js/posapp/components/pos/Customer.vue posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891ac465a48832689f4079539ade65f