### PR TITLE
fix: resolve brand detection for offers

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -88,6 +88,16 @@ export default {
 		return combined.find((el) => el.posa_row_id == row_id);
 	},
 
+	// Normalize brand from different possible fields
+	getLineBrand(line) {
+		let brand = line.brand || line.item_brand;
+		if (!brand && this.item_details_cache) {
+			brand = this.item_details_cache[line.item_code]?.brand;
+		}
+		if (!brand) return null;
+		return String(brand).trim().toLowerCase();
+	},
+
 	checkQtyAnountOffer(offer, qty, amount) {
 		let min_qty = false;
 		let max_qty = false;
@@ -220,8 +230,12 @@ export default {
 				let total_count = 0;
 				let total_amount = 0;
 				const combined = [...this.items, ...this.packed_items];
+				const offerBrand = String(offer.brand || "")
+					.trim()
+					.toLowerCase();
 				combined.forEach((item) => {
-					if (!item.posa_is_offer && item.brand === offer.brand) {
+					const lineBrand = this.getLineBrand(item);
+					if (!item.posa_is_offer && lineBrand && lineBrand === offerBrand) {
 						if (
 							offer.offer === "Item Price" &&
 							item.posa_offer_applied &&


### PR DESCRIPTION
## Summary
- extract brand from multiple fields to compare offers reliably
- apply brand offer using normalized line brands

## Testing
- `npx eslint frontend/src/posapp/components/pos/invoiceOfferMethods.js && echo ESLINT_OK`
- `npx prettier frontend/src/posapp/components/pos/invoiceOfferMethods.js --check && echo PRETTIER_OK`


------
https://chatgpt.com/codex/tasks/task_e_68b1606d4a848326bc4fd2b74d2bbe6a