### PR TITLE
Handle cache initialization failures gracefully

### DIFF
--- a/posawesome/public/js/offline/cache.js
+++ b/posawesome/public/js/offline/cache.js
@@ -84,12 +84,14 @@ export const memoryInitPromise = (async () => {
 		} else {
 			memory.cache_version = storedVersion || CACHE_VERSION;
 		}
-		// Mark caches initialized
-		memory.cache_ready = true;
-		persist("cache_ready", true);
-	} catch (e) {
-		console.error("Failed to initialize memory from DB", e);
-	}
+                // Mark caches initialized
+                memory.cache_ready = true;
+                persist("cache_ready", true);
+                return true;
+        } catch (e) {
+                console.error("Failed to initialize memory from DB", e);
+                throw e;
+        }
 })();
 
 // Reset cached invoices and customers after syncing

--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -141,11 +141,23 @@ export default {
 			this.page = page;
 		},
 
-		async initializeData() {
-			await initPromise;
-			await memoryInitPromise;
-			this.cacheReady = true;
-			checkDbHealth().catch(() => {});
+                async initializeData() {
+                        await initPromise;
+                        try {
+                                const success = await memoryInitPromise;
+                                if (success) {
+                                        this.cacheReady = true;
+                                } else {
+                                        this.cacheReady = false;
+                                        alert("Failed to initialize local cache. Please refresh and try again.");
+                                        return;
+                                }
+                        } catch (e) {
+                                this.cacheReady = false;
+                                alert("Failed to initialize local cache. Please refresh and try again.");
+                                return;
+                        }
+                        checkDbHealth().catch(() => {});
 			// Load POS profile from cache or storage
 			const openingData = getOpeningStorage();
 			if (openingData && openingData.pos_profile) {


### PR DESCRIPTION
## Summary
- return success flag or throw on cache memory initialization failure
- only mark cache ready on successful initialization and notify user on error

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6891ac745c548326b07139f97572103e