### PR TITLE
Ensure logout clears session before redirect

### DIFF
--- a/posawesome/public/js/posapp/Home.vue
+++ b/posawesome/public/js/posapp/Home.vue
@@ -379,7 +379,7 @@ export default {
 		},
 
 		handleLogout() {
-			window.location.href = "/app";
+			window.location.href = "/api/method/logout?redirect-to=/app";
 		},
 
 		handleRefreshCacheUsage() {


### PR DESCRIPTION
## Summary
- route logout through `/api/method/logout` so leaving the POS properly ends the session

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b2a0699c48326b7ea75df408a8b5a