### PR TITLE
fix: respect hide variant items setting

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -175,6 +175,9 @@ def get_items(
         if not posa_show_template_items:
             filters.update(HAS_VARIANTS_EXCLUSION)
 
+        if pos_profile.get("posa_hide_variants_items"):
+            filters["variant_of"] = ["is", "not set"]
+
         # Determine limit
         limit_page_length = None
         limit_start = None

--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2552,7 +2552,7 @@ export default {
 			}
 
 			// Apply template/variant filter
-			if (this.pos_profile?.posa_show_template_items && this.pos_profile?.posa_hide_variants_items) {
+			if (this.pos_profile?.posa_hide_variants_items) {
 				filteredItems = filteredItems.filter((item) => !item.variant_of);
 			}
 


### PR DESCRIPTION
## Summary
- hide variant items when `hide variant item` setting is enabled in the item selector
- filter out variant items on the server API when variant hiding is active

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `python -m py_compile posawesome/posawesome/api/items.py`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e0fc0a72483269d50f598a428c051