### PR TITLE
refactor: consolidate worker initialization

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -457,6 +457,7 @@ import {
 } from "../../../offline/index.js";
 import { useResponsive } from "../../composables/useResponsive.js";
 import { useRtl } from "../../composables/useRtl.js";
+import { initializeWorker } from "./workerUtils.js";
 
 export default {
 	mixins: [format],
@@ -2749,47 +2750,7 @@ export default {
                         }
                 });
 
-		if (typeof Worker !== "undefined") {
-			try {
-				// Use the plain URL so the service worker can match the cached file
-				// even when offline. Using a query string causes cache lookups to fail
-				// which results in "Failed to fetch a worker script" errors.
-				const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
-				this.itemWorker = new Worker(workerUrl, { type: "classic" });
-
-				this.itemWorker.onerror = function (event) {
-					console.error("Worker error:", event);
-					console.error("Message:", event.message);
-					console.error("Filename:", event.filename);
-					console.error("Line number:", event.lineno);
-				};
-				console.log("Created worker");
-			} catch (e) {
-				console.error("Failed to start item worker", e);
-				this.itemWorker = null;
-			}
-		}
-
-		if (typeof Worker !== "undefined") {
-			try {
-				// Use the plain URL so the service worker can match the cached file
-				// even when offline. Using a query string causes cache lookups to fail
-				// which results in "Failed to fetch a worker script" errors.
-				const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
-				this.itemWorker = new Worker(workerUrl, { type: "classic" });
-
-				this.itemWorker.onerror = function (event) {
-					console.error("Worker error:", event);
-					console.error("Message:", event.message);
-					console.error("Filename:", event.filename);
-					console.error("Line number:", event.lineno);
-				};
-				console.log("Created worker");
-			} catch (e) {
-				console.error("Failed to start item worker", e);
-				this.itemWorker = null;
-			}
-		}
+               this.itemWorker = initializeWorker(this.itemWorker);
 
 		// Setup auto-refresh for item quantities
 		// Trigger an immediate refresh once items are available

--- a/posawesome/public/js/posapp/components/pos/workerUtils.js
+++ b/posawesome/public/js/posapp/components/pos/workerUtils.js
@@ -1,0 +1,20 @@
+export function initializeWorker(existingWorker) {
+  if (typeof Worker !== "undefined" && !existingWorker) {
+    try {
+      const workerUrl = "/assets/posawesome/js/posapp/workers/itemWorker.js";
+      const worker = new Worker(workerUrl, { type: "classic" });
+      worker.onerror = function (event) {
+        console.error("Worker error:", event);
+        console.error("Message:", event.message);
+        console.error("Filename:", event.filename);
+        console.error("Line number:", event.lineno);
+      };
+      console.log("Created worker");
+      return worker;
+    } catch (e) {
+      console.error("Failed to start item worker", e);
+      return null;
+    }
+  }
+  return existingWorker;
+}

--- a/posawesome/public/js/posapp/components/pos/workerUtils.test.js
+++ b/posawesome/public/js/posapp/components/pos/workerUtils.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { initializeWorker } from './workerUtils.js';
+
+test('initializeWorker creates worker only once and emits no warnings', () => {
+  let constructionCount = 0;
+  const originalWorker = global.Worker;
+  const originalWarn = console.warn;
+  let warnCount = 0;
+
+  global.Worker = class {
+    constructor(url, opts) {
+      constructionCount++;
+      this.url = url;
+      this.opts = opts;
+    }
+    terminate() {}
+  };
+
+  console.warn = () => {
+    warnCount++;
+  };
+
+  let worker = initializeWorker(null);
+  worker = initializeWorker(worker);
+
+  assert.equal(constructionCount, 1);
+  assert.equal(warnCount, 0);
+
+  console.warn = originalWarn;
+  global.Worker = originalWorker;
+});


### PR DESCRIPTION
## Summary
- remove duplicate worker startup in `ItemsSelector.vue`
- expose shared `initializeWorker` utility to avoid multiple workers
- add node test verifying worker starts once without console warnings

## Testing
- `node --no-warnings --test posawesome/public/js/posapp/components/pos/workerUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689eeae38ae88326bac51d843926d6f2