### PR TITLE
fix: show coupon error message

### DIFF
--- a/frontend/src/posapp/components/pos/PosCoupons.vue
+++ b/frontend/src/posapp/components/pos/PosCoupons.vue
@@ -142,7 +142,7 @@ export default {
 						const res = r.message;
 						if (res.msg != "Apply" || !res.coupon) {
 							vm.eventBus.emit("show_message", {
-								text: res.msg,
+								title: res.msg,
 								color: "error",
 							});
 						} else {


### PR DESCRIPTION
## Summary
- ensure invalid coupon codes show descriptive error

## Testing
- `npx prettier --write frontend/src/posapp/components/pos/PosCoupons.vue`
- `npx eslint frontend/src/posapp/components/pos/PosCoupons.vue -f json`


------
https://chatgpt.com/codex/tasks/task_e_68a3700399008326b8c165b546de1cda