### PR TITLE
feat: improve offline module loading resilience

### DIFF
--- a/posawesome/posawesome/page/posapp/posapp.js
+++ b/posawesome/posawesome/page/posapp/posapp.js
@@ -1,12 +1,19 @@
 // Include onscan.js
+/* global frappe, $ */
 
 async function loadOfflineModule() {
 	try {
-		const manifest = await fetch("/assets/posawesome/dist/js/manifest.json").then((r) => r.json());
-		for (const value of Object.values(manifest)) {
-			if (value.isEntry && value.src && value.src.endsWith("offline/index.js")) {
-				return import(`/assets/posawesome/dist/js/${value.file}`);
+		const response = await fetch("/assets/posawesome/dist/js/manifest.json");
+		const contentType = response.headers.get("content-type") || "";
+		if (response.ok && contentType.includes("application/json")) {
+			const manifest = await response.json();
+			for (const value of Object.values(manifest)) {
+				if (value.isEntry && value.src && value.src.endsWith("offline/index.js")) {
+					return import(`/assets/posawesome/dist/js/${value.file}`);
+				}
 			}
+		} else {
+			console.warn(`Failed to load manifest (${response.status})`);
 		}
 	} catch (err) {
 		console.warn("Failed to load offline chunk", err);
@@ -17,6 +24,7 @@ async function loadOfflineModule() {
 frappe.pages["posapp"].on_page_load = async function (wrapper) {
 	await setupLanguage();
 
+	// eslint-disable-next-line no-unused-vars
 	var page = frappe.ui.make_app_page({
 		parent: wrapper,
 		title: "POS Awesome",


### PR DESCRIPTION
## Summary
- ensure offline module manifest is fetched only when the response is OK and JSON
- warn with HTTP status and fall back to default offline module when manifest can't be used

## Testing
- `npx prettier --write posawesome/posawesome/page/posapp/posapp.js`
- `npx eslint posawesome/posawesome/page/posapp/posapp.js`


------
https://chatgpt.com/codex/tasks/task_e_6892e3b7783c832681cb70bdc5ab2979