### PR TITLE
Reset filtered items when clearing search

### DIFF
--- a/ItemsSelector_mod.vue
+++ b/ItemsSelector_mod.vue
@@ -2322,11 +2322,14 @@ export default {
 
 			return combinations;
 		},
-		clearSearch() {
-			this.search_backup = this.first_search;
-			this.first_search = "";
-			// No need to call get_items() again
-		},
+                clearSearch() {
+                        this.search_backup = this.first_search;
+                        this.first_search = "";
+                        // Reset the visible items to the full list
+                        this.loadVisibleItems(true);
+                        // Refresh items from the server if needed
+                        this.get_items();
+                },
 
 		restoreSearch() {
 			if (this.first_search === "") {

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1817,12 +1817,15 @@ export default {
 
 			return combinations;
 		},
-		clearSearch() {
-			this.search_backup = this.first_search;
-			this.first_search = "";
-			this.search = "";
-			// No need to call get_items() again
-		},
+                clearSearch() {
+                        this.search_backup = this.first_search;
+                        this.first_search = "";
+                        this.search = "";
+                        // Reset the visible items to the full list
+                        this.loadVisibleItems(true);
+                        // Refresh items from the server if needed
+                        this.get_items();
+                },
 
 		restoreSearch() {
 			if (this.first_search === "") {


### PR DESCRIPTION
## Summary
- Ensure clearSearch resets visible items by reloading the full item list
- Trigger server item refresh after clearing search

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689b1df5108083268e635178975e0b48