### PR TITLE
Add pagination safeguards and server timestamps

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -6,16 +6,19 @@ import json
 import frappe
 from erpnext.accounts.doctype.pos_profile.pos_profile import get_item_groups
 from erpnext.stock.doctype.batch.batch import (
-	get_batch_no,
-	get_batch_qty,
+        get_batch_no,
+        get_batch_qty,
 )
 from erpnext.stock.get_item_details import get_item_details
 from frappe import _
-from frappe.utils import cstr, flt, get_datetime, nowdate
+from frappe.utils import cstr, flt, get_datetime, now, nowdate
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.caching import redis_cache
 
 from .utils import HAS_VARIANTS_EXCLUSION
+
+
+MAX_PAGE_LENGTH = 500
 
 
 def get_stock_availability(item_code, warehouse):
@@ -102,13 +105,14 @@ def get_items(
 			       return ivalue if ivalue >= 0 else None
 		       except (TypeError, ValueError):
 			       return None
-
 		limit = _to_positive_int(limit)
-		offset = _to_positive_int(offset)
+		offset = _to_positive_int(offset) or 0
 
-		search_limit = 0
-		if use_limit_search:
-			search_limit = pos_profile.get("posa_search_limit") or 500
+		search_limit = pos_profile.get("posa_search_limit") if use_limit_search else MAX_PAGE_LENGTH
+		search_limit = min(search_limit or MAX_PAGE_LENGTH, MAX_PAGE_LENGTH)
+
+		if not limit or limit > MAX_PAGE_LENGTH:
+			limit = search_limit
 
 		result = []
 
@@ -158,46 +162,34 @@ def get_items(
 			filters.update(HAS_VARIANTS_EXCLUSION)
 
 		# Determine limit
-		limit_page_length = None
-		limit_start = None
-
-		# When a specific search term is provided, fetch all matching
-		# items. Applying a limit in this scenario can truncate results
-		# and prevent relevant items from appearing in the item selector.
-		if not search_value:
-			if limit is not None:
-				limit_page_length = limit
-				if offset:
-					limit_start = offset
-			elif use_limit_search:
-				limit_page_length = search_limit
-				if pos_profile.get("posa_force_reload_items"):
-					limit_page_length = None
+		limit_page_length = limit
+		limit_start = offset
 
 		items_data = frappe.get_all(
 			"Item",
 			filters=filters,
 			or_filters=or_filters if or_filters else None,
-			fields=[
-				"name as item_code",
-				"item_name",
-				"description",
-				"stock_uom",
-				"image",
-				"is_stock_item",
-				"has_variants",
-				"variant_of",
-				"item_group",
-				"idx",
-				"has_batch_no",
-				"has_serial_no",
-				"max_discount",
-				"brand",
-			],
-			limit_start=limit_start,
-			limit_page_length=limit_page_length,
-			order_by="item_name asc",
-		)
+                        fields=[
+                                "name as item_code",
+                                "item_name",
+                                "description",
+                                "stock_uom",
+                                "image",
+                                "is_stock_item",
+                                "has_variants",
+                                "variant_of",
+                                "item_group",
+                                "idx",
+                                "has_batch_no",
+                                "has_serial_no",
+                                "max_discount",
+                                "brand",
+                                "modified",
+                        ],
+                        limit_start=limit_start,
+                        limit_page_length=limit_page_length,
+                        order_by="item_name asc",
+                )
 
 		if items_data:
 			details = get_items_details(
@@ -242,7 +234,7 @@ def get_items(
 		return result
 
 	if use_price_list:
-		return __get_items(
+		items = __get_items(
 			pos_profile_name,
 			warehouse,
 			price_list,
@@ -254,7 +246,7 @@ def get_items(
 			item_group,
 		)
 	else:
-		return _get_items(
+		items = _get_items(
 			pos_profile,
 			price_list,
 			item_group,
@@ -264,6 +256,8 @@ def get_items(
 			offset,
 			modified_after,
 		)
+
+	return {"items": items, "server_timestamp": now()}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- enforce limit/offset with safe upper bound on Sales Order search API and return a server timestamp
- cap item lookups to a configurable maximum, include modified metadata, and provide a server timestamp for sync clients

## Testing
- `pytest`
- `python -m py_compile posawesome/posawesome/api/sales_orders.py posawesome/posawesome/api/items.py`


------
https://chatgpt.com/codex/tasks/task_e_689c5728b4b083268476d1d1b40dba8b