### PR TITLE
feat: harden service worker manifest fetch

### DIFF
--- a/posawesome/www/sw.js
+++ b/posawesome/www/sw.js
@@ -1,43 +1,64 @@
 const CACHE_NAME = "posawesome-cache-v1";
 const MAX_CACHE_ITEMS = 1000;
+const MANIFEST_URL = "/assets/posawesome/dist/js/manifest.json";
 
 async function enforceCacheLimit(cache) {
-	const keys = await cache.keys();
-	if (keys.length > MAX_CACHE_ITEMS) {
-		const excess = keys.length - MAX_CACHE_ITEMS;
-		for (let i = 0; i < excess; i++) {
-			await cache.delete(keys[i]);
-		}
-	}
+        const keys = await cache.keys();
+        if (keys.length > MAX_CACHE_ITEMS) {
+                const excess = keys.length - MAX_CACHE_ITEMS;
+                for (let i = 0; i < excess; i++) {
+                        await cache.delete(keys[i]);
+                }
+        }
+}
+
+async function loadManifest(retries = 1) {
+        for (let attempt = 0; attempt <= retries; attempt++) {
+                try {
+                        const resp = await fetch(MANIFEST_URL, { cache: "no-store" });
+                        const contentType = resp.headers.get("content-type") || "";
+                        if (resp.ok && contentType.includes("application/json")) {
+                                return await resp.json();
+                        }
+                        console.warn(
+                                `SW install invalid manifest response (attempt ${attempt + 1})`,
+                        );
+                } catch (err) {
+                        console.warn(
+                                `SW install failed to fetch manifest (attempt ${attempt + 1})`,
+                                err,
+                        );
+                }
+        }
+        console.warn(
+                "SW install proceeding without dynamic resources; manifest unreachable",
+        );
+        return null;
 }
 
 self.addEventListener("install", (event) => {
-	self.skipWaiting();
-	event.waitUntil(
-		(async () => {
-			const cache = await caches.open(CACHE_NAME);
-			const resources = [
+        self.skipWaiting();
+        event.waitUntil(
+                (async () => {
+                        const cache = await caches.open(CACHE_NAME);
+                        const resources = [
 				"/app/posapp",
 				"/assets/posawesome/js/posapp/workers/itemWorker.js",
 				"/assets/posawesome/js/libs/dexie.min.js",
 				"/manifest.json",
-				"/offline.html",
-			];
-			try {
-				const manifest = await fetch("/assets/posawesome/dist/js/manifest.json").then((r) =>
-					r.json(),
-				);
-				Object.values(manifest).forEach((item) => {
-					resources.push(`/assets/posawesome/dist/js/${item.file}`);
-				});
-			} catch (err) {
-				console.warn("SW install failed to load manifest", err);
-			}
-			await Promise.all(
-				resources.map(async (url) => {
-					try {
-						const resp = await fetch(url);
-						if (resp && resp.ok) {
+                                "/offline.html",
+                        ];
+                        const manifest = await loadManifest();
+                        if (manifest) {
+                                Object.values(manifest).forEach((item) => {
+                                        resources.push(`/assets/posawesome/dist/js/${item.file}`);
+                                });
+                        }
+                        await Promise.all(
+                                resources.map(async (url) => {
+                                        try {
+                                                const resp = await fetch(url);
+                                                if (resp && resp.ok) {
 							await cache.put(url, resp.clone());
 						}
 					} catch (err) {
@@ -73,13 +94,14 @@ self.addEventListener("fetch", (event) => {
 	if (event.request.mode === "navigate") {
 		event.respondWith(
 			(async () => {
-				try {
-					return await fetch(event.request);
-				} catch (err) {
-					const cached = await caches.match(event.request, { ignoreSearch: true });
-					if (cached) {
-						return cached;
-					}
+                                try {
+                                        return await fetch(event.request);
+                                } catch (err) {
+                                        console.warn("SW navigation fetch failed", err);
+                                        const cached = await caches.match(event.request, { ignoreSearch: true });
+                                        if (cached) {
+                                                return cached;
+                                        }
 
 					const appShell = await caches.match("/app/posapp");
 					if (appShell) {
@@ -105,26 +127,28 @@ self.addEventListener("fetch", (event) => {
 				if (cached) {
 					return cached;
 				}
-				const resp = await fetch(event.request);
-				if (resp && resp.ok && resp.status === 200) {
-					try {
-						const clone = resp.clone();
-						const cache = await caches.open(CACHE_NAME);
-						await cache.put(event.request, clone);
-						await enforceCacheLimit(cache);
-					} catch (e) {
-						console.warn("SW cache put failed", e);
-					}
-				}
-				return resp;
-			} catch (err) {
-				try {
-					const fallback = await caches.match(event.request);
-					return fallback || Response.error();
-				} catch (e) {
-					return Response.error();
-				}
-			}
-		})(),
-	);
+                                const resp = await fetch(event.request);
+                                if (resp && resp.ok && resp.status === 200) {
+                                        try {
+                                                const clone = resp.clone();
+                                                const cache = await caches.open(CACHE_NAME);
+                                                await cache.put(event.request, clone);
+                                                await enforceCacheLimit(cache);
+                                        } catch (e) {
+                                                console.warn("SW cache put failed", e);
+                                        }
+                                }
+                                return resp;
+                        } catch (err) {
+                                console.warn("SW fetch handler failed", err);
+                                try {
+                                        const fallback = await caches.match(event.request);
+                                        return fallback || Response.error();
+                                } catch (e) {
+                                        console.warn("SW fallback retrieval failed", e);
+                                        return Response.error();
+                                }
+                        }
+                })(),
+        );
 });


### PR DESCRIPTION
## Summary
- improve manifest loading by validating response and content-type
- proceed without dynamic assets if manifest unreachable
- add retry and skip cache to avoid stale manifests

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint posawesome/www/sw.js`


------
https://chatgpt.com/codex/tasks/task_e_6892e3c15a8c83268688aa9105205a8f