### PR TITLE
Allow variant templates with zero stock to appear in POS

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -343,7 +343,11 @@ def get_items(
 						fields=["attribute", "attribute_value"],
 						filters={"parent": item.item_code, "parentfield": "attributes"},
 					)
-				if posa_display_items_in_stock and (not item_stock_qty or item_stock_qty < 0):
+				if (
+					posa_display_items_in_stock
+					and (not item_stock_qty or item_stock_qty < 0)
+					and not item.has_variants
+				):
 					pass
 				else:
 					row = {}

--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -417,7 +417,11 @@ def get_items(
 						fields=["attribute", "attribute_value"],
 						filters={"parent": item.item_code, "parentfield": "attributes"},
 					)
-				if posa_display_items_in_stock and (not item_stock_qty or item_stock_qty < 0):
+				if (
+					posa_display_items_in_stock
+					and (not item_stock_qty or item_stock_qty < 0)
+					and not item.has_variants
+				):
 					pass
 				else:
 					row = {}


### PR DESCRIPTION
## Summary
- Include item templates with variants even if template stock is zero
- Apply variant-aware zero-stock filtering in POS API
