### PR TITLE
fix: allow choosing give product

### DIFF
--- a/frontend/src/posapp/components/pos/PosOffers.vue
+++ b/frontend/src/posapp/components/pos/PosOffers.vue
@@ -29,12 +29,9 @@
 							@click="toggleOfferApplied(item)"
 							v-model="item.offer_applied"
 							:disabled="
-								(item.offer == 'Give Product' &&
-									!item.give_item &&
-									!(item.replace_cheapest_item || item.replace_item)) ||
-								(item.offer == 'Grand Total' &&
-									discount_percentage_offer_name &&
-									discount_percentage_offer_name != item.name)
+								item.offer == 'Grand Total' &&
+								discount_percentage_offer_name &&
+								discount_percentage_offer_name != item.name
 							"
 						></v-checkbox-btn>
 					</template>
@@ -127,6 +124,22 @@ export default {
 			let list_offers = [];
 			list_offers = [...this.pos_offers];
 			this.pos_offers = list_offers;
+		},
+		toggleOfferApplied(item) {
+			if (
+				item.offer === "Give Product" &&
+				!item.give_item &&
+				!(item.replace_cheapest_item || item.replace_item)
+			) {
+				this.expanded = [item.row_id];
+				this.eventBus.emit("show_message", {
+					title: __("Select give item before applying offer"),
+					color: "warning",
+				});
+				item.offer_applied = false;
+				return;
+			}
+			this.forceUpdateItem();
 		},
 		makeid(length) {
 			let result = "";

--- a/frontend/src/posapp/components/pos/PosOffers.vue
+++ b/frontend/src/posapp/components/pos/PosOffers.vue
@@ -31,7 +31,7 @@
 							:disabled="
 								(item.offer == 'Give Product' &&
 									!item.give_item &&
-									(!offer.replace_cheapest_item || !offer.replace_item)) ||
+									!(item.replace_cheapest_item || item.replace_item)) ||
 								(item.offer == 'Grand Total' &&
 									discount_percentage_offer_name &&
 									discount_percentage_offer_name != item.name)
@@ -86,6 +86,7 @@
 </template>
 
 <script>
+/* global __ */
 import format from "../../format";
 export default {
 	mixins: [format],
@@ -185,7 +186,14 @@ export default {
 						}
 					}
 					if (newOffer.offer == "Give Product" && !newOffer.give_item) {
-						newOffer.give_item = this.get_give_items(newOffer)[0].item_code;
+						const giveItems = this.get_give_items(newOffer);
+						if (giveItems.length === 1) {
+							const single = giveItems[0];
+							newOffer.give_item = single.item_code || single;
+						} else {
+							newOffer.give_item = null;
+							newOffer.offer_applied = false;
+						}
 					}
 					this.pos_offers.push(newOffer);
 					this.eventBus.emit("show_message", {
@@ -243,7 +251,7 @@ export default {
 	watch: {
 		pos_offers: {
 			deep: true,
-			handler(pos_offers) {
+			handler() {
 				this.handelOffers();
 				this.updateCounters();
 				this.updatePosCoupuns();


### PR DESCRIPTION
## Summary
- allow cashier to select give product instead of auto-picking first in group
- correct offer checkbox disabled logic when give item not chosen

## Testing
- `npx prettier --check frontend/src/posapp/components/pos/PosOffers.vue`
- `npx eslint frontend/src/posapp/components/pos/PosOffers.vue`

------
https://chatgpt.com/codex/tasks/task_e_68ac03df406883269bf53cc6b71da8a5