### PR TITLE
feat: migrate initial POS state to Pinia

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dexie": "^4.0.11",
     "lodash": "^4.17.21",
     "mitt": "^3.0.1",
+    "pinia": "^2.1.7",
     "socket.io-client": "^4.8.1",
     "vue": "^3.3.4",
     "vue-qrcode-reader": "^5.7.2",

--- a/posawesome/public/js/posapp/composables/useOffers.js
+++ b/posawesome/public/js/posapp/composables/useOffers.js
@@ -1,16 +1,19 @@
 import { ref, getCurrentInstance } from "vue";
 import { getCachedOffers, saveOffers } from "../../offline/index.js";
+import { usePosStore } from "../stores/usePosStore.js";
 
 export function useOffers() {
     const { proxy } = getCurrentInstance();
     const eventBus = proxy?.eventBus;
     const offers = ref([]);
+    const posStore = usePosStore();
 
     function get_offers(profileName, posProfile) {
         if (posProfile && posProfile.posa_local_storage) {
             const cached = getCachedOffers();
             if (cached.length) {
                 offers.value = cached;
+                posStore.setOffers(cached);
                 eventBus?.emit("set_offers", cached);
             }
         }
@@ -21,6 +24,7 @@ export function useOffers() {
                     console.info("LoadOffers");
                     saveOffers(r.message);
                     offers.value = r.message;
+                    posStore.setOffers(r.message);
                     eventBus?.emit("set_offers", r.message);
                 }
             })
@@ -29,6 +33,7 @@ export function useOffers() {
                 const cached = getCachedOffers();
                 if (cached.length) {
                     offers.value = cached;
+                    posStore.setOffers(cached);
                     eventBus?.emit("set_offers", cached);
                 }
             });

--- a/posawesome/public/js/posapp/composables/usePosShift.js
+++ b/posawesome/public/js/posapp/composables/usePosShift.js
@@ -1,4 +1,5 @@
 import { ref, getCurrentInstance } from "vue";
+import { usePosStore } from "../stores/usePosStore.js";
 import {
     initPromise,
     checkDbHealth,
@@ -11,6 +12,7 @@ import {
 export function usePosShift(openDialog) {
     const { proxy } = getCurrentInstance();
     const eventBus = proxy?.eventBus;
+    const posStore = usePosStore();
 
     const pos_profile = ref(null);
     const pos_opening_shift = ref(null);
@@ -26,6 +28,8 @@ export function usePosShift(openDialog) {
                 if (r.message) {
                     pos_profile.value = r.message.pos_profile;
                     pos_opening_shift.value = r.message.pos_opening_shift;
+                    posStore.setProfile(pos_profile.value);
+                    posStore.setShift(pos_opening_shift.value);
                     if (pos_profile.value.taxes_and_charges) {
                         frappe.call({
                             method: "frappe.client.get",
@@ -61,6 +65,8 @@ export function usePosShift(openDialog) {
                     if (data) {
                         pos_profile.value = data.pos_profile;
                         pos_opening_shift.value = data.pos_opening_shift;
+                        posStore.setProfile(pos_profile.value);
+                        posStore.setShift(pos_opening_shift.value);
                         eventBus?.emit("register_pos_profile", data);
                         eventBus?.emit("set_company", data.company);
                         try {
@@ -79,6 +85,8 @@ export function usePosShift(openDialog) {
                 if (data) {
                     pos_profile.value = data.pos_profile;
                     pos_opening_shift.value = data.pos_opening_shift;
+                    posStore.setProfile(pos_profile.value);
+                    posStore.setShift(pos_opening_shift.value);
                     eventBus?.emit("register_pos_profile", data);
                     eventBus?.emit("set_company", data.company);
                     try {
@@ -116,6 +124,8 @@ export function usePosShift(openDialog) {
                 if (r.message) {
                     pos_opening_shift.value = null;
                     pos_profile.value = null;
+                    posStore.setShift(null);
+                    posStore.setProfile(null);
                     clearOpeningStorage();
                     eventBus?.emit("show_message", {
                         title: `POS Shift Closed`,

--- a/posawesome/public/js/posapp/posapp.js
+++ b/posawesome/public/js/posapp/posapp.js
@@ -4,6 +4,7 @@ import Dexie from "dexie/dist/dexie.mjs";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import "@vuepic/vue-datepicker/dist/main.css";
 import eventBus from "./bus";
+import { createPinia } from "pinia";
 import themePlugin from "./plugins/theme.js";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
@@ -75,12 +76,14 @@ frappe.PosApp.posapp = class {
 				},
 			},
 		});
-		const app = createApp(Home);
-		app.component("VueDatePicker", VueDatePicker);
-		app.use(eventBus);
-		app.use(vuetify);
-		app.use(themePlugin, { vuetify });
-		app.mount(this.$el[0]);
+                const pinia = createPinia();
+                const app = createApp(Home);
+                app.use(pinia);
+                app.component("VueDatePicker", VueDatePicker);
+                app.use(eventBus);
+                app.use(vuetify);
+                app.use(themePlugin, { vuetify });
+                app.mount(this.$el[0]);
 
 		if (!document.querySelector('link[rel="manifest"]')) {
 			const link = document.createElement("link");

--- a/posawesome/public/js/posapp/stores/usePosStore.js
+++ b/posawesome/public/js/posapp/stores/usePosStore.js
@@ -1,0 +1,25 @@
+import { defineStore } from "pinia";
+
+export const usePosStore = defineStore("pos", {
+    state: () => ({
+        profile: null,
+        offers: [],
+        shift: null,
+    }),
+    getters: {
+        getProfile: (state) => state.profile,
+        getOffers: (state) => state.offers,
+        getShift: (state) => state.shift,
+    },
+    actions: {
+        setProfile(profile) {
+            this.profile = profile;
+        },
+        setOffers(offers) {
+            this.offers = offers;
+        },
+        setShift(shift) {
+            this.shift = shift;
+        },
+    },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -435,6 +435,11 @@
     "@vue/compiler-dom" "3.5.17"
     "@vue/shared" "3.5.17"
 
+"@vue/devtools-api@^6.6.3":
+  version "6.6.4"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
+
 "@vue/reactivity@3.5.17":
   version "3.5.17"
   resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.5.17.tgz#169b5dcf96c7f23788e5ed9745ec8a7227f2125e"
@@ -1110,6 +1115,14 @@ picomatch@^4.0.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
   integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
+pinia@^2.1.7:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.3.1.tgz#54c476675b72f5abcfafa24a7582531ea8c23d94"
+  integrity sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==
+  dependencies:
+    "@vue/devtools-api" "^6.6.3"
+    vue-demi "^0.14.10"
+
 postcss-selector-parser@^6.0.15:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
@@ -1283,6 +1296,11 @@ vite@^6.2.4:
     tinyglobby "^0.2.13"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vue-demi@^0.14.10:
+  version "0.14.10"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
+  integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
 
 vue-eslint-parser@^10.2.0:
   version "10.2.0"


### PR DESCRIPTION
## Summary
- add a Pinia store for POS profile, offers and shift data
- bootstrap Pinia in the app entry and consume the store in Home and Pos views
- keep composables in sync with the store for offers and shift