### PR TITLE
feat: add POS Awesome User Settings doctype structure

### DIFF
--- a/posawesome/posawesome/doctype/pos_awesome_user_settings/pos_awesome_user_settings.js
+++ b/posawesome/posawesome/doctype/pos_awesome_user_settings/pos_awesome_user_settings.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2024, Youssef Restom and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("POS Awesome User Settings", {
+	// refresh: function(frm) {
+	// }
+});

--- a/posawesome/posawesome/doctype/pos_awesome_user_settings/pos_awesome_user_settings.json
+++ b/posawesome/posawesome/doctype/pos_awesome_user_settings/pos_awesome_user_settings.json
@@ -1,0 +1,34 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-01-01 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [],
+ "fields": [],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2024-01-01 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "POSAwesome",
+ "name": "POS Awesome User Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/posawesome/posawesome/doctype/pos_awesome_user_settings/pos_awesome_user_settings.py
+++ b/posawesome/posawesome/doctype/pos_awesome_user_settings/pos_awesome_user_settings.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2024, Youssef Restom and contributors
+# For license information, please see license.txt
+
+
+# import frappe
+from frappe.model.document import Document
+
+
+class POSAwesomeUserSettings(Document):
+    pass

--- a/posawesome/posawesome/doctype/pos_awesome_user_settings/test_pos_awesome_user_settings.py
+++ b/posawesome/posawesome/doctype/pos_awesome_user_settings/test_pos_awesome_user_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Youssef Restom and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+
+class TestPOSAwesomeUserSettings(unittest.TestCase):
+    pass


### PR DESCRIPTION
## Summary
- add placeholder DocType `POS Awesome User Settings`
- scaffold server class, client stub and basic test for future settings migration

## Testing
- `ruff check posawesome/posawesome/doctype/pos_awesome_user_settings/pos_awesome_user_settings.py posawesome/posawesome/doctype/pos_awesome_user_settings/test_pos_awesome_user_settings.py`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68b32b21684483269343046767cb677e