### PR TITLE
Ensure POS logout triggers server logout

### DIFF
--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script>
+/* global frappe */
 import Navbar from "./components/Navbar.vue";
 import POS from "./components/pos/Pos.vue";
 import Payments from "./components/payments/Pay.vue";
@@ -373,17 +374,21 @@ export default {
 			}
 		},
 
-		handleToggleTheme() {
-			// Use the global theme plugin instead of local state
-			this.$theme.toggle();
-		},
+                handleToggleTheme() {
+                        // Use the global theme plugin instead of local state
+                        this.$theme.toggle();
+                },
 
-		handleLogout() {
-			window.location.href = "/app";
-		},
+                handleLogout() {
+                        frappe
+                                .call("logout")
+                                .finally(() => {
+                                        window.location.href = "/app";
+                                });
+                },
 
-		handleRefreshCacheUsage() {
-			this.cacheUsageLoading = true;
+                handleRefreshCacheUsage() {
+                        this.cacheUsageLoading = true;
 			getCacheUsageEstimate()
 				.then((usage) => {
 					this.cacheUsage = usage.percentage || 0;


### PR DESCRIPTION
## Summary
- Call Frappe logout API before redirecting to the app page
- Declare global `frappe` in POS Home component

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b2a0699c48326b7ea75df408a8b5a