### PR TITLE
fix: await item details in price refresh

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -758,9 +758,13 @@ export default {
 
 			vm.loading = true;
 
-			const itemCodes = vm.filtered_items.map((it) => it.item_code);
-			const cacheResult = getCachedItemDetails(vm.pos_profile.name, vm.active_price_list, itemCodes);
-			const updates = [];
+                        const itemCodes = vm.filtered_items.map((it) => it.item_code);
+                        const cacheResult = await getCachedItemDetails(
+                                vm.pos_profile.name,
+                                vm.active_price_list,
+                                itemCodes,
+                        );
+                        const updates = [];
 
 			cacheResult.cached.forEach((det) => {
 				const item = vm.filtered_items.find((it) => it.item_code === det.item_code);


### PR DESCRIPTION
## Summary
- await `getCachedItemDetails` before using cached item data in `refreshPricesForVisibleItems`

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue && echo 'eslint ok'`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689446753b208326872b90e27998c78c