### PR TITLE
feat: allow western number format in rtl

### DIFF
--- a/frontend/src/posapp/components/Navbar.vue
+++ b/frontend/src/posapp/components/Navbar.vue
@@ -95,10 +95,10 @@
 		/>
 
 		<!-- Snackbar for notifications -->
-		<v-snackbar 
-			v-model="snack" 
-			:timeout="snackTimeout" 
-			:color="snackColor" 
+		<v-snackbar
+			v-model="snack"
+			:timeout="snackTimeout"
+			:color="snackColor"
 			:location="isRtl ? 'top left' : 'top right'"
 		>
 			{{ snackText }}
@@ -110,6 +110,7 @@
 </template>
 
 <script>
+/* global frappe */
 import NavbarAppBar from "./navbar/NavbarAppBar.vue";
 import NavbarDrawer from "./navbar/NavbarDrawer.vue";
 import NavbarMenu from "./navbar/NavbarMenu.vue";
@@ -132,7 +133,7 @@ export default {
 		return {
 			isRtl,
 			rtlStyles,
-			rtlClasses
+			rtlClasses,
 		};
 	},
 	components: {
@@ -189,7 +190,7 @@ export default {
 		},
 		loadingMessage: {
 			type: String,
-			default: 'Loading app data...',
+			default: "Loading app data...",
 		},
 	},
 	data() {
@@ -201,8 +202,8 @@ export default {
 				{ text: "POS", icon: "mdi-network-pos" },
 				{ text: "Payments", icon: "mdi-credit-card" },
 			],
-                        company: "POS Awesome",
-                        companyImg: posLogo,
+			company: "POS Awesome",
+			companyImg: posLogo,
 			showAboutDialog: false,
 			showOfflineInvoices: false,
 			freeze: false,
@@ -289,8 +290,15 @@ export default {
 				return;
 			}
 			try {
+				let westernPref = null;
+				if (typeof localStorage !== "undefined") {
+					westernPref = localStorage.getItem("use_western_numerals");
+				}
 				await forceClearAllCache();
 				await clearAllCaches({ confirmBeforeClear: false }).catch(() => {});
+				if (westernPref !== null && typeof localStorage !== "undefined") {
+					localStorage.setItem("use_western_numerals", westernPref);
+				}
 				this.showMessage({
 					color: "success",
 					title: this.__("Cache cleared successfully"),

--- a/frontend/src/posapp/components/navbar/NavbarMenu.vue
+++ b/frontend/src/posapp/components/navbar/NavbarMenu.vue
@@ -309,6 +309,7 @@ export default {
 			loading: false,
 			changing: false,
 			useWesternNumerals: false,
+			originalWesternNumerals: false,
 			notification: {
 				show: false,
 				message: "",
@@ -319,7 +320,11 @@ export default {
 	},
 	computed: {
 		canChangeLanguage() {
-			return this.selectedLanguage !== this.currentLanguage && !this.changing;
+			return (
+				(this.selectedLanguage !== this.currentLanguage ||
+					this.useWesternNumerals !== this.originalWesternNumerals) &&
+				!this.changing
+			);
 		},
 		selectedLanguageName() {
 			const lang = this.availableLanguages.find((l) => l.code === this.selectedLanguage);
@@ -347,6 +352,7 @@ export default {
 			} catch {
 				this.useWesternNumerals = false;
 			}
+			this.originalWesternNumerals = this.useWesternNumerals;
 		},
 
 		saveWesternPreference() {
@@ -364,8 +370,14 @@ export default {
 		},
 
 		async changeLanguage() {
-			if (!this.canChangeLanguage) {
-				this.showNotification("Cannot change language - same language selected", "warning");
+			if (this.selectedLanguage === this.currentLanguage) {
+				this.originalWesternNumerals = this.useWesternNumerals;
+				this.showNotification("Settings updated. Reloading...", "success");
+				this.closeLanguageDialog();
+				this.$emit("clear-cache");
+				setTimeout(() => {
+					window.location.reload();
+				}, 200);
 				return;
 			}
 
@@ -433,6 +445,7 @@ export default {
 		closeLanguageDialog() {
 			this.showLanguageDialog = false;
 			this.selectedLanguage = this.currentLanguage;
+			this.originalWesternNumerals = this.useWesternNumerals;
 		},
 
 		showNotification(message, type = "info", timeout = 3000) {

--- a/frontend/src/posapp/components/pos/Returns.vue
+++ b/frontend/src/posapp/components/pos/Returns.vue
@@ -9,7 +9,12 @@
 					<!-- Invoice ID and Date Range search -->
 					<v-row class="mb-2">
 						<v-col cols="12">
-							<v-alert dense type="info" text outlined v-if="!from_date && !to_date">
+							<v-alert
+								density="compact"
+								type="info"
+								variant="outlined"
+								v-if="!from_date && !to_date"
+							>
 								<small>{{ __("Use date range to search for older invoices") }}</small>
 							</v-alert>
 						</v-col>
@@ -155,11 +160,11 @@
 							theme="dark"
 							@click="search_invoices"
 						>
-							<v-icon left>mdi-magnify</v-icon>
+							<v-icon start>mdi-magnify</v-icon>
 							{{ __("Search") }}
 						</v-btn>
 						<v-btn variant="text" class="ml-2" color="warning" theme="dark" @click="clear_search">
-							<v-icon left>mdi-refresh</v-icon>
+							<v-icon start>mdi-refresh</v-icon>
 							{{ __("Clear") }}
 						</v-btn>
 						<v-btn
@@ -205,8 +210,7 @@
 							<div class="text-center mt-3" v-if="has_more_invoices">
 								<v-btn
 									color="primary"
-									text
-									outlined
+									variant="outlined"
 									:loading="loading_more"
 									@click="load_more_invoices"
 								>
@@ -238,7 +242,8 @@
 </template>
 
 <script>
-import format from "../../format";
+/* global __, frappe */
+import format, { formatUtils } from "../../format";
 
 export default {
 	mixins: [format],
@@ -309,15 +314,16 @@ export default {
 		formatDateDisplay(dateStr) {
 			if (!dateStr) return "";
 			try {
-				// Convert YYYY-MM-DD to DD-MM-YYYY
-				const parts = dateStr.split("-");
+				const western = formatUtils.fromArabicNumerals(String(dateStr));
+				const parts = western.split("-");
 				if (parts.length === 3) {
-					return `${parts[2]}-${parts[1]}-${parts[0]}`;
+					const formatted = `${parts[2]}-${parts[1]}-${parts[0]}`;
+					return formatUtils.toArabicNumerals(formatted);
 				}
 			} catch (error) {
 				console.error("Error formatting date:", error);
 			}
-			return dateStr;
+			return formatUtils.toArabicNumerals(String(dateStr));
 		},
 		formatFromDate() {
 			if (this.from_date) {
@@ -333,22 +339,22 @@ export default {
 					}
 					// Handle string in YYYY-MM-DD format
 					else if (typeof this.from_date === "string" && this.from_date.includes("-")) {
-						const parts = this.from_date.split("-");
+						const parts = formatUtils.fromArabicNumerals(this.from_date).split("-");
 						if (parts.length === 3) {
 							dateString = `${parts[2]}-${parts[1]}-${parts[0]}`;
 						} else {
-							dateString = this.from_date;
+							dateString = formatUtils.fromArabicNumerals(this.from_date);
 						}
 					}
 					// Handle any other format - just display as is
 					else {
-						dateString = String(this.from_date);
+						dateString = formatUtils.fromArabicNumerals(String(this.from_date));
 					}
 
-					this.from_date_formatted = dateString;
+					this.from_date_formatted = formatUtils.toArabicNumerals(dateString);
 				} catch (error) {
 					console.error("Error formatting from_date:", error);
-					this.from_date_formatted = String(this.from_date);
+					this.from_date_formatted = formatUtils.toArabicNumerals(String(this.from_date));
 				}
 			} else {
 				this.from_date_formatted = null;
@@ -368,22 +374,22 @@ export default {
 					}
 					// Handle string in YYYY-MM-DD format
 					else if (typeof this.to_date === "string" && this.to_date.includes("-")) {
-						const parts = this.to_date.split("-");
+						const parts = formatUtils.fromArabicNumerals(this.to_date).split("-");
 						if (parts.length === 3) {
 							dateString = `${parts[2]}-${parts[1]}-${parts[0]}`;
 						} else {
-							dateString = this.to_date;
+							dateString = formatUtils.fromArabicNumerals(this.to_date);
 						}
 					}
 					// Handle any other format - just display as is
 					else {
-						dateString = String(this.to_date);
+						dateString = formatUtils.fromArabicNumerals(String(this.to_date));
 					}
 
-					this.to_date_formatted = dateString;
+					this.to_date_formatted = formatUtils.toArabicNumerals(dateString);
 				} catch (error) {
 					console.error("Error formatting to_date:", error);
-					this.to_date_formatted = String(this.to_date);
+					this.to_date_formatted = formatUtils.toArabicNumerals(String(this.to_date));
 				}
 			} else {
 				this.to_date_formatted = null;
@@ -444,17 +450,18 @@ export default {
 						String(vm.from_date.getDate()).padStart(2, "0"),
 					].join("-");
 				} else if (typeof vm.from_date === "string") {
-					if (vm.from_date.includes("/")) {
+					const fromStr = formatUtils.fromArabicNumerals(vm.from_date);
+					if (fromStr.includes("/")) {
 						// Convert DD/MM/YYYY to YYYY-MM-DD
-						const parts = vm.from_date.split("/");
+						const parts = fromStr.split("/");
 						if (parts.length === 3) {
 							formattedFromDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
 						}
-					} else if (vm.from_date.includes("-")) {
-						const parts = vm.from_date.split("-");
+					} else if (fromStr.includes("-")) {
+						const parts = fromStr.split("-");
 						if (parts.length === 3) {
 							if (parts[0].length === 4) {
-								formattedFromDate = vm.from_date; // Already YYYY-MM-DD
+								formattedFromDate = fromStr; // Already YYYY-MM-DD
 							} else {
 								formattedFromDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
 							}
@@ -475,17 +482,18 @@ export default {
 						String(vm.to_date.getDate()).padStart(2, "0"),
 					].join("-");
 				} else if (typeof vm.to_date === "string") {
-					if (vm.to_date.includes("/")) {
+					const toStr = formatUtils.fromArabicNumerals(vm.to_date);
+					if (toStr.includes("/")) {
 						// Convert DD/MM/YYYY to YYYY-MM-DD
-						const parts = vm.to_date.split("/");
+						const parts = toStr.split("/");
 						if (parts.length === 3) {
 							formattedToDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
 						}
-					} else if (vm.to_date.includes("-")) {
-						const parts = vm.to_date.split("-");
+					} else if (toStr.includes("-")) {
+						const parts = toStr.split("-");
 						if (parts.length === 3) {
 							if (parts[0].length === 4) {
-								formattedToDate = vm.to_date; // Already YYYY-MM-DD
+								formattedToDate = toStr; // Already YYYY-MM-DD
 							} else {
 								formattedToDate = `${parts[2]}-${parts[1]}-${parts[0]}`;
 							}
@@ -498,8 +506,8 @@ export default {
 			}
 
 			// Process amount filters
-			let minAmount = vm.min_amount ? parseFloat(vm.min_amount) : null;
-			let maxAmount = vm.max_amount ? parseFloat(vm.max_amount) : null;
+			let minAmount = vm.min_amount ? parseFloat(formatUtils.fromArabicNumerals(vm.min_amount)) : null;
+			let maxAmount = vm.max_amount ? parseFloat(formatUtils.fromArabicNumerals(vm.max_amount)) : null;
 
 			// Save current search parameters for "load more" functionality
 			this.current_search_params = {

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1,19 +1,20 @@
 import { silentPrint } from "../../plugins/print.js";
+import { formatUtils } from "../../format.js";
 /* global __, frappe, flt */
 
 export default {
-        checkOfferIsAppley(item, offer) {
-                let applied = false;
-                const item_offers = JSON.parse(item.posa_offers);
-                for (const row_id of item_offers) {
-                        const exist_offer = this.posa_offers.find((el) => row_id == el.row_id);
-                        if (exist_offer && exist_offer.offer_name == offer.name) {
-                                applied = true;
-                                break;
-                        }
-                }
-                return applied;
-        },
+	checkOfferIsAppley(item, offer) {
+		let applied = false;
+		const item_offers = JSON.parse(item.posa_offers);
+		for (const row_id of item_offers) {
+			const exist_offer = this.posa_offers.find((el) => row_id == el.row_id);
+			if (exist_offer && exist_offer.offer_name == offer.name) {
+				applied = true;
+				break;
+			}
+		}
+		return applied;
+	},
 
 	handelOffers() {
 		const offers = [];
@@ -82,10 +83,10 @@ export default {
 		return result;
 	},
 
-        getItemFromRowID(row_id) {
-                const combined = [...this.items, ...this.packed_items];
-                return combined.find((el) => el.posa_row_id == row_id);
-        },
+	getItemFromRowID(row_id) {
+		const combined = [...this.items, ...this.packed_items];
+		return combined.find((el) => el.posa_row_id == row_id);
+	},
 
 	checkQtyAnountOffer(offer, qty, amount) {
 		let min_qty = false;
@@ -147,265 +148,261 @@ export default {
 		}
 	},
 
-        getItemOffer(offer) {
-                let apply_offer = null;
-                if (offer.apply_on === "Item Code") {
-                        if (this.checkOfferCoupon(offer)) {
-                                const combined = [...this.items, ...this.packed_items];
-                                combined.forEach((item) => {
-                                        if (!item.posa_is_offer && item.item_code === offer.item) {
-                                                if (
-                                                        offer.offer === "Item Price" &&
-                                                        item.posa_offer_applied &&
-                                                        !this.checkOfferIsAppley(item, offer)
-                                                ) {
-                                                        return;
-                                                }
-                                                const items = [];
-                                                const rate = item.original_price_list_rate || item.price_list_rate;
-                                                const res = this.checkQtyAnountOffer(
-                                                        offer,
-                                                        item.stock_qty,
-                                                        item.stock_qty * rate,
-                                                );
-                                                if (res.apply) {
-                                                        items.push(item.posa_row_id);
-                                                        offer.items = items;
-                                                        apply_offer = offer;
-                                                }
-                                        }
-                                });
-                        }
-                }
-                return apply_offer;
-        },
+	getItemOffer(offer) {
+		let apply_offer = null;
+		if (offer.apply_on === "Item Code") {
+			if (this.checkOfferCoupon(offer)) {
+				const combined = [...this.items, ...this.packed_items];
+				combined.forEach((item) => {
+					if (!item.posa_is_offer && item.item_code === offer.item) {
+						if (
+							offer.offer === "Item Price" &&
+							item.posa_offer_applied &&
+							!this.checkOfferIsAppley(item, offer)
+						) {
+							return;
+						}
+						const items = [];
+						const rate = item.original_price_list_rate || item.price_list_rate;
+						const res = this.checkQtyAnountOffer(offer, item.stock_qty, item.stock_qty * rate);
+						if (res.apply) {
+							items.push(item.posa_row_id);
+							offer.items = items;
+							apply_offer = offer;
+						}
+					}
+				});
+			}
+		}
+		return apply_offer;
+	},
 
-        getGroupOffer(offer) {
-                let apply_offer = null;
-                if (offer.apply_on === "Item Group") {
-                        if (this.checkOfferCoupon(offer)) {
-                                const items = [];
-                                let total_count = 0;
-                                let total_amount = 0;
-                                const combined = [...this.items, ...this.packed_items];
-                                combined.forEach((item) => {
-                                        if (!item.posa_is_offer && item.item_group === offer.item_group) {
-                                                if (
-                                                        offer.offer === "Item Price" &&
-                                                        item.posa_offer_applied &&
-                                                        !this.checkOfferIsAppley(item, offer)
-                                                ) {
-                                                        return;
-                                                }
-                                                total_count += item.stock_qty;
-                                                const rate = item.original_price_list_rate || item.price_list_rate;
-                                                total_amount += item.stock_qty * rate;
-                                                items.push(item.posa_row_id);
-                                        }
-                                });
-                                if (total_count || total_amount) {
-                                        const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
-                                        if (res.apply) {
-                                                offer.items = items;
-                                                apply_offer = offer;
-                                        }
-                                }
-                        }
-                }
-                return apply_offer;
-        },
+	getGroupOffer(offer) {
+		let apply_offer = null;
+		if (offer.apply_on === "Item Group") {
+			if (this.checkOfferCoupon(offer)) {
+				const items = [];
+				let total_count = 0;
+				let total_amount = 0;
+				const combined = [...this.items, ...this.packed_items];
+				combined.forEach((item) => {
+					if (!item.posa_is_offer && item.item_group === offer.item_group) {
+						if (
+							offer.offer === "Item Price" &&
+							item.posa_offer_applied &&
+							!this.checkOfferIsAppley(item, offer)
+						) {
+							return;
+						}
+						total_count += item.stock_qty;
+						const rate = item.original_price_list_rate || item.price_list_rate;
+						total_amount += item.stock_qty * rate;
+						items.push(item.posa_row_id);
+					}
+				});
+				if (total_count || total_amount) {
+					const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
+					if (res.apply) {
+						offer.items = items;
+						apply_offer = offer;
+					}
+				}
+			}
+		}
+		return apply_offer;
+	},
 
-        getBrandOffer(offer) {
-                let apply_offer = null;
-                if (offer.apply_on === "Brand") {
-                        if (this.checkOfferCoupon(offer)) {
-                                const items = [];
-                                let total_count = 0;
-                                let total_amount = 0;
-                                const combined = [...this.items, ...this.packed_items];
-                                combined.forEach((item) => {
-                                        if (!item.posa_is_offer && item.brand === offer.brand) {
-                                                if (
-                                                        offer.offer === "Item Price" &&
-                                                        item.posa_offer_applied &&
-                                                        !this.checkOfferIsAppley(item, offer)
-                                                ) {
-                                                        return;
-                                                }
-                                                total_count += item.stock_qty;
-                                                const rate = item.original_price_list_rate || item.price_list_rate;
-                                                total_amount += item.stock_qty * rate;
-                                                items.push(item.posa_row_id);
-                                        }
-                                });
-                                if (total_count || total_amount) {
-                                        const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
-                                        if (res.apply) {
-                                                offer.items = items;
-                                                apply_offer = offer;
-                                        }
-                                }
-                        }
-                }
-                return apply_offer;
-        },
-        getTransactionOffer(offer) {
-                let apply_offer = null;
-                if (offer.apply_on === "Transaction") {
-                        if (this.checkOfferCoupon(offer)) {
-                                const combined = [...this.items, ...this.packed_items];
-                                let total_qty = 0;
-                                let total_amount = 0;
-                                const items = [];
-                                combined.forEach((item) => {
-                                        if (!item.posa_is_offer && !item.posa_is_replace) {
-                                                total_qty += item.stock_qty;
-                                                const rate = item.original_price_list_rate || item.price_list_rate;
-                                                total_amount += item.stock_qty * rate;
-                                                items.push(item.posa_row_id);
-                                        }
-                                });
-                                const total_count = total_qty;
-                                if (total_count || total_amount) {
-                                        const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
-                                        if (res.apply) {
-                                                offer.items = items;
-                                                apply_offer = offer;
-                                        }
-                                }
-                        }
-                }
-                return apply_offer;
-        },
+	getBrandOffer(offer) {
+		let apply_offer = null;
+		if (offer.apply_on === "Brand") {
+			if (this.checkOfferCoupon(offer)) {
+				const items = [];
+				let total_count = 0;
+				let total_amount = 0;
+				const combined = [...this.items, ...this.packed_items];
+				combined.forEach((item) => {
+					if (!item.posa_is_offer && item.brand === offer.brand) {
+						if (
+							offer.offer === "Item Price" &&
+							item.posa_offer_applied &&
+							!this.checkOfferIsAppley(item, offer)
+						) {
+							return;
+						}
+						total_count += item.stock_qty;
+						const rate = item.original_price_list_rate || item.price_list_rate;
+						total_amount += item.stock_qty * rate;
+						items.push(item.posa_row_id);
+					}
+				});
+				if (total_count || total_amount) {
+					const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
+					if (res.apply) {
+						offer.items = items;
+						apply_offer = offer;
+					}
+				}
+			}
+		}
+		return apply_offer;
+	},
+	getTransactionOffer(offer) {
+		let apply_offer = null;
+		if (offer.apply_on === "Transaction") {
+			if (this.checkOfferCoupon(offer)) {
+				const combined = [...this.items, ...this.packed_items];
+				let total_qty = 0;
+				let total_amount = 0;
+				const items = [];
+				combined.forEach((item) => {
+					if (!item.posa_is_offer && !item.posa_is_replace) {
+						total_qty += item.stock_qty;
+						const rate = item.original_price_list_rate || item.price_list_rate;
+						total_amount += item.stock_qty * rate;
+						items.push(item.posa_row_id);
+					}
+				});
+				const total_count = total_qty;
+				if (total_count || total_amount) {
+					const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
+					if (res.apply) {
+						offer.items = items;
+						apply_offer = offer;
+					}
+				}
+			}
+		}
+		return apply_offer;
+	},
 
 	updatePosOffers(offers) {
 		this.eventBus.emit("update_pos_offers", offers);
 	},
 
-        updateInvoiceOffers(offers) {
-                this.posa_offers.forEach((invoiceOffer) => {
-                        const existOffer = offers.find((offer) => invoiceOffer.row_id == offer.row_id);
-                        if (!existOffer) {
-                                this.removeApplyOffer(invoiceOffer);
-                        }
-                });
-                offers.forEach((offer) => {
-                        const existOffer = this.posa_offers.find((invoiceOffer) => invoiceOffer.row_id == offer.row_id);
-                        if (existOffer) {
-                                existOffer.items = JSON.stringify(offer.items);
-                                if (
-                                        existOffer.offer === "Give Product" &&
-                                        existOffer.give_item &&
-                                        existOffer.give_item != offer.give_item
-                                ) {
-                                        const combined = [...this.items, ...this.packed_items];
-                                        const item_to_remove = combined.find(
-                                                (item) => item.posa_row_id == existOffer.give_item_row_id,
-                                        );
-                                        if (item_to_remove) {
-                                                const updated_item_offers = offer.items.filter(
-                                                        (row_id) => row_id != item_to_remove.posa_row_id,
-                                                );
-                                                offer.items = updated_item_offers;
-                                                const collection = this.items.includes(item_to_remove)
-                                                        ? this.items
-                                                        : this.packed_items;
-                                                const idx = collection.findIndex(
-                                                        (el) => el.posa_row_id == item_to_remove.posa_row_id,
-                                                );
-                                                if (idx > -1) collection.splice(idx, 1);
-                                                existOffer.give_item_row_id = null;
-                                                existOffer.give_item = null;
-                                        }
-                                        const newItemOffer = this.ApplyOnGiveProduct(offer);
-                                        if (offer.replace_cheapest_item) {
-                                                const cheapestItem = this.getCheapestItem(offer);
-                                                const oldBaseItem = combined.find(
-                                                        (el) => el.posa_row_id == item_to_remove.posa_is_replace,
-                                                );
-                                                newItemOffer.qty = item_to_remove.qty;
-                                                if (oldBaseItem && !oldBaseItem.posa_is_replace) {
-                                                        oldBaseItem.qty += item_to_remove.qty;
-                                                } else {
-                                                        const restoredItem = this.ApplyOnGiveProduct(
-                                                                {
-                                                                        given_qty: item_to_remove.qty,
-                                                                },
-                                                                item_to_remove.item_code,
-                                                        );
-                                                        restoredItem.posa_is_offer = 0;
-                                                        this.items.unshift(restoredItem);
-                                                }
-                                                newItemOffer.posa_is_offer = 0;
-                                                newItemOffer.posa_is_replace = cheapestItem.posa_row_id;
-                                                const diffQty = cheapestItem.qty - newItemOffer.qty;
-                                                if (diffQty <= 0) {
-                                                        newItemOffer.qty += diffQty;
-                                                        const baseCollection = this.items.includes(cheapestItem)
-                                                                ? this.items
-                                                                : this.packed_items;
-                                                        const baseIndex = baseCollection.findIndex(
-                                                                (el) => el.posa_row_id == cheapestItem.posa_row_id,
-                                                        );
-                                                        if (baseIndex > -1) baseCollection.splice(baseIndex, 1);
-                                                        newItemOffer.posa_row_id = cheapestItem.posa_row_id;
-                                                        newItemOffer.posa_is_replace = newItemOffer.posa_row_id;
-                                                } else {
-                                                        cheapestItem.qty = diffQty;
-                                                }
-                                        }
-                                        this.items.unshift(newItemOffer);
-                                        existOffer.give_item_row_id = newItemOffer.posa_row_id;
-                                        existOffer.give_item = newItemOffer.item_code;
-                                } else if (
-                                        existOffer.offer === "Give Product" &&
-                                        existOffer.give_item &&
-                                        existOffer.give_item == offer.give_item &&
-                                        (offer.replace_item || offer.replace_cheapest_item)
-                                ) {
-                                        this.$nextTick(function () {
-                                                const offerItem = this.getItemFromRowID(existOffer.give_item_row_id);
-                                                const diff = offer.given_qty - offerItem.qty;
-                                                if (diff > 0) {
-                                                        const itemsRowID = JSON.parse(existOffer.items);
-                                                        const itemsList = [];
-                                                        itemsRowID.forEach((row_id) => {
-                                                                itemsList.push(this.getItemFromRowID(row_id));
-                                                        });
-                                                        const existItem = itemsList.find(
-                                                                (el) =>
-                                                                        el.item_code == offerItem.item_code &&
-                                                                        el.posa_is_replace != offerItem.posa_row_id,
-                                                        );
-                                                        if (existItem) {
-                                                                const diffExistQty = existItem.qty - diff;
-                                                                if (diffExistQty > 0) {
-                                                                        offerItem.qty += diff;
-                                                                        existItem.qty -= diff;
-                                                                } else {
-                                                                        offerItem.qty += existItem.qty;
-                                                                        const col = this.items.includes(existItem)
-                                                                                ? this.items
-                                                                                : this.packed_items;
-                                                                        const idx2 = col.findIndex(
-                                                                                (el) => el.posa_row_id == existItem.posa_row_id,
-                                                                        );
-                                                                        if (idx2 > -1) col.splice(idx2, 1);
-                                                                }
-                                                        }
-                                                }
-                                        });
-                                } else if (existOffer.offer === "Item Price") {
-                                        this.ApplyOnPrice(offer);
-                                } else if (existOffer.offer === "Grand Total") {
-                                        this.ApplyOnTotal(offer);
-                                }
-                                this.addOfferToItems(existOffer);
-                        } else {
-                                this.applyNewOffer(offer);
-                        }
-                });
-        },
+	updateInvoiceOffers(offers) {
+		this.posa_offers.forEach((invoiceOffer) => {
+			const existOffer = offers.find((offer) => invoiceOffer.row_id == offer.row_id);
+			if (!existOffer) {
+				this.removeApplyOffer(invoiceOffer);
+			}
+		});
+		offers.forEach((offer) => {
+			const existOffer = this.posa_offers.find((invoiceOffer) => invoiceOffer.row_id == offer.row_id);
+			if (existOffer) {
+				existOffer.items = JSON.stringify(offer.items);
+				if (
+					existOffer.offer === "Give Product" &&
+					existOffer.give_item &&
+					existOffer.give_item != offer.give_item
+				) {
+					const combined = [...this.items, ...this.packed_items];
+					const item_to_remove = combined.find(
+						(item) => item.posa_row_id == existOffer.give_item_row_id,
+					);
+					if (item_to_remove) {
+						const updated_item_offers = offer.items.filter(
+							(row_id) => row_id != item_to_remove.posa_row_id,
+						);
+						offer.items = updated_item_offers;
+						const collection = this.items.includes(item_to_remove)
+							? this.items
+							: this.packed_items;
+						const idx = collection.findIndex(
+							(el) => el.posa_row_id == item_to_remove.posa_row_id,
+						);
+						if (idx > -1) collection.splice(idx, 1);
+						existOffer.give_item_row_id = null;
+						existOffer.give_item = null;
+					}
+					const newItemOffer = this.ApplyOnGiveProduct(offer);
+					if (offer.replace_cheapest_item) {
+						const cheapestItem = this.getCheapestItem(offer);
+						const oldBaseItem = combined.find(
+							(el) => el.posa_row_id == item_to_remove.posa_is_replace,
+						);
+						newItemOffer.qty = item_to_remove.qty;
+						if (oldBaseItem && !oldBaseItem.posa_is_replace) {
+							oldBaseItem.qty += item_to_remove.qty;
+						} else {
+							const restoredItem = this.ApplyOnGiveProduct(
+								{
+									given_qty: item_to_remove.qty,
+								},
+								item_to_remove.item_code,
+							);
+							restoredItem.posa_is_offer = 0;
+							this.items.unshift(restoredItem);
+						}
+						newItemOffer.posa_is_offer = 0;
+						newItemOffer.posa_is_replace = cheapestItem.posa_row_id;
+						const diffQty = cheapestItem.qty - newItemOffer.qty;
+						if (diffQty <= 0) {
+							newItemOffer.qty += diffQty;
+							const baseCollection = this.items.includes(cheapestItem)
+								? this.items
+								: this.packed_items;
+							const baseIndex = baseCollection.findIndex(
+								(el) => el.posa_row_id == cheapestItem.posa_row_id,
+							);
+							if (baseIndex > -1) baseCollection.splice(baseIndex, 1);
+							newItemOffer.posa_row_id = cheapestItem.posa_row_id;
+							newItemOffer.posa_is_replace = newItemOffer.posa_row_id;
+						} else {
+							cheapestItem.qty = diffQty;
+						}
+					}
+					this.items.unshift(newItemOffer);
+					existOffer.give_item_row_id = newItemOffer.posa_row_id;
+					existOffer.give_item = newItemOffer.item_code;
+				} else if (
+					existOffer.offer === "Give Product" &&
+					existOffer.give_item &&
+					existOffer.give_item == offer.give_item &&
+					(offer.replace_item || offer.replace_cheapest_item)
+				) {
+					this.$nextTick(function () {
+						const offerItem = this.getItemFromRowID(existOffer.give_item_row_id);
+						const diff = offer.given_qty - offerItem.qty;
+						if (diff > 0) {
+							const itemsRowID = JSON.parse(existOffer.items);
+							const itemsList = [];
+							itemsRowID.forEach((row_id) => {
+								itemsList.push(this.getItemFromRowID(row_id));
+							});
+							const existItem = itemsList.find(
+								(el) =>
+									el.item_code == offerItem.item_code &&
+									el.posa_is_replace != offerItem.posa_row_id,
+							);
+							if (existItem) {
+								const diffExistQty = existItem.qty - diff;
+								if (diffExistQty > 0) {
+									offerItem.qty += diff;
+									existItem.qty -= diff;
+								} else {
+									offerItem.qty += existItem.qty;
+									const col = this.items.includes(existItem)
+										? this.items
+										: this.packed_items;
+									const idx2 = col.findIndex(
+										(el) => el.posa_row_id == existItem.posa_row_id,
+									);
+									if (idx2 > -1) col.splice(idx2, 1);
+								}
+							}
+						}
+					});
+				} else if (existOffer.offer === "Item Price") {
+					this.ApplyOnPrice(offer);
+				} else if (existOffer.offer === "Grand Total") {
+					this.ApplyOnTotal(offer);
+				}
+				this.addOfferToItems(existOffer);
+			} else {
+				this.applyNewOffer(offer);
+			}
+		});
+	},
 
 	removeApplyOffer(invoiceOffer) {
 		if (invoiceOffer.offer === "Item Price") {
@@ -413,23 +410,17 @@ export default {
 			const index = this.posa_offers.findIndex((el) => el.row_id === invoiceOffer.row_id);
 			this.posa_offers.splice(index, 1);
 		}
-                if (invoiceOffer.offer === "Give Product") {
-                        const combined = [...this.items, ...this.packed_items];
-                        const item_to_remove = combined.find(
-                                (item) => item.posa_row_id == invoiceOffer.give_item_row_id,
-                        );
-                        const index = this.posa_offers.findIndex((el) => el.row_id === invoiceOffer.row_id);
-                        this.posa_offers.splice(index, 1);
-                        if (item_to_remove) {
-                                const collection = this.items.includes(item_to_remove)
-                                        ? this.items
-                                        : this.packed_items;
-                                const idx = collection.findIndex(
-                                        (el) => el.posa_row_id == item_to_remove.posa_row_id,
-                                );
-                                if (idx > -1) collection.splice(idx, 1);
-                        }
-                }
+		if (invoiceOffer.offer === "Give Product") {
+			const combined = [...this.items, ...this.packed_items];
+			const item_to_remove = combined.find((item) => item.posa_row_id == invoiceOffer.give_item_row_id);
+			const index = this.posa_offers.findIndex((el) => el.row_id === invoiceOffer.row_id);
+			this.posa_offers.splice(index, 1);
+			if (item_to_remove) {
+				const collection = this.items.includes(item_to_remove) ? this.items : this.packed_items;
+				const idx = collection.findIndex((el) => el.posa_row_id == item_to_remove.posa_row_id);
+				if (idx > -1) collection.splice(idx, 1);
+			}
+		}
 		if (invoiceOffer.offer === "Grand Total") {
 			this.RemoveOnTotal(invoiceOffer);
 			const index = this.posa_offers.findIndex((el) => el.row_id === invoiceOffer.row_id);
@@ -442,76 +433,72 @@ export default {
 		this.deleteOfferFromItems(invoiceOffer);
 	},
 
-        applyNewOffer(offer) {
-                this.isApplyingOffer = true;
-                if (offer.offer === "Item Price") {
-                        this.ApplyOnPrice(offer);
-                }
-                if (offer.offer === "Give Product") {
-                        let itemsRowID;
-                        if (typeof offer.items === "string") {
-                                itemsRowID = JSON.parse(offer.items);
-                        } else {
-                                itemsRowID = offer.items;
-                        }
-                        if (offer.apply_on == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
-                                const item = this.ApplyOnGiveProduct(offer, offer.item);
-                                item.posa_is_replace = itemsRowID[0];
-                                const combined = [...this.items, ...this.packed_items];
-                                const baseItem = combined.find((el) => el.posa_row_id == item.posa_is_replace);
-                                const diffQty = baseItem.qty - offer.given_qty;
-                                item.posa_is_offer = 0;
-                                if (diffQty <= 0) {
-                                        item.qty = baseItem.qty;
-                                        const collection = this.items.includes(baseItem) ? this.items : this.packed_items;
-                                        const idx = collection.findIndex(
-                                                (el) => el.posa_row_id == baseItem.posa_row_id,
-                                        );
-                                        if (idx > -1) collection.splice(idx, 1);
-                                        item.posa_row_id = item.posa_is_replace;
-                                } else {
-                                        baseItem.qty = diffQty;
-                                }
-                                this.items.unshift(item);
-                                offer.give_item_row_id = item.posa_row_id;
-                        } else if (
-                                offer.apply_on == "Item Group" &&
-                                offer.apply_type == "Item Group" &&
-                                offer.replace_cheapest_item
-                        ) {
-                                const itemsList = [];
-                                itemsRowID.forEach((row_id) => {
-                                        itemsList.push(this.getItemFromRowID(row_id));
-                                });
-                                const baseItem = itemsList.find((el) => el.item_code == offer.give_item);
-                                const item = this.ApplyOnGiveProduct(offer, offer.give_item);
-                                item.posa_is_offer = 0;
-                                item.posa_is_replace = baseItem.posa_row_id;
-                                const diffQty = baseItem.qty - offer.given_qty;
-                                if (diffQty <= 0) {
-                                        item.qty = baseItem.qty;
-                                        const collection = this.items.includes(baseItem) ? this.items : this.packed_items;
-                                        const idx = collection.findIndex(
-                                                (el) => el.posa_row_id == baseItem.posa_row_id,
-                                        );
-                                        if (idx > -1) collection.splice(idx, 1);
-                                        item.posa_row_id = item.posa_is_replace;
-                                } else {
-                                        baseItem.qty = diffQty;
-                                }
-                                this.items.unshift(item);
-                                offer.give_item_row_id = item.posa_row_id;
-                        } else {
-                                const item = this.ApplyOnGiveProduct(offer);
-                                this.items.unshift(item);
-                                if (item) {
-                                        offer.give_item_row_id = item.posa_row_id;
-                                }
-                        }
-                }
-                if (offer.offer === "Grand Total") {
-                        this.ApplyOnTotal(offer);
-                }
+	applyNewOffer(offer) {
+		this.isApplyingOffer = true;
+		if (offer.offer === "Item Price") {
+			this.ApplyOnPrice(offer);
+		}
+		if (offer.offer === "Give Product") {
+			let itemsRowID;
+			if (typeof offer.items === "string") {
+				itemsRowID = JSON.parse(offer.items);
+			} else {
+				itemsRowID = offer.items;
+			}
+			if (offer.apply_on == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
+				const item = this.ApplyOnGiveProduct(offer, offer.item);
+				item.posa_is_replace = itemsRowID[0];
+				const combined = [...this.items, ...this.packed_items];
+				const baseItem = combined.find((el) => el.posa_row_id == item.posa_is_replace);
+				const diffQty = baseItem.qty - offer.given_qty;
+				item.posa_is_offer = 0;
+				if (diffQty <= 0) {
+					item.qty = baseItem.qty;
+					const collection = this.items.includes(baseItem) ? this.items : this.packed_items;
+					const idx = collection.findIndex((el) => el.posa_row_id == baseItem.posa_row_id);
+					if (idx > -1) collection.splice(idx, 1);
+					item.posa_row_id = item.posa_is_replace;
+				} else {
+					baseItem.qty = diffQty;
+				}
+				this.items.unshift(item);
+				offer.give_item_row_id = item.posa_row_id;
+			} else if (
+				offer.apply_on == "Item Group" &&
+				offer.apply_type == "Item Group" &&
+				offer.replace_cheapest_item
+			) {
+				const itemsList = [];
+				itemsRowID.forEach((row_id) => {
+					itemsList.push(this.getItemFromRowID(row_id));
+				});
+				const baseItem = itemsList.find((el) => el.item_code == offer.give_item);
+				const item = this.ApplyOnGiveProduct(offer, offer.give_item);
+				item.posa_is_offer = 0;
+				item.posa_is_replace = baseItem.posa_row_id;
+				const diffQty = baseItem.qty - offer.given_qty;
+				if (diffQty <= 0) {
+					item.qty = baseItem.qty;
+					const collection = this.items.includes(baseItem) ? this.items : this.packed_items;
+					const idx = collection.findIndex((el) => el.posa_row_id == baseItem.posa_row_id);
+					if (idx > -1) collection.splice(idx, 1);
+					item.posa_row_id = item.posa_is_replace;
+				} else {
+					baseItem.qty = diffQty;
+				}
+				this.items.unshift(item);
+				offer.give_item_row_id = item.posa_row_id;
+			} else {
+				const item = this.ApplyOnGiveProduct(offer);
+				this.items.unshift(item);
+				if (item) {
+					offer.give_item_row_id = item.posa_row_id;
+				}
+			}
+		}
+		if (offer.offer === "Grand Total") {
+			this.ApplyOnTotal(offer);
+		}
 		if (offer.offer === "Loyalty Point") {
 			this.eventBus.emit("show_message", {
 				title: __("Loyalty Point Offer Applied"),
@@ -531,10 +518,10 @@ export default {
 			coupon_based: offer.coupon_based,
 			coupon: offer.coupon,
 		};
-                this.posa_offers.push(newOffer);
-                this.addOfferToItems(newOffer);
-                this.isApplyingOffer = false;
-        },
+		this.posa_offers.push(newOffer);
+		this.addOfferToItems(newOffer);
+		this.isApplyingOffer = false;
+	},
 
 	ApplyOnGiveProduct(offer, item_code) {
 		if (!item_code) {
@@ -668,14 +655,14 @@ export default {
 		return new_item;
 	},
 
-        ApplyOnPrice(offer) {
-                console.log("Applying price offer:", offer);
-                if (!offer) return;
+	ApplyOnPrice(offer) {
+		console.log("Applying price offer:", offer);
+		if (!offer) return;
 
-                const combined = [...this.items, ...this.packed_items];
-                combined.forEach((item) => {
-                        // Check if offer.items exists and is valid
-                        if (!item || !offer.items || !Array.isArray(offer.items)) return;
+		const combined = [...this.items, ...this.packed_items];
+		combined.forEach((item) => {
+			// Check if offer.items exists and is valid
+			if (!item || !offer.items || !Array.isArray(offer.items)) return;
 
 			if (offer.items.includes(item.posa_row_id)) {
 				// Ensure posa_offers is initialized and valid
@@ -734,40 +721,39 @@ export default {
 
 						// Calculate discount in base currency first
 						// Use normalized price * current conversion factor
-                                               const base_price = this.flt(
-                                                       (item.original_base_price_list_rate ||
-                                                               item.base_price_list_rate / conversion_factor) *
-                                                               conversion_factor,
-                                                       this.currency_precision,
-                                               );
-                                               const base_discount = this.flt(
-                                                       (base_price * offer.discount_percentage) / 100,
-                                                       this.currency_precision,
-                                               );
-                                               item.base_discount_amount = base_discount;
-                                               item.base_rate = this.flt(base_price - base_discount, this.currency_precision);
+						const base_price = this.flt(
+							(item.original_base_price_list_rate ||
+								item.base_price_list_rate / conversion_factor) * conversion_factor,
+							this.currency_precision,
+						);
+						const base_discount = this.flt(
+							(base_price * offer.discount_percentage) / 100,
+							this.currency_precision,
+						);
+						item.base_discount_amount = base_discount;
+						item.base_rate = this.flt(base_price - base_discount, this.currency_precision);
 
-                                               // Keep price_list_rate aligned with the discounted rate so offers
-                                               // aren't immediately overwritten by price list values.
-                                               item.base_price_list_rate = item.base_rate;
+						// Keep price_list_rate aligned with the discounted rate so offers
+						// aren't immediately overwritten by price list values.
+						item.base_price_list_rate = item.base_rate;
 
-                                               // Convert to selected currency if needed
-                                               const baseCurrency = this.price_list_currency || this.pos_profile.currency;
-                                               if (this.selected_currency !== baseCurrency) {
-                                                       item.rate = this.flt(
-                                                               item.base_rate * this.exchange_rate,
-                                                               this.currency_precision,
-                                                       );
-                                                       item.price_list_rate = item.rate;
-                                                       item.discount_amount = this.flt(
-                                                               base_discount * this.exchange_rate,
-                                                               this.currency_precision,
-                                                       );
-                                               } else {
-                                                       item.rate = item.base_rate;
-                                                       item.price_list_rate = item.base_rate;
-                                                       item.discount_amount = base_discount;
-                                               }
+						// Convert to selected currency if needed
+						const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+						if (this.selected_currency !== baseCurrency) {
+							item.rate = this.flt(
+								item.base_rate * this.exchange_rate,
+								this.currency_precision,
+							);
+							item.price_list_rate = item.rate;
+							item.discount_amount = this.flt(
+								base_discount * this.exchange_rate,
+								this.currency_precision,
+							);
+						} else {
+							item.rate = item.base_rate;
+							item.price_list_rate = item.base_rate;
+							item.discount_amount = base_discount;
+						}
 					}
 
 					// Calculate final amounts
@@ -792,12 +778,12 @@ export default {
 		});
 	},
 
-        RemoveOnPrice(offer) {
-                console.log("Removing price offer:", offer);
-                if (!offer) return;
+	RemoveOnPrice(offer) {
+		console.log("Removing price offer:", offer);
+		if (!offer) return;
 
-                const combined = [...this.items, ...this.packed_items];
-                combined.forEach((item) => {
+		const combined = [...this.items, ...this.packed_items];
+		combined.forEach((item) => {
 			if (!item || !item.posa_offers) return;
 
 			try {
@@ -930,75 +916,75 @@ export default {
 		}
 	},
 
-        addOfferToItems(offer) {
-                if (!offer || !offer.items) return;
+	addOfferToItems(offer) {
+		if (!offer || !offer.items) return;
 
-                try {
-                        const offer_items = typeof offer.items === "string" ? JSON.parse(offer.items) : offer.items;
-                        if (!Array.isArray(offer_items)) return;
+		try {
+			const offer_items = typeof offer.items === "string" ? JSON.parse(offer.items) : offer.items;
+			if (!Array.isArray(offer_items)) return;
 
-                        const combined = [...this.items, ...this.packed_items];
-                        offer_items.forEach((el) => {
-                                combined.forEach((exist_item) => {
-                                        if (!exist_item || !exist_item.posa_row_id) return;
+			const combined = [...this.items, ...this.packed_items];
+			offer_items.forEach((el) => {
+				combined.forEach((exist_item) => {
+					if (!exist_item || !exist_item.posa_row_id) return;
 
-                                        if (exist_item.posa_row_id == el) {
-                                                const item_offers = exist_item.posa_offers ? JSON.parse(exist_item.posa_offers) : [];
-                                                if (!Array.isArray(item_offers)) return;
+					if (exist_item.posa_row_id == el) {
+						const item_offers = exist_item.posa_offers ? JSON.parse(exist_item.posa_offers) : [];
+						if (!Array.isArray(item_offers)) return;
 
-                                                if (!item_offers.includes(offer.row_id)) {
-                                                        item_offers.push(offer.row_id);
-                                                        if (offer.offer === "Item Price") {
-                                                                exist_item.posa_offer_applied = 1;
-                                                        }
-                                                }
-                                                exist_item.posa_offers = JSON.stringify(item_offers);
-                                        }
-                                });
-                        });
-                } catch (error) {
-                        console.error("Error adding offer to items:", error);
-                        this.eventBus.emit("show_message", {
-                                title: __("Error adding offer to items"),
-                                color: "error",
-                                message: error.message,
-                        });
-                }
-        },
+						if (!item_offers.includes(offer.row_id)) {
+							item_offers.push(offer.row_id);
+							if (offer.offer === "Item Price") {
+								exist_item.posa_offer_applied = 1;
+							}
+						}
+						exist_item.posa_offers = JSON.stringify(item_offers);
+					}
+				});
+			});
+		} catch (error) {
+			console.error("Error adding offer to items:", error);
+			this.eventBus.emit("show_message", {
+				title: __("Error adding offer to items"),
+				color: "error",
+				message: error.message,
+			});
+		}
+	},
 
-        deleteOfferFromItems(offer) {
-                if (!offer || !offer.items) return;
+	deleteOfferFromItems(offer) {
+		if (!offer || !offer.items) return;
 
-                try {
-                        const offer_items = typeof offer.items === "string" ? JSON.parse(offer.items) : offer.items;
-                        if (!Array.isArray(offer_items)) return;
+		try {
+			const offer_items = typeof offer.items === "string" ? JSON.parse(offer.items) : offer.items;
+			if (!Array.isArray(offer_items)) return;
 
-                        const combined = [...this.items, ...this.packed_items];
-                        offer_items.forEach((el) => {
-                                combined.forEach((exist_item) => {
-                                        if (!exist_item || !exist_item.posa_row_id) return;
+			const combined = [...this.items, ...this.packed_items];
+			offer_items.forEach((el) => {
+				combined.forEach((exist_item) => {
+					if (!exist_item || !exist_item.posa_row_id) return;
 
-                                        if (exist_item.posa_row_id == el) {
-                                                const item_offers = exist_item.posa_offers ? JSON.parse(exist_item.posa_offers) : [];
-                                                if (!Array.isArray(item_offers)) return;
+					if (exist_item.posa_row_id == el) {
+						const item_offers = exist_item.posa_offers ? JSON.parse(exist_item.posa_offers) : [];
+						if (!Array.isArray(item_offers)) return;
 
-                                                const updated_item_offers = item_offers.filter((row_id) => row_id != offer.row_id);
-                                                if (offer.offer === "Item Price") {
-                                                        exist_item.posa_offer_applied = 0;
-                                                }
-                                                exist_item.posa_offers = JSON.stringify(updated_item_offers);
-                                        }
-                                });
-                        });
-                } catch (error) {
-                        console.error("Error deleting offer from items:", error);
-                        this.eventBus.emit("show_message", {
-                                title: __("Error deleting offer from items"),
-                                color: "error",
-                                message: error.message,
-                        });
-                }
-        },
+						const updated_item_offers = item_offers.filter((row_id) => row_id != offer.row_id);
+						if (offer.offer === "Item Price") {
+							exist_item.posa_offer_applied = 0;
+						}
+						exist_item.posa_offers = JSON.stringify(updated_item_offers);
+					}
+				});
+			});
+		} catch (error) {
+			console.error("Error deleting offer from items:", error);
+			this.eventBus.emit("show_message", {
+				title: __("Error deleting offer from items"),
+				color: "error",
+				message: error.message,
+			});
+		}
+	},
 
 	validate_due_date(item) {
 		const today = frappe.datetime.now_date();
@@ -1049,38 +1035,41 @@ export default {
 	formatDateForBackend(date) {
 		if (!date) return null;
 		if (typeof date === "string") {
-			if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-				return date;
+			const western = formatUtils.fromArabicNumerals(date);
+			if (/^\d{4}-\d{2}-\d{2}$/.test(western)) {
+				return western;
 			}
-			if (/^\d{1,2}-\d{1,2}-\d{4}$/.test(date)) {
-				const [d, m, y] = date.split("-");
+			if (/^\d{1,2}-\d{1,2}-\d{4}$/.test(western)) {
+				const [d, m, y] = western.split("-");
 				return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}`;
 			}
+			date = western;
 		}
-		const d = new Date(date);
+		const d = new Date(formatUtils.fromArabicNumerals(String(date)));
 		if (!isNaN(d.getTime())) {
 			const year = d.getFullYear();
 			const month = `0${d.getMonth() + 1}`.slice(-2);
 			const day = `0${d.getDate()}`.slice(-2);
 			return `${year}-${month}-${day}`;
 		}
-		return date;
+		return formatUtils.fromArabicNumerals(String(date));
 	},
 
 	formatDateForDisplay(date) {
 		if (!date) return "";
-		if (typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
-			const [y, m, d] = date.split("-");
-			return `${d}-${m}-${y}`;
+		const western = formatUtils.fromArabicNumerals(String(date));
+		if (typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(western)) {
+			const [y, m, d] = western.split("-");
+			return formatUtils.toArabicNumerals(`${d}-${m}-${y}`);
 		}
-		const d = new Date(date);
+		const d = new Date(western);
 		if (!isNaN(d.getTime())) {
 			const year = d.getFullYear();
 			const month = `0${d.getMonth() + 1}`.slice(-2);
 			const day = `0${d.getDate()}`.slice(-2);
-			return `${day}-${month}-${year}`;
+			return formatUtils.toArabicNumerals(`${day}-${month}-${year}`);
 		}
-		return date;
+		return formatUtils.toArabicNumerals(western);
 	},
 
 	toggleOffer(item) {

--- a/frontend/src/posapp/format.js
+++ b/frontend/src/posapp/format.js
@@ -1,26 +1,62 @@
+/* global frappe, flt, get_currency_symbol */
 // Utility functions for RTL number formatting (standalone)
 const formatUtils = {
 	// Check if current language/layout is RTL
 	isRtl() {
 		// Check via frappe utils first
-		if (typeof frappe !== 'undefined' && frappe.utils && typeof frappe.utils.is_rtl === 'function') {
+		if (typeof frappe !== "undefined" && frappe.utils && typeof frappe.utils.is_rtl === "function") {
 			return frappe.utils.is_rtl();
 		}
 		// Check HTML dir attribute
-		const htmlDir = document.documentElement.dir || document.body.dir || '';
-		if (htmlDir.toLowerCase() === 'rtl') return true;
+		const htmlDir = document.documentElement.dir || document.body.dir || "";
+		if (htmlDir.toLowerCase() === "rtl") return true;
 		// Check language
-		const docLang = document.documentElement.lang || '';
-		const rtlLanguages = ['ar', 'he', 'fa', 'ur', 'ps', 'sd', 'ku', 'dv'];
-		return rtlLanguages.some(lang => docLang.toLowerCase().startsWith(lang));
+		const docLang = document.documentElement.lang || "";
+		const rtlLanguages = ["ar", "he", "fa", "ur", "ps", "sd", "ku", "dv"];
+		return rtlLanguages.some((lang) => docLang.toLowerCase().startsWith(lang));
+	},
+
+	// Determine if user prefers Western numerals even in RTL
+	useWestern() {
+		try {
+			// Check a stored preference first
+			const stored = localStorage.getItem("use_western_numerals");
+			if (stored !== null) {
+				return ["1", "true", "yes"].includes(stored.toLowerCase());
+			}
+		} catch {
+			/* localStorage not available */
+		}
+		// Fallback to frappe boot settings if provided
+		if (typeof frappe !== "undefined") {
+			const bootVal =
+				frappe.boot?.use_western_numerals || frappe.boot?.pos_profile?.use_western_numerals;
+			if (typeof bootVal !== "undefined") {
+				return Boolean(bootVal);
+			}
+		}
+		return false;
+	},
+
+	// Helper to check if Arabic numerals should be used
+	shouldUseArabic() {
+		return this.isRtl() && !this.useWestern();
 	},
 
 	// Convert Western numerals to Arabic-Indic numerals
 	toArabicNumerals(str) {
-		if (!this.isRtl()) return str;
+		if (!this.shouldUseArabic()) return str;
 		const westernToArabic = {
-			'0': '٠', '1': '١', '2': '٢', '3': '٣', '4': '٤',
-			'5': '٥', '6': '٦', '7': '٧', '8': '٨', '9': '٩'
+			0: "٠",
+			1: "١",
+			2: "٢",
+			3: "٣",
+			4: "٤",
+			5: "٥",
+			6: "٦",
+			7: "٧",
+			8: "٨",
+			9: "٩",
 		};
 		return String(str).replace(/[0-9]/g, (match) => westernToArabic[match]);
 	},
@@ -28,22 +64,33 @@ const formatUtils = {
 	// Convert Arabic-Indic numerals back to Western numerals for parsing
 	fromArabicNumerals(str) {
 		const arabicToWestern = {
-			'٠': '0', '١': '1', '٢': '2', '٣': '3', '٤': '4',
-			'٥': '5', '٦': '6', '٧': '7', '٨': '8', '٩': '9'
+			"٠": "0",
+			"١": "1",
+			"٢": "2",
+			"٣": "3",
+			"٤": "4",
+			"٥": "5",
+			"٦": "6",
+			"٧": "7",
+			"٨": "8",
+			"٩": "9",
 		};
-		return String(str).replace(/[٠-٩]/g, (match) => arabicToWestern[match]);
+		return String(str)
+			.replace(/[٠-٩]/g, (match) => arabicToWestern[match])
+			.replace(/٬/g, ",")
+			.replace(/٫/g, ".");
 	},
 
 	// Get appropriate locale for number formatting
 	getNumberLocale() {
-		if (this.isRtl()) {
-			const lang = document.documentElement.lang || 'ar';
-			if (lang.startsWith('ar')) return 'ar-SA'; // Arabic Saudi Arabia
-			if (lang.startsWith('fa')) return 'fa-IR'; // Persian Iran
-			return 'ar-SA'; // Default to Arabic
+		if (this.shouldUseArabic()) {
+			const lang = document.documentElement.lang || "ar";
+			if (lang.startsWith("ar")) return "ar-SA"; // Arabic Saudi Arabia
+			if (lang.startsWith("fa")) return "fa-IR"; // Persian Iran
+			return "ar-SA"; // Default to Arabic
 		}
-		return 'en-US';
-	}
+		return "en-US";
+	},
 };
 
 export default {
@@ -68,7 +115,7 @@ export default {
 			if (value === null || value === undefined) {
 				value = 0;
 			}
-			let number = Number(String(value).replace(/,/g, ""));
+			let number = Number(formatUtils.fromArabicNumerals(String(value)).replace(/,/g, ""));
 			if (isNaN(number)) number = 0;
 			let prec = precision != null ? Number(precision) : Number(this.currency_precision) || 2;
 			// Clamp precision to the valid range 0-20 to avoid RangeError
@@ -80,13 +127,11 @@ export default {
 			let formatted = number.toLocaleString(locale, {
 				minimumFractionDigits: prec,
 				maximumFractionDigits: prec,
-				useGrouping: true
+				useGrouping: true,
 			});
 
-			// For Arabic, convert to Arabic-Indic numerals
-			if (formatUtils.isRtl()) {
-				formatted = formatUtils.toArabicNumerals(formatted);
-			}
+			// Convert to Arabic-Indic numerals if needed
+			formatted = formatUtils.toArabicNumerals(formatted);
 
 			return formatted;
 		},
@@ -95,7 +140,7 @@ export default {
 			if (value === null || value === undefined) {
 				value = 0;
 			}
-			let number = Number(String(value).replace(/,/g, ""));
+			let number = Number(formatUtils.fromArabicNumerals(String(value)).replace(/,/g, ""));
 			if (isNaN(number)) number = 0;
 			let prec = precision != null ? Number(precision) : Number(this.float_precision) || 2;
 			// Clamp precision to the valid range 0-20 to avoid RangeError
@@ -107,13 +152,11 @@ export default {
 			let formatted = number.toLocaleString(locale, {
 				minimumFractionDigits: prec,
 				maximumFractionDigits: prec,
-				useGrouping: true
+				useGrouping: true,
 			});
 
-			// For Arabic, convert to Arabic-Indic numerals
-			if (formatUtils.isRtl()) {
-				formatted = formatUtils.toArabicNumerals(formatted);
-			}
+			// Convert to Arabic-Indic numerals if needed
+			formatted = formatUtils.toArabicNumerals(formatted);
 
 			return formatted;
 		},
@@ -174,7 +217,7 @@ export default {
 		// Check if a value is negative for CSS class binding
 		isNegative(value) {
 			if (value === null || value === undefined) return false;
-			const number = Number(String(value).replace(/,/g, ""));
+			const number = Number(formatUtils.fromArabicNumerals(String(value)).replace(/,/g, ""));
 			return !isNaN(number) && number < 0;
 		},
 
@@ -183,7 +226,7 @@ export default {
 			if (value === null || value === undefined) {
 				value = 0;
 			}
-			let number = Number(String(value).replace(/,/g, ""));
+			let number = Number(formatUtils.fromArabicNumerals(String(value)).replace(/,/g, ""));
 			if (isNaN(number)) number = 0;
 			let prec = precision != null ? Number(precision) : Number(this.currency_precision) || 2;
 			// Clamp precision to the valid range 0-20 to avoid RangeError
@@ -195,13 +238,11 @@ export default {
 			let formatted = number.toLocaleString(locale, {
 				minimumFractionDigits: prec,
 				maximumFractionDigits: prec,
-				useGrouping: true
+				useGrouping: true,
 			});
 
-			// For Arabic, convert to Arabic-Indic numerals
-			if (formatUtils.isRtl()) {
-				formatted = formatUtils.toArabicNumerals(formatted);
-			}
+			// Convert to Arabic-Indic numerals if needed
+			formatted = formatUtils.toArabicNumerals(formatted);
 
 			return formatted;
 		},
@@ -211,7 +252,7 @@ export default {
 			if (value === null || value === undefined) {
 				value = 0;
 			}
-			let number = Number(String(value).replace(/,/g, ""));
+			let number = Number(formatUtils.fromArabicNumerals(String(value)).replace(/,/g, ""));
 			if (isNaN(number)) number = 0;
 			let prec = precision != null ? Number(precision) : Number(this.float_precision) || 2;
 			// Clamp precision to the valid range 0-20 to avoid RangeError
@@ -223,13 +264,11 @@ export default {
 			let formatted = number.toLocaleString(locale, {
 				minimumFractionDigits: prec,
 				maximumFractionDigits: prec,
-				useGrouping: true
+				useGrouping: true,
 			});
 
-			// For Arabic, convert to Arabic-Indic numerals
-			if (formatUtils.isRtl()) {
-				formatted = formatUtils.toArabicNumerals(formatted);
-			}
+			// Convert to Arabic-Indic numerals if needed
+			formatted = formatUtils.toArabicNumerals(formatted);
 
 			return formatted;
 		},

--- a/frontend/src/posapp/format.js
+++ b/frontend/src/posapp/format.js
@@ -1,6 +1,6 @@
 /* global frappe, flt, get_currency_symbol */
 // Utility functions for RTL number formatting (standalone)
-const formatUtils = {
+export const formatUtils = {
 	// Check if current language/layout is RTL
 	isRtl() {
 		// Check via frappe utils first


### PR DESCRIPTION
## Summary
- allow POS to prefer western numerals/separators even when RTL
- convert Arabic-Indic numerals and separators back to western for parsing
- use new preference in currency/float formatting utilities

## Testing
- `npx prettier frontend/src/posapp/format.js -w`
- `npx eslint frontend/src/posapp/format.js`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68aea6aae9e48326807a7136b0ec984c