### PR TITLE
feat: normalize brand lookup

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -375,6 +375,7 @@ export default {
 			currency_precision: 6, // Currency precision for display
 			new_line: false, // Add new line for item
 			available_stock_cache: {},
+			brand_cache: {},
 			delivery_charges: [], // List of delivery charges
 			delivery_charges_rate: 0, // Selected delivery charge rate
 			selected_delivery_charge: "", // Selected delivery charge object

--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -20,12 +20,13 @@ from .invoices import (
 	validate_return_items,
 )
 from .items import (
-	get_item_attributes,
-	get_item_detail,
-	get_items,
-	get_items_count,
-	get_items_details,
-	get_items_from_barcode,
+        get_item_attributes,
+       get_item_brand,
+        get_item_detail,
+        get_items,
+        get_items_count,
+        get_items_details,
+        get_items_from_barcode,
 	get_items_groups,
 )
 from .offers import (


### PR DESCRIPTION
## Summary
- add brand normalization helper for items with fallback to template brand
- cache brand lookups on the frontend and query backend when missing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*
- `cd frontend && yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b1d6e859948326b61fc25cad18f7d3