### PR TITLE
Ensure consistent item pagination ordering

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -126,7 +126,7 @@ def get_items(
 		# Build ORM filters
 		filters = {"disabled": 0, "is_sales_item": 1, "is_fixed_asset": 0}
 		if start_after:
-			filters["name"] = [">", start_after]
+			filters["item_name"] = [">", start_after]
 		if modified_after:
 			try:
 				parsed_modified_after = get_datetime(modified_after)
@@ -177,8 +177,6 @@ def get_items(
 		limit_page_length = None
 		limit_start = None
 		order_by = "item_name asc"
-		if start_after:
-			order_by = "name asc"
 
 		# When a specific search term is provided, fetch all matching
 		# items. Applying a limit in this scenario can truncate results

--- a/posawesome/posawesome/api/test_items_numeric_code.py
+++ b/posawesome/posawesome/api/test_items_numeric_code.py
@@ -1,0 +1,45 @@
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from posawesome.posawesome.api.items import get_items
+
+
+class TestNumericItemCodes(FrappeTestCase):
+    def setUp(self):
+        items = [
+            ("ALPHA-TEST", "Alpha"),
+            ("BETA-TEST", "Beta"),
+            ("002", "Gamma"),
+        ]
+        for code, name in items:
+            if frappe.db.exists("Item", code):
+                item = frappe.get_doc("Item", code)
+                item.item_name = name
+                item.is_sales_item = 1
+                item.is_fixed_asset = 0
+                item.save(ignore_permissions=True)
+            else:
+                frappe.get_doc(
+                    {
+                        "doctype": "Item",
+                        "item_code": code,
+                        "item_name": name,
+                        "stock_uom": "Nos",
+                        "is_stock_item": 0,
+                        "item_group": "All Item Groups",
+                        "is_sales_item": 1,
+                        "is_fixed_asset": 0,
+                    }
+                ).insert(ignore_permissions=True, ignore_mandatory=True)
+
+    def test_numeric_code_appears_without_search(self):
+        pos_profile = json.dumps({"name": "TestProfile"})
+        with patch("posawesome.posawesome.api.items.get_items_details", return_value=[]):
+            first_page = get_items(pos_profile, limit=2)
+            last_name = first_page[-1]["item_name"]
+            second_page = get_items(pos_profile, limit=2, start_after=last_name)
+        codes = [i["item_code"] for i in second_page]
+        self.assertIn("002", codes)

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1300,10 +1300,10 @@ export default {
 					}
 				}
 
-                                if (hasMore) {
-                                        const last = items[items.length - 1]?.item_code || null;
-                                        this.backgroundLoadItems(last, null, false, requestToken, items.length);
-                                }
+                               if (hasMore) {
+                                       const last = items[items.length - 1]?.item_name || null;
+                                       this.backgroundLoadItems(last, null, false, requestToken, items.length);
+                               }
 			} catch (error) {
 				console.error("Failed to load items:", error);
 				frappe.msgprint(__("Failed to load items. Please try again."));
@@ -1343,7 +1343,7 @@ export default {
 					if (this.items_request_token !== requestToken) {
 						return;
 					}
-                                        let lastItemCode = null;
+                                       let lastItemName = null;
                                         const count = await new Promise((resolve) => {
                                                 this.itemWorker.onmessage = async (ev) => {
                                                         if (this.items_request_token !== requestToken) {
@@ -1357,7 +1357,7 @@ export default {
                                                                         if (existing) Object.assign(existing, it);
                                                                         else this.items.push(it);
                                                                 });
-                                                                lastItemCode = newItems[newItems.length - 1]?.item_code || null;
+                                                               lastItemName = newItems[newItems.length - 1]?.item_name || null;
                                                                 this.eventBus.emit("set_all_items", this.items);
                                                                 if (
                                                                         this.pos_profile &&
@@ -1394,15 +1394,15 @@ export default {
                                         const newLoaded = loaded + count;
                                         const progress = Math.min(99, Math.round((newLoaded / (newLoaded + limit)) * 100));
                                         this.eventBus.emit("data-load-progress", { name: "items", progress });
-                                        if (count === limit) {
-                                                await this.backgroundLoadItems(
-                                                        lastItemCode,
-                                                        syncSince,
-                                                        clearBefore,
-                                                        requestToken,
-                                                        newLoaded,
-                                                );
-                                        } else {
+                                       if (count === limit) {
+                                               await this.backgroundLoadItems(
+                                                       lastItemName,
+                                                       syncSince,
+                                                       clearBefore,
+                                                       requestToken,
+                                                       newLoaded,
+                                               );
+                                       } else {
 						if (this.storageAvailable && this.localStorageAvailable) {
 							setItemsLastSync(new Date().toISOString());
 						}
@@ -1466,16 +1466,16 @@ export default {
 						const newLoaded = loaded + rows.length;
 						const progress = Math.min(99, Math.round((newLoaded / (newLoaded + limit)) * 100));
 						this.eventBus.emit("data-load-progress", { name: "items", progress });
-                                                if (rows.length === limit) {
-                                                        const nextStart = rows[rows.length - 1]?.item_code || null;
-                                                        await this.backgroundLoadItems(
-                                                                nextStart,
-                                                                syncSince,
-                                                                clearBefore,
-                                                                requestToken,
-                                                                newLoaded,
-                                                        );
-                                                } else {
+                                               if (rows.length === limit) {
+                                                       const nextStart = rows[rows.length - 1]?.item_name || null;
+                                                       await this.backgroundLoadItems(
+                                                               nextStart,
+                                                               syncSince,
+                                                               clearBefore,
+                                                               requestToken,
+                                                               newLoaded,
+                                                       );
+                                               } else {
 							if (this.storageAvailable && this.localStorageAvailable) {
 								setItemsLastSync(new Date().toISOString());
 							}


### PR DESCRIPTION
## Summary
- Order and paginate items by `item_name` consistently in API
- Track last `item_name` when loading more items on the front-end
- Add regression test for numeric item codes appearing in listings

## Testing
- `ruff check posawesome/posawesome/api/items.py posawesome/posawesome/api/test_items_numeric_code.py`
- `pytest posawesome/posawesome/api/test_items_numeric_code.py::TestNumericItemCodes::test_numeric_code_appears_without_search -q` *(fails: ModuleNotFoundError: No module named 'frappe.utils')*


------
https://chatgpt.com/codex/tasks/task_e_689ddf41c418832694d4c35907c643ca