### PR TITLE
feat: use indexed queries for item search

### DIFF
--- a/posawesome/public/js/offline/core.js
+++ b/posawesome/public/js/offline/core.js
@@ -3,13 +3,29 @@ import { withWriteLock } from "./db-utils.js";
 
 // --- Dexie initialization ---------------------------------------------------
 export const db = new Dexie("posawesome_offline");
-db.version(4).stores({
-	keyval: "&key",
-	queue: "&key",
-	cache: "&key",
-	items: "&item_code,item_name,item_group",
-	item_prices: "&[price_list+item_code],price_list,item_code",
-});
+db.version(5)
+	.stores({
+		keyval: "&key",
+		queue: "&key",
+		cache: "&key",
+		items: "&item_code,item_name,item_group,*barcodes,*name_keywords",
+		item_prices: "&[price_list+item_code],price_list,item_code",
+	})
+	.upgrade((tx) =>
+		tx
+			.table("items")
+			.toCollection()
+			.modify((item) => {
+				item.barcodes = Array.isArray(item.item_barcode)
+					? item.item_barcode.map((b) => b.barcode).filter(Boolean)
+					: item.item_barcode
+						? [String(item.item_barcode)]
+						: [];
+				item.name_keywords = item.item_name
+					? item.item_name.toLowerCase().split(/\s+/).filter(Boolean)
+					: [];
+			}),
+	);
 
 export const KEY_TABLE_MAP = {
 	offline_invoices: "queue",
@@ -73,7 +89,7 @@ export function initPersistWorker() {
 		const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
 		try {
 			persistWorker = new Worker(workerUrl, { type: "classic" });
-		} catch (err) {
+		} catch {
 			persistWorker = new Worker(workerUrl, { type: "module" });
 		}
 	} catch (e) {


### PR DESCRIPTION
## Summary
- replace item search filtering with indexed Dexie queries and fallback scan
- extend Dexie schema with barcode and name keyword indexes
- populate new indexes in worker to speed lookups

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint posawesome/public/js/offline/core.js posawesome/public/js/offline/items.js posawesome/public/js/posapp/workers/itemWorker.js`
- `npx prettier --check posawesome/public/js/offline/core.js posawesome/public/js/offline/items.js posawesome/public/js/posapp/workers/itemWorker.js`


------
https://chatgpt.com/codex/tasks/task_e_6893b6d78b7c83268f7126f315c4a9da