### PR TITLE
Fix logout to call Frappe endpoint

### DIFF
--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -378,9 +378,9 @@ export default {
 			this.$theme.toggle();
 		},
 
-		handleLogout() {
-			window.location.href = "/app";
-		},
+               handleLogout() {
+                       window.location.href = "/?cmd=logout&redirect-to=/app";
+               },
 
 		handleRefreshCacheUsage() {
 			this.cacheUsageLoading = true;


### PR DESCRIPTION
## Summary
- Call Frappe logout endpoint and redirect to /app so POS logout clears the session

## Testing
- `npx prettier --check posawesome/public/js/posapp/Home.vue` (fails: Code style issues found in the above file)
- `npx eslint posawesome/public/js/posapp/Home.vue` (fails: 'MAX_QUEUE_ITEMS' is defined but never used, 'frappe' is not defined, '$' is not defined)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689b2a0699c48326b7ea75df408a8b5a