### PR TITLE
fix: handle variable scale barcode prefix length

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1756,36 +1756,49 @@ export default {
 				vm.search_from_scanner = false;
 			}
 		}, 300),
-		get_item_qty(first_search) {
-			const qtyVal = this.qty != null ? this.qty : 1;
-			let scal_qty = Math.abs(qtyVal);
-			if (first_search.startsWith(this.pos_profile.posa_scale_barcode_start)) {
-				let pesokg1 = first_search.substr(7, 5);
-				let pesokg;
-				if (pesokg1.startsWith("0000")) {
-					pesokg = "0.00" + pesokg1.substr(4);
-				} else if (pesokg1.startsWith("000")) {
-					pesokg = "0.0" + pesokg1.substr(3);
-				} else if (pesokg1.startsWith("00")) {
-					pesokg = "0." + pesokg1.substr(2);
-				} else if (pesokg1.startsWith("0")) {
-					pesokg = pesokg1.substr(1, 1) + "." + pesokg1.substr(2, pesokg1.length);
-				} else if (!pesokg1.startsWith("0")) {
-					pesokg = pesokg1.substr(0, 2) + "." + pesokg1.substr(2, pesokg1.length);
-				}
-				scal_qty = pesokg;
-			}
-			if (this.hide_qty_decimals) {
-				scal_qty = Math.trunc(scal_qty);
-			}
-			return scal_qty;
-		},
-		get_search(first_search) {
-			if (!first_search) return "";
-			return first_search.startsWith(this.pos_profile.posa_scale_barcode_start)
-				? first_search.substr(0, 7)
-				: first_search;
-		},
+                get_item_qty(first_search) {
+                        const qtyVal = this.qty != null ? this.qty : 1;
+                        let scal_qty = Math.abs(qtyVal);
+                        const prefix_len =
+                                this.pos_profile.posa_scale_barcode_start?.length || 0;
+                        if (first_search.startsWith(this.pos_profile.posa_scale_barcode_start)) {
+                                const weight_len = 5;
+                                const barcode_len = first_search.length;
+                                const item_digits = barcode_len - prefix_len - weight_len - 1;
+                                const weight_start = prefix_len + item_digits;
+                                let pesokg1 = first_search.substr(weight_start, weight_len);
+                                let pesokg;
+                                if (pesokg1.startsWith("0000")) {
+                                        pesokg = "0.00" + pesokg1.substr(4);
+                                } else if (pesokg1.startsWith("000")) {
+                                        pesokg = "0.0" + pesokg1.substr(3);
+                                } else if (pesokg1.startsWith("00")) {
+                                        pesokg = "0." + pesokg1.substr(2);
+                                } else if (pesokg1.startsWith("0")) {
+                                        pesokg = pesokg1.substr(1, 1) + "." + pesokg1.substr(2, pesokg1.length);
+                                } else if (!pesokg1.startsWith("0")) {
+                                        pesokg = pesokg1.substr(0, 2) + "." + pesokg1.substr(2, pesokg1.length);
+                                }
+                                scal_qty = pesokg;
+                        }
+                        if (this.hide_qty_decimals) {
+                                scal_qty = Math.trunc(scal_qty);
+                        }
+                        return scal_qty;
+                },
+                get_search(first_search) {
+                        if (!first_search) return "";
+                        const prefix_len =
+                                this.pos_profile.posa_scale_barcode_start?.length || 0;
+                        if (first_search.startsWith(this.pos_profile.posa_scale_barcode_start)) {
+                                const weight_len = 5;
+                                const barcode_len = first_search.length;
+                                const item_digits = barcode_len - prefix_len - weight_len - 1;
+                                const item_code = first_search.substr(prefix_len, item_digits);
+                                return this.pos_profile.posa_scale_barcode_start + item_code;
+                        }
+                        return first_search;
+                },
 		esc_event() {
 			this.search = null;
 			this.first_search = null;


### PR DESCRIPTION
## Summary
- handle scale barcode prefixes of varying length when parsing weights
- adjust search to use dynamic prefix-based slicing
- derive item code and quantity from scale barcode using barcode length

## Testing
- `npx --yes eslint frontend/src/posapp/components/pos/ItemsSelector.vue && echo "eslint success"`
- `yarn build >/tmp/build.log && tail -n 20 /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_68af40b1e44c832694dce717d38baa58