### PR TITLE
feat: validate closing amount input

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/ClosingDialog.vue
@@ -44,7 +44,7 @@
 									<template v-slot:item.closing_amount="props">
 										<v-text-field
 											v-model="props.item.closing_amount"
-											:rules="[max25chars]"
+											:rules="[validateNumber]"
 											:label="frappe._('Edit')"
 											single-line
 											counter
@@ -110,6 +110,7 @@
 </template>
 
 <script>
+/* global __ */
 import format from "../../format";
 export default {
 	mixins: [format],
@@ -138,7 +139,7 @@ export default {
 				sortable: true,
 			},
 		],
-		max25chars: (v) => v.length <= 20 || "Input too long!", // TODO : should validate as number
+		validateNumber: (v) => !isNaN(Number(v)) || "Invalid number",
 		pagination: {},
 	}),
 	watch: {},


### PR DESCRIPTION
## Summary
- validate closing amount input using numeric check
- enforce validator for closing amount field

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ClosingDialog.vue -f json`
- `npx prettier --check posawesome/public/js/posapp/components/pos/ClosingDialog.vue`
- `node - <<'NODE'
const validateNumber = (v) => !isNaN(Number(v)) || 'Invalid number';
console.log('123 =>', validateNumber('123'));
console.log('abc =>', validateNumber('abc'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6892e2f413b883268a537eb4df7928b4