### PR TITLE
feat: defer searches during background loading

### DIFF
--- a/frontend/src/posapp/components/pos/Customer.vue
+++ b/frontend/src/posapp/components/pos/Customer.vue
@@ -14,7 +14,9 @@
 			item-title="customer_name"
 			item-value="name"
 			:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-			:no-data-text="__('Customers not found')"
+			:no-data-text="
+				isCustomerBackgroundLoading ? __('Loading customer data...') : __('Customers not found')
+			"
 			hide-details
 			:customFilter="() => true"
 			:disabled="effectiveReadonly || loadingCustomers"
@@ -159,15 +161,15 @@
 /* global frappe __ */
 import UpdateCustomer from "./UpdateCustomer.vue";
 import {
-        db,
-        checkDbHealth,
-        setCustomerStorage,
-        memoryInitPromise,
-        getCustomersLastSync,
-        setCustomersLastSync,
-       getCustomerStorageCount,
-       clearCustomerStorage,
-       isOffline,
+	db,
+	checkDbHealth,
+	setCustomerStorage,
+	memoryInitPromise,
+	getCustomersLastSync,
+	setCustomersLastSync,
+	getCustomerStorageCount,
+	clearCustomerStorage,
+	isOffline,
 } from "../../../offline/index.js";
 import _ from "lodash";
 
@@ -194,6 +196,9 @@ export default {
 		hasMore: true,
 		nextCustomerStart: null,
 		searchDebounce: null,
+		// Track background loading state and pending searches
+		isCustomerBackgroundLoading: false,
+		pendingCustomerSearch: null,
 	}),
 
 	components: {
@@ -206,7 +211,7 @@ export default {
 		},
 
 		filteredCustomers() {
-			return this.customers;
+			return this.isCustomerBackgroundLoading ? [] : this.customers;
 		},
 	},
 
@@ -288,6 +293,10 @@ export default {
 		},
 
 		onCustomerSearch(val) {
+			if (this.isCustomerBackgroundLoading) {
+				this.pendingCustomerSearch = val;
+				return;
+			}
 			this.searchDebounce(val);
 		},
 
@@ -362,66 +371,74 @@ export default {
 			}
 		},
 
-               async backgroundLoadCustomers(startAfter, syncSince) {
-                       const limit = this.pageSize;
-                       try {
-                               let cursor = startAfter;
-                               while (cursor) {
-                                       const rows = await this.fetchCustomerPage(cursor, syncSince, limit);
-                                       await setCustomerStorage(rows);
-                                       if (rows.length === limit) {
-                                               cursor = rows[rows.length - 1]?.name || null;
-                                               this.nextCustomerStart = cursor;
-                                       } else {
-                                               cursor = null;
-                                               this.nextCustomerStart = null;
-                                               setCustomersLastSync(new Date().toISOString());
-                                               this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-                                               this.eventBus.emit("data-loaded", "customers");
-                                       }
-                               }
-                       } catch (err) {
-                               console.error("Failed to background load customers", err);
-                       }
-               },
+		async backgroundLoadCustomers(startAfter, syncSince) {
+			const limit = this.pageSize;
+			this.isCustomerBackgroundLoading = true;
+			try {
+				let cursor = startAfter;
+				while (cursor) {
+					const rows = await this.fetchCustomerPage(cursor, syncSince, limit);
+					await setCustomerStorage(rows);
+					if (rows.length === limit) {
+						cursor = rows[rows.length - 1]?.name || null;
+						this.nextCustomerStart = cursor;
+					} else {
+						cursor = null;
+						this.nextCustomerStart = null;
+						setCustomersLastSync(new Date().toISOString());
+						this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
+						this.eventBus.emit("data-loaded", "customers");
+					}
+				}
+			} catch (err) {
+				console.error("Failed to background load customers", err);
+			} finally {
+				this.isCustomerBackgroundLoading = false;
+				if (this.pendingCustomerSearch !== null) {
+					this.searchDebounce(this.pendingCustomerSearch);
+					if (this.searchDebounce.flush) {
+						this.searchDebounce.flush();
+					}
+					this.pendingCustomerSearch = null;
+				}
+			}
+		},
 
-               async verifyServerCustomerCount() {
-                       if (isOffline()) return;
-                       try {
-                               const localCount = await getCustomerStorageCount();
-                               const res = await frappe.call({
-                                       method: "posawesome.posawesome.api.customers.get_customers_count",
-                                       args: { pos_profile: this.pos_profile.pos_profile },
-                               });
-                               const serverCount = res.message || 0;
-                               if (typeof serverCount === "number") {
-                                       if (serverCount > localCount) {
-                                               const syncSince = getCustomersLastSync();
-                                               const rows = await this.fetchCustomerPage(null, syncSince, this.pageSize);
-                                               await setCustomerStorage(rows);
-                                               const startAfter =
-                                                       rows.length === this.pageSize
-                                                               ? rows[rows.length - 1]?.name || null
-                                                               : null;
-                                               if (startAfter) {
-                                                       this.backgroundLoadCustomers(startAfter, syncSince);
-                                               } else {
-                                                       setCustomersLastSync(new Date().toISOString());
-                                                       this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-                                                       this.eventBus.emit("data-loaded", "customers");
-                                               }
-                                               await this.searchCustomers(this.searchTerm);
-                                       } else if (serverCount < localCount) {
-                                               await clearCustomerStorage();
-                                               setCustomersLastSync(null);
-                                               this.customers = [];
-                                               await this.get_customer_names();
-                                       }
-                               }
-                       } catch (err) {
-                               console.error("Error verifying customer count:", err);
-                       }
-               },
+		async verifyServerCustomerCount() {
+			if (isOffline()) return;
+			try {
+				const localCount = await getCustomerStorageCount();
+				const res = await frappe.call({
+					method: "posawesome.posawesome.api.customers.get_customers_count",
+					args: { pos_profile: this.pos_profile.pos_profile },
+				});
+				const serverCount = res.message || 0;
+				if (typeof serverCount === "number") {
+					if (serverCount > localCount) {
+						const syncSince = getCustomersLastSync();
+						const rows = await this.fetchCustomerPage(null, syncSince, this.pageSize);
+						await setCustomerStorage(rows);
+						const startAfter =
+							rows.length === this.pageSize ? rows[rows.length - 1]?.name || null : null;
+						if (startAfter) {
+							this.backgroundLoadCustomers(startAfter, syncSince);
+						} else {
+							setCustomersLastSync(new Date().toISOString());
+							this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
+							this.eventBus.emit("data-loaded", "customers");
+						}
+						await this.searchCustomers(this.searchTerm);
+					} else if (serverCount < localCount) {
+						await clearCustomerStorage();
+						setCustomersLastSync(null);
+						this.customers = [];
+						await this.get_customer_names();
+					}
+				}
+			} catch (err) {
+				console.error("Error verifying customer count:", err);
+			}
+		},
 
 		fetchCustomerPage(startAfter, modifiedAfter, limit) {
 			return new Promise((resolve, reject) => {
@@ -442,38 +459,38 @@ export default {
 			});
 		},
 
-               async get_customer_names() {
-                       const localCount = await getCustomerStorageCount();
-                       if (localCount > 0) {
-                               this.customers_loaded = true;
-                               await this.searchCustomers(this.searchTerm);
-                               await this.verifyServerCustomerCount();
-                               return;
-                       }
-                       const syncSince = getCustomersLastSync();
-                       this.eventBus.emit("data-load-progress", { name: "customers", progress: 0 });
-                       this.loadingCustomers = true;
-                       try {
-                               const rows = await this.fetchCustomerPage(null, syncSince, this.pageSize);
-                               await setCustomerStorage(rows);
-                               this.nextCustomerStart =
-                                       rows.length === this.pageSize ? rows[rows.length - 1]?.name || null : null;
-                               if (this.nextCustomerStart) {
-                                       // Load remaining customers in the background
-                                       this.backgroundLoadCustomers(this.nextCustomerStart, syncSince);
-                               } else {
-                                       setCustomersLastSync(new Date().toISOString());
-                                       this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-                                       this.eventBus.emit("data-loaded", "customers");
-                               }
-                               this.customers_loaded = true;
-                       } catch (err) {
-                               console.error("Failed to fetch customers:", err);
-                       } finally {
-                               this.loadingCustomers = false;
-                               await this.searchCustomers(this.searchTerm);
-                       }
-               },
+		async get_customer_names() {
+			const localCount = await getCustomerStorageCount();
+			if (localCount > 0) {
+				this.customers_loaded = true;
+				await this.searchCustomers(this.searchTerm);
+				await this.verifyServerCustomerCount();
+				return;
+			}
+			const syncSince = getCustomersLastSync();
+			this.eventBus.emit("data-load-progress", { name: "customers", progress: 0 });
+			this.loadingCustomers = true;
+			try {
+				const rows = await this.fetchCustomerPage(null, syncSince, this.pageSize);
+				await setCustomerStorage(rows);
+				this.nextCustomerStart =
+					rows.length === this.pageSize ? rows[rows.length - 1]?.name || null : null;
+				if (this.nextCustomerStart) {
+					// Load remaining customers in the background
+					this.backgroundLoadCustomers(this.nextCustomerStart, syncSince);
+				} else {
+					setCustomersLastSync(new Date().toISOString());
+					this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
+					this.eventBus.emit("data-loaded", "customers");
+				}
+				this.customers_loaded = true;
+			} catch (err) {
+				console.error("Failed to fetch customers:", err);
+			} finally {
+				this.loadingCustomers = false;
+				await this.searchCustomers(this.searchTerm);
+			}
+		},
 
 		new_customer() {
 			this.eventBus.emit("open_update_customer", null);


### PR DESCRIPTION
## Summary
- keep background item loading active and show a loading message in the selector
- delay item searches until background load completes
- show customer loading status and defer customer searches until data is ready

## Testing
- `npx prettier --write frontend/src/posapp/components/pos/ItemsSelector.vue frontend/src/posapp/components/pos/Customer.vue`
- `npx eslint frontend/src/posapp/components/pos/ItemsSelector.vue frontend/src/posapp/components/pos/Customer.vue`


------
https://chatgpt.com/codex/tasks/task_e_68b0650442448326b8774cc0bc87a30d