### PR TITLE
Fix batch number search in item selector

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1227,10 +1227,17 @@ export default {
 						include_image: 1,
 					},
 				});
-				const message = response.message || {};
-				const items = Array.isArray(message) ? message : message.items || [];
-				vm.flags = message.flags || {};
-				console.log("[ItemsSelector] server responded", { count: items.length });
+                                const message = response.message || {};
+                                let items = [];
+                                if (Array.isArray(message)) {
+                                        items = message;
+                                } else if (Array.isArray(message.items)) {
+                                        items = message.items;
+                                } else if (message.items && typeof message.items === "object") {
+                                        items = Object.values(message.items);
+                                }
+                                vm.flags = message.flags || {};
+                                console.log("[ItemsSelector] server responded", { count: items.length });
 
 				// Process items
 				items.forEach((item) => {
@@ -1331,9 +1338,16 @@ export default {
 						},
 						freeze: false,
 					});
-					const message = res.message || {};
-					const itemsRes = Array.isArray(message) ? message : message.items || [];
-					this.flags = message.flags || {};
+                                        const message = res.message || {};
+                                        let itemsRes = [];
+                                        if (Array.isArray(message)) {
+                                                itemsRes = message;
+                                        } else if (Array.isArray(message.items)) {
+                                                itemsRes = message.items;
+                                        } else if (message.items && typeof message.items === "object") {
+                                                itemsRes = Object.values(message.items);
+                                        }
+                                        this.flags = message.flags || {};
 					console.log("[ItemsSelector] background load server response", {
 						count: itemsRes.length,
 					});
@@ -1451,9 +1465,16 @@ export default {
 							console.log("[ItemsSelector] background load token mismatch in callback");
 							return;
 						}
-						const message = r.message || {};
-						const rows = Array.isArray(message) ? message : message.items || [];
-						this.flags = message.flags || {};
+                                                const message = r.message || {};
+                                                let rows = [];
+                                                if (Array.isArray(message)) {
+                                                        rows = message;
+                                                } else if (Array.isArray(message.items)) {
+                                                        rows = message.items;
+                                                } else if (message.items && typeof message.items === "object") {
+                                                        rows = Object.values(message.items);
+                                                }
+                                                this.flags = message.flags || {};
 						console.log("[ItemsSelector] background load callback items", { count: rows.length });
 						rows.forEach((it) => {
 							const existing = this.items.find((i) => i.item_code === it.item_code);

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -298,7 +298,10 @@ def get_items(
             if len(items_data) < page_size:
                 break
 
-        return result[:limit_page_length] if limit_page_length else result
+        return {
+            "items": result[:limit_page_length] if limit_page_length else result,
+            "flags": data,
+        }
 
     if use_price_list:
         return __get_items(

--- a/posawesome/posawesome/api/test_items_numeric_code.py
+++ b/posawesome/posawesome/api/test_items_numeric_code.py
@@ -40,8 +40,8 @@ class TestNumericItemCodes(FrappeTestCase):
         with patch(
             "posawesome.posawesome.api.items.get_items_details", return_value=[]
         ):
-            first_page = get_items(pos_profile, limit=2)
+            first_page = get_items(pos_profile, limit=2)["items"]
             last_name = first_page[-1]["item_name"]
-            second_page = get_items(pos_profile, limit=2, start_after=last_name)
+            second_page = get_items(pos_profile, limit=2, start_after=last_name)["items"]
         codes = [i["item_code"] for i in second_page]
         self.assertIn("002", codes)


### PR DESCRIPTION
## Summary
- return item search flags from get_items API
- handle batch/serial search flags in ItemsSelector and skip client-side filtering
- adjust tests for new get_items response structure

## Testing
- `npx eslint frontend/src/posapp/components/pos/ItemsSelector.vue`
- `ruff check posawesome/posawesome/api/items.py posawesome/posawesome/api/test_items_numeric_code.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68a2da93506483269321e3ae03be7f72