### PR TITLE
Enforce API search limits and expose server timestamps

### DIFF
--- a/posawesome/posawesome/api/customers.py
+++ b/posawesome/posawesome/api/customers.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import json
 import frappe
-from frappe.utils import nowdate, flt, cstr, get_datetime
+from frappe.utils import nowdate, flt, cstr, get_datetime, now_datetime
 from frappe import _
 from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
 	get_loyalty_program_details_with_points,
@@ -58,9 +58,23 @@ def get_customer_names(pos_profile, limit=None, offset=None, modified_after=None
 	def __get_customer_names(pos_profile, limit=None, offset=None, modified_after=None):
 		return _get_customer_names(pos_profile, limit, offset, modified_after)
 
-	def _get_customer_names(pos_profile, limit=None, offset=None, modified_after=None):
-		pos_profile = json.loads(pos_profile)
-		filters = {"disabled": 0}
+        def _get_customer_names(pos_profile, limit=None, offset=None, modified_after=None):
+                pos_profile = json.loads(pos_profile)
+                filters = {"disabled": 0}
+
+                def _to_positive_int(value):
+                        try:
+                                ivalue = int(value)
+                                return ivalue if ivalue >= 0 else None
+                        except (TypeError, ValueError):
+                                return None
+
+                limit = _to_positive_int(limit)
+                offset = _to_positive_int(offset) or 0
+                max_limit = 1000
+                if limit is None:
+                        limit = 500
+                limit = min(limit, max_limit)
 
 		customer_groups = get_customer_groups(pos_profile)
 		if customer_groups:
@@ -76,19 +90,21 @@ def get_customer_names(pos_profile, limit=None, offset=None, modified_after=None
 		customers = frappe.get_all(
 		        "Customer",
 		        filters=filters,
-		        fields=[
-				"name",
-				"mobile_no",
-				"email_id",
-				"tax_id",
-				"customer_name",
-				"primary_address",
-			],
-		        order_by="name",
-		        limit_start=offset,
-		        limit_page_length=limit,
-		)
-		return customers
+                        fields=[
+                                "name",
+                                "mobile_no",
+                                "email_id",
+                                "tax_id",
+                                "customer_name",
+                                "primary_address",
+                                "modified",
+                        ],
+                        order_by="name",
+                        limit_start=offset,
+                        limit_page_length=limit,
+                )
+                frappe.response["server_timestamp"] = now_datetime().isoformat()
+                return customers
 
 	if _pos_profile.get("posa_use_server_cache") and not (limit or offset or modified_after):
 		return __get_customer_names(pos_profile, limit, offset, modified_after)

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -11,7 +11,7 @@ from erpnext.stock.doctype.batch.batch import (
 )
 from erpnext.stock.get_item_details import get_item_details
 from frappe import _
-from frappe.utils import cstr, flt, get_datetime, nowdate
+from frappe.utils import cstr, flt, get_datetime, nowdate, now_datetime
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.caching import redis_cache
 
@@ -103,12 +103,17 @@ def get_items(
 		       except (TypeError, ValueError):
 			       return None
 
-		limit = _to_positive_int(limit)
-		offset = _to_positive_int(offset)
+                limit = _to_positive_int(limit)
+                offset = _to_positive_int(offset) or 0
 
-		search_limit = 0
-		if use_limit_search:
-			search_limit = pos_profile.get("posa_search_limit") or 500
+                # Always enforce a reasonable upper cap on limits
+                max_limit = 1000
+                default_limit = (
+                        pos_profile.get("posa_search_limit") if use_limit_search else 500
+                )
+                if limit is None:
+                        limit = default_limit or 500
+                limit = min(limit, max_limit)
 
 		result = []
 
@@ -157,43 +162,31 @@ def get_items(
 		if not posa_show_template_items:
 			filters.update(HAS_VARIANTS_EXCLUSION)
 
-		# Determine limit
-		limit_page_length = None
-		limit_start = None
-
-		# When a specific search term is provided, fetch all matching
-		# items. Applying a limit in this scenario can truncate results
-		# and prevent relevant items from appearing in the item selector.
-		if not search_value:
-			if limit is not None:
-				limit_page_length = limit
-				if offset:
-					limit_start = offset
-			elif use_limit_search:
-				limit_page_length = search_limit
-				if pos_profile.get("posa_force_reload_items"):
-					limit_page_length = None
+                # Apply limit and offset uniformly to protect the database
+                limit_page_length = limit
+                limit_start = offset
 
 		items_data = frappe.get_all(
 			"Item",
 			filters=filters,
 			or_filters=or_filters if or_filters else None,
-			fields=[
-				"name as item_code",
-				"item_name",
-				"description",
-				"stock_uom",
-				"image",
-				"is_stock_item",
-				"has_variants",
-				"variant_of",
-				"item_group",
-				"idx",
-				"has_batch_no",
-				"has_serial_no",
-				"max_discount",
-				"brand",
-			],
+                        fields=[
+                                "name as item_code",
+                                "item_name",
+                                "description",
+                                "stock_uom",
+                                "image",
+                                "is_stock_item",
+                                "has_variants",
+                                "variant_of",
+                                "item_group",
+                                "idx",
+                                "has_batch_no",
+                                "has_serial_no",
+                                "max_discount",
+                                "brand",
+                                "modified",
+                        ],
 			limit_start=limit_start,
 			limit_page_length=limit_page_length,
 			order_by="item_name asc",
@@ -239,7 +232,8 @@ def get_items(
 				})
 				result.append(row)
 
-		return result
+                frappe.response["server_timestamp"] = now_datetime().isoformat()
+                return result
 
 	if use_price_list:
 		return __get_items(

--- a/posawesome/public/js/posapp/components/pos/Customer.vue
+++ b/posawesome/public/js/posapp/components/pos/Customer.vue
@@ -319,7 +319,7 @@ export default {
                                        if (rows.length === limit) {
                                                this.backgroundLoadCustomers(offset + limit, syncSince, newLoaded);
                                        } else {
-                                               setCustomersLastSync(new Date().toISOString());
+                                               setCustomersLastSync(r.server_timestamp || new Date().toISOString());
                                                this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
                                                this.eventBus.emit("data-loaded", "customers");
                                                this.customers_loaded = true;
@@ -396,7 +396,7 @@ export default {
                                                        vm.eventBus.emit("data-load-progress", { name: "customers", progress });
                                                        vm.backgroundLoadCustomers(vm.customersPageLimit, syncSince, vm.customers.length);
                                                } else {
-                                                       setCustomersLastSync(new Date().toISOString());
+                                                       setCustomersLastSync(r.server_timestamp || new Date().toISOString());
                                                        vm.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
                                                        vm.eventBus.emit("data-loaded", "customers");
                                                        vm.customers_loaded = true;

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1376,9 +1376,9 @@ export default {
 							newLoaded,
 						);
 					} else {
-						if (this.storageAvailable && this.localStorageAvailable) {
-							setItemsLastSync(new Date().toISOString());
-						}
+                                                if (this.storageAvailable && this.localStorageAvailable) {
+                                                        setItemsLastSync(res.server_timestamp || new Date().toISOString());
+                                                }
 						if (this.itemWorker) {
 							this.itemWorker.terminate();
 							this.itemWorker = null;
@@ -1447,9 +1447,9 @@ export default {
 								newLoaded,
 							);
 						} else {
-							if (this.storageAvailable && this.localStorageAvailable) {
-								setItemsLastSync(new Date().toISOString());
-							}
+                                                        if (this.storageAvailable && this.localStorageAvailable) {
+                                                                setItemsLastSync(r.server_timestamp || new Date().toISOString());
+                                                        }
 							if (this.items && this.items.length > 0) {
 								await this.prePopulateStockCache(this.items);
 							}


### PR DESCRIPTION
## Summary
- enforce limit and offset with safe caps in item and customer search APIs
- return server timestamps and last-modified fields for incremental sync
- use server timestamps in POS frontend to track item and customer sync

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue posawesome/public/js/posapp/components/pos/Customer.vue`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c5728b4b083268476d1d1b40dba8b