### PR TITLE
fix: skip bundle parent from stock validation

### DIFF
--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -92,7 +92,10 @@ def _should_block(pos_profile):
 
 
 def _validate_stock_on_invoice(invoice_doc):
-        errors = _collect_stock_errors([d.as_dict() for d in invoice_doc.items])
+        items_to_check = [d.as_dict() for d in invoice_doc.items if d.get("is_stock_item")]
+        if hasattr(invoice_doc, "packed_items"):
+                items_to_check.extend([d.as_dict() for d in invoice_doc.packed_items])
+        errors = _collect_stock_errors(items_to_check)
         if errors and _should_block(invoice_doc.pos_profile):
                 frappe.throw(frappe.as_json({"errors": errors}), frappe.ValidationError)
 


### PR DESCRIPTION
## Summary
- skip non-stock bundle parents when validating invoice stock
- include bundle child items in stock validation

## Testing
- `python -m py_compile posawesome/posawesome/api/invoices.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68ac374bf9308326a62e9efa43dc12cf