### PR TITLE
fix: apply brand transaction offers across combined items & stable brand resolution

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1308,18 +1308,21 @@ export default {
 					const updated_item = response.message.find(
 						(element) => element.posa_row_id == item.posa_row_id,
 					);
-					if (updated_item) {
-						item.actual_qty = updated_item.actual_qty;
-						item.item_uoms = updated_item.item_uoms;
-						item.has_batch_no = updated_item.has_batch_no;
-						item.has_serial_no = updated_item.has_serial_no;
-						item.batch_no_data = updated_item.batch_no_data;
-						item.serial_no_data = updated_item.serial_no_data;
-                                               if (updated_item.rate !== undefined) {
-                                                       if (!item.locked_price && !item.posa_offer_applied) {
-                                                               if (updated_item.rate !== 0 || !item.rate) {
-                                                                       item.rate = updated_item.rate;
-                                                                       item.price_list_rate =
+                                        if (updated_item) {
+                                                item.actual_qty = updated_item.actual_qty;
+                                                item.item_uoms = updated_item.item_uoms;
+                                                item.has_batch_no = updated_item.has_batch_no;
+                                                item.has_serial_no = updated_item.has_serial_no;
+                                                item.batch_no_data = updated_item.batch_no_data;
+                                                item.serial_no_data = updated_item.serial_no_data;
+                                                if (updated_item.brand) {
+                                                        item.brand = updated_item.brand;
+                                                }
+                                                if (updated_item.rate !== undefined) {
+                                                        if (!item.locked_price && !item.posa_offer_applied) {
+                                                                if (updated_item.rate !== 0 || !item.rate) {
+                                                                        item.rate = updated_item.rate;
+                                                                        item.price_list_rate =
                                                                                updated_item.price_list_rate || updated_item.rate;
                                                                }
                                                        } else if (!item.price_list_rate) {
@@ -1398,15 +1401,18 @@ export default {
 				},
 			},
 			callback: function (r) {
-				if (r.message) {
-					const data = r.message;
-					if (!item.warehouse) {
-						item.warehouse = vm.pos_profile.warehouse;
-					}
-					// Ensure price list currency is synced from server response
-					if (data.price_list_currency) {
-						vm.price_list_currency = data.price_list_currency;
-					}
+                                        if (r.message) {
+                                                const data = r.message;
+                                                if (!item.warehouse) {
+                                                        item.warehouse = vm.pos_profile.warehouse;
+                                                }
+                                                if (data.brand) {
+                                                        item.brand = data.brand;
+                                                }
+                                                // Ensure price list currency is synced from server response
+                                                if (data.price_list_currency) {
+                                                        vm.price_list_currency = data.price_list_currency;
+                                                }
 
 					if (!item.original_currency) {
 						item.original_currency =

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -83,10 +83,20 @@ export default {
 		return result;
 	},
 
-	getItemFromRowID(row_id) {
-		const combined = [...this.items, ...this.packed_items];
-		return combined.find((el) => el.posa_row_id == row_id);
-	},
+        getItemFromRowID(row_id) {
+                const combined = [...this.items, ...this.packed_items];
+                return combined.find((el) => el.posa_row_id == row_id);
+        },
+
+        // Normalize brand from different possible fields
+        getLineBrand(line) {
+                let brand = line.brand || line.item_brand;
+                if (!brand && this.item_details_cache) {
+                        brand = this.item_details_cache[line.item_code]?.brand;
+                }
+                if (!brand) return null;
+                return String(brand).trim().toLowerCase();
+        },
 
 	checkQtyAnountOffer(offer, qty, amount) {
 		let min_qty = false;
@@ -212,40 +222,42 @@ export default {
 		return apply_offer;
 	},
 
-	getBrandOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Brand") {
-			if (this.checkOfferCoupon(offer)) {
-				const items = [];
-				let total_count = 0;
-				let total_amount = 0;
-				const combined = [...this.items, ...this.packed_items];
-				combined.forEach((item) => {
-					if (!item.posa_is_offer && item.brand === offer.brand) {
-						if (
-							offer.offer === "Item Price" &&
-							item.posa_offer_applied &&
-							!this.checkOfferIsAppley(item, offer)
-						) {
-							return;
-						}
-						total_count += item.stock_qty;
-						const rate = item.original_price_list_rate || item.price_list_rate;
-						total_amount += item.stock_qty * rate;
-						items.push(item.posa_row_id);
-					}
-				});
-				if (total_count || total_amount) {
-					const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
-					if (res.apply) {
-						offer.items = items;
-						apply_offer = offer;
-					}
-				}
-			}
-		}
-		return apply_offer;
-	},
+        getBrandOffer(offer) {
+                let apply_offer = null;
+                if (offer.apply_on === "Brand") {
+                        if (this.checkOfferCoupon(offer)) {
+                                const items = [];
+                                let total_count = 0;
+                                let total_amount = 0;
+                                const offerBrand = String(offer.brand || "").trim().toLowerCase();
+                                const combined = [...this.items, ...this.packed_items];
+                                combined.forEach((item) => {
+                                        const lineBrand = this.getLineBrand(item);
+                                        if (!item.posa_is_offer && lineBrand === offerBrand) {
+                                                if (
+                                                        offer.offer === "Item Price" &&
+                                                        item.posa_offer_applied &&
+                                                        !this.checkOfferIsAppley(item, offer)
+                                                ) {
+                                                        return;
+                                                }
+                                                total_count += item.stock_qty;
+                                                const rate = item.original_price_list_rate || item.price_list_rate;
+                                                total_amount += item.stock_qty * rate;
+                                                items.push(item.posa_row_id);
+                                        }
+                                });
+                                if (total_count || total_amount) {
+                                        const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
+                                        if (res.apply) {
+                                                offer.items = items;
+                                                apply_offer = offer;
+                                        }
+                                }
+                        }
+                }
+                return apply_offer;
+        },
 	getTransactionOffer(offer) {
 		let apply_offer = null;
 		if (offer.apply_on === "Transaction") {


### PR DESCRIPTION
## Summary
- normalize line brand lookup across items and packed children
- use unified items set for brand offer evaluation
- populate item brand from detail lookups to cover bundle children

## Testing
- `npx eslint frontend/src/posapp/components/pos/invoiceOfferMethods.js frontend/src/posapp/components/pos/invoiceItemMethods.js`

------
https://chatgpt.com/codex/tasks/task_e_68b157304df88326b333e06d999c12ed