### PR TITLE
fix: cap item quantity to available stock

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -195,7 +195,6 @@
 						:currencySymbol="currencySymbol"
 						:isNumber="isNumber"
 						:setFormatedQty="setFormatedQty"
-						:calcStockQty="calc_stock_qty"
 						:setFormatedCurrency="setFormatedCurrency"
 						:calcPrices="calc_prices"
 						:calcUom="calc_uom"
@@ -246,6 +245,7 @@
 </template>
 
 <script>
+/* global frappe, __ */
 import format from "../../format";
 import Customer from "./Customer.vue";
 import DeliveryCharges from "./DeliveryCharges.vue";
@@ -259,7 +259,6 @@ import invoiceComputed from "./invoiceComputed";
 import invoiceWatchers from "./invoiceWatchers";
 import offerMethods from "./invoiceOfferMethods";
 import shortcutMethods from "./invoiceShortcuts";
-import { isOffline, saveCustomerBalance, getCachedCustomerBalance } from "../../../offline";
 
 export default {
 	name: "POSInvoice",
@@ -563,19 +562,52 @@ export default {
 			this.posting_date = date;
 			this.$forceUpdate();
 		},
-		// Override setFormatedFloat for qty field to handle return mode
-		setFormatedQty(item, field_name, precision, no_negative, value) {
-			// Use the regular formatter method from the mixin
-			let parsedValue = this.setFormatedFloat(item, field_name, precision, no_negative, value);
+                // Override setFormatedFloat for qty field to handle stock limits and return mode
+                setFormatedQty(item, field_name, precision, no_negative, value) {
+                        // Parse and set the value using the mixin's formatter
+                        let parsedValue = this.setFormatedFloat(
+                                item,
+                                field_name,
+                                precision,
+                                no_negative,
+                                value,
+                        );
 
-			// Ensure negative value for return invoices
-			if (this.isReturnInvoice && parsedValue > 0) {
-				parsedValue = -Math.abs(parsedValue);
-				item[field_name] = parsedValue;
-			}
+                        // Enforce available stock limits
+                        if (
+                                item.max_qty !== undefined &&
+                                this.flt(item[field_name]) > this.flt(item.max_qty)
+                        ) {
+                                if (
+                                        this.pos_profile.posa_block_sale_beyond_available_qty &&
+                                        !this.stock_settings.allow_negative_stock
+                                ) {
+                                        item[field_name] = item.max_qty;
+                                        parsedValue = item.max_qty;
+                                        this.eventBus.emit("show_message", {
+                                                title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
+                                                        this.formatFloat(item.max_qty),
+                                                ]),
+                                                color: "error",
+                                        });
+                                } else {
+                                        this.eventBus.emit("show_message", {
+                                                title: __("Stock is lower than requested. Proceeding may create negative stock."),
+                                                color: "warning",
+                                        });
+                                }
+                        }
 
-			return parsedValue;
-		},
+                        // Ensure negative value for return invoices
+                        if (this.isReturnInvoice && parsedValue > 0) {
+                                parsedValue = -Math.abs(parsedValue);
+                                item[field_name] = parsedValue;
+                        }
+
+                        // Recalculate stock quantity with the adjusted value
+                        this.calc_stock_qty(item, item[field_name]);
+                        return parsedValue;
+                },
 		async fetch_available_currencies() {
 			try {
 				console.log("Fetching available currencies...");
@@ -964,24 +996,23 @@ export default {
 		// Increase quantity of an item (handles return logic)
 		add_one(item) {
 			const proposed = item.qty + 1;
-			if (
-				this.pos_profile.posa_block_sale_beyond_available_qty &&
-				!this.stock_settings.allow_negative_stock &&
-				item.max_qty !== undefined &&
-				proposed > item.max_qty
-			) {
-				item.qty = item.max_qty;
-				this.calc_stock_qty(item, item.qty);
-				this.eventBus.emit("show_message", {
-					title: __("Only {0} in stock at {1}. Further quantity is blocked.", [
-						this.formatFloat(item.max_qty),
-						item.warehouse,
-					]),
-					color: "warning",
-				});
-				return;
-			}
-			item.qty = proposed;
+                        if (
+                                this.pos_profile.posa_block_sale_beyond_available_qty &&
+                                !this.stock_settings.allow_negative_stock &&
+                                item.max_qty !== undefined &&
+                                proposed > item.max_qty
+                        ) {
+                                item.qty = item.max_qty;
+                                this.calc_stock_qty(item, item.qty);
+                                this.eventBus.emit("show_message", {
+                                        title: __("Maximum available quantity is {0}. Quantity adjusted to match stock.", [
+                                                this.formatFloat(item.max_qty),
+                                        ]),
+                                        color: "error",
+                                });
+                                return;
+                        }
+                        item.qty = proposed;
 			if (item.qty == 0) {
 				this.remove_item(item);
 			}
@@ -1036,9 +1067,9 @@ export default {
 		this.loadColumnPreferences();
 		// Restore saved invoice height
 		this.loadInvoiceHeight();
-		this.eventBus.on("item-drag-start", (item) => {
-			this.showDropFeedback(true);
-		});
+                this.eventBus.on("item-drag-start", () => {
+                        this.showDropFeedback(true);
+                });
 		this.eventBus.on("item-drag-end", () => {
 			this.showDropFeedback(false);
 		});
@@ -1168,9 +1199,9 @@ export default {
 			this.posting_date = frappe.datetime.nowdate();
 		});
 		this.eventBus.on("calc_uom", this.calc_uom);
-		this.eventBus.on("item-drag-start", (item) => {
-			this.showDropFeedback(true);
-		});
+                this.eventBus.on("item-drag-start", () => {
+                        this.showDropFeedback(true);
+                });
 		this.eventBus.on("item-drag-end", () => {
 			this.showDropFeedback(false);
 		});

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -197,10 +197,15 @@
 											:model-value="
 												formatFloat(item.qty, hide_qty_decimals ? 0 : undefined)
 											"
-											@change="[
-												setFormatedQty(item, 'qty', null, false, $event.target.value),
-												calcStockQty(item, item.qty),
-											]"
+                                                                                        @change="
+                                                                                                setFormatedQty(
+                                                                                                        item,
+                                                                                                        'qty',
+                                                                                                        null,
+                                                                                                        false,
+                                                                                                        $event.target.value,
+                                                                                                )
+                                                                                        "
 											:rules="[isNumber]"
 											:disabled="!!item.posa_is_replace"
 											prepend-inner-icon="mdi-numeric"
@@ -634,7 +639,6 @@ export default {
 		currencySymbol: Function,
 		isNumber: Function,
 		setFormatedQty: Function,
-		calcStockQty: Function,
 		setFormatedCurrency: Function,
 		calcPrices: Function,
 		calcUom: Function,

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1709,39 +1709,64 @@ export default {
 		if (this.update_qty_limits) {
 			this.update_qty_limits(item);
 		}
-		if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
-			if (
-				this.pos_profile.posa_block_sale_beyond_available_qty &&
-				!this.stock_settings.allow_negative_stock
-			) {
-				item.qty = item.max_qty;
-				calcStockQty(item, item.qty, this);
-				this.eventBus.emit("show_message", {
-					title: __(`Only {0} in stock at {1}. Further quantity is blocked.`, [
-						this.formatFloat(item.max_qty),
-						item.warehouse,
-					]),
-					color: "warning",
-				});
-			} else {
-				this.eventBus.emit("show_message", {
-					title: __("Stock is lower than requested. Proceeding may create negative stock."),
-					color: "warning",
-				});
-			}
-		}
-	},
+                if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
+                        if (
+                                this.pos_profile.posa_block_sale_beyond_available_qty &&
+                                !this.stock_settings.allow_negative_stock
+                        ) {
+                                item.qty = item.max_qty;
+                                calcStockQty(item, item.qty, this);
+                                this.$forceUpdate();
+                                this.eventBus.emit("show_message", {
+                                        title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
+                                                this.formatFloat(item.max_qty),
+                                        ]),
+                                        color: "error",
+                                });
+                        } else {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Stock is lower than requested. Proceeding may create negative stock."),
+                                        color: "warning",
+                                });
+                        }
+                }
+        },
 
 	// Update quantity limits based on available stock
-	update_qty_limits(item) {
-		if (item && item.available_qty !== undefined) {
-			item.max_qty = flt(item.available_qty / (item.conversion_factor || 1));
-			item.disable_increment =
-				this.pos_profile.posa_block_sale_beyond_available_qty &&
-				!this.stock_settings.allow_negative_stock &&
-				item.qty >= item.max_qty;
-		}
-	},
+        update_qty_limits(item) {
+                if (item && item.available_qty !== undefined) {
+                        item.max_qty = flt(item.available_qty / (item.conversion_factor || 1));
+
+                        if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
+                                if (
+                                        this.pos_profile.posa_block_sale_beyond_available_qty &&
+                                        !this.stock_settings.allow_negative_stock
+                                ) {
+                                        item.qty = item.max_qty;
+                                        calcStockQty(item, item.qty, this);
+                                        this.$forceUpdate();
+                                        this.eventBus.emit("show_message", {
+                                                title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
+                                                        this.formatFloat(item.max_qty),
+                                                ]),
+                                                color: "error",
+                                        });
+                                } else {
+                                        this.eventBus.emit("show_message", {
+                                                title: __(
+                                                        "Stock is lower than requested. Proceeding may create negative stock.",
+                                                ),
+                                                color: "warning",
+                                        });
+                                }
+                        }
+
+                        item.disable_increment =
+                                this.pos_profile.posa_block_sale_beyond_available_qty &&
+                                !this.stock_settings.allow_negative_stock &&
+                                item.qty >= item.max_qty;
+                }
+        },
 
 	// Fetch available stock for an item and cache it
 	async fetch_available_qty(item) {


### PR DESCRIPTION
## Summary
- restrict quantity field to available stock and show warning
- clamp manual quantity input in invoice item methods and items table
- adjust quantity after stock fetch to avoid exceeding available inventory

## Testing
- `npx eslint frontend/src/posapp/components/pos/invoiceItemMethods.js frontend/src/posapp/components/pos/Invoice.vue frontend/src/posapp/components/pos/ItemsTable.vue`


------
https://chatgpt.com/codex/tasks/task_e_68a4b15e7b288326835601a509fb0b09