### PR TITLE
feat: add product bundle support in POS

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -26,7 +26,7 @@
 			<div class="dynamic-padding">
 				<v-alert
 					type="info"
-					dense
+					density="compact"
 					class="mb-2"
 					v-if="pos_profile.create_pos_invoice_instead_of_sales_invoice"
 				>
@@ -216,6 +216,7 @@
 						:toggleOffer="toggleOffer"
 						:changePriceListRate="change_price_list_rate"
 						:isNegative="isNegative"
+						:showBundleComponents="pos_profile.expand_bundle_items_in_cart"
 						@update:expanded="handleExpandedUpdate"
 						@reorder-items="handleItemReorder"
 						@add-item-from-drag="handleItemDrop"
@@ -993,50 +994,66 @@ export default {
 			return Math.round(amount);
 		},
 
-                // Increase quantity of an item (handles return logic)
-                add_one(item) {
-                        if (this.isReturnInvoice) {
-                                // For returns, make quantity more negative
-                                item.qty--;
-                        } else {
-                                const proposed = item.qty + 1;
-                                const blockSale =
-                                        !this.stock_settings.allow_negative_stock ||
-                                        this.pos_profile.posa_block_sale_beyond_available_qty;
-                                if (blockSale && item.max_qty !== undefined && proposed > item.max_qty) {
-                                        item.qty = item.max_qty;
-                                        this.calc_stock_qty(item, item.qty);
-                                        this.eventBus.emit("show_message", {
-                                                title: __("Maximum available quantity is {0}. Quantity adjusted to match stock.", [
-                                                        this.formatFloat(item.max_qty),
-                                                ]),
-                                                color: "error",
-                                        });
-                                        return;
-                                }
-                                item.qty = proposed;
-                        }
-                        if (item.qty == 0) {
-                                this.remove_item(item);
-                        }
-                        this.calc_stock_qty(item, item.qty);
-                        this.$forceUpdate();
-                },
+		// Increase quantity of an item (handles return logic)
+		add_one(item) {
+			if (this.isReturnInvoice) {
+				// For returns, make quantity more negative
+				item.qty--;
+			} else {
+				const proposed = item.qty + 1;
+				const blockSale =
+					!this.stock_settings.allow_negative_stock ||
+					this.pos_profile.posa_block_sale_beyond_available_qty;
+				if (blockSale && item.max_qty !== undefined && proposed > item.max_qty) {
+					item.qty = item.max_qty;
+					this.calc_stock_qty(item, item.qty);
+					this.eventBus.emit("show_message", {
+						title: __("Maximum available quantity is {0}. Quantity adjusted to match stock.", [
+							this.formatFloat(item.max_qty),
+						]),
+						color: "error",
+					});
+					return;
+				}
+				item.qty = proposed;
+			}
+			if (item.qty == 0) {
+				this.remove_item(item);
+			}
+			this.calc_stock_qty(item, item.qty);
+			if (item.is_bundle) {
+				this.items
+					.filter((it) => it.parent_bundle_code === item.item_code)
+					.forEach((ch) => {
+						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
+						this.calc_stock_qty(ch, ch.qty);
+					});
+			}
+			this.$forceUpdate();
+		},
 
-                // Decrease quantity of an item (handles return logic)
-                subtract_one(item) {
-                        if (this.isReturnInvoice) {
-                                // For returns, move quantity toward zero
-                                item.qty++;
-                        } else {
-                                item.qty--;
-                        }
-                        if (item.qty == 0) {
-                                this.remove_item(item);
-                        }
-                        this.calc_stock_qty(item, item.qty);
-                        this.$forceUpdate();
-                },
+		// Decrease quantity of an item (handles return logic)
+		subtract_one(item) {
+			if (this.isReturnInvoice) {
+				// For returns, move quantity toward zero
+				item.qty++;
+			} else {
+				item.qty--;
+			}
+			if (item.qty == 0) {
+				this.remove_item(item);
+			}
+			this.calc_stock_qty(item, item.qty);
+			if (item.is_bundle) {
+				this.items
+					.filter((it) => it.parent_bundle_code === item.item_code)
+					.forEach((ch) => {
+						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
+						this.calc_stock_qty(ch, ch.qty);
+					});
+			}
+			this.$forceUpdate();
+		},
 
 		// Handle item reordering from drag and drop
 		handleItemReorder(reorderData) {

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -220,44 +220,58 @@
                                                 @reorder-items="handleItemReorder"
                                                 @add-item-from-drag="handleItemDrop"
                                                 @show-drop-feedback="showDropFeedback"
-                                                @item-dropped="showDropFeedback(false)"
-                                                @view-packed="scrollToPackedItems"
-                                        />
-			<div v-if="packed_items.length" ref="packedItemsSection" class="mt-4">
-				<div class="text-subtitle-1 mb-2">{{ __("Packing List") }} ({{ packed_items.length }})</div>
-				<v-alert type="warning" density="compact" class="mb-2">
-					{{ __("For 'Product Bundle' items, Warehouse, Serial No and Batch No will be considered from the 'Packing List' table. If Warehouse and Batch No are same for all packing items for any 'Product Bundle' item, those values can be entered in the main Item table; values will be copied to 'Packing List' table.") }}
-				</v-alert>
-				<v-data-table
-					:headers="packedItemsHeaders"
-					:items="packed_items"
-					class="elevation-1"
-					hide-default-footer
-					density="compact"
-				>
-					<template v-slot:item.index="{ index }">
-						{{ index + 1 }}
-					</template>
-					<template v-slot:item.qty="{ item }">
-						{{ formatFloat(item.qty) }}
-					</template>
-					<template v-slot:item.rate="{ item }">
-						<div class="currency-display">
-							<span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
-							<span class="amount-value">{{ formatCurrency(item.rate) }}</span>
-						</div>
-					</template>
-					<template v-slot:item.warehouse="{ item }">
-						<v-text-field v-model="item.warehouse" hide-details density="compact" />
-					</template>
-					<template v-slot:item.batch_no="{ item }">
-						<v-text-field v-model="item.batch_no" hide-details density="compact" />
-					</template>
-					<template v-slot:item.serial_no="{ item }">
-						<v-text-field v-model="item.serial_no" hide-details density="compact" />
-					</template>
-				</v-data-table>
-			</div>
+                                               @item-dropped="showDropFeedback(false)"
+                                               @view-packed="openPackedItems"
+                                       />
+                       <v-dialog v-model="show_packed_dialog" max-width="800px">
+                               <v-card>
+                                       <v-card-title class="d-flex align-center">
+                                               <span>{{ __("Packing List") }} ({{ packed_dialog_items.length }})</span>
+                                               <v-spacer></v-spacer>
+                                               <v-btn
+                                                       icon="mdi-close"
+                                                       variant="text"
+                                                       density="compact"
+                                                       @click="show_packed_dialog = false"
+                                               ></v-btn>
+                                       </v-card-title>
+                                       <v-divider></v-divider>
+                                       <v-card-text>
+                                               <v-alert type="warning" density="compact" class="mb-2">
+                                                       {{ __("For 'Product Bundle' items, Warehouse, Serial No and Batch No will be considered from the 'Packing List' table. If Warehouse and Batch No are same for all packing items for any 'Product Bundle' item, those values can be entered in the main Item table; values will be copied to 'Packing List' table.") }}
+                                               </v-alert>
+                                               <v-data-table
+                                                       :headers="packedItemsHeaders"
+                                                       :items="packed_dialog_items"
+                                                       class="elevation-1"
+                                                       hide-default-footer
+                                                       density="compact"
+                                               >
+                                                       <template v-slot:item.index="{ index }">
+                                                               {{ index + 1 }}
+                                                       </template>
+                                                       <template v-slot:item.qty="{ item }">
+                                                               {{ formatFloat(item.qty) }}
+                                                       </template>
+                                                       <template v-slot:item.rate="{ item }">
+                                                               <div class="currency-display">
+                                                                       <span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
+                                                                       <span class="amount-value">{{ formatCurrency(item.rate) }}</span>
+                                                               </div>
+                                                       </template>
+                                                       <template v-slot:item.warehouse="{ item }">
+                                                               <v-text-field v-model="item.warehouse" hide-details density="compact" />
+                                                       </template>
+                                                       <template v-slot:item.batch_no="{ item }">
+                                                               <v-text-field v-model="item.batch_no" hide-details density="compact" />
+                                                       </template>
+                                                       <template v-slot:item.serial_no="{ item }">
+                                                               <v-text-field v-model="item.serial_no" hide-details density="compact" />
+                                                       </template>
+                                               </v-data-table>
+                                       </v-card-text>
+                               </v-card>
+                       </v-dialog>
                                 </div>
 			</div>
 		</v-card>
@@ -323,8 +337,10 @@ export default {
 			additional_discount: 0,
 			additional_discount_percentage: 0,
 			total_tax: 0,
-                        items: [], // List of invoice items
-                        packed_items: [], // Packed items for bundles
+                       items: [], // List of invoice items
+                       packed_items: [], // Packed items for bundles
+                       packed_dialog_items: [], // Packed items displayed in dialog
+                       show_packed_dialog: false, // Packing list dialog visibility
 			posOffers: [], // All available offers
 			posa_offers: [], // Offers applied to this invoice
 			posa_coupons: [], // Coupons applied
@@ -452,14 +468,12 @@ export default {
                                 }
                         }
                 },
-                scrollToPackedItems() {
-                        this.$nextTick(() => {
-                                const section = this.$refs.packedItemsSection;
-                                if (section && section.scrollIntoView) {
-                                        section.scrollIntoView({ behavior: "smooth" });
-                                }
-                        });
-                },
+               openPackedItems(bundle_id) {
+                       this.packed_dialog_items = this.packed_items.filter(
+                               (it) => it.bundle_id === bundle_id,
+                       );
+                       this.show_packed_dialog = true;
+               },
                 toggleColumnSelection() {
 			// Create a copy of selected columns for temporary editing
 			this.temp_selected_columns = [...this.selected_columns];

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -607,6 +607,14 @@ export default {
 
 			// Recalculate stock quantity with the adjusted value
 			this.calc_stock_qty(item, item[field_name]);
+			if (field_name === "qty" && item.is_bundle) {
+				this.items
+					.filter((it) => it.parent_bundle_code === item.item_code)
+					.forEach((ch) => {
+						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
+						this.calc_stock_qty(ch, ch.qty);
+					});
+			}
 			return parsedValue;
 		},
 		async fetch_available_currencies() {

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -135,6 +135,44 @@
 			<template v-slot:expanded-row="{ item }">
 				<td :colspan="headers.length" class="ma-0 pa-0">
 					<div class="expanded-content">
+						<div v-if="item.is_bundle && showBundleComponents" class="bundle-components mb-2">
+							<v-expansion-panels variant="accordion">
+								<v-expansion-panel>
+									<v-expansion-panel-title>
+										{{ __("Included Items") }}
+										(
+										{{
+											items.filter((it) => it.parent_bundle_code === item.item_code)
+												.length
+										}}
+										)
+									</v-expansion-panel-title>
+									<v-expansion-panel-text>
+										<v-list density="compact">
+											<v-list-item
+												v-for="child in items.filter(
+													(it) => it.parent_bundle_code === item.item_code,
+												)"
+												:key="child.posa_row_id"
+											>
+												<div class="d-flex justify-space-between">
+													<span>{{ child.item_code }} - {{ child.item_name }}</span>
+													<span
+														>{{
+															formatFloat(
+																child.qty,
+																hide_qty_decimals ? 0 : undefined,
+															)
+														}}
+														{{ child.uom }}</span
+													>
+												</div>
+											</v-list-item>
+										</v-list>
+									</v-expansion-panel-text>
+								</v-expansion-panel>
+							</v-expansion-panels>
+						</div>
 						<!-- Enhanced Action Panel with better visual hierarchy -->
 						<div class="action-panel">
 							<div class="action-panel-header">
@@ -727,9 +765,6 @@ export default {
 			return false;
 		},
 		filteredItems() {
-			if (this.showBundleComponents) {
-				return this.items;
-			}
 			return this.items.filter((it) => !it.posa_is_bundle_component);
 		},
 	},

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -137,17 +137,7 @@
 			<!-- Expanded row content using Vuetify's built-in system -->
 			<template v-slot:expanded-row="{ item }">
 				<td :colspan="headers.length" class="ma-0 pa-0">
-					<div class="expanded-content">
-			<div v-if="item.is_bundle" class="mb-2">
-				<v-btn
-					size="small"
-					variant="text"
-					color="primary"
-					@click.stop="$emit('view-packed', item.bundle_id)"
-				>
-					{{ __("View Packed Items") }}
-				</v-btn>
-			</div>
+                                        <div class="expanded-content">
 						<!-- Enhanced Action Panel with better visual hierarchy -->
 						<div class="action-panel">
 							<div class="action-panel-header">
@@ -155,19 +145,31 @@
 								<span class="action-panel-title">{{ __("Quick Actions") }}</span>
 							</div>
 							<div class="action-panel-content">
-								<div class="action-button-group">
-									<v-btn
-										:disabled="!!item.posa_is_replace"
-										size="large"
-										color="error"
-										variant="tonal"
-										class="item-action-btn delete-btn"
-										@click.stop="removeItem(item)"
-									>
-										<v-icon size="large">mdi-trash-can-outline</v-icon>
-										<span class="action-label">{{ __("Remove") }}</span>
-									</v-btn>
-								</div>
+                                                                <div class="action-button-group">
+                                                                        <v-btn
+                                                                                :disabled="!!item.posa_is_replace"
+                                                                                size="large"
+                                                                                color="error"
+                                                                                variant="tonal"
+                                                                                class="item-action-btn delete-btn"
+                                                                                @click.stop="removeItem(item)"
+                                                                        >
+                                                                                <v-icon size="large">mdi-trash-can-outline</v-icon>
+                                                                                <span class="action-label">{{ __("Remove") }}</span>
+                                                                        </v-btn>
+                                                                        <v-btn
+                                                                                v-if="item.is_bundle"
+                                                                                :disabled="!!item.posa_is_replace"
+                                                                                size="large"
+                                                                                color="primary"
+                                                                                variant="tonal"
+                                                                                class="item-action-btn bundle-btn"
+                                                                                @click.stop="$emit('view-packed', item.bundle_id)"
+                                                                        >
+                                                                                <v-icon size="large">mdi-package-variant</v-icon>
+                                                                                <span class="action-label">{{ __("Bundle Items") }}</span>
+                                                                        </v-btn>
+                                                                </div>
 
 								<div class="action-button-group">
 									<v-btn

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -167,9 +167,9 @@
                                                                                 @click.stop="$emit('view-packed', item.bundle_id)"
                                                                         >
                                                                                 <v-icon size="large">mdi-package-variant</v-icon>
-                                                                                <span class="action-label">{{ __("Bundle Items") }}</span>
-                                                                        </v-btn>
-                                                                </div>
+                                                                               <span class="action-label">{{ __("Items Included") }}</span>
+                                                                       </v-btn>
+                                                               </div>
 
 								<div class="action-button-group">
 									<v-btn

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -9,7 +9,7 @@
 	>
 		<v-data-table-virtual
 			:headers="headers"
-			:items="items"
+			:items="filteredItems"
 			:theme="$theme.current"
 			:expanded="expanded"
 			show-expand
@@ -693,6 +693,7 @@ export default {
 		toggleOffer: Function,
 		changePriceListRate: Function,
 		isNegative: Function,
+		showBundleComponents: Boolean,
 	},
 	data() {
 		return {
@@ -724,6 +725,12 @@ export default {
 				console.error("Failed to load item selector settings:", e);
 			}
 			return false;
+		},
+		filteredItems() {
+			if (this.showBundleComponents) {
+				return this.items;
+			}
+			return this.items.filter((it) => !it.posa_is_bundle_component);
 		},
 	},
 	methods: {

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -9,7 +9,7 @@
 	>
 		<v-data-table-virtual
 			:headers="headers"
-			:items="filteredItems"
+                        :items="items"
 			:theme="$theme.current"
 			:expanded="expanded"
 			show-expand
@@ -33,11 +33,14 @@
 		>
 			<!-- Item name column -->
 			<template v-slot:item.item_name="{ item }">
-				<div class="d-flex align-center">
-					<span>{{ item.item_name }}</span>
-					<v-chip v-if="item.name_overridden" color="primary" size="x-small" class="ml-1">{{
-						__("Edited")
-					}}</v-chip>
+                                <div class="d-flex align-center">
+                                        <span>{{ item.item_name }}</span>
+                                        <v-chip v-if="item.is_bundle" color="secondary" size="x-small" class="ml-1">{{
+                                                __("Bundle")
+                                        }}</v-chip>
+                                        <v-chip v-if="item.name_overridden" color="primary" size="x-small" class="ml-1">{{
+                                                __("Edited")
+                                        }}</v-chip>
 					<v-icon
 						v-if="pos_profile.posa_allow_line_item_name_override && !item.posa_is_replace"
 						size="x-small"
@@ -135,44 +138,16 @@
 			<template v-slot:expanded-row="{ item }">
 				<td :colspan="headers.length" class="ma-0 pa-0">
 					<div class="expanded-content">
-						<div v-if="item.is_bundle && showBundleComponents" class="bundle-components mb-2">
-							<v-expansion-panels variant="accordion">
-								<v-expansion-panel>
-									<v-expansion-panel-title>
-										{{ __("Included Items") }}
-										(
-										{{
-											items.filter((it) => it.parent_bundle_code === item.item_code)
-												.length
-										}}
-										)
-									</v-expansion-panel-title>
-									<v-expansion-panel-text>
-										<v-list density="compact">
-											<v-list-item
-												v-for="child in items.filter(
-													(it) => it.parent_bundle_code === item.item_code,
-												)"
-												:key="child.posa_row_id"
-											>
-												<div class="d-flex justify-space-between">
-													<span>{{ child.item_code }} - {{ child.item_name }}</span>
-													<span
-														>{{
-															formatFloat(
-																child.qty,
-																hide_qty_decimals ? 0 : undefined,
-															)
-														}}
-														{{ child.uom }}</span
-													>
-												</div>
-											</v-list-item>
-										</v-list>
-									</v-expansion-panel-text>
-								</v-expansion-panel>
-							</v-expansion-panels>
-						</div>
+			<div v-if="item.is_bundle" class="mb-2">
+				<v-btn
+					size="small"
+					variant="text"
+					color="primary"
+					@click.stop="$emit('view-packed', item.bundle_id)"
+				>
+					{{ __("View Packed Items") }}
+				</v-btn>
+			</div>
 						<!-- Enhanced Action Panel with better visual hierarchy -->
 						<div class="action-panel">
 							<div class="action-panel-header">
@@ -731,7 +706,6 @@ export default {
 		toggleOffer: Function,
 		changePriceListRate: Function,
 		isNegative: Function,
-		showBundleComponents: Boolean,
 	},
 	data() {
 		return {
@@ -763,9 +737,6 @@ export default {
 				console.error("Failed to load item selector settings:", e);
 			}
 			return false;
-		},
-		filteredItems() {
-			return this.items.filter((it) => !it.posa_is_bundle_component);
 		},
 	},
 	methods: {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1249,9 +1249,10 @@ export default {
 			// Validate stock availability before submitting
 			if (!isOffline()) {
 				try {
+					const itemsToCheck = this.invoice_doc.items.filter((it) => !it.is_bundle);
 					const stockCheck = await frappe.call({
 						method: "posawesome.posawesome.api.invoices.validate_cart_items",
-						args: { items: JSON.stringify(this.invoice_doc.items) },
+						args: { items: JSON.stringify(itemsToCheck) },
 					});
 					if (stockCheck.message && stockCheck.message.length) {
 						const msg = stockCheck.message

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -161,27 +161,37 @@ export default {
 			this.invoiceTypes = ["Return"];
 		}
 
-		this.invoice_doc = data;
-		this.items = data.items || [];
-		console.log("Items set:", this.items.length, "items");
+                this.invoice_doc = data;
+                this.items = data.items || [];
+                this.packed_items = data.packed_items || [];
+                console.log("Items set:", this.items.length, "items");
 
-		if (this.items.length > 0) {
-			this.update_items_details(this.items);
-			this.posa_offers = data.posa_offers || [];
-			this.items.forEach((item) => {
-				if (!item.posa_row_id) {
-					item.posa_row_id = this.makeid(20);
-				}
-				if (item.batch_no) {
-					this.set_batch_qty(item, item.batch_no);
-				}
-				if (!item.original_item_name) {
-					item.original_item_name = item.item_name;
-				}
-			});
-		} else {
-			console.log("Warning: No items in return invoice");
-		}
+                if (this.items.length > 0) {
+                        this.update_items_details(this.items);
+                        this.posa_offers = data.posa_offers || [];
+                        this.items.forEach((item) => {
+                                if (!item.posa_row_id) {
+                                        item.posa_row_id = this.makeid(20);
+                                }
+                                if (item.batch_no) {
+                                        this.set_batch_qty(item, item.batch_no);
+                                }
+                                if (!item.original_item_name) {
+                                        item.original_item_name = item.item_name;
+                                }
+                        });
+                } else {
+                        console.log("Warning: No items in return invoice");
+                }
+
+                if (this.packed_items.length > 0) {
+                        this.update_items_details(this.packed_items);
+                        this.packed_items.forEach((pi) => {
+                                if (!pi.posa_row_id) {
+                                        pi.posa_row_id = this.makeid(20);
+                                }
+                        });
+                }
 
 		this.customer = data.customer;
 		this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
@@ -353,8 +363,19 @@ export default {
 		doc.is_return = isReturn ? 1 : 0;
 
 		// Calculate amounts in selected currency
-		const items = this.get_invoice_items();
-		doc.items = items;
+                const items = this.get_invoice_items();
+                doc.items = items;
+                doc.packed_items = (this.packed_items || []).map((pi) => ({
+                        parent_item: pi.parent_item,
+                        item_code: pi.item_code,
+                        item_name: pi.item_name,
+                        qty: flt(pi.qty),
+                        uom: pi.uom,
+                        warehouse: pi.warehouse,
+                        batch_no: pi.batch_no,
+                        serial_no: pi.serial_no,
+                        rate: flt(pi.rate),
+                }));
 
 		// Calculate totals in selected currency ensuring negative values for returns
 		let total = this.Total;
@@ -1520,20 +1541,8 @@ export default {
 					item.has_batch_no = data.has_batch_no;
 
 					// Calculate final amount
-					item.amount = vm.flt(item.qty * item.rate, vm.currency_precision);
-					item.base_amount = vm.flt(item.qty * item.base_rate, vm.currency_precision);
-					if (item.posa_is_bundle_component) {
-						Object.assign(item, {
-							rate: 0,
-							price_list_rate: 0,
-							base_rate: 0,
-							base_price_list_rate: 0,
-							discount_amount: 0,
-							base_discount_amount: 0,
-							amount: 0,
-							base_amount: 0,
-						});
-					}
+                                        item.amount = vm.flt(item.qty * item.rate, vm.currency_precision);
+                                        item.base_amount = vm.flt(item.qty * item.base_rate, vm.currency_precision);
 
 					// Log updated rates for debugging
 					console.log(`Updated rates for ${item.item_code} on expand:`, {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -349,8 +349,7 @@ export default {
 		doc.customer = this.customer;
 
 		// Determine if this is a return invoice
-                const isReturn = this.isReturnInvoice;
-                const usesPosInvoice = this.pos_profile.create_pos_invoice_instead_of_sales_invoice;
+		const isReturn = this.isReturnInvoice;
 		doc.is_return = isReturn ? 1 : 0;
 
 		// Calculate amounts in selected currency
@@ -617,11 +616,11 @@ export default {
 
 	// Prepare items array for invoice doc
 	get_invoice_items() {
-                const items_list = [];
-                const isReturn = this.isReturnInvoice;
-                const usesPosInvoice = this.pos_profile.create_pos_invoice_instead_of_sales_invoice;
+		const items_list = [];
+		const isReturn = this.isReturnInvoice;
+		const usesPosInvoice = this.pos_profile.create_pos_invoice_instead_of_sales_invoice;
 
-                this.items.forEach((item) => {
+		this.items.forEach((item) => {
 			const new_item = {
 				item_code: item.item_code,
 				// Retain the item name for offline invoices
@@ -638,22 +637,22 @@ export default {
 				uom: item.uom,
 				conversion_factor: item.conversion_factor,
 				serial_no: item.serial_no,
-                                // Link to original invoice item when doing returns
-                                // Needed for backend validation that the item exists in
-                                // the referenced Sales or POS Invoice
-                                ...(item.sales_invoice_item && { sales_invoice_item: item.sales_invoice_item }),
-                                ...(item.pos_invoice_item && { pos_invoice_item: item.pos_invoice_item }),
+				// Link to original invoice item when doing returns
+				// Needed for backend validation that the item exists in
+				// the referenced Sales or POS Invoice
+				...(item.sales_invoice_item && { sales_invoice_item: item.sales_invoice_item }),
+				...(item.pos_invoice_item && { pos_invoice_item: item.pos_invoice_item }),
 				discount_percentage: flt(item.discount_percentage),
 				batch_no: item.batch_no,
 				posa_notes: item.posa_notes,
 				posa_delivery_date: this.formatDateForBackend(item.posa_delivery_date),
 			};
-                        if (isReturn) {
-                                const refField = usesPosInvoice ? "pos_invoice_item" : "sales_invoice_item";
-                                if (!new_item[refField] && item.name) {
-                                        new_item[refField] = item.name;
-                                }
-                        }
+			if (isReturn) {
+				const refField = usesPosInvoice ? "pos_invoice_item" : "sales_invoice_item";
+				if (!new_item[refField] && item.name) {
+					new_item[refField] = item.name;
+				}
+			}
 
 			// Handle currency conversion for rates and amounts
 			const baseCurrency = this.price_list_currency || this.pos_profile.currency;
@@ -1523,6 +1522,18 @@ export default {
 					// Calculate final amount
 					item.amount = vm.flt(item.qty * item.rate, vm.currency_precision);
 					item.base_amount = vm.flt(item.qty * item.base_rate, vm.currency_precision);
+					if (item.posa_is_bundle_component) {
+						Object.assign(item, {
+							rate: 0,
+							price_list_rate: 0,
+							base_rate: 0,
+							base_price_list_rate: 0,
+							discount_amount: 0,
+							base_discount_amount: 0,
+							amount: 0,
+							base_amount: 0,
+						});
+					}
 
 					// Log updated rates for debugging
 					console.log(`Updated rates for ${item.item_code} on expand:`, {

--- a/frontend/src/posapp/composables/useBundles.js
+++ b/frontend/src/posapp/composables/useBundles.js
@@ -1,0 +1,27 @@
+/* global frappe */
+
+const cache = new Map();
+
+export function useBundles() {
+	const getComponents = async (bundleCode) => {
+		const cached = cache.get(bundleCode);
+		const now = Date.now();
+		if (cached && now - cached.ts < 60000) {
+			return cached.data;
+		}
+		try {
+			const r = await frappe.call({
+				method: "posawesome.posawesome.api.bundles.get_bundle_components",
+				args: { bundles: [bundleCode] },
+			});
+			const data = r.message && r.message[bundleCode] ? r.message[bundleCode] : [];
+			cache.set(bundleCode, { data, ts: now });
+			return data;
+		} catch (e) {
+			console.error("Failed to fetch bundle components", e);
+			return [];
+		}
+	};
+
+	return { getBundleComponents: getComponents };
+}

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -31,6 +31,8 @@ export function useItemAddition() {
                 parent.warehouse = null;
                 parent.stock_qty = 0;
                 parent.bundle_id = context.makeid ? context.makeid(10) : Math.random().toString(36).substr(2, 10);
+                // Force reactivity so the bundle badge appears immediately
+                context.items = [...context.items];
                 for (const comp of components) {
                         const child = {
                                 parent_item: parent.item_code,
@@ -374,12 +376,15 @@ export function useItemAddition() {
 		new_item.conversion_factor = 1;
 		new_item.posa_offers = JSON.stringify([]);
 		new_item.posa_offer_applied = 0;
-		new_item.posa_is_offer = item.posa_is_offer;
-		new_item.posa_is_replace = item.posa_is_replace || null;
-		new_item.is_free_item = 0;
-		new_item.posa_notes = "";
-		new_item.posa_delivery_date = "";
-		new_item.posa_row_id = context.makeid ? context.makeid(20) : Math.random().toString(36).substr(2, 20);
+                new_item.posa_is_offer = item.posa_is_offer;
+                new_item.posa_is_replace = item.posa_is_replace || null;
+                new_item.is_free_item = 0;
+                new_item.is_bundle = 0;
+                new_item.is_bundle_parent = 0;
+                new_item.bundle_id = null;
+                new_item.posa_notes = "";
+                new_item.posa_delivery_date = "";
+                new_item.posa_row_id = context.makeid ? context.makeid(20) : Math.random().toString(36).substr(2, 20);
 		if (new_item.has_serial_no && !new_item.serial_no_selected) {
 			new_item.serial_no_selected = [];
 			new_item.serial_no_selected_count = 0;

--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -1,58 +1,59 @@
 """Expose API functions for POS Awesome."""
 
+from .bundles import get_bundle_components
 from .customers import (
-    create_customer,
-    get_customer_addresses,
-    get_customer_info,
-    get_customer_names,
-    get_sales_person_names,
-    make_address,
-    set_customer_info,
+	create_customer,
+	get_customer_addresses,
+	get_customer_info,
+	get_customer_names,
+	get_sales_person_names,
+	make_address,
+	set_customer_info,
 )
 from .invoices import (
-    delete_invoice,
-    get_draft_invoices,
-    search_invoices_for_return,
-    submit_invoice,
-    update_invoice,
-    validate_return_items,
+	delete_invoice,
+	get_draft_invoices,
+	search_invoices_for_return,
+	submit_invoice,
+	update_invoice,
+	validate_return_items,
 )
 from .items import (
-    get_item_attributes,
-    get_item_detail,
-    get_items,
-    get_items_details,
-    get_items_from_barcode,
-    get_items_groups,
-    get_items_count,
+	get_item_attributes,
+	get_item_detail,
+	get_items,
+	get_items_count,
+	get_items_details,
+	get_items_from_barcode,
+	get_items_groups,
 )
 from .offers import (
-    get_active_gift_coupons,
-    get_applicable_delivery_charges,
-    get_offers,
-    get_pos_coupon,
+	get_active_gift_coupons,
+	get_applicable_delivery_charges,
+	get_offers,
+	get_pos_coupon,
 )
 from .payments import (
-    create_payment_request,
-    get_available_credit,
+	create_payment_request,
+	get_available_credit,
 )
 from .sales_orders import (
-    search_orders,
-    submit_sales_order,
-    update_sales_order,
+	search_orders,
+	submit_sales_order,
+	update_sales_order,
 )
 from .shifts import (
-    check_opening_shift,
-    create_opening_voucher,
-    get_opening_dialog_data,
+	check_opening_shift,
+	create_opening_voucher,
+	get_opening_dialog_data,
 )
 from .utilities import (
-    get_app_branch,
-    get_app_info,
-    get_language_options,
-    get_selling_price_lists,
-    get_translation_dict,
-    get_version,
-    get_pos_profile_tax_inclusive,
+	get_app_branch,
+	get_app_info,
+	get_language_options,
+	get_pos_profile_tax_inclusive,
+	get_selling_price_lists,
+	get_translation_dict,
+	get_version,
 )
 from .utils import get_active_pos_profile, get_default_warehouse

--- a/posawesome/posawesome/api/bundles.py
+++ b/posawesome/posawesome/api/bundles.py
@@ -20,11 +20,10 @@ def get_bundle_components(bundles):
 
 	result = {}
 	for code in bundles or []:
-		try:
-			bundle = frappe.get_doc("Product Bundle", code)
-		except frappe.DoesNotExistError:
+		if not frappe.db.exists("Product Bundle", code):
 			result[code] = []
 			continue
+		bundle = frappe.get_doc("Product Bundle", code)
 
 		components = []
 		for row in bundle.items:

--- a/posawesome/posawesome/api/bundles.py
+++ b/posawesome/posawesome/api/bundles.py
@@ -1,0 +1,49 @@
+import json
+
+import frappe
+from frappe import _
+
+
+@frappe.whitelist()
+def get_bundle_components(bundles):
+	"""Return component items for Product Bundles.
+
+	Args:
+	    bundles (str | list): JSON string or list of bundle item codes.
+
+	Returns:
+	    dict: mapping of bundle_code -> list of components dicts with
+	    item_code, qty, uom, is_batch, is_serial.
+	"""
+	if isinstance(bundles, str):
+		bundles = json.loads(bundles)
+
+	result = {}
+	for code in bundles or []:
+		try:
+			bundle = frappe.get_doc("Product Bundle", code)
+		except frappe.DoesNotExistError:
+			result[code] = []
+			continue
+
+		components = []
+		for row in bundle.items:
+			item = frappe.db.get_value(
+				"Item",
+				row.item_code,
+				["has_batch_no", "has_serial_no", "stock_uom"],
+				as_dict=True,
+			)
+			uom = row.uom or (item.stock_uom if item else None)
+			components.append(
+				{
+					"item_code": row.item_code,
+					"qty": row.qty,
+					"uom": uom,
+					"is_batch": item.has_batch_no if item else 0,
+					"is_serial": item.has_serial_no if item else 0,
+				}
+			)
+		result[code] = components
+
+	return result


### PR DESCRIPTION
## Summary
- add backend API to fetch product bundle component items
- expand bundle items in the POS cart and cache components client‑side
- hide bundle components in cart view and validate stock only for child items
- format bundle-related code with repository tab settings

## Testing
- `npx eslint frontend/src/posapp/composables/useBundles.js frontend/src/posapp/composables/useItemAddition.js frontend/src/posapp/components/pos/Invoice.vue frontend/src/posapp/components/pos/ItemsTable.vue frontend/src/posapp/components/pos/Payments.vue`
- `ruff check posawesome/posawesome/api/bundles.py posawesome/posawesome/api/__init__.py`
- `pytest` *(fails: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68aad974950c8326ac21078221af23c7