### PR TITLE
fix: correct item search flag and exact match guard

### DIFF
--- a/posawesome/posawesome/api/customers.py
+++ b/posawesome/posawesome/api/customers.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import json
 import frappe
-from frappe.utils import nowdate, flt, cstr
+from frappe.utils import nowdate, flt, cstr, get_datetime
 from frappe import _
 from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
 	get_loyalty_program_details_with_points,
@@ -67,7 +67,11 @@ def get_customer_names(pos_profile, limit=None, offset=None, modified_after=None
 			filters["customer_group"] = ["in", customer_groups]
 
 		if modified_after:
-		        filters["modified"] = [">", modified_after]
+			try:
+				parsed_modified_after = get_datetime(modified_after)
+			except Exception:
+				frappe.throw(_("modified_after must be a valid ISO datetime"))
+			filters["modified"] = [">", parsed_modified_after.isoformat()]
 
 		customers = frappe.get_all(
 		        "Customer",
@@ -337,7 +341,7 @@ def set_customer_info(customer, fieldname, value=""):
 def get_customer_addresses(customer):
 	return frappe.db.sql(
 		"""
-	SELECT 
+	SELECT
 	    address.name,
 	    address.address_line1,
 	    address.address_line2,

--- a/posawesome/posawesome/api/posapp.py
+++ b/posawesome/posawesome/api/posapp.py
@@ -196,7 +196,7 @@ def get_items(
 
 		today = nowdate()
 		warehouse = pos_profile.get("warehouse")
-		use_limit_search = pos_profile.get("pose_use_limit_search")
+		use_limit_search = pos_profile.get("posa_use_limit_search")
 		search_serial_no = pos_profile.get("posa_search_serial_no")
 		search_batch_no = pos_profile.get("posa_search_batch_no")
 		posa_show_template_items = pos_profile.get("posa_show_template_items")
@@ -237,7 +237,7 @@ def get_items(
 			batch_no = data.get("batch_no") if data.get("batch_no") else ""
 			barcode = data.get("barcode") if data.get("barcode") else ""
 
-			condition += get_seearch_items_conditions(item_code, serial_no, batch_no, barcode)
+			condition += get_search_items_conditions(item_code, serial_no, batch_no, barcode)
 			if item_group:
 				# Escape item_group to avoid SQL errors with special characters
 				safe_item_group = frappe.db.escape("%" + item_group + "%")
@@ -2411,12 +2411,12 @@ def search_serial_or_batch_or_barcode_number(search_value, search_serial_no):
 	return {}
 
 
-def get_seearch_items_conditions(item_code, serial_no, batch_no, barcode):
+def get_search_items_conditions(item_code, serial_no, batch_no, barcode):
 	"""Build item search conditions safely."""
 	# Gracefully handle missing item_code values to avoid TypeErrors
 	item_code = item_code or ""
 
-	if serial_no or batch_no or barcode:
+	if item_code and (serial_no or batch_no or barcode):
 		return " and name = {0}".format(frappe.db.escape(item_code))
 
 	return """ and (name like {item_code} or item_name like {item_code})""".format(


### PR DESCRIPTION
## Summary
- correct typo by reading `posa_use_limit_search` flag in both `items.get_items` and `posapp.get_items`
- rename item search helper to `get_search_items_conditions`
- guard serial/batch/barcode exact match lookups to avoid empty `item_code` in item name filter
- treat blank or null UOM values as missing when checking existing Item Price records
- validate optional `modified_after` value as ISO timestamp before applying filters in item and customer queries
