### PR TITLE
chore: align semantic-release version to v15.4.2

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["develop"],
+  "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "posawesome",
+  "version": "15.4.2",
   "scripts": {
     "dev": "cd frontend && yarn dev",
     "build": "cd frontend && yarn build",


### PR DESCRIPTION
## Summary
- configure semantic-release to use numeric tag format for existing release tags
- set package.json version to 15.4.2

## Testing
- `yarn build` *(fails: process did not complete in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a431ee32ec83268843418377f5cfc3