### PR TITLE
Remove inconsistent type hints

### DIFF
--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -2,7 +2,6 @@
 # For license information, please see license.txt
 
 import json
-from typing import Dict, List
 
 import frappe
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
@@ -24,7 +23,7 @@ from posawesome.posawesome.api.utilities import (
 )  # Updated imports
 
 
-def get_latest_rate(from_currency: str, to_currency: str):
+def get_latest_rate(from_currency, to_currency):
 	"""Return the most recent Currency Exchange rate and its date."""
 	rate_doc = frappe.get_all(
 		"Currency Exchange",
@@ -641,7 +640,7 @@ def get_available_currencies():
 
 
 @frappe.whitelist()
-def fetch_exchange_rate(currency: str, company: str, posting_date: str = None):
+def fetch_exchange_rate(currency, company, posting_date=None):
 	"""Return latest exchange rate and its date."""
 	company_currency = frappe.get_cached_value("Company", company, "default_currency")
 	rate, date = get_latest_rate(currency, company_currency)
@@ -649,14 +648,14 @@ def fetch_exchange_rate(currency: str, company: str, posting_date: str = None):
 
 
 @frappe.whitelist()
-def fetch_exchange_rate_pair(from_currency: str, to_currency: str, posting_date: str = None):
+def fetch_exchange_rate_pair(from_currency, to_currency, posting_date=None):
 	"""Return latest exchange rate between two currencies along with rate date."""
 	rate, date = get_latest_rate(from_currency, to_currency)
 	return {"exchange_rate": rate, "date": date}
 
 
 @frappe.whitelist()
-def get_price_list_currency(price_list: str) -> str:
+def get_price_list_currency(price_list):
 	"""Return the currency of the given Price List."""
 	if not price_list:
 		return None

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -336,8 +336,8 @@ def get_item_variants(pos_profile, parent_item_code, price_list=None, customer=N
 
 	from collections import defaultdict
 
-	attributes_meta: dict[str, set] = defaultdict(set)
-	item_attr_map: dict[str, list] = defaultdict(list)
+	attributes_meta = defaultdict(set)
+	item_attr_map = defaultdict(list)
 
 	for row in attr_rows:
 		attributes_meta[row.attribute].add(row.attribute_value)

--- a/posawesome/posawesome/api/utilities.py
+++ b/posawesome/posawesome/api/utilities.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import json
 import frappe
 from frappe.utils import cstr, add_to_date, get_datetime
-from typing import List, Dict
 import time
 import os
 import psutil
@@ -132,7 +131,7 @@ def get_selling_price_lists():
 
 
 @frappe.whitelist()
-def get_app_info() -> Dict[str, List[Dict[str, str]]]:
+def get_app_info():
 	"""
 	Return a list of installed apps and their versions.
 	"""
@@ -191,9 +190,9 @@ def get_language_options():
 
 	languages = {"en"}
 
-	def normalize(code: str) -> str:
-		"""Return language code normalized for comparison."""
-		return code.strip().lower().replace("_", "-")
+       def normalize(code):
+               """Return language code normalized for comparison."""
+               return code.strip().lower().replace("_", "-")
 
 	# Collect languages from translation CSV files
 	for app in frappe.get_installed_apps():
@@ -214,7 +213,7 @@ def get_language_options():
 
 
 @frappe.whitelist()
-def get_translation_dict(lang: str) -> dict:
+def get_translation_dict(lang):
 	"""Return translations for the given language from all installed apps."""
 	from frappe.translate import get_translations_from_csv
 
@@ -249,7 +248,7 @@ def get_translation_dict(lang: str) -> dict:
 
 
 @frappe.whitelist()
-def get_pos_profile_tax_inclusive(pos_profile: str):
+def get_pos_profile_tax_inclusive(pos_profile):
 	"""Return the 'posa_tax_inclusive' setting for the given POS Profile."""
 	if not pos_profile:
 		return None


### PR DESCRIPTION
## Summary
- Remove `typing` imports and inline annotations for consistency
- Drop function return and parameter type hints across API modules

## Testing
- `python -m ruff check .` (fails: 135 errors, 91 fixable)

------
https://chatgpt.com/codex/tasks/task_e_689c5cb91cc08326bca5e6706125ba78