### PR TITLE
fix: handle overpayment change as cash

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1,44 +1,87 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
 	<div class="pa-0">
-		<v-card :class="['selection mx-auto pa-1 my-0 mt-3', isDarkTheme ? '' : 'bg-grey-lighten-5']"
-			:style="isDarkTheme ? 'background-color:#1E1E1E' : ''" style="max-height: 68vh; height: 68vh">
-			<v-progress-linear :active="loading" :indeterminate="loading" absolute location="top"
-				color="info"></v-progress-linear>
-                        <div ref="paymentContainer" class="overflow-y-auto pa-2" style="max-height: 67vh">
+		<v-card
+			:class="['selection mx-auto pa-1 my-0 mt-3', isDarkTheme ? '' : 'bg-grey-lighten-5']"
+			:style="isDarkTheme ? 'background-color:#1E1E1E' : ''"
+			style="max-height: 68vh; height: 68vh"
+		>
+			<v-progress-linear
+				:active="loading"
+				:indeterminate="loading"
+				absolute
+				location="top"
+				color="info"
+			></v-progress-linear>
+			<div ref="paymentContainer" class="overflow-y-auto pa-2" style="max-height: 67vh">
 				<!-- Payment Summary (Paid, To Be Paid, Change) -->
 				<v-row v-if="invoice_doc" class="pa-1" dense>
 					<v-col cols="7">
-						<v-text-field variant="solo" color="primary" :label="frappe._('Paid Amount')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
-							v-model="total_payments_display" readonly :prefix="currencySymbol(invoice_doc.currency)"
-							density="compact" @click="showPaidAmount"></v-text-field>
+						<v-text-field
+							variant="solo"
+							color="primary"
+							:label="frappe._('Paid Amount')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							v-model="total_payments_display"
+							readonly
+							:prefix="currencySymbol(invoice_doc.currency)"
+							density="compact"
+							@click="showPaidAmount"
+						></v-text-field>
 					</v-col>
 					<v-col cols="5">
-						<v-text-field variant="solo" color="primary" label="To Be Paid"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
-							v-model="diff_payment_display" :prefix="currencySymbol(invoice_doc.currency)"
-							density="compact" @focus="showDiffPayment" persistent-placeholder></v-text-field>
+						<v-text-field
+							variant="solo"
+							color="primary"
+							label="To Be Paid"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							v-model="diff_payment_display"
+							:prefix="currencySymbol(invoice_doc.currency)"
+							density="compact"
+							@focus="showDiffPayment"
+							persistent-placeholder
+						></v-text-field>
 					</v-col>
 
 					<!-- Paid Change (if applicable) -->
-					<v-col cols="7" v-if="credit_change > 0 && !invoice_doc.is_return">
-						<v-text-field variant="solo" color="primary" :label="frappe._('Paid Change')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field"
-							:model-value="formatCurrency(paid_change)" :prefix="currencySymbol(invoice_doc.currency)"
-							:rules="paid_change_rules" density="compact" readonly type="text"
-							@click="showPaidChange"></v-text-field>
+					<v-col cols="7" v-if="total_change > 0 && !invoice_doc.is_return">
+						<v-text-field
+							variant="solo"
+							color="primary"
+							:label="frappe._('Paid Change')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							:model-value="formatCurrency(paid_change)"
+							:prefix="currencySymbol(invoice_doc.currency)"
+							:rules="paid_change_rules"
+							density="compact"
+							readonly
+							type="text"
+							@click="showPaidChange"
+						></v-text-field>
 					</v-col>
 
 					<!-- Credit Change (if applicable) -->
-					<v-col cols="5" v-if="credit_change > 0 && !invoice_doc.is_return">
-						<v-text-field variant="solo" color="primary" :label="frappe._('Credit Change')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field"
-							:model-value="formatCurrency(credit_change)" :prefix="currencySymbol(invoice_doc.currency)"
-							density="compact" type="text" @change="
+					<v-col cols="5" v-if="total_change > 0 && !invoice_doc.is_return">
+						<v-text-field
+							variant="solo"
+							color="primary"
+							:label="frappe._('Credit Change')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							:model-value="formatCurrency(credit_change)"
+							:prefix="currencySymbol(invoice_doc.currency)"
+							density="compact"
+							type="text"
+							@change="
 								setFormatedCurrency(this, 'credit_change', null, false, $event);
-							updateCreditChange(this.credit_change);
-							"></v-text-field>
+								updateCreditChange(this.credit_change);
+							"
+						></v-text-field>
 					</v-col>
 				</v-row>
 
@@ -48,21 +91,30 @@
 				<div v-if="is_cashback">
 					<v-row class="payments pa-1" v-for="payment in invoice_doc.payments" :key="payment.name">
 						<v-col cols="6" v-if="!is_mpesa_c2b_payment(payment)">
-							<v-text-field density="compact" variant="solo" color="primary"
-								:label="frappe._(payment.mode_of_payment)" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-								class="dark-field sleek-field" hide-details
+							<v-text-field
+								density="compact"
+								variant="solo"
+								color="primary"
+								:label="frappe._(payment.mode_of_payment)"
+								:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+								class="dark-field sleek-field"
+								hide-details
 								:model-value="formatCurrency(payment.amount)"
-								@change="setFormatedCurrency(payment, 'amount', null, false, $event)" :rules="[
+								@change="setFormatedCurrency(payment, 'amount', null, false, $event)"
+								:rules="[
 									isNumber,
 									(v) =>
 										!payment.mode_of_payment.toLowerCase().includes('cash') ||
 										this.is_credit_sale ||
 										v >=
-										(this.invoice_doc.rounded_total ||
-											this.invoice_doc.grand_total) ||
+											(this.invoice_doc.rounded_total ||
+												this.invoice_doc.grand_total) ||
 										'Cash payment cannot be less than invoice total when credit sale is off',
-								]" :prefix="currencySymbol(invoice_doc.currency)" @focus="set_rest_amount(payment.idx)"
-								:readonly="invoice_doc.is_return"></v-text-field>
+								]"
+								:prefix="currencySymbol(invoice_doc.currency)"
+								@focus="set_rest_amount(payment.idx)"
+								:readonly="invoice_doc.is_return"
+							></v-text-field>
 						</v-col>
 						<v-col cols="6" v-if="!is_mpesa_c2b_payment(payment)">
 							<v-btn block color="primary" theme="dark" @click="set_full_amount(payment.idx)">
@@ -78,10 +130,18 @@
 						</v-col>
 
 						<!-- Request Payment for Phone Type -->
-						<v-col cols="3" v-if="payment.type === 'Phone' && payment.amount > 0 && request_payment_field"
-							class="pl-1">
-							<v-btn block color="success" theme="dark" :disabled="payment.amount === 0"
-								@click="request_payment(payment)">
+						<v-col
+							cols="3"
+							v-if="payment.type === 'Phone' && payment.amount > 0 && request_payment_field"
+							class="pl-1"
+						>
+							<v-btn
+								block
+								color="success"
+								theme="dark"
+								:disabled="payment.amount === 0"
+								@click="request_payment(payment)"
+							>
 								{{ __("Request") }}
 							</v-btn>
 						</v-col>
@@ -89,45 +149,82 @@
 				</div>
 
 				<!-- Loyalty Points Redemption -->
-				<v-row class="payments pa-1"
-					v-if="invoice_doc && available_points_amount > 0 && !invoice_doc.is_return">
+				<v-row
+					class="payments pa-1"
+					v-if="invoice_doc && available_points_amount > 0 && !invoice_doc.is_return"
+				>
 					<v-col cols="7">
-						<v-text-field density="compact" variant="solo" color="primary"
-							:label="frappe._('Redeem Loyalty Points')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" hide-details :model-value="formatCurrency(loyalty_amount)"
-							type="text" @change="setFormatedCurrency(this, 'loyalty_amount', null, false, $event)"
-							:prefix="currencySymbol(invoice_doc.currency)"></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Redeem Loyalty Points')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							:model-value="formatCurrency(loyalty_amount)"
+							type="text"
+							@change="setFormatedCurrency(this, 'loyalty_amount', null, false, $event)"
+							:prefix="currencySymbol(invoice_doc.currency)"
+						></v-text-field>
 					</v-col>
 					<v-col cols="5">
-						<v-text-field density="compact" variant="solo" color="primary"
-							:label="frappe._('You can redeem up to')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" hide-details
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('You can redeem up to')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
 							:model-value="formatFloat(available_points_amount)"
-							:prefix="currencySymbol(invoice_doc.currency)" readonly></v-text-field>
+							:prefix="currencySymbol(invoice_doc.currency)"
+							readonly
+						></v-text-field>
 					</v-col>
 				</v-row>
 
 				<!-- Customer Credit Redemption -->
-				<v-row class="payments pa-1" v-if="
-					invoice_doc &&
-					available_customer_credit > 0 &&
-					!invoice_doc.is_return &&
-					redeem_customer_credit
-				">
+				<v-row
+					class="payments pa-1"
+					v-if="
+						invoice_doc &&
+						available_customer_credit > 0 &&
+						!invoice_doc.is_return &&
+						redeem_customer_credit
+					"
+				>
 					<v-col cols="7">
-						<v-text-field density="compact" variant="solo" color="primary"
-							:label="frappe._('Redeemed Customer Credit')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" hide-details
-							:model-value="formatCurrency(redeemed_customer_credit)" type="text" @change="
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Redeemed Customer Credit')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							:model-value="formatCurrency(redeemed_customer_credit)"
+							type="text"
+							@change="
 								setFormatedCurrency(this, 'redeemed_customer_credit', null, false, $event)
-								" :prefix="currencySymbol(invoice_doc.currency)" readonly></v-text-field>
+							"
+							:prefix="currencySymbol(invoice_doc.currency)"
+							readonly
+						></v-text-field>
 					</v-col>
 					<v-col cols="5">
-						<v-text-field density="compact" variant="solo" color="primary"
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
 							:label="frappe._('You can redeem credit up to')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
 							:model-value="formatCurrency(available_customer_credit)"
-							:prefix="currencySymbol(invoice_doc.currency)" readonly></v-text-field>
+							:prefix="currencySymbol(invoice_doc.currency)"
+							readonly
+						></v-text-field>
 					</v-col>
 				</v-row>
 
@@ -136,63 +233,146 @@
 				<!-- Invoice Totals (Net, Tax, Total, Discount, Grand, Rounded) -->
 				<v-row class="pa-1">
 					<v-col cols="6">
-						<v-text-field density="compact" variant="solo" color="primary" :label="frappe._('Net Total')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field"
-							:model-value="formatCurrency(invoice_doc.net_total, displayCurrency)" readonly
-							:prefix="currencySymbol()" persistent-placeholder></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Net Total')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							:model-value="formatCurrency(invoice_doc.net_total, displayCurrency)"
+							readonly
+							:prefix="currencySymbol()"
+							persistent-placeholder
+						></v-text-field>
 					</v-col>
 					<v-col cols="6">
-						<v-text-field density="compact" variant="solo" color="primary"
-							:label="frappe._('Tax and Charges')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" hide-details :model-value="formatCurrency(invoice_doc.total_taxes_and_charges, displayCurrency)
-								" readonly :prefix="currencySymbol()" persistent-placeholder></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Tax and Charges')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							:model-value="
+								formatCurrency(invoice_doc.total_taxes_and_charges, displayCurrency)
+							"
+							readonly
+							:prefix="currencySymbol()"
+							persistent-placeholder
+						></v-text-field>
 					</v-col>
 					<v-col cols="6">
-						<v-text-field density="compact" variant="solo" color="primary" :label="frappe._('Total Amount')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
-							:model-value="formatCurrency(invoice_doc.total, displayCurrency)" readonly
-							:prefix="currencySymbol()" persistent-placeholder></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Total Amount')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							:model-value="formatCurrency(invoice_doc.total, displayCurrency)"
+							readonly
+							:prefix="currencySymbol()"
+							persistent-placeholder
+						></v-text-field>
 					</v-col>
 					<v-col cols="6">
-						<v-text-field density="compact" variant="solo" color="primary" :label="diff_label"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
-							:model-value="formatCurrency(diff_payment, displayCurrency)" readonly
-							:prefix="currencySymbol()" persistent-placeholder></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="diff_label"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							:model-value="formatCurrency(diff_payment, displayCurrency)"
+							readonly
+							:prefix="currencySymbol()"
+							persistent-placeholder
+						></v-text-field>
 					</v-col>
 					<v-col cols="6">
-						<v-text-field density="compact" variant="solo" color="primary"
-							:label="frappe._('Discount Amount')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" hide-details
-							:model-value="formatCurrency(invoice_doc.discount_amount)" readonly
-							:prefix="currencySymbol(invoice_doc.currency)" persistent-placeholder></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Discount Amount')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							:model-value="formatCurrency(invoice_doc.discount_amount)"
+							readonly
+							:prefix="currencySymbol(invoice_doc.currency)"
+							persistent-placeholder
+						></v-text-field>
 					</v-col>
 					<v-col cols="6">
-						<v-text-field density="compact" variant="solo" color="primary" :label="frappe._('Grand Total')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" class="dark-field sleek-field" hide-details
-							:model-value="formatCurrency(invoice_doc.grand_total)" readonly
-							:prefix="currencySymbol(invoice_doc.currency)" persistent-placeholder></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Grand Total')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							:model-value="formatCurrency(invoice_doc.grand_total)"
+							readonly
+							:prefix="currencySymbol(invoice_doc.currency)"
+							persistent-placeholder
+						></v-text-field>
 					</v-col>
 					<v-col v-if="invoice_doc.rounded_total" cols="6">
-						<v-text-field density="compact" variant="solo" color="primary"
-							:label="frappe._('Rounded Total')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" hide-details
-							:model-value="formatCurrency(invoice_doc.rounded_total)" readonly
-							:prefix="currencySymbol(invoice_doc.currency)" persistent-placeholder></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Rounded Total')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							:model-value="formatCurrency(invoice_doc.rounded_total)"
+							readonly
+							:prefix="currencySymbol(invoice_doc.currency)"
+							persistent-placeholder
+						></v-text-field>
 					</v-col>
 
 					<!-- Delivery Date and Address (if applicable) -->
 					<v-col cols="6" v-if="pos_profile.posa_allow_sales_order && invoiceType === 'Order'">
-						<VueDatePicker v-model="new_delivery_date" model-type="format" format="dd-MM-yyyy"
-							:min-date="new Date()" auto-apply :dark="isDarkTheme" class="dark-field sleek-field"
-							@update:model-value="update_delivery_date()" />
+						<VueDatePicker
+							v-model="new_delivery_date"
+							model-type="format"
+							format="dd-MM-yyyy"
+							:min-date="new Date()"
+							auto-apply
+							:dark="isDarkTheme"
+							class="dark-field sleek-field"
+							@update:model-value="update_delivery_date()"
+						/>
 					</v-col>
 					<!-- Shipping Address Selection (if delivery date is set) -->
 					<v-col cols="12" v-if="invoice_doc.posa_delivery_date">
-						<v-autocomplete density="compact" clearable auto-select-first variant="solo" color="primary"
-							:label="frappe._('Address')" v-model="invoice_doc.shipping_address_name" :items="addresses"
-							item-title="address_title" item-value="name" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" :no-data-text="__('Address not found')" hide-details
-							:customFilter="addressFilter" append-icon="mdi-plus" @click:append="new_address">
+						<v-autocomplete
+							density="compact"
+							clearable
+							auto-select-first
+							variant="solo"
+							color="primary"
+							:label="frappe._('Address')"
+							v-model="invoice_doc.shipping_address_name"
+							:items="addresses"
+							item-title="address_title"
+							item-value="name"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							:no-data-text="__('Address not found')"
+							hide-details
+							:customFilter="addressFilter"
+							append-icon="mdi-plus"
+							@click:append="new_address"
+						>
 							<template v-slot:item="{ item }">
 								<v-list-item>
 									<v-list-item-title class="text-primary text-subtitle-1">
@@ -226,9 +406,18 @@
 
 					<!-- Additional Notes (if enabled in POS profile) -->
 					<v-col cols="12" v-if="pos_profile.posa_display_additional_notes">
-						<v-textarea class="pa-0 dark-field sleek-field" variant="solo" density="compact"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'" clearable color="primary" auto-grow rows="2"
-							:label="frappe._('Additional Notes')" v-model="invoice_doc.posa_notes"></v-textarea>
+						<v-textarea
+							class="pa-0 dark-field sleek-field"
+							variant="solo"
+							density="compact"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							clearable
+							color="primary"
+							auto-grow
+							rows="2"
+							:label="frappe._('Additional Notes')"
+							v-model="invoice_doc.posa_notes"
+						></v-textarea>
 					</v-col>
 				</v-row>
 
@@ -237,16 +426,38 @@
 					<v-divider></v-divider>
 					<v-row class="pa-1" justify="center" align="start">
 						<v-col cols="6">
-							<v-text-field v-model="invoice_doc.po_no" :label="frappe._('Purchase Order')" variant="solo"
-								density="compact" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-								class="dark-field sleek-field" clearable color="primary" hide-details></v-text-field>
+							<v-text-field
+								v-model="invoice_doc.po_no"
+								:label="frappe._('Purchase Order')"
+								variant="solo"
+								density="compact"
+								:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+								class="dark-field sleek-field"
+								clearable
+								color="primary"
+								hide-details
+							></v-text-field>
 						</v-col>
 						<v-col cols="6">
-							<VueDatePicker v-model="new_po_date" model-type="format" format="dd-MM-yyyy"
-								:min-date="new Date()" auto-apply :dark="isDarkTheme" class="dark-field sleek-field"
-								@update:model-value="update_po_date()" />
-							<v-text-field v-model="invoice_doc.po_date" :label="frappe._('Purchase Order Date')"
-								readonly variant="solo" density="compact" hide-details color="primary"></v-text-field>
+							<VueDatePicker
+								v-model="new_po_date"
+								model-type="format"
+								format="dd-MM-yyyy"
+								:min-date="new Date()"
+								auto-apply
+								:dark="isDarkTheme"
+								class="dark-field sleek-field"
+								@update:model-value="update_po_date()"
+							/>
+							<v-text-field
+								v-model="invoice_doc.po_date"
+								:label="frappe._('Purchase Order Date')"
+								readonly
+								variant="solo"
+								density="compact"
+								hide-details
+								color="primary"
+							></v-text-field>
 						</v-col>
 					</v-row>
 				</div>
@@ -255,72 +466,130 @@
 
 				<!-- Switches for Write Off and Credit Sale -->
 				<v-row class="pa-1" align="start" no-gutters>
-					<v-col cols="6" v-if="
-						pos_profile.posa_allow_write_off_change &&
-						credit_change > 0 &&
-						!invoice_doc.is_return
-					">
-						<v-switch v-model="is_write_off_change" flat :label="frappe._('Write Off Difference Amount')"
-							class="my-0 pa-1"></v-switch>
+					<v-col
+						cols="6"
+						v-if="
+							pos_profile.posa_allow_write_off_change &&
+							total_change > 0 &&
+							!invoice_doc.is_return
+						"
+					>
+						<v-switch
+							v-model="is_write_off_change"
+							flat
+							:label="frappe._('Write Off Difference Amount')"
+							class="my-0 pa-1"
+						></v-switch>
 					</v-col>
 					<v-col cols="6" v-if="pos_profile.posa_allow_credit_sale && !invoice_doc.is_return">
 						<v-switch v-model="is_credit_sale" :label="frappe._('Credit Sale?')"></v-switch>
 					</v-col>
 					<v-col cols="6" v-if="invoice_doc.is_return && pos_profile.use_cashback">
-						<v-switch v-model="is_cashback" flat :label="frappe._('Cashback?')"
-							class="my-0 pa-1"></v-switch>
+						<v-switch
+							v-model="is_cashback"
+							flat
+							:label="frappe._('Cashback?')"
+							class="my-0 pa-1"
+						></v-switch>
 					</v-col>
 					<v-col cols="6" v-if="invoice_doc.is_return">
-						<v-switch v-model="is_credit_return" flat :label="frappe._('Credit Return?')"
-							class="my-0 pa-1"></v-switch>
+						<v-switch
+							v-model="is_credit_return"
+							flat
+							:label="frappe._('Credit Return?')"
+							class="my-0 pa-1"
+						></v-switch>
 					</v-col>
 					<v-col cols="6" v-if="is_credit_sale">
-						<VueDatePicker v-model="new_credit_due_date" model-type="format" format="dd-MM-yyyy"
-							:min-date="new Date()" auto-apply :dark="isDarkTheme" class="dark-field sleek-field"
-							@update:model-value="update_credit_due_date()" />
-						<v-text-field class="mt-2 dark-field sleek-field" density="compact" variant="solo" type="number"
-							min="0" max="365" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							v-model.number="credit_due_days" :label="frappe._('Days until due')" hide-details
-							@change="applyDuePreset(credit_due_days)"></v-text-field>
+						<VueDatePicker
+							v-model="new_credit_due_date"
+							model-type="format"
+							format="dd-MM-yyyy"
+							:min-date="new Date()"
+							auto-apply
+							:dark="isDarkTheme"
+							class="dark-field sleek-field"
+							@update:model-value="update_credit_due_date()"
+						/>
+						<v-text-field
+							class="mt-2 dark-field sleek-field"
+							density="compact"
+							variant="solo"
+							type="number"
+							min="0"
+							max="365"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							v-model.number="credit_due_days"
+							:label="frappe._('Days until due')"
+							hide-details
+							@change="applyDuePreset(credit_due_days)"
+						></v-text-field>
 						<div class="mt-1">
-							<v-chip v-for="d in credit_due_presets" :key="d" size="small" class="ma-1" variant="solo"
-								color="primary" @click="applyDuePreset(d)">
+							<v-chip
+								v-for="d in credit_due_presets"
+								:key="d"
+								size="small"
+								class="ma-1"
+								variant="solo"
+								color="primary"
+								@click="applyDuePreset(d)"
+							>
 								{{ d }} {{ frappe._("days") }}
 							</v-chip>
 						</div>
 					</v-col>
 					<v-col cols="6" v-if="!invoice_doc.is_return && pos_profile.use_customer_credit">
-						<v-switch v-model="redeem_customer_credit" flat :label="frappe._('Use Customer Credit')"
+						<v-switch
+							v-model="redeem_customer_credit"
+							flat
+							:label="frappe._('Use Customer Credit')"
 							class="my-0 pa-1"
-							@update:model-value="get_available_credit(redeem_customer_credit)"></v-switch>
+							@update:model-value="get_available_credit(redeem_customer_credit)"
+						></v-switch>
 					</v-col>
 				</v-row>
 
 				<!-- Customer Credit Details -->
-				<div v-if="
-					invoice_doc &&
-					available_customer_credit > 0 &&
-					!invoice_doc.is_return &&
-					redeem_customer_credit
-				">
+				<div
+					v-if="
+						invoice_doc &&
+						available_customer_credit > 0 &&
+						!invoice_doc.is_return &&
+						redeem_customer_credit
+					"
+				>
 					<v-row v-for="(row, idx) in customer_credit_dict" :key="idx">
 						<v-col cols="4">
 							<div class="pa-2 py-3">{{ row.credit_origin }}</div>
 						</v-col>
 						<v-col cols="4">
-							<v-text-field density="compact" variant="solo" color="primary"
-								:label="frappe._('Available Credit')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-								class="dark-field sleek-field" hide-details
-								:model-value="formatCurrency(row.total_credit)" readonly
-								:prefix="currencySymbol(invoice_doc.currency)"></v-text-field>
+							<v-text-field
+								density="compact"
+								variant="solo"
+								color="primary"
+								:label="frappe._('Available Credit')"
+								:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+								class="dark-field sleek-field"
+								hide-details
+								:model-value="formatCurrency(row.total_credit)"
+								readonly
+								:prefix="currencySymbol(invoice_doc.currency)"
+							></v-text-field>
 						</v-col>
 						<v-col cols="4">
-							<v-text-field density="compact" variant="solo" color="primary"
-								:label="frappe._('Redeem Credit')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-								class="dark-field sleek-field" hide-details type="text"
+							<v-text-field
+								density="compact"
+								variant="solo"
+								color="primary"
+								:label="frappe._('Redeem Credit')"
+								:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+								class="dark-field sleek-field"
+								hide-details
+								type="text"
 								:model-value="formatCurrency(row.credit_to_redeem)"
 								@change="setFormatedCurrency(row, 'credit_to_redeem', null, false, $event)"
-								:prefix="currencySymbol(invoice_doc.currency)"></v-text-field>
+								:prefix="currencySymbol(invoice_doc.currency)"
+							></v-text-field>
 						</v-col>
 					</v-row>
 				</div>
@@ -334,11 +603,22 @@
 							{{ sales_persons.length }} sales persons found
 						</p>
 						<p v-else class="mt-1 mb-1 text-subtitle-2 text-red">No sales persons found</p>
-						<v-select density="compact" clearable variant="solo" color="primary"
-							:label="frappe._('Sales Person')" v-model="sales_person" :items="sales_persons"
-							item-title="title" item-value="value" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" :no-data-text="__('Sales Person not found')" hide-details
-							:disabled="readonly"></v-select>
+						<v-select
+							density="compact"
+							clearable
+							variant="solo"
+							color="primary"
+							:label="frappe._('Sales Person')"
+							v-model="sales_person"
+							:items="sales_persons"
+							item-title="title"
+							item-value="value"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							:no-data-text="__('Sales Person not found')"
+							hide-details
+							:disabled="readonly"
+						></v-select>
 					</v-col>
 				</v-row>
 			</div>
@@ -347,29 +627,43 @@
 		<!-- Action Buttons -->
 		<v-card flat class="cards mb-0 mt-3 pa-0">
 			<v-row align="start" no-gutters>
-                               <v-col cols="6">
-                                       <v-btn
-                                               ref="submitButton"
-                                               block
-                                               size="large"
-                                               color="primary"
-                                               theme="dark"
-                                               @click="submit"
-                                               :loading="loading"
-                                               :disabled="loading || vaildatPayment"
-                                               :class="{ 'submit-highlight': highlightSubmit }"
-                                       >
-                                               {{ __("Submit") }}
-                                       </v-btn>
-                               </v-col>
+				<v-col cols="6">
+					<v-btn
+						ref="submitButton"
+						block
+						size="large"
+						color="primary"
+						theme="dark"
+						@click="submit"
+						:loading="loading"
+						:disabled="loading || vaildatPayment"
+						:class="{ 'submit-highlight': highlightSubmit }"
+					>
+						{{ __("Submit") }}
+					</v-btn>
+				</v-col>
 				<v-col cols="6" class="pl-1">
-					<v-btn block size="large" color="success" theme="dark" @click="submit(undefined, false, true)"
-						:loading="loading" :disabled="loading || vaildatPayment">
+					<v-btn
+						block
+						size="large"
+						color="success"
+						theme="dark"
+						@click="submit(undefined, false, true)"
+						:loading="loading"
+						:disabled="loading || vaildatPayment"
+					>
 						{{ __("Submit & Print") }}
 					</v-btn>
 				</v-col>
 				<v-col cols="12">
-					<v-btn block class="mt-2 pa-1" size="large" color="error" theme="dark" @click="back_to_invoice">
+					<v-btn
+						block
+						class="mt-2 pa-1"
+						size="large"
+						color="error"
+						theme="dark"
+						@click="back_to_invoice"
+					>
 						{{ __("Cancel Payment") }}
 					</v-btn>
 				</v-col>
@@ -383,9 +677,18 @@
 				</v-card-title>
 				<v-card-text class="pa-0">
 					<v-container>
-						<v-text-field density="compact" variant="solo" type="number" min="0" max="365"
-							class="dark-field sleek-field" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							v-model.number="custom_days_value" :label="frappe._('Days')" hide-details></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							type="number"
+							min="0"
+							max="365"
+							class="dark-field sleek-field"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							v-model.number="custom_days_value"
+							:label="frappe._('Days')"
+							hide-details
+						></v-text-field>
 					</v-container>
 				</v-card-text>
 				<v-card-actions>
@@ -408,10 +711,17 @@
 				</v-card-title>
 				<v-card-text class="pa-0">
 					<v-container>
-						<v-text-field density="compact" variant="solo" color="primary"
-							:label="frappe._('Mobile Number')" :bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field" hide-details v-model="invoice_doc.contact_mobile"
-							type="number"></v-text-field>
+						<v-text-field
+							density="compact"
+							variant="solo"
+							color="primary"
+							:label="frappe._('Mobile Number')"
+							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="dark-field sleek-field"
+							hide-details
+							v-model="invoice_doc.contact_mobile"
+							type="number"
+						></v-text-field>
 					</v-container>
 				</v-card-text>
 				<v-card-actions>
@@ -467,23 +777,23 @@ export default {
 			redeem_customer_credit: false, // Redeem customer credit?
 			customer_credit_dict: [], // List of available customer credits
 			paid_change_rules: [], // Validation rules for paid change
-                        phone_dialog: false, // Show phone payment dialog
-                        custom_days_dialog: false, // Show custom days dialog
-                        custom_days_value: null, // Custom days entry
-                        new_delivery_date: null, // New delivery date value
-                        new_po_date: null, // New PO date value
-                        new_credit_due_date: null, // New credit due date value
-                        credit_due_days: null, // Number of days until due
-                        credit_due_presets: [7, 14, 30], // Preset options for due days
-                        customer_info: "", // Customer info
-                        mpesa_modes: [], // List of available M-Pesa modes
-                        sales_persons: [], // List of sales persons
-                        sales_person: "", // Selected sales person
-                        addresses: [], // List of customer addresses
-                        is_user_editing_paid_change: false, // User interaction flag
-                       highlightSubmit: false, // Highlight state for submit button
-                };
-        },
+			phone_dialog: false, // Show phone payment dialog
+			custom_days_dialog: false, // Show custom days dialog
+			custom_days_value: null, // Custom days entry
+			new_delivery_date: null, // New delivery date value
+			new_po_date: null, // New PO date value
+			new_credit_due_date: null, // New credit due date value
+			credit_due_days: null, // Number of days until due
+			credit_due_presets: [7, 14, 30], // Preset options for due days
+			customer_info: "", // Customer info
+			mpesa_modes: [], // List of available M-Pesa modes
+			sales_persons: [], // List of sales persons
+			sales_person: "", // Selected sales person
+			addresses: [], // List of customer addresses
+			is_user_editing_paid_change: false, // User interaction flag
+			highlightSubmit: false, // Highlight state for submit button
+		};
+	},
 	computed: {
 		// Get currency symbol for given or current currency
 		currencySymbol() {
@@ -562,11 +872,11 @@ export default {
 				return diff >= 0 ? diff : 0;
 			}
 
-			return diff >= 0 ? diff : 0;
+			return diff;
 		},
 
-		// Calculate change to be given back to customer
-		credit_change() {
+		// Calculate total change to return
+		total_change() {
 			// For multi-currency, use grand_total instead of rounded_total
 			let invoice_total;
 			if (
@@ -757,34 +1067,34 @@ export default {
 			this.eventBus.emit("show_payment", "false");
 			this.eventBus.emit("set_customer_readonly", false);
 		},
-               // Highlight and focus the submit button when payment screen opens
-              handleShowPayment(data) {
-                       if (data === "true") {
-                               this.$nextTick(() => {
-                                       setTimeout(() => {
-                                               const btn = this.$refs.submitButton;
-                                               const el = btn && btn.$el ? btn.$el : btn;
-                                               if (el) {
-                                                       el.scrollIntoView({ behavior: "smooth", block: "center" });
-                                                       el.focus();
-                                                       this.highlightSubmit = true;
-                                               }
-                                       }, 100);
-                               });
-                       } else {
-                               this.highlightSubmit = false;
-                       }
-               },
-               // Reset all cash payments to zero
-               reset_cash_payments() {
-                       this.invoice_doc.payments.forEach((payment) => {
-                               if (payment.mode_of_payment.toLowerCase() === "cash") {
-                                       payment.amount = 0;
-                                }
-                        });
-                },
-                // Ensure all payments are negative for return invoices
-                ensureReturnPaymentsAreNegative() {
+		// Highlight and focus the submit button when payment screen opens
+		handleShowPayment(data) {
+			if (data === "true") {
+				this.$nextTick(() => {
+					setTimeout(() => {
+						const btn = this.$refs.submitButton;
+						const el = btn && btn.$el ? btn.$el : btn;
+						if (el) {
+							el.scrollIntoView({ behavior: "smooth", block: "center" });
+							el.focus();
+							this.highlightSubmit = true;
+						}
+					}, 100);
+				});
+			} else {
+				this.highlightSubmit = false;
+			}
+		},
+		// Reset all cash payments to zero
+		reset_cash_payments() {
+			this.invoice_doc.payments.forEach((payment) => {
+				if (payment.mode_of_payment.toLowerCase() === "cash") {
+					payment.amount = 0;
+				}
+			});
+		},
+		// Ensure all payments are negative for return invoices
+		ensureReturnPaymentsAreNegative() {
 			if (!this.invoice_doc || !this.invoice_doc.is_return || !this.is_cashback) {
 				return;
 			}
@@ -926,7 +1236,7 @@ export default {
 			if (
 				!this.invoice_doc.is_return &&
 				this.redeemed_customer_credit >
-				(this.invoice_doc.rounded_total || this.invoice_doc.grand_total)
+					(this.invoice_doc.rounded_total || this.invoice_doc.grand_total)
 			) {
 				this.eventBus.emit("show_message", {
 					title: `Cannot redeem customer credit more than invoice total`,
@@ -1273,7 +1583,7 @@ export default {
 			if (vm.pos_profile.posa_local_storage && getSalesPersonsStorage().length) {
 				try {
 					vm.sales_persons = getSalesPersonsStorage();
-				} catch (e) { }
+				} catch (e) {}
 			}
 			frappe.call({
 				method: "posawesome.posawesome.api.utilities.get_sales_person_names",
@@ -1668,16 +1978,16 @@ export default {
 			this.eventBus.on("set_mpesa_payment", (data) => {
 				this.set_mpesa_payment(data);
 			});
-                        // Clear any stored invoice when parent emits clear_invoice
-                        this.eventBus.on("clear_invoice", () => {
-                                this.invoice_doc = "";
-                                this.is_return = false;
-                                this.is_credit_return = false;
-                        });
-                        // Scroll to top when payment view is shown
-                        this.eventBus.on("show_payment", this.handleShowPayment);
-                });
-        },
+			// Clear any stored invoice when parent emits clear_invoice
+			this.eventBus.on("clear_invoice", () => {
+				this.invoice_doc = "";
+				this.is_return = false;
+				this.is_credit_return = false;
+			});
+			// Scroll to top when payment view is shown
+			this.eventBus.on("show_payment", this.handleShowPayment);
+		});
+	},
 	// Lifecycle hook: beforeUnmount
 	beforeUnmount() {
 		// Remove all event listeners
@@ -1689,11 +1999,11 @@ export default {
 		this.eventBus.off("set_pos_settings");
 		this.eventBus.off("set_customer_info_to_edit");
 		this.eventBus.off("set_mpesa_payment");
-                this.eventBus.off("clear_invoice");
-                this.eventBus.off("network-online", this.syncPendingInvoices);
-                this.eventBus.off("server-online", this.syncPendingInvoices);
-                this.eventBus.off("show_payment", this.handleShowPayment);
-        },
+		this.eventBus.off("clear_invoice");
+		this.eventBus.off("network-online", this.syncPendingInvoices);
+		this.eventBus.off("server-online", this.syncPendingInvoices);
+		this.eventBus.off("show_payment", this.handleShowPayment);
+	},
 	// Lifecycle hook: unmounted
 	unmounted() {
 		// Remove keyboard shortcut listener
@@ -1717,12 +2027,12 @@ export default {
 }
 
 .cards {
-        background-color: var(--surface-secondary) !important;
+	background-color: var(--surface-secondary) !important;
 }
 
 .submit-highlight {
-       box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
-       transition: box-shadow 0.3s ease-in-out;
+	box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
+	transition: box-shadow 0.3s ease-in-out;
 }
 
 /* Dark mode styling for input fields */


### PR DESCRIPTION
## Summary
- offset change by subtracting overpayment from cash payments and tracking paid change
- use provided credit change amount when generating advance payment entry

## Testing
- `python -m py_compile posawesome/posawesome/api/invoices.py`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a2ffd5d064832685b25bb2389ad29f