### PR TITLE
Fix batch number search in item selector

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -298,7 +298,10 @@ def get_items(
             if len(items_data) < page_size:
                 break
 
-        return result[:limit_page_length] if limit_page_length else result
+        return {
+            "items": result[:limit_page_length] if limit_page_length else result,
+            "flags": data,
+        }
 
     if use_price_list:
         return __get_items(

--- a/posawesome/posawesome/api/test_items_numeric_code.py
+++ b/posawesome/posawesome/api/test_items_numeric_code.py
@@ -40,8 +40,8 @@ class TestNumericItemCodes(FrappeTestCase):
         with patch(
             "posawesome.posawesome.api.items.get_items_details", return_value=[]
         ):
-            first_page = get_items(pos_profile, limit=2)
+            first_page = get_items(pos_profile, limit=2)["items"]
             last_name = first_page[-1]["item_name"]
-            second_page = get_items(pos_profile, limit=2, start_after=last_name)
+            second_page = get_items(pos_profile, limit=2, start_after=last_name)["items"]
         codes = [i["item_code"] for i in second_page]
         self.assertIn("002", codes)


### PR DESCRIPTION
## Summary
- return item search flags from get_items API
- handle batch/serial search flags in ItemsSelector and skip client-side filtering
- adjust tests for new get_items response structure
- normalize get_items responses to handle non-array shapes

## Testing
- `npx eslint frontend/src/posapp/components/pos/ItemsSelector.vue`
- `ruff check posawesome/posawesome/api/items.py posawesome/posawesome/api/test_items_numeric_code.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68a2da93506483269321e3ae03be7f72