### PR TITLE
fix: fetch items when local storage disabled

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1836,18 +1836,19 @@ export default {
 				} else {
 					vm.get_items(true);
 				}
-			} else {
-				// Save the current filtered items before search to maintain quantity data
-				const current_items = [...vm.filtered_items];
-				vm.enter_event();
+                       } else {
+                               // When local storage is disabled, always fetch items
+                               // from the server so searches aren't limited to the
+                               // initially loaded set.
+                               await vm.get_items(true);
+                               vm.enter_event();
 
-				// After search, update quantities for newly filtered items
-				if (vm.filtered_items && vm.filtered_items.length > 0) {
-					setTimeout(() => {
-						vm.update_items_details(vm.filtered_items);
-					}, 300);
-				}
-			}
+                               if (vm.filtered_items && vm.filtered_items.length > 0) {
+                                       setTimeout(() => {
+                                               vm.update_items_details(vm.filtered_items);
+                                       }, 300);
+                               }
+                       }
 
 			// Clear the input only when triggered via scanner
 			if (fromScanner) {


### PR DESCRIPTION
## Summary
- ensure item searches query server when browser local storage is disabled

## Testing
- `npx eslint frontend/src/posapp/components/pos/ItemsSelector.vue`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b07280e2d88326b8640d7277df94a8