### PR TITLE
feat: share item details request

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -430,10 +430,10 @@ export default {
 		customer: null,
 		new_line: false,
 		qty: 1,
-		refresh_interval: null,
-		currentRequest: null,
-		abortController: null,
-		itemDetailsRetryCount: 0,
+               refresh_interval: null,
+               abortController: null,
+               itemDetailsRequestCache: { key: null, promise: null, result: null },
+               itemDetailsRetryCount: 0,
 		itemDetailsRetryTimeout: null,
 		items_loaded: false,
 		selected_currency: "",
@@ -685,105 +685,164 @@ export default {
                         }
                         this.isOverflowing = el.scrollHeight > maxHeight;
                 },
-                refreshPricesForVisibleItems() {
+                async fetchItemDetails(items) {
+                        const profile = this.pos_profile ? this.pos_profile.name : "";
+                        const priceList = this.active_price_list;
+                        const itemCodes = (items || []).map((it) => it.item_code).sort();
+                        const key = JSON.stringify([profile, priceList, itemCodes]);
+
+                        if (
+                                this.itemDetailsRequestCache.key === key &&
+                                this.itemDetailsRequestCache.result
+                        ) {
+                                return this.itemDetailsRequestCache.result;
+                        }
+
+                        if (
+                                this.itemDetailsRequestCache.key === key &&
+                                this.itemDetailsRequestCache.promise
+                        ) {
+                                return this.itemDetailsRequestCache.promise;
+                        }
+
+                        this.cancelItemDetailsRequest();
+                        this.itemDetailsRequestCache.key = key;
+
+                        this.abortController = new AbortController();
+                        const requestPromise = frappe
+                                .call({
+                                        method: "posawesome.posawesome.api.items.get_items_details",
+                                        args: {
+                                                pos_profile: JSON.stringify(this.pos_profile),
+                                                items_data: JSON.stringify(items),
+                                                price_list: this.active_price_list,
+                                        },
+                                        freeze: false,
+                                        signal: this.abortController.signal,
+                                })
+                                .then((r) => {
+                                        const msg = (r && r.message) || [];
+                                        if (this.itemDetailsRequestCache.key === key) {
+                                                this.itemDetailsRequestCache.result = msg;
+                                        }
+                                        return msg;
+                                })
+                                .catch((err) => {
+                                        if (err.name !== "AbortError") {
+                                                console.error("Error fetching item details:", err);
+                                        }
+                                        throw err;
+                                })
+                                .finally(() => {
+                                        if (this.itemDetailsRequestCache.key === key) {
+                                                this.itemDetailsRequestCache.promise = null;
+                                        }
+                                        this.abortController = null;
+                                });
+
+                        this.itemDetailsRequestCache.promise = requestPromise;
+                        return requestPromise;
+                },
+                cancelItemDetailsRequest() {
+                        if (this.abortController) {
+                                this.abortController.abort();
+                                this.abortController = null;
+                        }
+                        if (this.itemDetailsRequestCache) {
+                                this.itemDetailsRequestCache.key = null;
+                                this.itemDetailsRequestCache.promise = null;
+                                this.itemDetailsRequestCache.result = null;
+                        }
+                },
+                async refreshPricesForVisibleItems() {
                         const vm = this;
                         if (!vm.filtered_items || vm.filtered_items.length === 0) return;
 
-			vm.loading = true;
+                        vm.loading = true;
 
-			// Cancel previous request if any
-			if (vm.currentRequest) {
-				vm.abortController.abort();
-				vm.currentRequest = null;
-			}
+                        const itemCodes = vm.filtered_items.map((it) => it.item_code);
+                        const cacheResult = getCachedItemDetails(vm.pos_profile.name, vm.active_price_list, itemCodes);
+                        const updates = [];
 
-			const itemCodes = vm.filtered_items.map((it) => it.item_code);
-			const cacheResult = getCachedItemDetails(vm.pos_profile.name, vm.active_price_list, itemCodes);
-			const updates = [];
+                        cacheResult.cached.forEach((det) => {
+                                const item = vm.filtered_items.find((it) => it.item_code === det.item_code);
+                                if (item) {
+                                        const upd = {
+                                                actual_qty: det.actual_qty,
+                                                serial_no_data: det.serial_no_data,
+                                                batch_no_data: det.batch_no_data,
+                                        };
+                                        if (det.item_uoms && det.item_uoms.length > 0) {
+                                                upd.item_uoms = det.item_uoms;
+                                                saveItemUOMs(item.item_code, det.item_uoms);
+                                        }
+                                        if (det.rate !== undefined) {
+                                                if (det.rate !== 0 || !item.rate) {
+                                                        upd.rate = det.rate;
+                                                        upd.price_list_rate = det.price_list_rate || det.rate;
+                                                }
+                                        }
+                                        updates.push({ item, upd });
+                                }
+                        });
 
-			cacheResult.cached.forEach((det) => {
-				const item = vm.filtered_items.find((it) => it.item_code === det.item_code);
-				if (item) {
-					const upd = {
-						actual_qty: det.actual_qty,
-						serial_no_data: det.serial_no_data,
-						batch_no_data: det.batch_no_data,
-					};
-					if (det.item_uoms && det.item_uoms.length > 0) {
-						upd.item_uoms = det.item_uoms;
-						saveItemUOMs(item.item_code, det.item_uoms);
-					}
-					if (det.rate !== undefined) {
-						if (det.rate !== 0 || !item.rate) {
-							upd.rate = det.rate;
-							upd.price_list_rate = det.price_list_rate || det.rate;
-						}
-					}
-					updates.push({ item, upd });
-				}
-			});
+                        if (cacheResult.missing.length === 0) {
+                                vm.$nextTick(() => {
+                                        updates.forEach(({ item, upd }) => Object.assign(item, upd));
+                                        updateLocalStockCache(cacheResult.cached);
+                                        vm.loading = false;
+                                });
+                                return;
+                        }
 
-			if (cacheResult.missing.length === 0) {
-				vm.$nextTick(() => {
-					updates.forEach(({ item, upd }) => Object.assign(item, upd));
-					updateLocalStockCache(cacheResult.cached);
-					vm.loading = false;
-				});
-				return;
-			}
+                        const itemsToFetch = vm.filtered_items.filter((it) =>
+                                cacheResult.missing.includes(it.item_code),
+                        );
 
-			vm.abortController = new AbortController();
-			const itemsToFetch = vm.filtered_items.filter((it) => cacheResult.missing.includes(it.item_code));
+                        try {
+                                const details = await vm.fetchItemDetails(itemsToFetch);
+                                details.forEach((updItem) => {
+                                        const item = vm.filtered_items.find(
+                                                (it) => it.item_code === updItem.item_code,
+                                        );
+                                        if (item) {
+                                                const upd = {
+                                                        actual_qty: updItem.actual_qty,
+                                                        serial_no_data: updItem.serial_no_data,
+                                                        batch_no_data: updItem.batch_no_data,
+                                                };
+                                                if (updItem.item_uoms && updItem.item_uoms.length > 0) {
+                                                        upd.item_uoms = updItem.item_uoms;
+                                                        saveItemUOMs(item.item_code, updItem.item_uoms);
+                                                }
+                                                if (updItem.rate !== undefined) {
+                                                        if (updItem.rate !== 0 || !item.rate) {
+                                                                upd.rate = updItem.rate;
+                                                                upd.price_list_rate =
+                                                                        updItem.price_list_rate || updItem.rate;
+                                                        }
+                                                }
+                                                updates.push({ item, upd });
+                                        }
+                                });
 
-			frappe.call({
-				method: "posawesome.posawesome.api.items.get_items_details",
-				args: {
-					pos_profile: JSON.stringify(vm.pos_profile),
-					items_data: JSON.stringify(itemsToFetch),
-					price_list: vm.active_price_list,
-				},
-				freeze: false,
-				signal: vm.abortController.signal,
-				callback: function (r) {
-					if (r.message) {
-						r.message.forEach((updItem) => {
-							const item = vm.filtered_items.find((it) => it.item_code === updItem.item_code);
-							if (item) {
-								const upd = {
-									actual_qty: updItem.actual_qty,
-									serial_no_data: updItem.serial_no_data,
-									batch_no_data: updItem.batch_no_data,
-								};
-								if (updItem.item_uoms && updItem.item_uoms.length > 0) {
-									upd.item_uoms = updItem.item_uoms;
-									saveItemUOMs(item.item_code, updItem.item_uoms);
-								}
-								if (updItem.rate !== undefined) {
-									if (updItem.rate !== 0 || !item.rate) {
-										upd.rate = updItem.rate;
-										upd.price_list_rate = updItem.price_list_rate || updItem.rate;
-									}
-								}
-								updates.push({ item, upd });
-							}
-						});
-
-						vm.$nextTick(() => {
-							updates.forEach(({ item, upd }) => Object.assign(item, upd));
-							updateLocalStockCache(r.message);
-							saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, r.message);
-							vm.loading = false;
-						});
-					}
-				},
-				error: function (err) {
-					if (err.name !== "AbortError") {
-						console.error("Error fetching item details:", err);
-						vm.loading = false;
-					}
-				},
-			});
-		},
+                                vm.$nextTick(() => {
+                                        updates.forEach(({ item, upd }) => Object.assign(item, upd));
+                                        updateLocalStockCache(details);
+                                        saveItemDetailsCache(
+                                                vm.pos_profile.name,
+                                                vm.active_price_list,
+                                                details,
+                                        );
+                                        vm.loading = false;
+                                });
+                        } catch (err) {
+                                if (err.name !== "AbortError") {
+                                        console.error("Error fetching item details:", err);
+                                        vm.loading = false;
+                                }
+                        }
+                },
 
 		show_offers() {
 			this.eventBus.emit("show_offers", "true");
@@ -809,10 +868,11 @@ export default {
 			this.items_loaded = false;
 			this.get_items(true);
 		},
-		async get_items(force_server = false) {
-			await initPromise;
-			await checkDbHealth();
-			const request_token = ++this.items_request_token;
+               async get_items(force_server = false) {
+                        await initPromise;
+                        await checkDbHealth();
+                        this.cancelItemDetailsRequest();
+                        const request_token = ++this.items_request_token;
 			if (!this.pos_profile) {
 				console.error("No POS Profile");
 				return;
@@ -1426,8 +1486,10 @@ export default {
 				this.$refs.debounce_search.focus();
 			}
 		},
-		search_onchange: _.debounce(async function (newSearchTerm) {
-			const vm = this;
+               search_onchange: _.debounce(async function (newSearchTerm) {
+                       const vm = this;
+
+                       vm.cancelItemDetailsRequest();
 
 			// Determine the actual query string and trim whitespace
 			const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
@@ -1586,84 +1648,72 @@ export default {
 				return;
 			}
 
-			// Cancel previous request
-			if (vm.currentRequest) {
-				vm.abortController.abort();
-				vm.currentRequest = null;
-			}
+                       const itemsToFetch = items.filter(
+                               (it) => cacheResult.missing.includes(it.item_code) && !it.has_variants,
+                       );
 
-			vm.abortController = new AbortController();
+                       if (itemsToFetch.length === 0) {
+                               vm.itemDetailsRetryCount = 0;
+                               return;
+                       }
 
-			const itemsToFetch = items.filter(
-				(it) => cacheResult.missing.includes(it.item_code) && !it.has_variants,
-			);
+                       try {
+                               const details = await vm.fetchItemDetails(itemsToFetch);
+                               if (details && details.length) {
+                                       vm.itemDetailsRetryCount = 0;
+                                       let qtyChanged = false;
+                                       let updatedItems = [];
 
-			if (itemsToFetch.length === 0) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                                       items.forEach((item) => {
+                                               const updated_item = details.find(
+                                                       (element) => element.item_code == item.item_code,
+                                               );
+                                               if (updated_item) {
+                                                       const prev_qty = item.actual_qty;
 
-			try {
-				vm.currentRequest = await frappe.call({
-					method: "posawesome.posawesome.api.items.get_items_details",
-					args: {
-						pos_profile: JSON.stringify(vm.pos_profile),
-						items_data: JSON.stringify(itemsToFetch),
-						price_list: vm.active_price_list,
-					},
-					freeze: false,
-					signal: vm.abortController.signal,
-				});
+                                                       updatedItems.push({
+                                                               item: item,
+                                                               updates: {
+                                                                       actual_qty: updated_item.actual_qty,
+                                                                       serial_no_data: updated_item.serial_no_data,
+                                                                       batch_no_data: updated_item.batch_no_data,
+                                                                       has_batch_no: updated_item.has_batch_no,
+                                                                       has_serial_no: updated_item.has_serial_no,
+                                                                       item_uoms:
+                                                                               updated_item.item_uoms &&
+                                                                               updated_item.item_uoms.length > 0
+                                                                                       ? updated_item.item_uoms
+                                                                                       : item.item_uoms,
+                                                               },
+                                                       });
 
-				const r = vm.currentRequest;
-				if (r && r.message) {
-					vm.itemDetailsRetryCount = 0;
-					let qtyChanged = false;
-					let updatedItems = [];
+                                                       if (prev_qty > 0 && updated_item.actual_qty === 0) {
+                                                               qtyChanged = true;
+                                                       }
 
-					items.forEach((item) => {
-						const updated_item = r.message.find((element) => element.item_code == item.item_code);
-						if (updated_item) {
-							const prev_qty = item.actual_qty;
+                                                       if (updated_item.item_uoms && updated_item.item_uoms.length > 0) {
+                                                               saveItemUOMs(item.item_code, updated_item.item_uoms);
+                                                       }
+                                               }
+                                       });
 
-							updatedItems.push({
-								item: item,
-								updates: {
-									actual_qty: updated_item.actual_qty,
-									serial_no_data: updated_item.serial_no_data,
-									batch_no_data: updated_item.batch_no_data,
-									has_batch_no: updated_item.has_batch_no,
-									has_serial_no: updated_item.has_serial_no,
-									item_uoms:
-										updated_item.item_uoms && updated_item.item_uoms.length > 0
-											? updated_item.item_uoms
-											: item.item_uoms,
-								},
-							});
+                                       updatedItems.forEach(({ item, updates }) => {
+                                               Object.assign(item, updates);
+                                               vm.applyCurrencyConversionToItem(item);
+                                       });
 
-							if (prev_qty > 0 && updated_item.actual_qty === 0) {
-								qtyChanged = true;
-							}
+                                       updateLocalStockCache(details);
+                                       saveItemDetailsCache(
+                                               vm.pos_profile.name,
+                                               vm.active_price_list,
+                                               details,
+                                       );
 
-							if (updated_item.item_uoms && updated_item.item_uoms.length > 0) {
-								saveItemUOMs(item.item_code, updated_item.item_uoms);
-							}
-						}
-					});
-
-					updatedItems.forEach(({ item, updates }) => {
-						Object.assign(item, updates);
-						vm.applyCurrencyConversionToItem(item);
-					});
-
-					updateLocalStockCache(r.message);
-					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, r.message);
-
-					if (qtyChanged) {
-						vm.$forceUpdate();
-					}
-				}
-			} catch (err) {
+                                       if (qtyChanged) {
+                                               vm.$forceUpdate();
+                                       }
+                               }
+                       } catch (err) {
 				if (err.name !== "AbortError") {
 					console.error("Error fetching item details:", err);
 					items.forEach((item) => {


### PR DESCRIPTION
## Summary
- share cached `get_items_details` request between price refresh and item updates
- abort outstanding item detail calls when a new search or reload begins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6893b6e7b8a48326a7f049ab2dcc176b