### PR TITLE
fix: preserve item search text on backspace

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -683,13 +683,13 @@ export default {
 			const newLen = (val || "").trim().length;
 			const oldLen = (oldVal || "").trim().length;
 			if (newLen >= 3) {
-				// Call without arguments so search_onchange treats it like an Enter key
-				this.search_onchange();
-			} else if (oldLen >= 3 && newLen < 3) {
-				// Reset items when falling below the threshold
-				this.clearSearch();
-			}
-		}, 300),
+                       // Call without arguments so search_onchange treats it like an Enter key
+                       this.search_onchange();
+               } else if (oldLen >= 3 && newLen === 0) {
+                       // Reset items only when search is fully cleared
+                       this.clearSearch();
+               }
+               }, 300),
 
 		// Refresh item prices whenever the user changes currency
 		selected_currency() {


### PR DESCRIPTION
## Summary
- avoid clearing the search field when text length falls below 3

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint frontend/src/posapp/components/pos/ItemsSelector.vue`


------
https://chatgpt.com/codex/tasks/task_e_68a59154fd888326a74658dd03d8d0c5