### PR TITLE
fix: fetch batch data based on item warehouse

### DIFF
--- a/frontend/src/posapp/components/pos/Variants.vue
+++ b/frontend/src/posapp/components/pos/Variants.vue
@@ -90,16 +90,17 @@ import { ensurePosProfile } from "../../../utils/pos_profile.js";
 import _ from "lodash";
 import placeholderImage from "./placeholder-image.png";
 export default {
-	data: () => ({
-		varaintsDialog: false,
-		parentItem: null,
-		items: null,
-		filters: {},
-		filterdItems: [],
-		pos_profile: null,
-		attributes_meta: {},
-		displayCount: 100,
-	}),
+        data: () => ({
+                varaintsDialog: false,
+                parentItem: null,
+                items: null,
+                filters: {},
+                filterdItems: [],
+                pos_profile: null,
+                attributes_meta: {},
+                displayCount: 100,
+                placeholderImage,
+        }),
 
 	computed: {
 		variantsItems() {
@@ -236,11 +237,11 @@ export default {
 							typeof item.item_attributes === "string" &&
 							item.item_attributes.trim().startsWith("[")
 						) {
-							try {
-								attrs = JSON.parse(item.item_attributes);
-							} catch (e) {
-								attrs = [];
-							}
+                                                        try {
+                                                                attrs = JSON.parse(item.item_attributes);
+                                                        } catch {
+                                                                attrs = [];
+                                                        }
 						}
 						for (const [attrName, val] of Object.entries(this.filters)) {
 							if (!val) continue;
@@ -299,7 +300,7 @@ export default {
 				const res = await frappe.call({
 					method: "posawesome.posawesome.api.items.get_item_detail",
 					args: {
-						warehouse: this.pos_profile.warehouse,
+                                                warehouse: item.warehouse || this.pos_profile.warehouse,
 						price_list: this.pos_profile.selling_price_list,
 						company: this.pos_profile.company,
 						item: JSON.stringify({

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1327,14 +1327,15 @@ export default {
 					transaction_type: "selling",
 					update_stock: this.pos_profile.update_stock,
 					price_list: this.get_price_list(),
-					has_batch_no: item.has_batch_no,
-					serial_no: item.serial_no,
-					batch_no: item.batch_no,
-					is_stock_item: item.is_stock_item,
-				},
-			},
-			callback: function (r) {
-				if (r.message) {
+                                        has_batch_no: item.has_batch_no,
+                                        has_serial_no: item.has_serial_no,
+                                        serial_no: item.serial_no,
+                                        batch_no: item.batch_no,
+                                        is_stock_item: item.is_stock_item,
+                                },
+                        },
+                        callback: function (r) {
+                                if (r.message) {
 					const data = r.message;
 					if (!item.warehouse) {
 						item.warehouse = vm.pos_profile.warehouse;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1303,14 +1303,14 @@ export default {
 		//   this.$forceUpdate();
 		// }
 
-		frappe.call({
-			method: "posawesome.posawesome.api.items.get_item_detail",
-			args: {
-				warehouse: this.pos_profile.warehouse,
-				doc: this.get_invoice_doc(),
-				price_list: this.selected_price_list || this.pos_profile.selling_price_list,
-				item: {
-					item_code: item.item_code,
+                frappe.call({
+                        method: "posawesome.posawesome.api.items.get_item_detail",
+                        args: {
+                                warehouse: item.warehouse || this.pos_profile.warehouse,
+                                doc: this.get_invoice_doc(),
+                                price_list: this.selected_price_list || this.pos_profile.selling_price_list,
+                                item: {
+                                        item_code: item.item_code,
 					customer: this.customer,
 					doctype: "Sales Invoice",
 					name: "New Sales Invoice 1",


### PR DESCRIPTION
## Summary
- use item's warehouse when expanding invoice rows to load batch and serial data
- pass item's warehouse to variant rate fetching and expose placeholder image

## Testing
- `npx eslint frontend/src/posapp/components/pos/invoiceItemMethods.js frontend/src/posapp/components/pos/Variants.vue`

------
https://chatgpt.com/codex/tasks/task_e_68a23cc279988326a8426f95bef50ff0