### PR TITLE
ci: auto-format code on push

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,36 +1,57 @@
 name: Format
 
 on:
-  push:
-    branches: ['**']
-  pull_request:
-    branches: ['**']
+    push:
+        branches: ["**"]
+    pull_request:
+        branches: ["**"]
 
 jobs:
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    format:
+        if: github.actor != 'github-actions[bot]'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
 
-      - name: Install Node dependencies
-        run: yarn install --frozen-lockfile
+            - name: Install Node dependencies
+              run: yarn install --frozen-lockfile
 
-      - name: Prettier Check
-        run: npx prettier --check "**/*.{js,vue,css,scss,html}"
+            - name: Prettier Format
+              if: github.event_name == 'push'
+              run: npx prettier --write "**/*.{js,vue,css,scss,html}"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+            - name: Prettier Check
+              if: github.event_name == 'pull_request'
+              run: npx prettier --check "**/*.{js,vue,css,scss,html}"
 
-      - name: Install Python formatting tools
-        run: pip install -r requirements-dev.txt
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.10"
 
-      - name: Black Check
-        run: black --check .
+            - name: Install Python formatting tools
+              run: pip install -r requirements-dev.txt
+
+            - name: Black Format
+              if: github.event_name == 'push'
+              run: black .
+
+            - name: Black Check
+              if: github.event_name == 'pull_request'
+              run: black --check .
+
+            - name: Commit changes
+              if: github.event_name == 'push'
+              uses: stefanzweifel/git-auto-commit-action@v5
+              with:
+                  commit_message: "chore: format code"
+                  commit_user_name: GitHub Actions
+                  commit_user_email: actions@github.com

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -17,7 +17,6 @@ from frappe.utils.caching import redis_cache
 from .utils import HAS_VARIANTS_EXCLUSION, get_item_groups, expand_item_groups
 
 
-
 def normalize_brand(brand: str) -> str:
     """Return a normalized representation of a brand name."""
     return cstr(brand).strip().lower()

--- a/posawesome/posawesome/api/utils.py
+++ b/posawesome/posawesome/api/utils.py
@@ -10,7 +10,7 @@ HAS_VARIANTS_EXCLUSION = {"has_variants": 0}
 
 def expand_item_groups(item_groups):
     """Expand any parent item groups to include their children.
-    
+
     This function takes a list of item groups and expands any parent groups
     to include all their descendants, while keeping leaf groups as-is.
     """
@@ -26,10 +26,10 @@ def expand_item_groups(item_groups):
     for group in item_groups:
         if not group:
             continue
-        
+
         # Check if this is a parent group
         is_group = frappe.db.get_value("Item Group", group, "is_group")
-        
+
         if is_group:
             # If it's a parent group, get all its children
             if get_child_groups:
@@ -79,9 +79,9 @@ def get_item_groups(pos_profile: str) -> list[str]:
     """Return all item groups for a POS profile, including descendants.
 
     The linked groups from the ``POS Item Group`` child table are
-    expanded to include all of their descendants. Results are cached 
+    expanded to include all of their descendants. Results are cached
     to avoid duplicate database calls within a process.
-    
+
 
     """
     if not pos_profile or not frappe.db.exists("DocType", "POS Item Group"):


### PR DESCRIPTION
## Summary
- format frontend with Prettier --write and backend with Black on push events
- auto-commit formatting changes on push
- keep Prettier and Black checks for pull requests

## Testing
- `npx prettier --check .github/workflows/format.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe74176c832698fcb661a9356e4f