### PR TITLE
fix: hide item variants when setting enabled

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2552,7 +2552,7 @@ export default {
 			}
 
 			// Apply template/variant filter
-			if (this.pos_profile?.posa_show_template_items && this.pos_profile?.posa_hide_variants_items) {
+			if (this.pos_profile?.posa_hide_variants_items) {
 				filteredItems = filteredItems.filter((item) => !item.variant_of);
 			}
 


### PR DESCRIPTION
## Summary
- honor `posa_hide_variants_items` setting when filtering items in selector

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`


------
https://chatgpt.com/codex/tasks/task_e_689e0fc0a72483269d50f598a428c051