### PR TITLE
refactor: reuse ORM item group retrieval

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -4,10 +4,9 @@
 import json
 
 import frappe
-from erpnext.accounts.doctype.pos_profile.pos_profile import get_item_groups
 from erpnext.stock.doctype.batch.batch import (
-	get_batch_no,
-	get_batch_qty,
+get_batch_no,
+get_batch_qty,
 )
 from erpnext.stock.get_item_details import get_item_details
 from frappe import _
@@ -15,7 +14,7 @@ from frappe.utils import cstr, flt, get_datetime, nowdate
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.caching import redis_cache
 
-from .utils import HAS_VARIANTS_EXCLUSION
+from .utils import HAS_VARIANTS_EXCLUSION, get_item_groups
 
 
 def get_stock_availability(item_code, warehouse):
@@ -123,7 +122,6 @@ def get_items(
 
 		# Add item group filter
 		item_groups = get_item_groups(pos_profile.get("name"))
-		item_groups = [g.strip("'") for g in item_groups]
 		if item_groups:
 			filters["item_group"] = ["in", item_groups]
 

--- a/posawesome/posawesome/api/utilities.py
+++ b/posawesome/posawesome/api/utilities.py
@@ -12,6 +12,9 @@ import os
 import psutil
 import functools
 
+from .utils import get_item_groups
+
+
 def get_version():
 	branch_name = get_app_branch("erpnext")
 	if "12" in branch_name:
@@ -58,13 +61,14 @@ def get_child_nodes(group_type, root):
 	)
 
 
-def get_item_group_condition(pos_profile):
-	cond = " and 1=1"
-	item_groups = get_item_groups(pos_profile)
-	if item_groups:
-		cond = " and item_group in (%s)" % (", ".join(["%s"] * len(item_groups)))
+def get_item_group_condition(pos_profile, item_groups=None):
+        cond = " and 1=1"
+        item_groups = item_groups or get_item_groups(pos_profile)
+        if item_groups:
+                cond = " and item_group in (%s)" % (", ".join(["%s"] * len(item_groups)))
+                return cond % tuple(item_groups)
 
-	return cond % tuple(item_groups)
+        return cond
 
 
 def add_taxes_from_tax_template(item, parent_doc):

--- a/posawesome/posawesome/api/utils.py
+++ b/posawesome/posawesome/api/utils.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
+
+from functools import cache
+
 import frappe
 
 # Reusable ORM filter to exclude template items
 HAS_VARIANTS_EXCLUSION = {"has_variants": 0}
+
 
 @frappe.whitelist()
 def get_active_pos_profile(user=None):
@@ -15,6 +19,7 @@ def get_active_pos_profile(user=None):
         return None
     return frappe.get_doc("POS Profile", profile).as_dict()
 
+
 @frappe.whitelist()
 def get_default_warehouse(company=None):
     """Return the default warehouse for the given company."""
@@ -25,3 +30,25 @@ def get_default_warehouse(company=None):
     if not warehouse:
         warehouse = frappe.db.get_single_value("Stock Settings", "default_warehouse")
     return warehouse
+
+
+@cache
+def get_item_groups(pos_profile: str) -> list[str]:
+    """Return item groups linked to a POS profile using the ORM.
+
+    Results are cached to avoid duplicate database calls when the same
+    profile's item groups are requested multiple times within a process.
+    Handles the case where the child DocType is missing by returning an
+    empty list instead of raising a database error.
+    """
+    if not pos_profile:
+        return []
+
+    if not frappe.db.exists("DocType", "POS Profile Item Group"):
+        return []
+
+    return frappe.get_all(
+        "POS Profile Item Group",
+        filters={"parent": pos_profile},
+        pluck="item_group",
+    )


### PR DESCRIPTION
## Summary
- add cached `get_item_groups` helper using ORM
- reuse cached item groups in item and utility APIs
- guard item group retrieval when the child DocType is missing

## Testing
- `ruff check posawesome/posawesome/api/utils.py posawesome/posawesome/api/items.py posawesome/posawesome/api/utilities.py`
- `python -m py_compile posawesome/posawesome/api/utils.py posawesome/posawesome/api/items.py posawesome/posawesome/api/utilities.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c5c6ce2188326a0b30b6f4213c9c8