### PR TITLE
fix: whitelist selling price lists

### DIFF
--- a/posawesome/posawesome/api/utilities.py
+++ b/posawesome/posawesome/api/utilities.py
@@ -126,7 +126,7 @@ def get_company_domain(company):
     return frappe.get_cached_value("Company", cstr(company), "domain")
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET", "POST"])
 def get_selling_price_lists():
     """Return all selling price lists"""
     return frappe.get_all(


### PR DESCRIPTION
## Summary
- allow fetching selling price lists via GET or POST

## Testing
- `python -m py_compile posawesome/posawesome/api/utilities.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68b817a6cf6483268037060bc40b33a6