### PR TITLE
Load POS items on profile registration

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2682,11 +2682,13 @@ export default {
                        });
 
 		// Event listeners
-		this.eventBus.on("register_pos_profile", (data) => {
-			this.pos_profile = data.pos_profile;
-			this.get_items();
-			this.items_view = this.pos_profile.posa_default_card_view ? "card" : "list";
-		});
+               this.eventBus.on("register_pos_profile", (data) => {
+                       this.pos_profile = data.pos_profile;
+                       this.items_view = this.pos_profile.posa_default_card_view ? "card" : "list";
+                       if (!this.items_loaded) {
+                               this.get_items();
+                       }
+               });
 		this.eventBus.on("update_cur_items_details", () => {
 			this.update_cur_items_details();
 		});


### PR DESCRIPTION
## Summary
- Load item data when POS profile registers and items aren't yet loaded

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e449d460083268ff04dcb682962ea