### PR TITLE
fix: prevent auto-adding items by code

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1797,9 +1797,12 @@ export default {
                                        }
                                });
                        }
-                       if (!match && new_item.item_code === search) {
-                               match = true;
-                       }
+                      if (!match && new_item.barcode === search) {
+                              match = true;
+                      }
+                      if (!match && Array.isArray(new_item.barcodes)) {
+                              match = new_item.barcodes.some((bc) => String(bc) === search);
+                      }
 
                        if (this.flags.serial_no) {
                                new_item.to_set_serial_no = this.flags.serial_no;


### PR DESCRIPTION
## Summary
- ensure only barcodes trigger automatic addition in item selector

## Testing
- `npx eslint frontend/src/posapp/components/pos/ItemsSelector.vue && echo 'ESLint passed'`


------
https://chatgpt.com/codex/tasks/task_e_68b1ee20cca88326b7ef61a8d17b422e