### PR TITLE
ci: pin black version and document formatting

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install Black
-        run: pip install black
+      - name: Install Python formatting tools
+        run: pip install -r requirements-dev.txt
 
       - name: Black Check
         run: black --check .

--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ For more details, see the [POS Awesome Wiki](https://github.com/yrestom/POS-Awes
 
 ---
 
+### Code Formatting
+
+This project uses Prettier and Black for consistent formatting. To format locally before
+pushing changes, run:
+
+```bash
+yarn prettier --write "**/*.{js,vue,css,scss,html}"
+pip install -r requirements-dev.txt
+black .
+```
+
+These commands will rewrite files in-place so the CI checks pass.
+
+---
+
 ### Contributing
 
 1. [Issue Guidelines](https://github.com/frappe/erpnext/wiki/Issue-Guidelines)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Development dependencies for code formatting
+black==25.1.0


### PR DESCRIPTION
## Summary
- document local formatting commands for Prettier and Black
- pin Black version via requirements-dev.txt and use it in formatting workflow

## Testing
- `npx prettier --check "**/*.{js,vue,css,scss,html}"`
- `black --check .` *(fails: would reformat utils.py, items.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f015727483269818d40ae38085bf