### PR TITLE
feat: fetch items on startup with offline fallback

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -2800,10 +2800,14 @@ export default {
 			}
 		}
 
-		// Load items if we have a profile and haven't loaded yet
-		if (this.pos_profile && this.pos_profile.name && !this.items_loaded) {
-			await this.get_items();
-		}
+               // Always load items on mount; prefer server when online
+               if (this.pos_profile && this.pos_profile.name) {
+                       if (isOffline()) {
+                               await this.get_items();
+                       } else {
+                               await this.get_items(true);
+                       }
+               }
 
 		// Setup barcode scanner if enabled
 		if (this.pos_profile?.posa_enable_barcode_scanning) {


### PR DESCRIPTION
## Summary
- Always load items when POS app mounts
- Load from server when online, fallback to local items when offline

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689eefc46cec8326bc51006da5796a45