### PR TITLE
feat: extend offer logic to bundles

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -359,10 +359,11 @@ export default {
 			packed_items: [], // Packed items for bundles
 			packed_dialog_items: [], // Packed items displayed in dialog
 			show_packed_dialog: false, // Packing list dialog visibility
-			posOffers: [], // All available offers
-			posa_offers: [], // Offers applied to this invoice
-			posa_coupons: [], // Coupons applied
-			allItems: [], // All items for offer logic
+                        posOffers: [], // All available offers
+                        posa_offers: [], // Offers applied to this invoice
+                        posa_coupons: [], // Coupons applied
+                        isApplyingOffer: false, // Flag to prevent offer watcher loops
+                        allItems: [], // All items for offer logic
 			discount_percentage_offer_name: null, // Track which offer is applied
 			invoiceTypes: ["Invoice", "Order"], // Types of invoices
 			invoiceType: "Invoice", // Current invoice type

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1479,30 +1479,19 @@ export default {
 									item.rate = item.base_rate;
 								}
 							}
-						} else {
-							// For items with offers, only update price_list_rate
-							const companyCurrency = vm.pos_profile.currency;
-							const baseCurrency = companyCurrency;
-
-							if (
-								vm.selected_currency === vm.price_list_currency &&
-								vm.selected_currency !== companyCurrency
-							) {
-								const conv = vm.conversion_rate || 1;
-								item.price_list_rate = vm.flt(
-									item.base_price_list_rate / conv,
-									vm.currency_precision,
-								);
-							} else if (vm.selected_currency !== baseCurrency) {
-								const exchange_rate = vm.exchange_rate || 1;
-								item.price_list_rate = vm.flt(
-									item.base_price_list_rate * exchange_rate,
-									vm.currency_precision,
-								);
-							} else {
-								item.price_list_rate = item.base_price_list_rate;
-							}
-						}
+                                               } else {
+                                                       // Preserve discounted price when an offer is applied so the
+                                                       // rate doesn't revert to the original price list value.
+                                                       const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
+                                                       if (vm.selected_currency !== baseCurrency) {
+                                                               item.price_list_rate = vm.flt(
+                                                                       item.base_rate * vm.exchange_rate,
+                                                                       vm.currency_precision,
+                                                               );
+                                                       } else {
+                                                               item.price_list_rate = item.base_rate;
+                                                       }
+                                               }
 
 						// Handle customer discount only if no offer is applied
 						if (

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1315,16 +1315,18 @@ export default {
 						item.has_serial_no = updated_item.has_serial_no;
 						item.batch_no_data = updated_item.batch_no_data;
 						item.serial_no_data = updated_item.serial_no_data;
-						if (updated_item.rate !== undefined) {
-							if (!item.locked_price) {
-								if (updated_item.rate !== 0 || !item.rate) {
-									item.rate = updated_item.rate;
-									item.price_list_rate = updated_item.price_list_rate || updated_item.rate;
-								}
-							} else if (!item.price_list_rate) {
-								item.price_list_rate = updated_item.price_list_rate || updated_item.rate;
-							}
-						}
+                                               if (updated_item.rate !== undefined) {
+                                                       if (!item.locked_price && !item.posa_offer_applied) {
+                                                               if (updated_item.rate !== 0 || !item.rate) {
+                                                                       item.rate = updated_item.rate;
+                                                                       item.price_list_rate =
+                                                                               updated_item.price_list_rate || updated_item.rate;
+                                                               }
+                                                       } else if (!item.price_list_rate) {
+                                                               item.price_list_rate =
+                                                                       updated_item.price_list_rate || updated_item.rate;
+                                                       }
+                                               }
 						if (updated_item.currency) {
 							item.currency = updated_item.currency;
 						}

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -1,4 +1,5 @@
 import { clearPriceListCache } from "../../../offline/index.js";
+/* global frappe */
 
 export default {
 	// Watch for customer change and update related data
@@ -30,13 +31,22 @@ export default {
 		});
 	},
 	// Watch for items array changes (deep) and re-handle offers
-	items: {
-		deep: true,
-		handler(items) {
-			this.handelOffers();
-			this.$forceUpdate();
-		},
-	},
+        items: {
+                deep: true,
+                handler() {
+                        if (this.isApplyingOffer) return;
+                        this.handelOffers();
+                        this.$forceUpdate();
+                },
+        },
+        packed_items: {
+                deep: true,
+                handler() {
+                        if (this.isApplyingOffer) return;
+                        this.handelOffers();
+                        this.$forceUpdate();
+                },
+        },
 	// Watch for invoice type change and emit
 	invoiceType() {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+/* global __, flt */
 
 export function useDiscounts() {
 	// Update additional discount amount based on percentage
@@ -180,39 +180,52 @@ export function useDiscounts() {
 			return;
 		}
 
-		if (!item.posa_offer_applied) {
-			if (item.price_list_rate) {
-				// Always work with base rates first
-				if (!item.base_price_list_rate) {
-					item.base_price_list_rate = item.price_list_rate;
-					item.base_rate = item.rate;
-				}
+                if (item.posa_offer_applied) {
+                        item.amount = context.flt(item.qty * item.rate, context.currency_precision);
+                        const baseCurrency = context.price_list_currency || context.pos_profile.currency;
+                        if (context.selected_currency !== baseCurrency) {
+                                item.base_amount = context.flt(
+                                        item.amount / context.exchange_rate,
+                                        context.currency_precision,
+                                );
+                        } else {
+                                item.base_amount = item.amount;
+                        }
+                        if (context.forceUpdate) context.forceUpdate();
+                        return;
+                }
 
-				// Convert to selected currency
-				const baseCurrency = context.price_list_currency || context.pos_profile.currency;
-				if (context.selected_currency !== baseCurrency) {
-					item.price_list_rate = context.flt(
-						item.base_price_list_rate / context.exchange_rate,
-						context.currency_precision,
-					);
-					item.rate = context.flt(
-						item.base_rate / context.exchange_rate,
-						context.currency_precision,
-					);
-				} else {
-					item.price_list_rate = item.base_price_list_rate;
-					item.rate = item.base_rate;
-				}
-			}
-		}
+                if (item.price_list_rate) {
+                        // Always work with base rates first
+                        if (!item.base_price_list_rate) {
+                                item.base_price_list_rate = item.price_list_rate;
+                                item.base_rate = item.rate;
+                        }
 
-		// Handle discounts
-		if (item.discount_percentage) {
-			// Calculate discount in selected currency
-			const price_list_rate = item.price_list_rate;
-			const discount_amount = context.flt(
-				(price_list_rate * item.discount_percentage) / 100,
-				context.currency_precision,
+                        // Convert to selected currency
+                        const baseCurrency = context.price_list_currency || context.pos_profile.currency;
+                        if (context.selected_currency !== baseCurrency) {
+                                item.price_list_rate = context.flt(
+                                        item.base_price_list_rate / context.exchange_rate,
+                                        context.currency_precision,
+                                );
+                                item.rate = context.flt(
+                                        item.base_rate / context.exchange_rate,
+                                        context.currency_precision,
+                                );
+                        } else {
+                                item.price_list_rate = item.base_price_list_rate;
+                                item.rate = item.base_rate;
+                        }
+                }
+
+                // Handle discounts
+                if (item.discount_percentage) {
+                        // Calculate discount in selected currency
+                        const price_list_rate = item.price_list_rate;
+                        const discount_amount = context.flt(
+                                (price_list_rate * item.discount_percentage) / 100,
+                                context.currency_precision,
 			);
 
 			item.discount_amount = discount_amount;

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -49,6 +49,9 @@ export function useItemAddition() {
                                 has_batch_no: comp.is_batch,
                                 has_serial_no: comp.is_serial,
                                 posa_row_id: context.makeid ? context.makeid(20) : Math.random().toString(36).substr(2, 20),
+                                posa_offers: JSON.stringify([]),
+                                posa_offer_applied: 0,
+                                posa_is_offer: 0,
                         };
                         context.packed_items.push(child);
                         if (context.update_item_detail) {


### PR DESCRIPTION
## Summary
- handle offers across item and packed item lists for bundles
- track offer metadata on bundle children and watch for changes
- guard offer application with a flag to avoid redundant recomputation
- ensure price list refreshes don't overwrite applied offer rates

## Testing
- `npx eslint frontend/src/posapp/components/pos/invoiceOfferMethods.js frontend/src/posapp/components/pos/invoiceItemMethods.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae041f8dd4832682debb5d7d286469