### PR TITLE
Reset search state before reloading POS items

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -435,25 +435,27 @@ import {
 	initializeStockCache,
 	searchStoredItems,
 	saveItemsBulk,
-	saveItems,
-	clearStoredItems,
-	getLocalStockCache,
-	setLocalStockCache,
-	initPromise,
-	memoryInitPromise,
-	checkDbHealth,
-	getCachedPriceListItems,
-	savePriceListItems,
-	clearPriceListCache,
-	updateLocalStockCache,
-	isStockCacheReady,
-	getCachedItemDetails,
-	saveItemDetailsCache,
-	saveItemGroups,
-	getCachedItemGroups,
-	getItemsLastSync,
-	setItemsLastSync,
-	forceClearAllCache,
+        saveItems,
+        clearStoredItems,
+        getLocalStockCache,
+        setLocalStockCache,
+        initPromise,
+        memoryInitPromise,
+        checkDbHealth,
+        getCachedPriceListItems,
+        savePriceListItems,
+        clearPriceListCache,
+        updateLocalStockCache,
+        clearLocalStockCache,
+        isStockCacheReady,
+        getCachedItemDetails,
+        saveItemDetailsCache,
+        saveItemGroups,
+        getCachedItemGroups,
+        clearItemGroups,
+        getItemsLastSync,
+        setItemsLastSync,
+        forceClearAllCache,
 } from "../../../offline/index.js";
 import { useResponsive } from "../../composables/useResponsive.js";
 import { useRtl } from "../../composables/useRtl.js";
@@ -1179,10 +1181,21 @@ export default {
 			}
 		},
                 async forceReloadItems() {
-                        // Clear cached price list items so the reload always
-                        // fetches the latest data from the server
+                        // Reset search-related state
+                        this.first_search = "";
+                        this.search = "";
+                        if (this.searchCache) {
+                                this.searchCache.clear();
+                        }
+
+                        // Clear cached data so the reload always fetches
+                        // the latest information from the server
                         await clearPriceListCache();
+                        await clearStoredItems();
+                        clearLocalStockCache();
+                        clearItemGroups();
                         await this.ensureStorageHealth();
+
                         this.items_loaded = false;
                         await this.get_items(true);
                 },


### PR DESCRIPTION
## Summary
- Reset search-related fields and caches when forcing item reload
- Import utilities to clear local stock and item group caches

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689eed0becc083269e2eb441ff44684a