### PR TITLE
refactor: debounce price refresh and streamline item loading

### DIFF
--- a/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
+++ b/posawesome/public/js/posapp/components/pos/invoiceWatchers.js
@@ -14,18 +14,10 @@ export default {
 		deep: true
 	},
 
-	// Watch for customer change and update related data
-	customer() {
-		this.close_payments();
-		this.eventBus.emit("set_customer", this.customer);
-		this.fetch_customer_details();
-		this.fetch_customer_balance();
-		this.set_delivery_charges();
-	},
-	// Watch for customer_info change and emit to edit form
-	customer_info() {
-		this.eventBus.emit("set_customer_info_to_edit", this.customer_info);
-	},
+        // Watch for customer_info change and emit to edit form
+        customer_info() {
+                this.eventBus.emit("set_customer_info_to_edit", this.customer_info);
+        },
 	// Watch for expanded row change and update item detail
 	expanded(data_value) {
 		if (data_value.length > 0) {
@@ -109,17 +101,17 @@ export default {
 	},
 
 	// Reactively update item prices when currency changes
-	selected_currency() {
-		clearPriceListCache(this.selected_price_list || this.pos_profile.selling_price_list);
-		if (this.items && this.items.length) {
-			this.update_item_rates();
-		}
-	},
+        selected_currency() {
+                clearPriceListCache(this.selected_price_list || this.pos_profile.selling_price_list);
+                if (this.items && this.items.length) {
+                        this.refreshPrices();
+                }
+        },
 
 	// Reactively update item prices when exchange rate changes
-	exchange_rate() {
-		if (this.items && this.items.length) {
-			this.update_item_rates();
-		}
-	},
+        exchange_rate() {
+                if (this.items && this.items.length) {
+                        this.refreshPrices();
+                }
+        },
 };

--- a/posawesome/public/js/posapp/composables/usePriceRefresh.js
+++ b/posawesome/public/js/posapp/composables/usePriceRefresh.js
@@ -1,0 +1,13 @@
+import debounce from "lodash/debounce";
+
+/**
+ * Create a debounced price refresh handler.
+ * @param {Function} updateFn - Function that updates item rates.
+ * @param {number} wait - Debounce delay in ms.
+ */
+export function usePriceRefresh(updateFn, wait = 300) {
+        const refreshPrices = debounce(() => {
+                updateFn();
+        }, wait);
+        return { refreshPrices };
+}


### PR DESCRIPTION
## Summary
- refactor price refresh to use debounced composable
- handle customer updates via explicit method instead of watcher
- only fetch items from server when cache is missing
