### PR TITLE
chore(release): sync python version

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,8 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
-    ["@semantic-release/git", { "assets": ["CHANGELOG.md", "package.json", "yarn.lock"] }],
+    ["@semantic-release/exec", { "prepareCmd": "python scripts/update_version.py ${nextRelease.version}" }],
+    ["@semantic-release/git", { "assets": ["CHANGELOG.md", "package.json", "yarn.lock", "posawesome/__init__.py"] }],
     "@semantic-release/github"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "dexie": "^4.0.11",
     "lodash": "^4.17.21",
     "mitt": "^3.0.1",
+    "nunjucks": "^3.2.4",
     "socket.io-client": "^4.8.1",
     "vite": "^6.2.4",
     "vite-plugin-static-copy": "^3.1.1",
     "vue": "^3.3.4",
     "vue-qrcode-reader": "^5.7.2",
     "vue-virtual-scroller": "^2.0.0-beta.8",
-    "vuetify": "^3.7.5",
-    "nunjucks": "^3.2.4"
+    "vuetify": "^3.7.5"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "devDependencies": {
@@ -29,6 +29,7 @@
     "@eslint/js": "^9.16.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",
+    "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.4",
     "@semantic-release/release-notes-generator": "^14.0.3",

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Update project version in package.json and posawesome/__init__.py."""
+import json
+import re
+from pathlib import Path
+import sys
+
+def replace_version_in_init(version: str) -> None:
+    init_path = Path("posawesome/__init__.py")
+    content = init_path.read_text()
+    new_content = re.sub(r'__version__\s*=\s*["\']([^"\']*)["\']', f'__version__ = "{version}"', content)
+    init_path.write_text(new_content)
+
+def replace_version_in_package_json(version: str) -> None:
+    pkg_path = Path("package.json")
+    data = json.loads(pkg_path.read_text())
+    data["version"] = version
+    pkg_path.write_text(json.dumps(data, indent=2) + "\n")
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit("Usage: update_version.py <version>")
+    version = sys.argv[1]
+    replace_version_in_init(version)
+    replace_version_in_package_json(version)
+
+if __name__ == "__main__":
+    main()

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,18 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-4.0.0.tgz#692810288239637f74396976a9340fbc0aa9f6f9"
   integrity sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==
 
+"@semantic-release/exec@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-7.1.0.tgz#cfaffe85a589aa0f385eede256904ce70acb829f"
+  integrity sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==
+  dependencies:
+    "@semantic-release/error" "^4.0.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    execa "^9.0.0"
+    lodash-es "^4.17.21"
+    parse-json "^8.0.0"
+
 "@semantic-release/git@^10.0.1":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-10.0.1.tgz#c646e55d67fae623875bf3a06a634dd434904498"


### PR DESCRIPTION
## Summary
- update release config to update Python package version
- add version bump script and exec plugin

## Testing
- `python scripts/update_version.py 16.0.0`
- `GITHUB_TOKEN=fake npx semantic-release --dry-run --repository-url https://example.com/fake.git` *(fails: unable to access 'https://example.com/fake.git')*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc8e6cfc832696e813ff510e8267