### PR TITLE
chore: use Node 20 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt-get install -y python3-dev python3-pip python3-setuptools python3-venv \
               libmysqlclient-dev redis-server curl software-properties-common git
 
-          curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+          curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
           sudo apt-get install -y nodejs yarn
 
       - name: Cache pip dependencies

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary
- use Node.js 20 when installing dependencies in CI
- run format workflow with Node.js 20

## Testing
- `yarn install --frozen-lockfile`


------
https://chatgpt.com/codex/tasks/task_e_68b5664ec6248326bcb5cd85e2882f63