### PR TITLE
refactor: streamline item reload logic

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1105,82 +1105,16 @@ export default {
 			}
 		},
 
-		show_offers() {
-			this.eventBus.emit("show_offers", "true");
-		},
-		show_coupons() {
-			this.eventBus.emit("show_coupons", "true");
-		},
-		async forceLoadItems() {
-			console.log("🚀 forceLoadItems called");
-			try {
-				// Ensure POS profile is available
-				if (!this.pos_profile) {
-					const profile = await ensurePosProfile();
-					if (profile) {
-						this.pos_profile = profile;
-					} else {
-						console.error("❌ Failed to get POS profile");
-						return;
-					}
-				}
-
-				// Go directly to API call for simplicity
-				console.log("🌐 Making direct API call to load items");
-				const requestBody = {
-					pos_profile: JSON.stringify(this.pos_profile),
-					price_list: this.customer_price_list || this.pos_profile.selling_price_list,
-					item_group: "",
-					search_value: "",
-					customer: this.customer,
-					limit: 50,
-					start_after: null,
-					include_image: 1,
-				};
-				frappe.dom.freeze();
-				frappe.call({
-					method: "posawesome.posawesome.api.items.get_items",
-					args: requestBody,
-					callback: (res) => {
-						frappe.dom.unfreeze();
-						if (!res.exc && Array.isArray(res.message)) {
-							this.items = res.message;
-							console.log("✅ Items loaded successfully:", this.items.length, "items");
-
-							// Set default quantities immediately for instant display
-							this.items.forEach((item) => {
-								item.actual_qty = 0; // Set default quantity
-							});
-
-							// Clear search cache when new items are loaded
-							if (this.searchCache) {
-								this.searchCache.clear();
-							}
-
-							this.eventBus.emit("set_all_items", this.items);
-
-							// Force a reactive update immediately
-							this.$nextTick(() => {
-								this.$forceUpdate();
-							});
-
-							// Load quantities in background (non-blocking)
-							setTimeout(() => {
-								this.update_items_details(this.items);
-							}, 100);
-						} else {
-							console.error("❌ Invalid response format");
-						}
-					},
-				});
-			} catch (error) {
-				console.error("❌ Error in forceLoadItems:", error.message);
-			}
-		},
-		async forceReloadItems() {
-			// Clear cached price list items so the reload always
-			// fetches the latest data from the server
-			await clearPriceListCache();
+               show_offers() {
+                       this.eventBus.emit("show_offers", "true");
+               },
+               show_coupons() {
+                       this.eventBus.emit("show_coupons", "true");
+               },
+               async forceReloadItems() {
+                       // Clear cached price list items so the reload always
+                       // fetches the latest data from the server
+                       await clearPriceListCache();
 			await this.ensureStorageHealth();
 			this.items_loaded = false;
 			await this.get_items(true);


### PR DESCRIPTION
## Summary
- remove legacy forceLoadItems method
- route item reloads through forceReloadItems and get_items

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm test` *(fails: missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e375f3108832681c26a12cd94e159