### PR TITLE
Allow overselling when block beyond stock disabled

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -189,6 +189,7 @@
 						:pos_profile="pos_profile"
 						:invoice_doc="invoice_doc"
 						:invoiceType="invoiceType"
+						:stock_settings="stock_settings"
 						:displayCurrency="displayCurrency"
 						:formatFloat="formatFloat"
 						:formatCurrency="formatCurrency"
@@ -562,52 +563,43 @@ export default {
 			this.posting_date = date;
 			this.$forceUpdate();
 		},
-                // Override setFormatedFloat for qty field to handle stock limits and return mode
-                setFormatedQty(item, field_name, precision, no_negative, value) {
-                        // Parse and set the value using the mixin's formatter
-                        let parsedValue = this.setFormatedFloat(
-                                item,
-                                field_name,
-                                precision,
-                                no_negative,
-                                value,
-                        );
+		// Override setFormatedFloat for qty field to handle stock limits and return mode
+		setFormatedQty(item, field_name, precision, no_negative, value) {
+			// Parse and set the value using the mixin's formatter
+			let parsedValue = this.setFormatedFloat(item, field_name, precision, no_negative, value);
 
-                        // Enforce available stock limits
-                        if (
-                                item.max_qty !== undefined &&
-                                this.flt(item[field_name]) > this.flt(item.max_qty)
-                        ) {
-                               const blockSale =
-                                       !this.stock_settings.allow_negative_stock ||
-                                       this.pos_profile.posa_block_sale_beyond_available_qty;
-                               if (blockSale) {
-                                       item[field_name] = item.max_qty;
-                                       parsedValue = item.max_qty;
-                                       this.eventBus.emit("show_message", {
-                                               title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
-                                                       this.formatFloat(item.max_qty),
-                                               ]),
-                                               color: "error",
-                                       });
-                               } else {
-                                       this.eventBus.emit("show_message", {
-                                               title: __("Stock is lower than requested. Proceeding may create negative stock."),
-                                               color: "warning",
-                                       });
-                               }
-                       }
+			// Enforce available stock limits
+			if (item.max_qty !== undefined && this.flt(item[field_name]) > this.flt(item.max_qty)) {
+				const blockSale =
+					!this.stock_settings.allow_negative_stock ||
+					this.pos_profile.posa_block_sale_beyond_available_qty;
+				if (blockSale) {
+					item[field_name] = item.max_qty;
+					parsedValue = item.max_qty;
+					this.eventBus.emit("show_message", {
+						title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
+							this.formatFloat(item.max_qty),
+						]),
+						color: "error",
+					});
+				} else {
+					this.eventBus.emit("show_message", {
+						title: __("Stock is lower than requested. Proceeding may create negative stock."),
+						color: "warning",
+					});
+				}
+			}
 
-                        // Ensure negative value for return invoices
-                        if (this.isReturnInvoice && parsedValue > 0) {
-                                parsedValue = -Math.abs(parsedValue);
-                                item[field_name] = parsedValue;
-                        }
+			// Ensure negative value for return invoices
+			if (this.isReturnInvoice && parsedValue > 0) {
+				parsedValue = -Math.abs(parsedValue);
+				item[field_name] = parsedValue;
+			}
 
-                        // Recalculate stock quantity with the adjusted value
-                        this.calc_stock_qty(item, item[field_name]);
-                        return parsedValue;
-                },
+			// Recalculate stock quantity with the adjusted value
+			this.calc_stock_qty(item, item[field_name]);
+			return parsedValue;
+		},
 		async fetch_available_currencies() {
 			try {
 				console.log("Fetching available currencies...");
@@ -996,25 +988,21 @@ export default {
 		// Increase quantity of an item (handles return logic)
 		add_one(item) {
 			const proposed = item.qty + 1;
-                       const blockSale =
-                               !this.stock_settings.allow_negative_stock ||
-                               this.pos_profile.posa_block_sale_beyond_available_qty;
-                       if (
-                               blockSale &&
-                               item.max_qty !== undefined &&
-                               proposed > item.max_qty
-                       ) {
-                               item.qty = item.max_qty;
-                               this.calc_stock_qty(item, item.qty);
-                               this.eventBus.emit("show_message", {
-                                       title: __("Maximum available quantity is {0}. Quantity adjusted to match stock.", [
-                                               this.formatFloat(item.max_qty),
-                                        ]),
-                                        color: "error",
-                                });
-                                return;
-                        }
-                        item.qty = proposed;
+			const blockSale =
+				!this.stock_settings.allow_negative_stock ||
+				this.pos_profile.posa_block_sale_beyond_available_qty;
+			if (blockSale && item.max_qty !== undefined && proposed > item.max_qty) {
+				item.qty = item.max_qty;
+				this.calc_stock_qty(item, item.qty);
+				this.eventBus.emit("show_message", {
+					title: __("Maximum available quantity is {0}. Quantity adjusted to match stock.", [
+						this.formatFloat(item.max_qty),
+					]),
+					color: "error",
+				});
+				return;
+			}
+			item.qty = proposed;
 			if (item.qty == 0) {
 				this.remove_item(item);
 			}
@@ -1069,9 +1057,9 @@ export default {
 		this.loadColumnPreferences();
 		// Restore saved invoice height
 		this.loadInvoiceHeight();
-                this.eventBus.on("item-drag-start", () => {
-                        this.showDropFeedback(true);
-                });
+		this.eventBus.on("item-drag-start", () => {
+			this.showDropFeedback(true);
+		});
 		this.eventBus.on("item-drag-end", () => {
 			this.showDropFeedback(false);
 		});
@@ -1201,9 +1189,9 @@ export default {
 			this.posting_date = frappe.datetime.nowdate();
 		});
 		this.eventBus.on("calc_uom", this.calc_uom);
-                this.eventBus.on("item-drag-start", () => {
-                        this.showDropFeedback(true);
-                });
+		this.eventBus.on("item-drag-start", () => {
+			this.showDropFeedback(true);
+		});
 		this.eventBus.on("item-drag-end", () => {
 			this.showDropFeedback(false);
 		});

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -29,34 +29,33 @@
 						val.map((v) => (typeof v === 'object' ? v.posa_row_id : v)),
 					)
 			"
-                        :search="itemSearch"
-                >
-                        <!-- Item name column -->
-                        <template v-slot:item.item_name="{ item }">
-                                <div class="d-flex align-center">
-                                        <span>{{ item.item_name }}</span>
-                                        <v-chip
-                                                v-if="item.name_overridden"
-                                                color="primary"
-                                                size="x-small"
-                                                class="ml-1"
-                                        >{{ __('Edited') }}</v-chip>
-                                        <v-icon
-                                                v-if="pos_profile.posa_allow_line_item_name_override && !item.posa_is_replace"
-                                                size="x-small"
-                                                class="ml-1"
-                                                @click.stop="openNameDialog(item)"
-                                        >mdi-pencil</v-icon>
-                                        <v-icon
-                                                v-if="item.name_overridden"
-                                                size="x-small"
-                                                class="ml-1"
-                                                @click.stop="resetItemName(item)"
-                                        >mdi-undo</v-icon>
-                                </div>
-                        </template>
+			:search="itemSearch"
+		>
+			<!-- Item name column -->
+			<template v-slot:item.item_name="{ item }">
+				<div class="d-flex align-center">
+					<span>{{ item.item_name }}</span>
+					<v-chip v-if="item.name_overridden" color="primary" size="x-small" class="ml-1">{{
+						__("Edited")
+					}}</v-chip>
+					<v-icon
+						v-if="pos_profile.posa_allow_line_item_name_override && !item.posa_is_replace"
+						size="x-small"
+						class="ml-1"
+						@click.stop="openNameDialog(item)"
+						>mdi-pencil</v-icon
+					>
+					<v-icon
+						v-if="item.name_overridden"
+						size="x-small"
+						class="ml-1"
+						@click.stop="resetItemName(item)"
+						>mdi-undo</v-icon
+					>
+				</div>
+			</template>
 
-                        <!-- Quantity column -->
+			<!-- Quantity column -->
 			<template v-slot:item.qty="{ item }">
 				<div class="amount-value" :class="{ 'negative-number': isNegative(item.qty) }">
 					{{ formatFloat(item.qty, hide_qty_decimals ? 0 : undefined) }}
@@ -172,7 +171,10 @@
 									<v-btn
 										:disabled="
 											!!item.posa_is_replace ||
-											(item.max_qty !== undefined && item.qty >= item.max_qty)
+											((!stock_settings.allow_negative_stock ||
+												pos_profile.posa_block_sale_beyond_available_qty) &&
+												item.max_qty !== undefined &&
+												item.qty >= item.max_qty)
 										"
 										size="large"
 										color="success"
@@ -222,15 +224,9 @@
 											:model-value="
 												formatFloat(item.qty, hide_qty_decimals ? 0 : undefined)
 											"
-                                                                                        @change="
-                                                                                                setFormatedQty(
-                                                                                                        item,
-                                                                                                        'qty',
-                                                                                                        null,
-                                                                                                        false,
-                                                                                                        $event.target.value,
-                                                                                                )
-                                                                                        "
+											@change="
+												setFormatedQty(item, 'qty', null, false, $event.target.value)
+											"
 											:rules="[isNumber]"
 											:disabled="!!item.posa_is_replace"
 											prepend-inner-icon="mdi-numeric"
@@ -641,26 +637,27 @@
 					</div>
 				</td>
 			</template>
-                </v-data-table-virtual>
-                <v-dialog v-model="editNameDialog" max-width="400">
-                        <v-card>
-                                <v-card-title>{{ __('Item Name') }}</v-card-title>
-                                <v-card-text>
-                                        <v-text-field v-model="editedName" :maxlength="140" />
-                                </v-card-text>
-                                <v-card-actions>
-                                        <v-btn
-                                                v-if="editNameTarget && editNameTarget.name_overridden"
-                                                variant="text"
-                                                @click="resetItemName(editNameTarget)"
-                                        >{{ __('Reset') }}</v-btn>
-                                        <v-spacer></v-spacer>
-                                        <v-btn variant="text" @click="editNameDialog = false">{{ __('Cancel') }}</v-btn>
-                                        <v-btn color="primary" variant="text" @click="saveItemName">{{ __('Save') }}</v-btn>
-                                </v-card-actions>
-                        </v-card>
-                </v-dialog>
-        </div>
+		</v-data-table-virtual>
+		<v-dialog v-model="editNameDialog" max-width="400">
+			<v-card>
+				<v-card-title>{{ __("Item Name") }}</v-card-title>
+				<v-card-text>
+					<v-text-field v-model="editedName" :maxlength="140" />
+				</v-card-text>
+				<v-card-actions>
+					<v-btn
+						v-if="editNameTarget && editNameTarget.name_overridden"
+						variant="text"
+						@click="resetItemName(editNameTarget)"
+						>{{ __("Reset") }}</v-btn
+					>
+					<v-spacer></v-spacer>
+					<v-btn variant="text" @click="editNameDialog = false">{{ __("Cancel") }}</v-btn>
+					<v-btn color="primary" variant="text" @click="saveItemName">{{ __("Save") }}</v-btn>
+				</v-card-actions>
+			</v-card>
+		</v-dialog>
+	</div>
 </template>
 
 <script>
@@ -676,6 +673,7 @@ export default {
 		pos_profile: Object,
 		invoice_doc: Object,
 		invoiceType: String,
+		stock_settings: Object,
 		displayCurrency: String,
 		formatFloat: Function,
 		formatCurrency: Function,
@@ -697,16 +695,16 @@ export default {
 		isNegative: Function,
 	},
 	data() {
-                return {
-                        draggedItem: null,
-                        draggedIndex: null,
-                        dragOverIndex: null,
-                        isDragging: false,
-                        pendingAdd: null,
-                        editNameDialog: false,
-                        editNameTarget: null,
-                        editedName: "",
-                };
+		return {
+			draggedItem: null,
+			draggedIndex: null,
+			dragOverIndex: null,
+			isDragging: false,
+			pendingAdd: null,
+			editNameDialog: false,
+			editNameTarget: null,
+			editedName: "",
+		};
 	},
 	computed: {
 		headerProps() {
@@ -763,57 +761,56 @@ export default {
 				console.error("Error parsing drag data:", error);
 			}
 		},
-                addItem(newItem) {
-                        // Find a matching item (by item_code, uom, and rate)
-                        const match = this.items.find(
-                                (item) =>
-                                        item.item_code === newItem.item_code &&
-                                        item.uom === newItem.uom &&
-                                        item.rate === newItem.rate,
-                        );
-                        if (match) {
-                                // If found, increment quantity
-                                match.qty += newItem.qty || 1;
-                                match.amount = match.qty * match.rate;
-                                this.$forceUpdate();
-                        } else {
-                                this.items.push({ ...newItem });
-                        }
-                },
-                addItemDebounced: _.debounce(function (item) {
-                        this.addItem(item);
-                }, 50),
-                openNameDialog(item) {
-                        this.editNameTarget = item;
-                        this.editedName = item.item_name;
-                        this.editNameDialog = true;
-                },
-                sanitizeName(name) {
-                        const div = document.createElement('div');
-                        div.innerHTML = name;
-                        return (div.textContent || div.innerText || '').trim().slice(0, 140);
-                },
-                saveItemName() {
-                        if (!this.editNameTarget) return;
-                        const clean = this.sanitizeName(this.editedName);
-                        if (!this.editNameTarget.original_item_name) {
-                                this.editNameTarget.original_item_name = this.editNameTarget.item_name;
-                        }
-                        this.editNameTarget.item_name = clean;
-                        this.editNameTarget.name_overridden =
-                                clean !== this.editNameTarget.original_item_name ? 1 : 0;
-                        this.editNameDialog = false;
-                },
-                resetItemName(item) {
-                        if (item && item.original_item_name) {
-                                item.item_name = item.original_item_name;
-                                item.name_overridden = 0;
-                        }
-                        if (this.editNameTarget === item) {
-                                this.editedName = item.item_name;
-                        }
-                },
-        },
+		addItem(newItem) {
+			// Find a matching item (by item_code, uom, and rate)
+			const match = this.items.find(
+				(item) =>
+					item.item_code === newItem.item_code &&
+					item.uom === newItem.uom &&
+					item.rate === newItem.rate,
+			);
+			if (match) {
+				// If found, increment quantity
+				match.qty += newItem.qty || 1;
+				match.amount = match.qty * match.rate;
+				this.$forceUpdate();
+			} else {
+				this.items.push({ ...newItem });
+			}
+		},
+		addItemDebounced: _.debounce(function (item) {
+			this.addItem(item);
+		}, 50),
+		openNameDialog(item) {
+			this.editNameTarget = item;
+			this.editedName = item.item_name;
+			this.editNameDialog = true;
+		},
+		sanitizeName(name) {
+			const div = document.createElement("div");
+			div.innerHTML = name;
+			return (div.textContent || div.innerText || "").trim().slice(0, 140);
+		},
+		saveItemName() {
+			if (!this.editNameTarget) return;
+			const clean = this.sanitizeName(this.editedName);
+			if (!this.editNameTarget.original_item_name) {
+				this.editNameTarget.original_item_name = this.editNameTarget.item_name;
+			}
+			this.editNameTarget.item_name = clean;
+			this.editNameTarget.name_overridden = clean !== this.editNameTarget.original_item_name ? 1 : 0;
+			this.editNameDialog = false;
+		},
+		resetItemName(item) {
+			if (item && item.original_item_name) {
+				item.item_name = item.original_item_name;
+				item.name_overridden = 0;
+			}
+			if (this.editNameTarget === item) {
+				this.editedName = item.item_name;
+			}
+		},
+	},
 };
 </script>
 


### PR DESCRIPTION
## Summary
- keep quantity increase button active when "Block Sale Beyond Available Qty" is off and negative stock is allowed
- wire stock settings into item table to evaluate increment limits

## Testing
- `npx eslint frontend/src/posapp/components/pos/ItemsTable.vue frontend/src/posapp/components/pos/Invoice.vue`
- `npx prettier --check frontend/src/posapp/components/pos/ItemsTable.vue frontend/src/posapp/components/pos/Invoice.vue`


------
https://chatgpt.com/codex/tasks/task_e_68a58132b4bc8326881a32dddd307525