### PR TITLE
feat: paginate item loading

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1,56 +1,108 @@
 <template>
 	<div :style="responsiveStyles">
-		<v-card :class="[
-			'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
-			isDarkTheme ? '' : 'bg-grey-lighten-5',
-			rtlClasses
-		]" :style="{
-			height: responsiveStyles['--container-height'],
-			maxHeight: responsiveStyles['--container-height'],
-			backgroundColor: isDarkTheme ? '#121212' : '',
-			resize: 'vertical',
-			overflow: 'auto',
-		}">
-			<v-progress-linear :active="loading" :indeterminate="loading" absolute location="top"
-				color="info"></v-progress-linear>
+		<v-card
+			:class="[
+				'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable',
+				isDarkTheme ? '' : 'bg-grey-lighten-5',
+				rtlClasses,
+			]"
+			:style="{
+				height: responsiveStyles['--container-height'],
+				maxHeight: responsiveStyles['--container-height'],
+				backgroundColor: isDarkTheme ? '#121212' : '',
+				resize: 'vertical',
+				overflow: 'auto',
+			}"
+		>
+			<v-progress-linear
+				:active="loading"
+				:indeterminate="loading"
+				absolute
+				location="top"
+				color="info"
+			></v-progress-linear>
 
 			<!-- Add dynamic-padding wrapper like Invoice component -->
 			<div class="dynamic-padding">
 				<div class="sticky-header">
 					<v-row class="items">
 						<v-col class="pb-0">
-							<v-text-field density="compact" clearable autofocus variant="solo" color="primary"
+							<v-text-field
+								density="compact"
+								clearable
+								autofocus
+								variant="solo"
+								color="primary"
 								:label="frappe._('Search Items')"
-								hint="Search by item code, serial number, batch no or barcode" hide-details
-								v-model="debounce_search" @keydown.esc="esc_event" @keydown.enter="search_onchange"
-								@click:clear="clearSearch" prepend-inner-icon="mdi-magnify"
-								@focus="handleItemSearchFocus" ref="debounce_search">
+								hint="Search by item code, serial number, batch no or barcode"
+								hide-details
+								v-model="debounce_search"
+								@keydown.esc="esc_event"
+								@keydown.enter="search_onchange"
+								@click:clear="clearSearch"
+								prepend-inner-icon="mdi-magnify"
+								@focus="handleItemSearchFocus"
+								ref="debounce_search"
+							>
 								<!-- Add camera scan button if enabled -->
 								<template v-slot:append-inner v-if="pos_profile.posa_enable_camera_scanning">
-									<v-btn icon="mdi-camera" size="small" color="primary" variant="text"
-										@click="startCameraScanning" :title="__('Scan with Camera')">
+									<v-btn
+										icon="mdi-camera"
+										size="small"
+										color="primary"
+										variant="text"
+										@click="startCameraScanning"
+										:title="__('Scan with Camera')"
+									>
 									</v-btn>
 								</template>
 							</v-text-field>
 						</v-col>
 						<v-col cols="3" class="pb-0" v-if="pos_profile.posa_input_qty">
-							<v-text-field density="compact" variant="solo" color="primary" :label="frappe._('QTY')"
-								hide-details v-model="debounce_qty" type="text" @keydown.enter="enter_event"
-								@keydown.esc="esc_event" @focus="clearQty"></v-text-field>
+							<v-text-field
+								density="compact"
+								variant="solo"
+								color="primary"
+								:label="frappe._('QTY')"
+								hide-details
+								v-model="debounce_qty"
+								type="text"
+								@keydown.enter="enter_event"
+								@keydown.esc="esc_event"
+								@focus="clearQty"
+							></v-text-field>
 						</v-col>
 						<v-col cols="2" class="pb-0" v-if="pos_profile.posa_new_line">
-							<v-checkbox v-model="new_line" color="accent" value="true" label="NLine" density="default"
-								hide-details></v-checkbox>
+							<v-checkbox
+								v-model="new_line"
+								color="accent"
+								value="true"
+								label="NLine"
+								density="default"
+								hide-details
+							></v-checkbox>
 						</v-col>
 						<v-col cols="12" class="dynamic-margin-xs">
 							<div class="settings-container">
-								<v-btn density="compact" variant="text" color="primary" prepend-icon="mdi-cog-outline"
-									@click="toggleItemSettings" class="settings-btn">
+								<v-btn
+									density="compact"
+									variant="text"
+									color="primary"
+									prepend-icon="mdi-cog-outline"
+									@click="toggleItemSettings"
+									class="settings-btn"
+								>
 									{{ __("Settings") }}
 								</v-btn>
 								<v-spacer></v-spacer>
-								<v-btn density="compact" variant="text" color="primary" prepend-icon="mdi-refresh"
-									@click="forceReloadItems" class="settings-btn">
+								<v-btn
+									density="compact"
+									variant="text"
+									color="primary"
+									prepend-icon="mdi-refresh"
+									@click="forceReloadItems"
+									class="settings-btn"
+								>
 									{{ __("Reload Items") }}
 								</v-btn>
 
@@ -59,39 +111,71 @@
 										<v-card-title class="text-h6 pa-4 d-flex align-center">
 											<span>{{ __("Item Selector Settings") }}</span>
 											<v-spacer></v-spacer>
-											<v-btn icon="mdi-close" variant="text" density="compact"
-												@click="show_item_settings = false">
+											<v-btn
+												icon="mdi-close"
+												variant="text"
+												density="compact"
+												@click="show_item_settings = false"
+											>
 											</v-btn>
 										</v-card-title>
 										<v-divider></v-divider>
 										<v-card-text class="pa-4">
-											<v-switch v-model="temp_hide_qty_decimals"
-												:label="__('Hide quantity decimals')" hide-details density="compact"
-												color="primary" class="mb-2"></v-switch>
-											<v-switch v-model="temp_hide_zero_rate_items"
-												:label="__('Hide zero rated items')" hide-details density="compact"
-												color="primary"></v-switch>
-											<v-switch v-model="temp_enable_custom_items_per_page"
-												:label="__('Custom items per page')" hide-details density="compact"
-												color="primary" class="mb-2">
+											<v-switch
+												v-model="temp_hide_qty_decimals"
+												:label="__('Hide quantity decimals')"
+												hide-details
+												density="compact"
+												color="primary"
+												class="mb-2"
+											></v-switch>
+											<v-switch
+												v-model="temp_hide_zero_rate_items"
+												:label="__('Hide zero rated items')"
+												hide-details
+												density="compact"
+												color="primary"
+											></v-switch>
+											<v-switch
+												v-model="temp_enable_custom_items_per_page"
+												:label="__('Custom items per page')"
+												hide-details
+												density="compact"
+												color="primary"
+												class="mb-2"
+											>
 											</v-switch>
-											<v-checkbox v-model="temp_force_server_items" :label="__('Always fetch items from server (ignore local cache)')
-												" hide-details density="compact" color="primary" class="mb-2"></v-checkbox>
-											<v-text-field v-if="temp_enable_custom_items_per_page"
-												v-model="temp_items_per_page" type="number" density="compact"
-												variant="outlined" color="primary"
-												:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" hide-details
-												:label="__('Items per page')" class="mb-2 dark-field">
+											<v-checkbox
+												v-model="temp_force_server_items"
+												:label="
+													__('Always fetch items from server (ignore local cache)')
+												"
+												hide-details
+												density="compact"
+												color="primary"
+												class="mb-2"
+											></v-checkbox>
+											<v-text-field
+												v-if="temp_enable_custom_items_per_page"
+												v-model="temp_items_per_page"
+												type="number"
+												density="compact"
+												variant="outlined"
+												color="primary"
+												:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+												hide-details
+												:label="__('Items per page')"
+												class="mb-2 dark-field"
+											>
 											</v-text-field>
 										</v-card-text>
 										<v-card-actions class="pa-4 pt-0">
-											<v-btn color="error" variant="text" @click="cancelItemSettings">{{
-												__("Cancel")
-											}}
+											<v-btn color="error" variant="text" @click="cancelItemSettings"
+												>{{ __("Cancel") }}
 											</v-btn>
 											<v-spacer></v-spacer>
-											<v-btn color="primary" variant="tonal" @click="applyItemSettings">{{
-												__("Apply") }}
+											<v-btn color="primary" variant="tonal" @click="applyItemSettings"
+												>{{ __("Apply") }}
 											</v-btn>
 										</v-card-actions>
 									</v-card>
@@ -103,18 +187,36 @@
 				<v-row class="items">
 					<v-col cols="12" class="pt-0 mt-0">
 						<div v-if="items_view == 'card'" class="items-card-container">
-							<div class="items-card-grid" ref="itemsContainer" @scroll.passive="onCardScroll"
-								:class="{ 'item-container': isOverflowing }">
-								<div v-for="item in filtered_items" :key="item.item_code" 
-									class="card-item-card" @click="add_item(item)"
-									:draggable="true" @dragstart="onDragStart($event, item)" @dragend="onDragEnd">
+							<div
+								class="items-card-grid"
+								ref="itemsContainer"
+								@scroll.passive="onCardScroll"
+								:class="{ 'item-container': isOverflowing }"
+							>
+								<div
+									v-for="item in filtered_items"
+									:key="item.item_code"
+									class="card-item-card"
+									@click="add_item(item)"
+									:draggable="true"
+									@dragstart="onDragStart($event, item)"
+									@dragend="onDragEnd"
+								>
 									<div class="card-item-image-container">
-										<v-img :src="item.image || '/assets/posawesome/js/posapp/components/pos/placeholder-image.png'"
-											class="card-item-image" aspect-ratio="1"
-											:alt="item.item_name">
+										<v-img
+											:src="
+												item.image ||
+												'/assets/posawesome/js/posapp/components/pos/placeholder-image.png'
+											"
+											class="card-item-image"
+											aspect-ratio="1"
+											:alt="item.item_name"
+										>
 											<template v-slot:placeholder>
 												<div class="image-placeholder">
-													<v-icon size="40" color="grey-lighten-2">mdi-image</v-icon>
+													<v-icon size="40" color="grey-lighten-2"
+														>mdi-image</v-icon
+													>
 												</div>
 											</template>
 										</v-img>
@@ -128,21 +230,36 @@
 											<div class="card-item-price">
 												<div class="primary-price">
 													<span class="currency-symbol">
-														{{ currencySymbol(item.original_currency || pos_profile.currency) }}
+														{{
+															currencySymbol(
+																item.original_currency ||
+																	pos_profile.currency,
+															)
+														}}
 													</span>
 													<span class="price-amount">
 														{{
 															format_currency(
 																item.base_price_list_rate || item.rate,
-																item.original_currency || pos_profile.currency,
-																ratePrecision(item.base_price_list_rate || item.rate),
+																item.original_currency ||
+																	pos_profile.currency,
+																ratePrecision(
+																	item.base_price_list_rate || item.rate,
+																),
 															)
 														}}
 													</span>
 												</div>
-												<div v-if="pos_profile.posa_allow_multi_currency && selected_currency !== pos_profile.currency"
-													class="secondary-price">
-													<span class="currency-symbol">{{ currencySymbol(selected_currency) }}</span>
+												<div
+													v-if="
+														pos_profile.posa_allow_multi_currency &&
+														selected_currency !== pos_profile.currency
+													"
+													class="secondary-price"
+												>
+													<span class="currency-symbol">{{
+														currencySymbol(selected_currency)
+													}}</span>
 													<span class="price-amount">
 														{{
 															format_currency(
@@ -155,9 +272,21 @@
 												</div>
 											</div>
 											<div class="card-item-stock">
-												<v-icon size="small" class="stock-icon">mdi-package-variant</v-icon>
-												<span class="stock-amount" :class="{ 'negative-number': isNegative(item.actual_qty) }">
-													{{ format_number(item.actual_qty, hide_qty_decimals ? 0 : 4) || 0 }}
+												<v-icon size="small" class="stock-icon"
+													>mdi-package-variant</v-icon
+												>
+												<span
+													class="stock-amount"
+													:class="{
+														'negative-number': isNegative(item.actual_qty),
+													}"
+												>
+													{{
+														format_number(
+															item.actual_qty,
+															hide_qty_decimals ? 0 : 4,
+														) || 0
+													}}
 												</span>
 												<span class="stock-uom">{{ item.stock_uom || "" }}</span>
 											</div>
@@ -167,11 +296,19 @@
 							</div>
 						</div>
 						<div v-else class="items-table-container">
-							<v-data-table-virtual :headers="headers" :items="filtered_items"
-								class="sleek-data-table overflow-y-auto" :style="{ height: 'calc(100% - 80px)' }"
-								item-key="item_code" fixed-header height="100%" :header-props="headerProps"
-								:no-data-text="__('No items found')" @click:row="click_item_row"
-								@scroll.passive="onListScroll">
+							<v-data-table-virtual
+								:headers="headers"
+								:items="filtered_items"
+								class="sleek-data-table overflow-y-auto"
+								:style="{ height: 'calc(100% - 80px)' }"
+								item-key="item_code"
+								fixed-header
+								height="100%"
+								:header-props="headerProps"
+								:no-data-text="__('No items found')"
+								@click:row="click_item_row"
+								@scroll.passive="onListScroll"
+							>
 								<template v-slot:item.rate="{ item }">
 									<div>
 										<div class="text-primary">
@@ -186,10 +323,13 @@
 												)
 											}}
 										</div>
-										<div v-if="
-											pos_profile.posa_allow_multi_currency &&
-											selected_currency !== pos_profile.currency
-										" class="text-success">
+										<div
+											v-if="
+												pos_profile.posa_allow_multi_currency &&
+												selected_currency !== pos_profile.currency
+											"
+											class="text-success"
+										>
 											{{ currencySymbol(selected_currency) }}
 											{{
 												format_currency(
@@ -202,10 +342,11 @@
 									</div>
 								</template>
 								<template v-slot:item.actual_qty="{ item }">
-									<span class="golden--text"
-										:class="{ 'negative-number': isNegative(item.actual_qty) }">{{
-											format_number(item.actual_qty, hide_qty_decimals ? 0 : 4)
-										}}</span>
+									<span
+										class="golden--text"
+										:class="{ 'negative-number': isNegative(item.actual_qty) }"
+										>{{ format_number(item.actual_qty, hide_qty_decimals ? 0 : 4) }}</span
+									>
 								</template>
 							</v-data-table-virtual>
 						</div>
@@ -216,12 +357,25 @@
 		<v-card class="cards mb-0 mt-3 dynamic-padding resizable" style="resize: vertical; overflow: auto">
 			<v-row no-gutters align="center" justify="center" class="dynamic-spacing-sm">
 				<v-col cols="12" class="mb-2">
-					<v-select :items="items_group" :label="frappe._('Items Group')" density="compact" variant="solo"
-						hide-details v-model="item_group"></v-select>
+					<v-select
+						:items="items_group"
+						:label="frappe._('Items Group')"
+						density="compact"
+						variant="solo"
+						hide-details
+						v-model="item_group"
+					></v-select>
 				</v-col>
 				<v-col cols="12" class="mb-2" v-if="pos_profile.posa_enable_price_list_dropdown !== false">
-					<v-text-field density="compact" variant="solo" color="primary" :label="frappe._('Price List')"
-						hide-details :model-value="active_price_list" readonly></v-text-field>
+					<v-text-field
+						density="compact"
+						variant="solo"
+						color="primary"
+						:label="frappe._('Price List')"
+						hide-details
+						:model-value="active_price_list"
+						readonly
+					></v-text-field>
 				</v-col>
 				<v-col cols="3" class="dynamic-margin-xs">
 					<v-btn-toggle v-model="items_view" color="primary" group density="compact" rounded>
@@ -230,21 +384,38 @@
 					</v-btn-toggle>
 				</v-col>
 				<v-col cols="5" class="dynamic-margin-xs">
-					<v-btn size="small" block color="warning" variant="text" @click="show_offers"
-						class="action-btn-consistent">
+					<v-btn
+						size="small"
+						block
+						color="warning"
+						variant="text"
+						@click="show_offers"
+						class="action-btn-consistent"
+					>
 						{{ offersCount }} {{ __("Offers") }}
 					</v-btn>
 				</v-col>
 				<v-col cols="4" class="dynamic-margin-xs">
-					<v-btn size="small" block color="primary" variant="text" @click="show_coupons"
-						class="action-btn-consistent">{{ couponsCount }} {{ __("Coupons") }}</v-btn>
+					<v-btn
+						size="small"
+						block
+						color="primary"
+						variant="text"
+						@click="show_coupons"
+						class="action-btn-consistent"
+						>{{ couponsCount }} {{ __("Coupons") }}</v-btn
+					>
 				</v-col>
 			</v-row>
 		</v-card>
 
 		<!-- Camera Scanner Component -->
-		<CameraScanner v-if="pos_profile.posa_enable_camera_scanning" ref="cameraScanner"
-			:scan-type="pos_profile.posa_camera_scan_type || 'Both'" @barcode-scanned="onBarcodeScanned" />
+		<CameraScanner
+			v-if="pos_profile.posa_enable_camera_scanning"
+			ref="cameraScanner"
+			:scan-type="pos_profile.posa_camera_scan_type || 'Both'"
+			@barcode-scanned="onBarcodeScanned"
+		/>
 	</div>
 </template>
 
@@ -261,13 +432,13 @@ import {
 	getLocalStock,
 	isOffline,
 	initializeStockCache,
-        searchStoredItems,
-        saveItemsBulk,
-        saveItems,
-        clearStoredItems,
-        getLocalStockCache,
-        setLocalStockCache,
-        initPromise,
+	searchStoredItems,
+	saveItemsBulk,
+	saveItems,
+	clearStoredItems,
+	getLocalStockCache,
+	setLocalStockCache,
+	initPromise,
 	memoryInitPromise,
 	checkDbHealth,
 	getCachedPriceListItems,
@@ -1034,6 +1205,7 @@ export default {
 			}
 
 			this.loading = true;
+			const requestToken = ++this.items_request_token;
 			this.eventBus.emit("data-load-progress", { name: "items", progress: 0 });
 
 			try {
@@ -1046,7 +1218,7 @@ export default {
 						item_group: gr,
 						search_value: sr,
 						customer: vm.customer,
-						limit: 1000,
+						limit: vm.itemsPageLimit,
 						offset: 0,
 					},
 				});
@@ -1054,11 +1226,12 @@ export default {
 				const items = response.message || [];
 
 				// Process items
-				items.forEach(item => {
+				items.forEach((item) => {
 					// Ensure UOMs
 					if (!item.item_uoms || item.item_uoms.length === 0) {
-						item.item_uoms = item.stock_uom ?
-							[{ uom: item.stock_uom, conversion_factor: 1.0 }] : [];
+						item.item_uoms = item.stock_uom
+							? [{ uom: item.stock_uom, conversion_factor: 1.0 }]
+							: [];
 					}
 
 					// Set default quantity
@@ -1067,34 +1240,43 @@ export default {
 					}
 				});
 
-                                vm.items = items;
-                                vm.items_loaded = true;
-                                vm.eventBus.emit("set_all_items", vm.items);
-                                vm.eventBus.emit("data-load-progress", { name: "items", progress: 100 });
+				vm.items = items;
+				vm.items_loaded = true;
+				vm.eventBus.emit("set_all_items", vm.items);
 
-                                if (
-                                        vm.pos_profile &&
-                                        vm.pos_profile.posa_local_storage &&
-                                        vm.storageAvailable &&
-                                        !vm.pos_profile.pose_use_limit_search
-                                ) {
-                                        try {
-                                                if (force_server) {
-                                                        await clearStoredItems();
-                                                }
-                                                await saveItemsBulk(vm.items);
-                                        } catch (e) {
-                                                console.error("Failed to persist items locally", e);
-                                                vm.markStorageUnavailable();
-                                        }
-                                }
-                        } catch (error) {
-                                console.error("Failed to load items:", error);
-                                frappe.msgprint(__("Failed to load items. Please try again."));
-                        } finally {
-                                vm.loading = false;
-                        }
-                },
+				const hasMore = items.length === vm.itemsPageLimit;
+				const progress = hasMore
+					? Math.min(99, Math.round((items.length / (items.length + vm.itemsPageLimit)) * 100))
+					: 100;
+				vm.eventBus.emit("data-load-progress", { name: "items", progress });
+
+				if (
+					vm.pos_profile &&
+					vm.pos_profile.posa_local_storage &&
+					vm.storageAvailable &&
+					!vm.pos_profile.pose_use_limit_search
+				) {
+					try {
+						if (force_server) {
+							await clearStoredItems();
+						}
+						await saveItemsBulk(vm.items);
+					} catch (e) {
+						console.error("Failed to persist items locally", e);
+						vm.markStorageUnavailable();
+					}
+				}
+
+				if (hasMore) {
+					this.backgroundLoadItems(vm.itemsPageLimit, null, false, requestToken, vm.itemsPageLimit);
+				}
+			} catch (error) {
+				console.error("Failed to load items:", error);
+				frappe.msgprint(__("Failed to load items. Please try again."));
+			} finally {
+				vm.loading = false;
+			}
+		},
 		async backgroundLoadItems(offset, syncSince, clearBefore = false, requestToken, loaded = offset) {
 			const limit = this.itemsPageLimit;
 			// When the limit is extremely high, treat it as
@@ -1127,13 +1309,37 @@ export default {
 						return;
 					}
 					const count = await new Promise((resolve) => {
-						this.itemWorker.onmessage = (ev) => {
+						this.itemWorker.onmessage = async (ev) => {
 							if (this.items_request_token !== requestToken) {
 								resolve(0);
 								return;
 							}
 							if (ev.data.type === "parsed") {
-								resolve(ev.data.items.length);
+								const newItems = ev.data.items || [];
+								newItems.forEach((it) => {
+									const existing = this.items.find((i) => i.item_code === it.item_code);
+									if (existing) Object.assign(existing, it);
+									else this.items.push(it);
+								});
+								this.eventBus.emit("set_all_items", this.items);
+								if (
+									this.pos_profile &&
+									this.pos_profile.posa_local_storage &&
+									this.storageAvailable &&
+									!this.pos_profile.pose_use_limit_search
+								) {
+									try {
+										if (clearBefore) {
+											await clearStoredItems();
+											clearBefore = false;
+										}
+										await saveItemsBulk(newItems);
+									} catch (e) {
+										console.error(e);
+										this.markStorageUnavailable();
+									}
+								}
+								resolve(newItems.length);
 							} else if (ev.data.type === "error") {
 								console.error("Item worker parse error:", ev.data.error);
 								resolve(0);
@@ -1835,15 +2041,15 @@ export default {
 
 			return combinations;
 		},
-                clearSearch() {
-                        this.search_backup = this.first_search;
-                        this.first_search = "";
-                        this.search = "";
-                        // Reset the visible items to the full list
-                        this.loadVisibleItems(true);
-                        // Refresh items from the server if needed
-                        this.get_items();
-                },
+		clearSearch() {
+			this.search_backup = this.first_search;
+			this.first_search = "";
+			this.search = "";
+			// Reset the visible items to the full list
+			this.loadVisibleItems(true);
+			// Refresh items from the server if needed
+			this.get_items();
+		},
 
 		restoreSearch() {
 			if (this.first_search === "") {
@@ -2258,33 +2464,31 @@ export default {
 
 			// Apply search filter
 			if (searchTerm) {
-				filteredItems = filteredItems.filter(item => {
-					const searchFields = [
-						item.item_code,
-						item.item_name,
-						item.barcode,
-						item.description
-					].filter(Boolean).map(field => field.toLowerCase());
+				filteredItems = filteredItems.filter((item) => {
+					const searchFields = [item.item_code, item.item_name, item.barcode, item.description]
+						.filter(Boolean)
+						.map((field) => field.toLowerCase());
 
-					return searchFields.some(field => field.includes(searchTerm));
+					return searchFields.some((field) => field.includes(searchTerm));
 				});
 			}
 
 			// Apply item group filter
 			if (this.item_group !== "ALL") {
-				filteredItems = filteredItems.filter(item =>
-					item.item_group && item.item_group.toLowerCase() === this.item_group.toLowerCase()
+				filteredItems = filteredItems.filter(
+					(item) =>
+						item.item_group && item.item_group.toLowerCase() === this.item_group.toLowerCase(),
 				);
 			}
 
 			// Apply zero rate filter
 			if (this.hide_zero_rate_items) {
-				filteredItems = filteredItems.filter(item => parseFloat(item.rate || 0) > 0);
+				filteredItems = filteredItems.filter((item) => parseFloat(item.rate || 0) > 0);
 			}
 
 			// Apply template/variant filter
 			if (this.pos_profile?.posa_show_template_items && this.pos_profile?.posa_hide_variants_items) {
-				filteredItems = filteredItems.filter(item => !item.variant_of);
+				filteredItems = filteredItems.filter((item) => !item.variant_of);
 			}
 
 			// Apply pagination
@@ -2292,7 +2496,7 @@ export default {
 			filteredItems = filteredItems.slice(0, limit);
 
 			// Ensure quantities are defined
-			filteredItems.forEach(item => {
+			filteredItems.forEach((item) => {
 				if (item.actual_qty === undefined || item.actual_qty === null) {
 					item.actual_qty = 0;
 				}
@@ -2627,11 +2831,16 @@ export default {
 .text-success,
 .golden--text {
 	/* Enhanced Arabic number font stack for maximum clarity */
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 	/* Force lining numbers for consistent height and alignment */
 	font-variant-numeric: lining-nums tabular-nums;
 	/* Additional OpenType features for better Arabic number rendering */
-	font-feature-settings: "tnum" 1, "lnum" 1, "kern" 1;
+	font-feature-settings:
+		"tnum" 1,
+		"lnum" 1,
+		"kern" 1;
 	/* Ensure crisp rendering */
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -2644,9 +2853,14 @@ export default {
 	color: #d32f2f !important;
 	font-weight: 600;
 	/* Same enhanced font stack for negative numbers */
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 	font-variant-numeric: lining-nums tabular-nums;
-	font-feature-settings: "tnum" 1, "lnum" 1, "kern" 1;
+	font-feature-settings:
+		"tnum" 1,
+		"lnum" 1,
+		"kern" 1;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
@@ -2656,9 +2870,14 @@ export default {
 .v-select :deep(input),
 .v-autocomplete :deep(input) {
 	/* Enhanced Arabic number font stack for input fields */
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 	font-variant-numeric: lining-nums tabular-nums;
-	font-feature-settings: "tnum" 1, "lnum" 1, "kern" 1;
+	font-feature-settings:
+		"tnum" 1,
+		"lnum" 1,
+		"kern" 1;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	letter-spacing: 0.01em;
@@ -2666,9 +2885,14 @@ export default {
 
 /* Enhanced card text for better Arabic number display */
 .dynamic-item-card .v-card-text {
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 	font-variant-numeric: lining-nums tabular-nums;
-	font-feature-settings: "tnum" 1, "lnum" 1, "kern" 1;
+	font-feature-settings:
+		"tnum" 1,
+		"lnum" 1,
+		"kern" 1;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
@@ -2770,7 +2994,9 @@ export default {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	/* Enhanced Arabic font support */
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 }
 
 .card-item-code {
@@ -2781,7 +3007,9 @@ export default {
 	padding: 2px 6px;
 	border-radius: 4px;
 	/* Enhanced Arabic font support */
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 }
 
 .card-item-details {
@@ -2817,13 +3045,20 @@ export default {
 .currency-symbol {
 	opacity: 0.8;
 	font-size: 0.85em;
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 }
 
 .price-amount {
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 	font-variant-numeric: lining-nums tabular-nums;
-	font-feature-settings: "tnum" 1, "lnum" 1, "kern" 1;
+	font-feature-settings:
+		"tnum" 1,
+		"lnum" 1,
+		"kern" 1;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
@@ -2844,9 +3079,14 @@ export default {
 
 .stock-amount {
 	font-weight: 600;
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 	font-variant-numeric: lining-nums tabular-nums;
-	font-feature-settings: "tnum" 1, "lnum" 1, "kern" 1;
+	font-feature-settings:
+		"tnum" 1,
+		"lnum" 1,
+		"kern" 1;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
@@ -2931,9 +3171,14 @@ export default {
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 	text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8);
 	/* Enhanced Arabic number font stack */
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 	font-variant-numeric: lining-nums tabular-nums;
-	font-feature-settings: "tnum" 1, "lnum" 1, "kern" 1;
+	font-feature-settings:
+		"tnum" 1,
+		"lnum" 1,
+		"kern" 1;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
@@ -2991,9 +3236,14 @@ export default {
 	vertical-align: middle;
 	color: #424242;
 	/* Enhanced Arabic number font stack */
-	font-family: "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma", sans-serif;
+	font-family:
+		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+		sans-serif;
 	font-variant-numeric: lining-nums tabular-nums;
-	font-feature-settings: "tnum" 1, "lnum" 1, "kern" 1;
+	font-feature-settings:
+		"tnum" 1,
+		"lnum" 1,
+		"kern" 1;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	letter-spacing: 0.01em;


### PR DESCRIPTION
## Summary
- allow configurable item page size in get_items
- background load additional item pages and persist each batch

## Testing
- `npx prettier --check posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b2438d040832691a54b5e254cc03f