### PR TITLE
fix: expand item search results

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -208,18 +208,22 @@ def get_items(
 		if not posa_show_template_items:
 			filters["has_variants"] = 0
 
-		# Determine limit
-		limit_page_length = None
-		limit_start = None
+                # Determine limit
+                limit_page_length = None
+                limit_start = None
 
-		if limit is not None:
-			limit_page_length = limit
-			if offset:
-				limit_start = offset
-		elif use_limit_search:
-			limit_page_length = search_limit
-			if pos_profile.get("posa_force_reload_items") and search_value:
-				limit_page_length = None
+                # When a specific search term is provided, fetch all matching
+                # items. Applying a limit in this scenario can truncate results
+                # and prevent relevant items from appearing in the item selector.
+                if not search_value:
+                        if limit is not None:
+                                limit_page_length = limit
+                                if offset:
+                                        limit_start = offset
+                        elif use_limit_search:
+                                limit_page_length = search_limit
+                                if pos_profile.get("posa_force_reload_items"):
+                                        limit_page_length = None
 
 		items_data = frappe.get_all(
 			"Item",

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -758,13 +758,13 @@ export default {
 
 			vm.loading = true;
 
-                        const itemCodes = vm.filtered_items.map((it) => it.item_code);
-                        const cacheResult = await getCachedItemDetails(
-                                vm.pos_profile.name,
-                                vm.active_price_list,
-                                itemCodes,
-                        );
-                        const updates = [];
+			const itemCodes = vm.filtered_items.map((it) => it.item_code);
+			const cacheResult = await getCachedItemDetails(
+				vm.pos_profile.name,
+				vm.active_price_list,
+				itemCodes,
+			);
+			const updates = [];
 
 			cacheResult.cached.forEach((det) => {
 				const item = vm.filtered_items.find((it) => it.item_code === det.item_code);
@@ -2351,11 +2351,14 @@ export default {
 
 				let final_filtered_list = [];
 				if (this.pos_profile.posa_show_template_items && this.pos_profile.posa_hide_variants_items) {
-					final_filtered_list = filtred_list
-						.filter((item) => !item.variant_of)
-						.slice(0, this.itemsPerPage);
+					final_filtered_list = filtred_list.filter((item) => !item.variant_of);
 				} else {
-					final_filtered_list = filtred_list.slice(0, this.itemsPerPage);
+					final_filtered_list = filtred_list;
+				}
+
+				// When searching, show all matching items. Otherwise, restrict to the configured page size.
+				if (!this.search) {
+					final_filtered_list = final_filtered_list.slice(0, this.itemsPerPage);
 				}
 
 				if (this.hide_zero_rate_items) {
@@ -2375,7 +2378,7 @@ export default {
 
 				return final_filtered_list;
 			} else {
-				const items_list = this.items.slice(0, this.itemsPerPage);
+				const items_list = this.search ? this.items : this.items.slice(0, this.itemsPerPage);
 
 				// Ensure quantities are defined
 				items_list.forEach((item) => {
@@ -2384,11 +2387,12 @@ export default {
 					}
 				});
 
+				let final_list = items_list;
 				if (this.hide_zero_rate_items) {
-					return items_list.filter((item) => parseFloat(item.rate) !== 0);
+					final_list = final_list.filter((item) => parseFloat(item.rate) !== 0);
 				}
 
-				return items_list;
+				return final_list;
 			}
 		},
 		debounce_search: {


### PR DESCRIPTION
## Summary
- avoid truncating server-side search results when a query is provided
- show all matching items in the selector instead of limiting to page size

## Testing
- `pytest`
- `npx prettier posawesome/public/js/posapp/components/pos/ItemsSelector.vue --write`


------
https://chatgpt.com/codex/tasks/task_e_68944eab24808326b343a19debfa75a2