### PR TITLE
fix: preserve scale barcode quantity

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1661,50 +1661,70 @@ export default {
 					item.base_price_list_rate = base_rate;
 				}
 
-				if (!item.qty || item.qty === 1) {
-					let qtyVal = this.qty != null ? this.qty : 1;
-					qtyVal = Math.abs(qtyVal);
-					if (this.hide_qty_decimals) {
-						qtyVal = Math.trunc(qtyVal);
-					}
-					item.qty = qtyVal;
-				}
-				this.eventBus.emit("add_item", item);
-				this.qty = 1;
-			}
-		},
-		async enter_event() {
-			let match = false;
-			if (!this.filtered_items.length || !this.first_search) {
-				return;
-			}
-			const qty = this.get_item_qty(this.first_search);
-			const new_item = { ...this.filtered_items[0] };
-			new_item.qty = flt(qty);
-			if (Array.isArray(new_item.item_barcode)) {
-				new_item.item_barcode.forEach((element) => {
-					if (this.search == element.barcode) {
-						new_item.uom = element.posa_uom;
-						match = true;
-					}
-				});
-			}
-			if (this.flags.serial_no) {
-				new_item.to_set_serial_no = this.flags.serial_no;
-			}
-			if (this.flags.batch_no) {
-				new_item.to_set_batch_no = this.flags.batch_no;
-			}
-			if (match) {
-				await this.add_item(new_item);
-				this.flags.serial_no = null;
-				this.flags.batch_no = null;
-				this.qty = 1;
-				// Clear search field after successfully adding an item
-				this.clearSearch();
-				this.$refs.debounce_search.focus();
-			}
-		},
+                                const hasBarcodeQty = item._barcode_qty;
+                                if (!item.qty || (item.qty === 1 && !hasBarcodeQty)) {
+                                        let qtyVal = this.qty != null ? this.qty : 1;
+                                        qtyVal = Math.abs(qtyVal);
+                                        if (this.hide_qty_decimals) {
+                                                qtyVal = Math.trunc(qtyVal);
+                                        }
+                                        item.qty = qtyVal;
+                                }
+                                const payload = { ...item };
+                                delete payload._barcode_qty;
+                                this.eventBus.emit("add_item", payload);
+                                this.qty = 1;
+                        }
+                },
+               async enter_event() {
+                       if (!this.filtered_items.length || !this.first_search) {
+                               return;
+                       }
+
+                       // Derive the searchable code and detect scale barcode
+                       const search = this.get_search(this.first_search);
+                       const isScaleBarcode =
+                               this.pos_profile?.posa_scale_barcode_start &&
+                               this.first_search.startsWith(this.pos_profile.posa_scale_barcode_start);
+                       this.search = search;
+
+                       const qty = parseFloat(this.get_item_qty(this.first_search));
+                       const new_item = { ...this.filtered_items[0] };
+                       new_item.qty = flt(qty);
+                       if (isScaleBarcode) {
+                               new_item._barcode_qty = true;
+                       }
+
+                       let match = false;
+                       if (Array.isArray(new_item.item_barcode)) {
+                               new_item.item_barcode.forEach((element) => {
+                                       if (search === element.barcode) {
+                                               new_item.uom = element.posa_uom;
+                                               match = true;
+                                       }
+                               });
+                       }
+                       if (!match && new_item.item_code === search) {
+                               match = true;
+                       }
+
+                       if (this.flags.serial_no) {
+                               new_item.to_set_serial_no = this.flags.serial_no;
+                       }
+                       if (this.flags.batch_no) {
+                               new_item.to_set_batch_no = this.flags.batch_no;
+                       }
+
+                       if (match) {
+                               await this.add_item(new_item);
+                               this.flags.serial_no = null;
+                               this.flags.batch_no = null;
+                               this.qty = 1;
+                               // Clear search field after successfully adding an item
+                               this.clearSearch();
+                               this.$refs.debounce_search.focus();
+                       }
+               },
 		search_onchange: _.debounce(async function (newSearchTerm) {
 			const vm = this;
 
@@ -1761,8 +1781,16 @@ export default {
                         let scal_qty = Math.abs(qtyVal);
                         const prefix_len =
                                 this.pos_profile.posa_scale_barcode_start?.length || 0;
+
                         if (first_search.startsWith(this.pos_profile.posa_scale_barcode_start)) {
-                                let pesokg1 = first_search.substr(prefix_len + 5, 5);
+                                // Determine item code length dynamically based on EAN-13 structure:
+                                // prefix + item_code + 5 qty digits + 1 check digit
+                                const item_code_len =
+                                        first_search.length - prefix_len - 6;
+                                let pesokg1 = first_search.substr(
+                                        prefix_len + item_code_len,
+                                        5,
+                                );
                                 let pesokg;
                                 if (pesokg1.startsWith("0000")) {
                                         pesokg = "0.00" + pesokg1.substr(4);
@@ -1786,9 +1814,13 @@ export default {
                         if (!first_search) return "";
                         const prefix_len =
                                 this.pos_profile.posa_scale_barcode_start?.length || 0;
-                        return first_search.startsWith(this.pos_profile.posa_scale_barcode_start)
-                                ? first_search.substr(0, prefix_len + 5)
-                                : first_search;
+                        if (!first_search.startsWith(this.pos_profile.posa_scale_barcode_start)) {
+                                return first_search;
+                        }
+                        // Calculate item code length from total barcode length
+                        const item_code_len =
+                                first_search.length - prefix_len - 6;
+                        return first_search.substr(0, prefix_len + item_code_len);
                 },
 		esc_event() {
 			this.search = null;
@@ -2192,70 +2224,82 @@ export default {
 				this.processScannedItem(scannedCode);
 			}, 300);
 		},
-		async processScannedItem(scannedCode) {
-			// First try to find exact match by barcode
-			let foundItem = this.items.find((item) => {
-				const barcodeMatch =
-					item.barcode === scannedCode ||
-					(Array.isArray(item.item_barcode) &&
-						item.item_barcode.some((b) => b.barcode === scannedCode)) ||
-					(Array.isArray(item.barcodes) && item.barcodes.some((bc) => String(bc) === scannedCode));
-				return barcodeMatch || item.item_code === scannedCode;
-			});
+                async processScannedItem(scannedCode) {
+                        // Handle scale barcodes by extracting the item code and quantity
+                        let searchCode = scannedCode;
+                        let qtyFromBarcode = null;
+                        if (
+                                this.pos_profile?.posa_scale_barcode_start &&
+                                scannedCode.startsWith(this.pos_profile.posa_scale_barcode_start)
+                        ) {
+                                searchCode = this.get_search(scannedCode);
+                                qtyFromBarcode = parseFloat(this.get_item_qty(scannedCode));
+                        }
 
-			if (foundItem) {
-				console.log("Found item by exact match:", foundItem);
-				this.addScannedItemToInvoice(foundItem, scannedCode);
-				return;
-			}
+                        // First try to find exact match by processed code
+                        let foundItem = this.items.find((item) => {
+                                const barcodeMatch =
+                                        item.barcode === searchCode ||
+                                        (Array.isArray(item.item_barcode) &&
+                                                item.item_barcode.some((b) => b.barcode === searchCode)) ||
+                                        (Array.isArray(item.barcodes) &&
+                                                item.barcodes.some((bc) => String(bc) === searchCode));
+                                return barcodeMatch || item.item_code === searchCode;
+                        });
 
-			// If not found locally, attempt to fetch from server by barcode
-			try {
-				const res = await frappe.call({
-					method: "posawesome.posawesome.api.items.get_items_from_barcode",
-					args: {
-						selling_price_list: this.active_price_list,
-						currency: this.pos_profile.currency,
-						barcode: scannedCode,
-					},
-				});
+                        if (foundItem) {
+                                console.log("Found item by processed code:", foundItem);
+                                this.addScannedItemToInvoice(foundItem, searchCode, qtyFromBarcode);
+                                return;
+                        }
 
-				if (res && res.message) {
-					const newItem = res.message;
-					this.items.push(newItem);
+                        // If not found locally, attempt to fetch from server using processed code
+                        try {
+                                const res = await frappe.call({
+                                        method: "posawesome.posawesome.api.items.get_items_from_barcode",
+                                        args: {
+                                                selling_price_list: this.active_price_list,
+                                                currency: this.pos_profile.currency,
+                                                barcode: searchCode,
+                                        },
+                                });
 
-					if (this.searchCache) {
-						this.searchCache.clear();
-					}
+                                if (res && res.message) {
+                                        const newItem = res.message;
+                                        this.items.push(newItem);
 
-					await saveItems(this.items);
-					await savePriceListItems(this.customer_price_list, this.items);
-					this.eventBus.emit("set_all_items", this.items);
-					await this.update_items_details([newItem]);
-					this.addScannedItemToInvoice(newItem, scannedCode);
-					return;
-				}
+                                        if (this.searchCache) {
+                                                this.searchCache.clear();
+                                        }
 
-				frappe.show_alert(
-					{
-						message: `${this.__("Item not found")}: ${scannedCode}`,
-						indicator: "red",
-					},
-					5,
-				);
-				return;
-			} catch (e) {
-				console.error("Error fetching item from barcode:", e);
-				frappe.show_alert(
-					{
-						message: `${this.__("Item not found")}: ${scannedCode}`,
-						indicator: "red",
-					},
-					5,
-				);
-				return;
-			}
-		},
+                                        await saveItems(this.items);
+                                        await savePriceListItems(this.customer_price_list, this.items);
+                                        this.eventBus.emit("set_all_items", this.items);
+                                        await this.update_items_details([newItem]);
+                                        this.addScannedItemToInvoice(newItem, searchCode, qtyFromBarcode);
+                                        return;
+                                }
+
+                                frappe.show_alert(
+                                        {
+                                                message: `${this.__("Item not found")}: ${scannedCode}`,
+                                                indicator: "red",
+                                        },
+                                        5,
+                                );
+                                return;
+                        } catch (e) {
+                                console.error("Error fetching item from barcode:", e);
+                                frappe.show_alert(
+                                        {
+                                                message: `${this.__("Item not found")}: ${scannedCode}`,
+                                                indicator: "red",
+                                        },
+                                        5,
+                                );
+                                return;
+                        }
+                },
 		searchItemsByCode(code) {
 			return this.items.filter((item) => {
 				const searchTerm = code.toLowerCase();
@@ -2274,8 +2318,8 @@ export default {
 				);
 			});
 		},
-		async addScannedItemToInvoice(item, scannedCode) {
-			console.log("Adding scanned item to invoice:", item, scannedCode);
+                async addScannedItemToInvoice(item, scannedCode, qtyFromBarcode = null) {
+                        console.log("Adding scanned item to invoice:", item, scannedCode);
 
 			// Clone the item to avoid mutating list data
 			const newItem = { ...item };
@@ -2311,8 +2355,14 @@ export default {
 				}
 			}
 
-			// Use existing add_item method with enhanced feedback
-			await this.add_item(newItem);
+                        // Apply quantity from scale barcode if available
+                        if (qtyFromBarcode !== null && !isNaN(qtyFromBarcode)) {
+                                newItem.qty = qtyFromBarcode;
+                                newItem._barcode_qty = true;
+                        }
+
+                        // Use existing add_item method with enhanced feedback
+                        await this.add_item(newItem);
 
 			// Show success message
 			frappe.show_alert(


### PR DESCRIPTION
## Summary
- ensure items scanned from scale barcodes keep the embedded quantity
- derive the item code from the scanned barcode and mark quantity as barcode-sourced during manual scans

## Testing
- `npx eslint frontend/src/posapp/components/pos/ItemsSelector.vue && echo 'eslint:success'`
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b003b1236c8326a65688cebf74af9b