### PR TITLE
chore: make release workflow manual

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - develop
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- trigger release workflow only via `workflow_dispatch`

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68ad3a504b548326837fb5c2bad6fee0