### PR TITLE
fix: reload items when search is empty

### DIFF
--- a/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/posawesome/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1177,14 +1177,21 @@ export default {
 				console.error("❌ Error in forceLoadItems:", error.message);
 			}
 		},
-		async forceReloadItems() {
-			// Clear cached price list items so the reload always
-			// fetches the latest data from the server
-			await clearPriceListCache();
-			await this.ensureStorageHealth();
-			this.items_loaded = false;
-			await this.get_items(true);
-		},
+                async forceReloadItems() {
+                        // Clear cached price list items so the reload always
+                        // fetches the latest data from the server
+                        await clearPriceListCache();
+                        await this.ensureStorageHealth();
+                        this.items_loaded = false;
+                        // If the search box is empty, ensure we fetch a fresh
+                        // set of items from the server rather than relying on
+                        // any previously cached search term.
+                        if (!this.first_search || !this.first_search.trim()) {
+                                await this.forceLoadItems();
+                        } else {
+                                await this.get_items(true);
+                        }
+                },
 		async verifyServerItemCount() {
 			if (isOffline()) {
 				return;


### PR DESCRIPTION
## Summary
- ensure reload items fetches fresh data when search box is blank

## Testing
- `npx eslint posawesome/public/js/posapp/components/pos/ItemsSelector.vue`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f161ef0c08326aa8edec77ad8133e