### PR TITLE
fix: persist discounts and stabilize offer updates

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -15,6 +15,21 @@ export default {
 	},
 
 	handelOffers() {
+		// Idempotency: skip reprocessing if nothing relevant changed
+		const offerHash = JSON.stringify({
+			items: this.items.map((i) => ({
+				code: i.item_code,
+				qty: i.qty,
+				rate: i.rate,
+				offers: i.posa_offers,
+			})),
+			offers: this.posOffers.map((o) => o.name),
+		});
+		if (offerHash === this._lastOfferHash) {
+			return;
+		}
+		this._lastOfferHash = offerHash;
+
 		const offers = [];
 		this.posOffers.forEach((offer) => {
 			if (offer.apply_on === "Item Code") {
@@ -737,6 +752,8 @@ export default {
 					});
 
 					item.posa_offer_applied = 1;
+					// Prevent further automatic rate resets
+					item._manual_rate_set = true;
 					this.$forceUpdate();
 				}
 			}

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -1,4 +1,5 @@
 import { clearPriceListCache } from "../../../offline/index.js";
+import _ from "lodash";
 
 export default {
 	// Watch for customer change and update related data
@@ -32,9 +33,14 @@ export default {
 	// Watch for items array changes (deep) and re-handle offers
 	items: {
 		deep: true,
-		handler(items) {
-			this.handelOffers();
-			this.$forceUpdate();
+		handler() {
+			if (!this._debouncedHandleOffers) {
+				this._debouncedHandleOffers = _.debounce(() => {
+					this.handelOffers();
+					this.$forceUpdate();
+				}, 100);
+			}
+			this._debouncedHandleOffers();
 		},
 	},
 	// Watch for invoice type change and emit

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -78,6 +78,9 @@ export function useDiscounts() {
 					break;
 
 				case "discount_amount":
+					// Mark rate as manually modified to persist
+					item._manual_rate_set = true;
+
 					// Ensure discount amount doesn't exceed price list rate
 					newValue = Math.min(newValue, converted_price_list_rate);
 
@@ -110,6 +113,9 @@ export function useDiscounts() {
 					break;
 
 				case "discount_percentage":
+					// Mark rate as manually modified to persist
+					item._manual_rate_set = true;
+
 					// Ensure percentage doesn't exceed 100%
 					newValue = Math.min(newValue, 100);
 					item.discount_percentage = context.flt(newValue, context.float_precision);
@@ -134,6 +140,11 @@ export function useDiscounts() {
 						context.currency_precision,
 					);
 					break;
+			}
+
+			// Reset manual flag when discounts are cleared
+			if (item.discount_amount === 0 && item.discount_percentage === 0 && fieldId !== "rate") {
+				item._manual_rate_set = false;
 			}
 
 			// Ensure rate doesn't go below zero
@@ -237,6 +248,15 @@ export function useDiscounts() {
 			item.base_amount = context.flt(item.amount / context.exchange_rate, context.currency_precision);
 		} else {
 			item.base_amount = item.amount;
+		}
+
+		// Persist manual rate when discounts are applied outside of offers
+		if (!item.posa_offer_applied) {
+			if (item.discount_amount > 0 || item.discount_percentage > 0) {
+				item._manual_rate_set = true;
+			} else if (item._manual_rate_set) {
+				item._manual_rate_set = false;
+			}
 		}
 
 		if (context.forceUpdate) context.forceUpdate();


### PR DESCRIPTION
## Summary
- keep manually discounted rates persistent on item objects
- debounce item watcher and add idempotent offer hashing
- guard offer-applied items against price resets

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68adf213b5088326a977d8f9e46446b5