### PR TITLE
fix: apply brand offers across all items

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -158,7 +158,7 @@ export default {
 						if (
 							offer.offer === "Item Price" &&
 							item.posa_offer_applied &&
-							!this.checkOfferIsAppley(item, offer)
+							this.checkOfferIsAppley(item, offer)
 						) {
 							return;
 						}
@@ -190,7 +190,7 @@ export default {
 						if (
 							offer.offer === "Item Price" &&
 							item.posa_offer_applied &&
-							!this.checkOfferIsAppley(item, offer)
+							this.checkOfferIsAppley(item, offer)
 						) {
 							return;
 						}
@@ -225,7 +225,7 @@ export default {
 						if (
 							offer.offer === "Item Price" &&
 							item.posa_offer_applied &&
-							!this.checkOfferIsAppley(item, offer)
+							this.checkOfferIsAppley(item, offer)
 						) {
 							return;
 						}


### PR DESCRIPTION
## Summary
- ensure items are only skipped when the same offer already exists
- apply consistent offer checks across item, group and brand offers

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b1606d4a848326bc4fd2b74d2bbe6a