### PR TITLE
feat: add composite indexes for frequent filters

### DIFF
--- a/posawesome/patches.txt
+++ b/posawesome/patches.txt
@@ -1,1 +1,2 @@
 posawesome.patches.add_item_price_index
+posawesome.patches.add_composite_indexes

--- a/posawesome/patches/add_composite_indexes.py
+++ b/posawesome/patches/add_composite_indexes.py
@@ -1,0 +1,59 @@
+import frappe
+
+
+def execute():
+	indexes = [
+		(
+			"Item",
+			[
+				"is_sales_item",
+				"disabled",
+				"is_fixed_asset",
+				"has_variants",
+				"item_group",
+				"item_name",
+			],
+			"sales_disabled_fixed_variants_group_name",
+		),
+		("Item Barcode", ["barcode"], "barcode"),
+		("Item Barcode", ["parent"], "parent"),
+		(
+			"Serial No",
+			["item_code", "warehouse", "status"],
+			"item_warehouse_status",
+		),
+		("Bin", ["item_code", "warehouse"], "item_code_warehouse"),
+		(
+			"Stock Ledger Entry",
+			[
+				"warehouse",
+				"item_code",
+				"batch_no",
+				"is_cancelled",
+				"posting_date",
+				"posting_time",
+				"creation",
+			],
+			"warehouse_item_batch_cancel_posting_creation",
+		),
+		("Batch", ["item", "disabled", "expiry_date"], "item_disabled_expiry"),
+		(
+			"Item Price",
+			[
+				"price_list",
+				"currency",
+				"selling",
+				"item_code",
+				"uom",
+				"valid_from",
+				"valid_upto",
+			],
+			"pricelist_currency_selling_item_uom_validfrom_upto",
+		),
+	]
+
+	for doctype, fields, index_name in indexes:
+		try:
+			frappe.db.add_index(doctype, fields, index_name=index_name)
+		except Exception as e:
+			frappe.log_error(str(e), "Add composite indexes")


### PR DESCRIPTION
## Summary
- add patch to create composite indexes for common filter combinations
- register new patch

## Testing
- `ruff check posawesome/patches/add_composite_indexes.py`
- `pytest`
- `ruff check .` *(fails: 162 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dc7ac9cc48326941008e4324d4364