### PR TITLE
feat: expand item groups functionality in API

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -14,7 +14,8 @@ from frappe.utils import cstr, flt, get_datetime, nowdate
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.caching import redis_cache
 
-from .utils import HAS_VARIANTS_EXCLUSION, get_item_groups
+from .utils import HAS_VARIANTS_EXCLUSION, get_item_groups, expand_item_groups
+
 
 
 def normalize_brand(brand: str) -> str:
@@ -117,6 +118,7 @@ def get_items(
         except Exception:
             item_groups = []
     item_groups = item_groups or get_item_groups(pos_profile_name)
+    item_groups = expand_item_groups(item_groups)
     item_groups_tuple = tuple(sorted(item_groups)) if item_groups else tuple()
 
     @redis_cache(ttl=ttl or 300)
@@ -416,6 +418,7 @@ def get_items_count(pos_profile, item_groups=None):
         except Exception:
             item_groups = []
     item_groups = item_groups or get_item_groups(pos_profile.get("name"))
+    item_groups = expand_item_groups(item_groups)
     filters = {"disabled": 0, "is_sales_item": 1, "is_fixed_asset": 0}
     if item_groups:
         filters["item_group"] = ["in", item_groups]

--- a/posawesome/posawesome/api/utils.py
+++ b/posawesome/posawesome/api/utils.py
@@ -8,6 +8,48 @@ import frappe
 HAS_VARIANTS_EXCLUSION = {"has_variants": 0}
 
 
+def expand_item_groups(item_groups):
+    """Expand any parent item groups to include their children.
+    
+    This function takes a list of item groups and expands any parent groups
+    to include all their descendants, while keeping leaf groups as-is.
+    """
+    if not item_groups:
+        return item_groups
+
+    try:
+        from erpnext.utilities.doctype.item_group.item_group import get_child_groups
+    except Exception:
+        get_child_groups = None
+
+    expanded_groups = set()
+    for group in item_groups:
+        if not group:
+            continue
+        
+        # Check if this is a parent group
+        is_group = frappe.db.get_value("Item Group", group, "is_group")
+        
+        if is_group:
+            # If it's a parent group, get all its children
+            if get_child_groups:
+                try:
+                    descendants = get_child_groups(group) or []
+                    expanded_groups.update(descendants)
+                except Exception:
+                    # Fallback to database method
+                    descendants = frappe.db.get_descendants("Item Group", group) or []
+                    expanded_groups.update(descendants)
+            else:
+                descendants = frappe.db.get_descendants("Item Group", group) or []
+                expanded_groups.update(descendants)
+        else:
+            # If it's a leaf group, add it directly
+            expanded_groups.add(group)
+
+    return list(expanded_groups)
+
+
 @frappe.whitelist()
 def get_active_pos_profile(user=None):
     """Return the active POS profile for the given user."""
@@ -36,40 +78,19 @@ def get_default_warehouse(company=None):
 def get_item_groups(pos_profile: str) -> list[str]:
     """Return all item groups for a POS profile, including descendants.
 
-    The linked groups from the ``POS Profile Item Group`` child table are
-    expanded to include all of their descendants using ERPNext's
-    ``get_child_groups`` utility. Results are cached to avoid duplicate
-    database calls within a process. If the child DocType is missing, an
-    empty list is returned instead of raising a database error.
-    """
+    The linked groups from the ``POS Item Group`` child table are
+    expanded to include all of their descendants. Results are cached 
+    to avoid duplicate database calls within a process.
+    
 
-    if not pos_profile or not frappe.db.exists("DocType", "POS Profile Item Group"):
+    """
+    if not pos_profile or not frappe.db.exists("DocType", "POS Item Group"):
         return []
 
-    try:
-        from erpnext.utilities.doctype.item_group.item_group import get_child_groups
-    except Exception:
-        get_child_groups = None
-
     groups = frappe.get_all(
-        "POS Profile Item Group",
+        "POS Item Group",
         filters={"parent": pos_profile},
         pluck="item_group",
     )
 
-    all_groups: set[str] = set()
-    for group in groups:
-        if not group:
-            continue
-        if get_child_groups:
-            try:
-                descendants = get_child_groups(group) or []
-            except Exception:
-                descendants = []
-        else:
-            descendants = frappe.db.get_descendants("Item Group", group) or []
-
-        all_groups.add(group)
-        all_groups.update(descendants)
-
-    return list(all_groups)
+    return expand_item_groups(groups)


### PR DESCRIPTION
- Added `expand_item_groups` function to include child groups for item groups.
- Updated `get_items` and `get_items_count` functions to utilize the new expansion logic.
- Refactored `get_item_groups` to call `expand_item_groups` for improved item group retrieval.