### PR TITLE
feat: migrate pos profile data to pinia store

### DIFF
--- a/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
+++ b/posawesome/public/js/posapp/components/pos/OpeningDialog.vue
@@ -125,12 +125,13 @@
 <script>
 import format from "../../format";
 import {
-	getOpeningDialogStorage,
-	setOpeningDialogStorage,
-	setOpeningStorage,
-	initPromise,
-	checkDbHealth,
+        getOpeningDialogStorage,
+        setOpeningDialogStorage,
+        setOpeningStorage,
+        initPromise,
+        checkDbHealth,
 } from "../../../offline/index.js";
+import { usePosProfileStore } from "../../stores/posProfile.js";
 
 export default {
 	mixins: [format],
@@ -242,34 +243,35 @@ export default {
 			});
 		},
 
-		submit_dialog() {
-			if (!this.payments_methods.length || !this.company || !this.pos_profile) {
-				return;
-			}
+                submit_dialog() {
+                        if (!this.payments_methods.length || !this.company || !this.pos_profile) {
+                                return;
+                        }
 
-			this.is_loading = true;
-			const vm = this;
+                        this.is_loading = true;
+                        const vm = this;
+                        const posProfileStore = usePosProfileStore();
 
-			return frappe
-				.call("posawesome.posawesome.api.shifts.create_opening_voucher", {
-					pos_profile: this.pos_profile,
-					company: this.company,
-					balance_details: this.payments_methods,
-				})
-				.then((r) => {
-					if (r.message) {
-						vm.eventBus.emit("register_pos_data", r.message);
-						vm.eventBus.emit("set_company", r.message.company);
-						try {
-							setOpeningStorage(r.message);
-						} catch (e) {
-							console.error("Failed to cache opening data", e);
-						}
-						vm.close_opening_dialog();
-						vm.is_loading = false;
-					}
-				});
-		},
+                        return frappe
+                                .call("posawesome.posawesome.api.shifts.create_opening_voucher", {
+                                        pos_profile: this.pos_profile,
+                                        company: this.company,
+                                        balance_details: this.payments_methods,
+                                })
+                                .then((r) => {
+                                        if (r.message) {
+                                                posProfileStore.registerPosData(r.message);
+                                                vm.eventBus.emit("set_company", r.message.company);
+                                                try {
+                                                        setOpeningStorage(r.message);
+                                                } catch (e) {
+                                                        console.error("Failed to cache opening data", e);
+                                                }
+                                                vm.close_opening_dialog();
+                                                vm.is_loading = false;
+                                        }
+                                });
+                },
 
 		go_desk() {
 			frappe.set_route("/");

--- a/posawesome/public/js/posapp/components/pos/Pos.vue
+++ b/posawesome/public/js/posapp/components/pos/Pos.vue
@@ -108,48 +108,42 @@ export default {
 		SalesOrders,
 	},
 
-	methods: {
-		create_opening_voucher() {
-			this.dialog = true;
-		},
-		get_pos_setting() {
+        methods: {
+                create_opening_voucher() {
+                        this.dialog = true;
+                },
+                get_pos_setting() {
 			frappe.db.get_doc("POS Settings", undefined).then((doc) => {
 				this.eventBus.emit("set_pos_settings", doc);
 			});
 		},
-		checkLoadingComplete() {
-			if (this.itemsLoaded && this.customersLoaded) {
-				console.info("Loading completed");
-			}
-		},
-	},
+                checkLoadingComplete() {
+                        if (this.itemsLoaded && this.customersLoaded) {
+                                console.info("Loading completed");
+                        }
+                },
+        },
 
-	mounted: function () {
-		this.$nextTick(function () {
-			this.check_opening_entry();
-			this.get_pos_setting();
-			this.eventBus.on("close_opening_dialog", () => {
-				this.dialog = false;
-			});
-			this.eventBus.on("register_pos_data", (data) => {
-				this.pos_profile = data.pos_profile;
-				this.get_offers(this.pos_profile.name, this.pos_profile);
-				this.pos_opening_shift = data.pos_opening_shift;
-				this.eventBus.emit("register_pos_profile", data);
-				console.info("LoadPosProfile");
-			});
-			// When profile is registered directly from composables,
-			// ensure offers are fetched as well
-			this.eventBus.on("register_pos_profile", (data) => {
-				if (data && data.pos_profile) {
-					this.get_offers(data.pos_profile.name, data.pos_profile);
-				}
-			});
+        watch: {
+                pos_profile(newVal) {
+                        if (newVal) {
+                                this.get_offers(newVal.name, newVal);
+                        }
+                },
+        },
+
+        mounted: function () {
+                this.$nextTick(function () {
+                        this.check_opening_entry();
+                        this.get_pos_setting();
+                        this.eventBus.on("close_opening_dialog", () => {
+                                this.dialog = false;
+                        });
                         this.eventBus.on("open_closing_dialog", () => {
                                 this.get_closing_data();
                         });
-			this.eventBus.on("submit_closing_pos", (data) => {
-				this.submit_closing_pos(data);
+                        this.eventBus.on("submit_closing_pos", (data) => {
+                                this.submit_closing_pos(data);
 			});
 
 			this.eventBus.on("items_loaded", () => {
@@ -161,17 +155,14 @@ export default {
 				this.checkLoadingComplete();
 			});
 		});
-	},
-	beforeUnmount() {
-		this.eventBus.off("close_opening_dialog");
-		this.eventBus.off("register_pos_data");
-		this.eventBus.off("register_pos_profile");
-		this.eventBus.off("LoadPosProfile");
+        },
+        beforeUnmount() {
+                this.eventBus.off("close_opening_dialog");
                 this.eventBus.off("open_closing_dialog");
                 this.eventBus.off("submit_closing_pos");
                 this.eventBus.off("items_loaded");
-		this.eventBus.off("customers_loaded");
-	},
+                this.eventBus.off("customers_loaded");
+        },
 	// In the created() or mounted() lifecycle hook
 	created() {
 		// Clean up expired customer balance cache on POS load

--- a/posawesome/public/js/posapp/composables/useItemAddition.js
+++ b/posawesome/public/js/posapp/composables/useItemAddition.js
@@ -1,7 +1,10 @@
-import { ref, nextTick } from "vue";
+/* global frappe, __ */
+import { nextTick } from "vue";
 import _ from "lodash";
+import { usePosProfileStore } from "../stores/posProfile.js";
 
 export function useItemAddition() {
+        const posProfileStore = usePosProfileStore();
 	// Remove item from invoice
 	const removeItem = (item, context) => {
 		const index = context.items.findIndex((el) => el.posa_row_id == item.posa_row_id);
@@ -68,14 +71,16 @@ export function useItemAddition() {
 
 			// Attempt to fetch an explicit rate for this UOM from the active price list
 			try {
-				const r = await frappe.call({
-					method: "posawesome.posawesome.api.items.get_price_for_uom",
-					args: {
-						item_code: new_item.item_code,
-						price_list: context.get_price_list ? context.get_price_list() : null,
-						uom: new_item.uom,
-					},
-				});
+                                const r = await frappe.call({
+                                        method: "posawesome.posawesome.api.items.get_price_for_uom",
+                                        args: {
+                                                item_code: new_item.item_code,
+                                                price_list:
+                                                        (context.get_price_list && context.get_price_list()) ||
+                                                        posProfileStore.posProfile?.selling_price_list,
+                                                uom: new_item.uom,
+                                        },
+                                });
 				if (r.message) {
 					const price = parseFloat(r.message);
 					const baseCurrency = context.price_list_currency || context.pos_profile.currency;

--- a/posawesome/public/js/posapp/composables/usePosShift.js
+++ b/posawesome/public/js/posapp/composables/usePosShift.js
@@ -1,4 +1,7 @@
-import { ref, getCurrentInstance } from "vue";
+/* global frappe */
+import { getCurrentInstance } from "vue";
+import { storeToRefs } from "pinia";
+import { usePosProfileStore } from "../stores/posProfile.js";
 import {
     initPromise,
     checkDbHealth,
@@ -12,8 +15,9 @@ export function usePosShift(openDialog) {
     const { proxy } = getCurrentInstance();
     const eventBus = proxy?.eventBus;
 
-    const pos_profile = ref(null);
-    const pos_opening_shift = ref(null);
+    const posProfileStore = usePosProfileStore();
+    const { posProfile: pos_profile, posOpeningShift: pos_opening_shift } =
+        storeToRefs(posProfileStore);
 
     async function check_opening_entry() {
         await initPromise;
@@ -24,9 +28,9 @@ export function usePosShift(openDialog) {
             })
             .then((r) => {
                 if (r.message) {
-                    pos_profile.value = r.message.pos_profile;
-                    pos_opening_shift.value = r.message.pos_opening_shift;
-                    if (pos_profile.value.taxes_and_charges) {
+                    posProfileStore.registerPosData(r.message);
+                    eventBus?.emit("register_pos_profile", r.message);
+                    if (pos_profile.value?.taxes_and_charges) {
                         frappe.call({
                             method: "frappe.client.get",
                             args: {
@@ -43,7 +47,6 @@ export function usePosShift(openDialog) {
                             },
                         });
                     }
-                    eventBus?.emit("register_pos_profile", r.message);
                     eventBus?.emit("set_company", r.message.company);
                     try {
                         frappe.realtime.emit("pos_profile_registered");
@@ -59,8 +62,7 @@ export function usePosShift(openDialog) {
                 } else {
                     const data = getOpeningStorage();
                     if (data) {
-                        pos_profile.value = data.pos_profile;
-                        pos_opening_shift.value = data.pos_opening_shift;
+                        posProfileStore.registerPosData(data);
                         eventBus?.emit("register_pos_profile", data);
                         eventBus?.emit("set_company", data.company);
                         try {
@@ -77,8 +79,7 @@ export function usePosShift(openDialog) {
             .catch(() => {
                 const data = getOpeningStorage();
                 if (data) {
-                    pos_profile.value = data.pos_profile;
-                    pos_opening_shift.value = data.pos_opening_shift;
+                    posProfileStore.registerPosData(data);
                     eventBus?.emit("register_pos_profile", data);
                     eventBus?.emit("set_company", data.company);
                     try {
@@ -114,8 +115,7 @@ export function usePosShift(openDialog) {
             )
             .then((r) => {
                 if (r.message) {
-                    pos_opening_shift.value = null;
-                    pos_profile.value = null;
+                    posProfileStore.clear();
                     clearOpeningStorage();
                     eventBus?.emit("show_message", {
                         title: `POS Shift Closed`,
@@ -126,5 +126,11 @@ export function usePosShift(openDialog) {
             });
     }
 
-    return { pos_profile, pos_opening_shift, check_opening_entry, get_closing_data, submit_closing_pos };
+    return {
+        pos_profile,
+        pos_opening_shift,
+        check_opening_entry,
+        get_closing_data,
+        submit_closing_pos,
+    };
 }

--- a/posawesome/public/js/posapp/stores/posProfile.js
+++ b/posawesome/public/js/posapp/stores/posProfile.js
@@ -1,0 +1,29 @@
+import { defineStore } from "pinia";
+
+export const usePosProfileStore = defineStore("posProfile", {
+        state: () => ({
+                posProfile: null,
+                posOpeningShift: null,
+        }),
+        actions: {
+                registerPosData(data) {
+                        if (data?.pos_profile) {
+                                this.posProfile = data.pos_profile;
+                        }
+                        if (data?.pos_opening_shift) {
+                                this.posOpeningShift = data.pos_opening_shift;
+                        }
+                },
+                setPosProfile(profile) {
+                        this.posProfile = profile;
+                },
+                setPosOpeningShift(shift) {
+                        this.posOpeningShift = shift;
+                },
+                clear() {
+                        this.posProfile = null;
+                        this.posOpeningShift = null;
+                },
+        },
+});
+


### PR DESCRIPTION
## Summary
- add a Pinia store for POS profile and opening shift
- refactor POS startup logic to read POS profile from the store
- update Home and Opening dialog components to use the new store
- restore legacy `register_pos_profile` event emissions so existing components stay in sync
- supply a fallback price list from the store when fetching UOM pricing

## Testing
- `npx eslint posawesome/public/js/posapp/composables/usePosShift.js posawesome/public/js/posapp/composables/useItemAddition.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68938db3a3288326943912c218d71b84