### PR TITLE
feat: cache minimal item details

### DIFF
--- a/posawesome/public/js/offline/items.js
+++ b/posawesome/public/js/offline/items.js
@@ -91,7 +91,7 @@ export async function getCachedPriceListItems(priceList, ttl = 24 * 60 * 60 * 10
 					: null;
 			})
 			.filter(Boolean);
-               return result;
+		return result;
 	} catch (e) {
 		console.error("Failed to get cached price list items", e);
 		return null;
@@ -121,7 +121,19 @@ export function saveItemDetailsCache(profileName, priceList, items) {
 
 		let cleanItems;
 		try {
-			cleanItems = JSON.parse(JSON.stringify(items));
+			// Store only fields required for offline usage
+			cleanItems = items.map((it) => ({
+				item_code: it.item_code,
+				actual_qty: it.actual_qty,
+				serial_no_data: it.serial_no_data,
+				batch_no_data: it.batch_no_data,
+				has_batch_no: it.has_batch_no,
+				has_serial_no: it.has_serial_no,
+				item_uoms: it.item_uoms,
+				rate: it.rate,
+				price_list_rate: it.price_list_rate,
+			}));
+			cleanItems = JSON.parse(JSON.stringify(cleanItems));
 		} catch (err) {
 			console.error("Failed to serialize item details", err);
 			cleanItems = [];
@@ -142,7 +154,7 @@ export function saveItemDetailsCache(profileName, priceList, items) {
 	}
 }
 
-export function getCachedItemDetails(profileName, priceList, itemCodes, ttl = 15 * 60 * 1000) {
+export async function getCachedItemDetails(profileName, priceList, itemCodes, ttl = 15 * 60 * 1000) {
 	try {
 		const cache = memory.item_details_cache || {};
 		const priceCache = cache[profileName]?.[priceList] || {};
@@ -157,7 +169,23 @@ export function getCachedItemDetails(profileName, priceList, itemCodes, ttl = 15
 				missing.push(code);
 			}
 		});
-               return { cached, missing };
+
+		if (cached.length) {
+			await checkDbHealth();
+			if (!db.isOpen()) await db.open();
+			const baseItems = await db
+				.table("items")
+				.where("item_code")
+				.anyOf(cached.map((it) => it.item_code))
+				.toArray();
+			const map = new Map(baseItems.map((it) => [it.item_code, it]));
+			cached.forEach((det, idx) => {
+				const base = map.get(det.item_code) || {};
+				cached[idx] = { ...base, ...det };
+			});
+		}
+
+		return { cached, missing };
 	} catch (e) {
 		console.error("Failed to get cached item details", e);
 		return { cached: [], missing: itemCodes };
@@ -202,19 +230,19 @@ export async function searchStoredItems({ search = "", itemGroup = "", limit = 1
 		if (itemGroup && itemGroup.toLowerCase() !== "all") {
 			collection = collection.where("item_group").equalsIgnoreCase(itemGroup);
 		}
-                if (search) {
-                        const term = search.toLowerCase();
-                        collection = collection.filter((it) => {
-                                const nameMatch = it.item_name && it.item_name.toLowerCase().includes(term);
-                                const codeMatch = it.item_code && it.item_code.toLowerCase().includes(term);
-                                const barcodeMatch = Array.isArray(it.item_barcode)
-                                        ? it.item_barcode.some((b) => b.barcode && b.barcode.toLowerCase() === term)
-                                        : it.item_barcode && String(it.item_barcode).toLowerCase().includes(term);
-                                return nameMatch || codeMatch || barcodeMatch;
-                        });
-                }
+		if (search) {
+			const term = search.toLowerCase();
+			collection = collection.filter((it) => {
+				const nameMatch = it.item_name && it.item_name.toLowerCase().includes(term);
+				const codeMatch = it.item_code && it.item_code.toLowerCase().includes(term);
+				const barcodeMatch = Array.isArray(it.item_barcode)
+					? it.item_barcode.some((b) => b.barcode && b.barcode.toLowerCase() === term)
+					: it.item_barcode && String(it.item_barcode).toLowerCase().includes(term);
+				return nameMatch || codeMatch || barcodeMatch;
+			});
+		}
 		const res = await collection.offset(offset).limit(limit).toArray();
-               return res;
+		return res;
 	} catch (e) {
 		console.error("Failed to query stored items", e);
 		return [];

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2,17 +2,17 @@
 	<div :style="responsiveStyles">
 		<v-card
 			:class="[
-                               'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
+				'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
 				isDarkTheme ? '' : 'bg-grey-lighten-5',
 			]"
 			:style="{
 				height: responsiveStyles['--container-height'],
 				maxHeight: responsiveStyles['--container-height'],
-                               backgroundColor: isDarkTheme ? '#121212' : '',
-                               resize: 'vertical',
-                                overflow: items_view === 'card' ? 'hidden' : 'auto',
-                        }"
-                >
+				backgroundColor: isDarkTheme ? '#121212' : '',
+				resize: 'vertical',
+				overflow: items_view === 'card' ? 'hidden' : 'auto',
+			}"
+		>
 			<v-progress-linear
 				:active="loading"
 				:indeterminate="loading"
@@ -179,14 +179,14 @@
 				</div>
 				<v-row class="items">
 					<v-col cols="12" class="pt-0 mt-0">
-                                               <div
-                                                       fluid
-                                                       class="items-grid dynamic-scroll"
-                                                       ref="itemsContainer"
-                                                       v-if="items_view == 'card'"
-                                                       :class="{ 'item-container': isOverflowing }"
-                                                       @scroll.passive="onCardScroll"
-                                               >
+						<div
+							fluid
+							class="items-grid dynamic-scroll"
+							ref="itemsContainer"
+							v-if="items_view == 'card'"
+							:class="{ 'item-container': isOverflowing }"
+							@scroll.passive="onCardScroll"
+						>
 							<v-card
 								v-for="item in filtered_items"
 								:key="item.item_code"
@@ -458,10 +458,10 @@ export default {
 		// effectively disables incremental loading.
 		itemsPageLimit: 10000,
 		// Track if the current search was triggered by a scanner
-                search_from_scanner: false,
-                currentPage: 0,
-                isOverflowing: false,
-        }),
+		search_from_scanner: false,
+		currentPage: 0,
+		isOverflowing: false,
+	}),
 
 	watch: {
 		customer: _.debounce(function () {
@@ -584,17 +584,17 @@ export default {
 				this.loadVisibleItems(true);
 			}
 		},
-                filtered_items(new_value, old_value) {
-                        // Update item details if items changed
-                        if (
-                                this.pos_profile &&
-                                !this.pos_profile.pose_use_limit_search &&
-                                new_value.length !== old_value.length
-                        ) {
-                                this.update_items_details(new_value);
-                        }
-                        this.$nextTick(this.checkItemContainerOverflow);
-                },
+		filtered_items(new_value, old_value) {
+			// Update item details if items changed
+			if (
+				this.pos_profile &&
+				!this.pos_profile.pose_use_limit_search &&
+				new_value.length !== old_value.length
+			) {
+				this.update_items_details(new_value);
+			}
+			this.$nextTick(this.checkItemContainerOverflow);
+		},
 		// Automatically search and add item whenever the query changes
 		first_search: _.debounce(function (val) {
 			// Call without arguments so search_onchange treats it like an Enter key
@@ -618,21 +618,21 @@ export default {
 			// Maintain the configured items per page on resize
 			this.itemsPerPage = this.items_per_page;
 		},
-                items_loaded(val) {
-                        if (val) {
-                                this.eventBus.emit("items_loaded");
-                        }
-                },
-                items_view() {
-                        this.$nextTick(() => {
-                                if (this.items_view === "card") {
-                                        this.checkItemContainerOverflow();
-                                } else {
-                                        this.isOverflowing = false;
-                                }
-                        });
-                },
-        },
+		items_loaded(val) {
+			if (val) {
+				this.eventBus.emit("items_loaded");
+			}
+		},
+		items_view() {
+			this.$nextTick(() => {
+				if (this.items_view === "card") {
+					this.checkItemContainerOverflow();
+				} else {
+					this.isOverflowing = false;
+				}
+			});
+		},
+	},
 
 	methods: {
 		async loadVisibleItems(reset = false) {
@@ -663,31 +663,29 @@ export default {
 				this.loadVisibleItems();
 			}
 		},
-                onListScroll(event) {
-                        const el = event.target;
-                        if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
-                                this.currentPage += 1;
-                                this.loadVisibleItems();
-                        }
-                },
-                checkItemContainerOverflow() {
-                        const el = this.$refs.itemsContainer;
-                        if (!el) {
-                                this.isOverflowing = false;
-                                return;
-                        }
-                        const maxHeight = parseFloat(
-                                getComputedStyle(el).getPropertyValue("--container-height")
-                        );
-                        if (isNaN(maxHeight)) {
-                                this.isOverflowing = false;
-                                return;
-                        }
-                        this.isOverflowing = el.scrollHeight > maxHeight;
-                },
-                refreshPricesForVisibleItems() {
-                        const vm = this;
-                        if (!vm.filtered_items || vm.filtered_items.length === 0) return;
+		onListScroll(event) {
+			const el = event.target;
+			if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+				this.currentPage += 1;
+				this.loadVisibleItems();
+			}
+		},
+		checkItemContainerOverflow() {
+			const el = this.$refs.itemsContainer;
+			if (!el) {
+				this.isOverflowing = false;
+				return;
+			}
+			const maxHeight = parseFloat(getComputedStyle(el).getPropertyValue("--container-height"));
+			if (isNaN(maxHeight)) {
+				this.isOverflowing = false;
+				return;
+			}
+			this.isOverflowing = el.scrollHeight > maxHeight;
+		},
+		async refreshPricesForVisibleItems() {
+			const vm = this;
+			if (!vm.filtered_items || vm.filtered_items.length === 0) return;
 
 			vm.loading = true;
 
@@ -698,7 +696,11 @@ export default {
 			}
 
 			const itemCodes = vm.filtered_items.map((it) => it.item_code);
-			const cacheResult = getCachedItemDetails(vm.pos_profile.name, vm.active_price_list, itemCodes);
+			const cacheResult = await getCachedItemDetails(
+				vm.pos_profile.name,
+				vm.active_price_list,
+				itemCodes,
+			);
 			const updates = [];
 
 			cacheResult.cached.forEach((det) => {
@@ -1528,7 +1530,11 @@ export default {
 			}
 
 			const itemCodes = items.map((it) => it.item_code);
-			const cacheResult = getCachedItemDetails(vm.pos_profile.name, vm.active_price_list, itemCodes);
+			const cacheResult = await getCachedItemDetails(
+				vm.pos_profile.name,
+				vm.active_price_list,
+				itemCodes,
+			);
 			cacheResult.cached.forEach((det) => {
 				const item = items.find((it) => it.item_code === det.item_code);
 				if (item) {
@@ -2470,12 +2476,12 @@ export default {
 			await forceClearAllCache();
 			await this.get_items(true);
 		}
-                this.scan_barcoud();
-                // Apply the configured items per page on mount
-                this.itemsPerPage = this.items_per_page;
-                window.addEventListener("resize", this.checkItemContainerOverflow);
-                this.$nextTick(this.checkItemContainerOverflow);
-        },
+		this.scan_barcoud();
+		// Apply the configured items per page on mount
+		this.itemsPerPage = this.items_per_page;
+		window.addEventListener("resize", this.checkItemContainerOverflow);
+		this.$nextTick(this.checkItemContainerOverflow);
+	},
 
 	beforeUnmount() {
 		// Clear interval when component is destroyed
@@ -2513,11 +2519,11 @@ export default {
 		this.eventBus.off("update_cur_items_details");
 		this.eventBus.off("update_offers_counters");
 		this.eventBus.off("update_coupons_counters");
-                this.eventBus.off("update_customer_price_list");
-                this.eventBus.off("update_customer");
-                this.eventBus.off("force_reload_items");
-                window.removeEventListener("resize", this.checkItemContainerOverflow);
-        },
+		this.eventBus.off("update_customer_price_list");
+		this.eventBus.off("update_customer");
+		this.eventBus.off("force_reload_items");
+		window.removeEventListener("resize", this.checkItemContainerOverflow);
+	},
 };
 </script>
 
@@ -2541,14 +2547,14 @@ export default {
 }
 
 .dynamic-scroll {
-       transition: max-height var(--transition-normal);
-       padding-bottom: var(--dynamic-xs);
+	transition: max-height var(--transition-normal);
+	padding-bottom: var(--dynamic-xs);
 }
 
 .item-container {
-       max-height: var(--container-height);
-       overflow-y: auto;
-       scrollbar-gutter: stable;
+	max-height: var(--container-height);
+	overflow-y: auto;
+	scrollbar-gutter: stable;
 }
 
 .items-grid {


### PR DESCRIPTION
## Summary
- cache only essential fields (qty, pricing, serial/batch data) for item details
- merge cached fields with stored base item data when reading
- await merged item details in ItemsSelector to update visible items

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893b7bd336c8326a34ed888d9d8d279