### PR TITLE
fix: respect rate and discount edit permissions

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsTable.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsTable.vue
@@ -233,7 +233,11 @@
 												setFormatedCurrency(item, 'rate', null, false, $event),
 												calcPrices(item, $event.target.value, $event),
 											]"
-											:disabled="!!item.posa_is_replace || !!item.posa_offer_applied"
+											:disabled="
+												!pos_profile.posa_allow_user_to_edit_rate ||
+												!!item.posa_is_replace ||
+												!!item.posa_offer_applied
+											"
 											prepend-inner-icon="mdi-currency-usd"
 										></v-text-field>
 									</div>
@@ -258,7 +262,11 @@
 												),
 												calcPrices(item, $event.target.value, $event),
 											]"
-											:disabled="!!item.posa_is_replace || !!item.posa_offer_applied"
+                                                                                        :disabled="
+                                                                                                !pos_profile.posa_allow_user_to_edit_item_discount ||
+                                                                                                !!item.posa_is_replace ||
+                                                                                                !!item.posa_offer_applied
+                                                                                        "
 											prepend-inner-icon="mdi-percent"
 										></v-text-field>
 									</div>
@@ -283,7 +291,11 @@
 												),
 												calcPrices(item, $event.target.value, $event),
 											]"
-											:disabled="!!item.posa_is_replace || !!item.posa_offer_applied"
+                                                                                        :disabled="
+                                                                                                !pos_profile.posa_allow_user_to_edit_item_discount ||
+                                                                                                !!item.posa_is_replace ||
+                                                                                                !!item.posa_offer_applied
+                                                                                        "
 											prepend-inner-icon="mdi-tag-minus"
 										></v-text-field>
 									</div>


### PR DESCRIPTION
## Summary
- disable rate field when POS profile disallows rate editing
- disable discount fields when POS profile disallows item discount editing

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsTable.vue`


------
https://chatgpt.com/codex/tasks/task_e_68974377495c8326af50046e39d783fd