### PR TITLE
fix: remove trailing comma in item worker

### DIFF
--- a/posawesome/public/js/posapp/workers/itemWorker.js
+++ b/posawesome/public/js/posapp/workers/itemWorker.js
@@ -33,7 +33,7 @@ let db;
 					item.name_keywords = item.item_name
 						? item.item_name.toLowerCase().split(/\s+/).filter(Boolean)
 						: [];
-				}),
+				})
 		);
 	try {
 		await db.open();


### PR DESCRIPTION
## Summary
- remove trailing comma in item worker Dexie upgrade to prevent syntax errors

## Testing
- `node --check posawesome/public/js/posapp/workers/itemWorker.js && echo 'syntax OK'`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894a9e519008326893d721892a4c3a4