### PR TITLE
fix: add apply/remove buttons

### DIFF
--- a/frontend/src/posapp/components/pos/PosOffers.vue
+++ b/frontend/src/posapp/components/pos/PosOffers.vue
@@ -24,20 +24,30 @@
 					:items-per-page="itemsPerPage"
 					hide-default-footer
 				>
-					<template v-slot:item.offer_applied="{ item }">
-						<v-checkbox-btn
-							@click="toggleOfferApplied"
-							v-model="item.offer_applied"
-							:disabled="
-								(item.offer == 'Give Product' &&
-									!item.give_item &&
-									(!item.replace_cheapest_item || !item.replace_item)) ||
-								(item.offer == 'Grand Total' &&
-									discount_percentage_offer_name &&
-									discount_percentage_offer_name != item.name)
-							"
-						></v-checkbox-btn>
-					</template>
+                                       <template v-slot:item.offer_applied="{ item }">
+                                               <v-btn
+                                                       v-if="!item.offer_applied"
+                                                       color="green"
+                                                       @click="applyOffer(item)"
+                                                       :disabled="
+                                                               (item.offer == 'Give Product' &&
+                                                                       !item.give_item &&
+                                                                       (!item.replace_cheapest_item || !item.replace_item)) ||
+                                                               (item.offer == 'Grand Total' &&
+                                                                       discount_percentage_offer_name &&
+                                                                       discount_percentage_offer_name != item.name)
+                                                       "
+                                               >
+                                                       {{ __("Apply") }}
+                                               </v-btn>
+                                               <v-btn
+                                                       v-else
+                                                       color="red"
+                                                       @click="removeOffer(item)"
+                                               >
+                                                       {{ __("Remove") }}
+                                               </v-btn>
+                                       </template>
 					<template v-slot:expanded-row="{ item }">
 						<td :colspan="items_headers.length">
 							<v-row class="mt-2">
@@ -163,10 +173,14 @@ export default {
 			list_offers = [...this.pos_offers];
 			this.pos_offers = list_offers;
 		},
-		toggleOfferApplied() {
-			// re-emit updated offers so watchers respond
-			this.forceUpdateItem();
-		},
+               applyOffer(item) {
+                       item.offer_applied = true;
+                       this.forceUpdateItem();
+               },
+               removeOffer(item) {
+                       item.offer_applied = false;
+                       this.forceUpdateItem();
+               },
 		makeid(length) {
 			let result = "";
 			const characters = "abcdefghijklmnopqrstuvwxyz0123456789";

--- a/frontend/src/posapp/components/pos/PosOffers.vue
+++ b/frontend/src/posapp/components/pos/PosOffers.vue
@@ -24,30 +24,26 @@
 					:items-per-page="itemsPerPage"
 					hide-default-footer
 				>
-                                       <template v-slot:item.offer_applied="{ item }">
-                                               <v-btn
-                                                       v-if="!item.offer_applied"
-                                                       color="green"
-                                                       @click="applyOffer(item)"
-                                                       :disabled="
-                                                               (item.offer == 'Give Product' &&
-                                                                       !item.give_item &&
-                                                                       (!item.replace_cheapest_item || !item.replace_item)) ||
-                                                               (item.offer == 'Grand Total' &&
-                                                                       discount_percentage_offer_name &&
-                                                                       discount_percentage_offer_name != item.name)
-                                                       "
-                                               >
-                                                       {{ __("Apply") }}
-                                               </v-btn>
-                                               <v-btn
-                                                       v-else
-                                                       color="red"
-                                                       @click="removeOffer(item)"
-                                               >
-                                                       {{ __("Remove") }}
-                                               </v-btn>
-                                       </template>
+					<template v-slot:item.offer_applied="{ item }">
+						<v-btn
+							v-if="!item.offer_applied"
+							color="green"
+							@click="applyOffer(item)"
+							:disabled="
+								(item.offer == 'Give Product' &&
+									!item.give_item &&
+									(!item.replace_cheapest_item || !item.replace_item)) ||
+								(item.offer == 'Grand Total' &&
+									discount_percentage_offer_name &&
+									discount_percentage_offer_name != item.name)
+							"
+						>
+							{{ __("Apply") }}
+						</v-btn>
+						<v-btn v-else color="red" @click="removeOffer(item)">
+							{{ __("Remove") }}
+						</v-btn>
+					</template>
 					<template v-slot:expanded-row="{ item }">
 						<td :colspan="items_headers.length">
 							<v-row class="mt-2">
@@ -173,14 +169,14 @@ export default {
 			list_offers = [...this.pos_offers];
 			this.pos_offers = list_offers;
 		},
-               applyOffer(item) {
-                       item.offer_applied = true;
-                       this.forceUpdateItem();
-               },
-               removeOffer(item) {
-                       item.offer_applied = false;
-                       this.forceUpdateItem();
-               },
+		applyOffer(item) {
+			item.offer_applied = true;
+			this.forceUpdateItem();
+		},
+		removeOffer(item) {
+			item.offer_applied = false;
+			this.forceUpdateItem();
+		},
 		makeid(length) {
 			let result = "";
 			const characters = "abcdefghijklmnopqrstuvwxyz0123456789";


### PR DESCRIPTION
## Summary
- replace single toggle with dedicated Apply (green) and Remove (red) buttons for POS offers

## Testing
- `npx eslint frontend/src/posapp/components/pos/PosOffers.vue`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b740b59f708326b55689a50fb8d256