### PR TITLE
feat: replace item offer checkbox with apply/remove buttons

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -442,7 +442,7 @@ export default {
 				{ title: __("Discount Amount"), key: "discount_amount", align: "start", required: false },
 				{ title: __("Rate"), key: "rate", align: "start", required: true },
 				{ title: __("Amount"), key: "amount", align: "start", required: true },
-				{ title: __("Offer?"), key: "posa_is_offer", align: "center", required: false },
+				{ title: __("Offer"), key: "posa_is_offer", align: "center", required: false },
 			];
 
 			// Initialize selected columns if empty

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -125,13 +125,28 @@
 				</div>
 			</template>
 
-			<!-- Offer checkbox column -->
+			<!-- Offer action column -->
 			<template v-slot:item.posa_is_offer="{ item }">
-				<v-checkbox-btn
-					v-model="item.posa_is_offer"
-					class="center"
-					@change="toggleOffer(item)"
-				></v-checkbox-btn>
+				<v-btn
+					v-if="!item.posa_offer_applied"
+					color="green"
+					@click="
+						item.posa_is_offer = 1;
+						toggleOffer(item);
+					"
+				>
+					{{ __("Apply Offer") }}
+				</v-btn>
+				<v-btn
+					v-else
+					color="red"
+					@click="
+						item.posa_is_offer = 0;
+						toggleOffer(item);
+					"
+				>
+					{{ __("Remove Offer") }}
+				</v-btn>
 			</template>
 
 			<!-- Expanded row content using Vuetify's built-in system -->

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1139,10 +1139,10 @@ export default {
 				item.discount_amount = 0;
 				item.rate = item.price_list_rate;
 				this.calc_item_price(item);
-				this.handelOffers();
 			}
+			this.handelOffers();
 			// Ensure Vue reactivity
 			this.$forceUpdate();
 		});
-	}, // Added missing comma here
+	},
 };


### PR DESCRIPTION
## Summary
- switch item table offer checkbox to Apply Offer/Remove Offer buttons
- label offer column without question mark
- show Remove Offer button when an offer is already applied
- always recompute offers when toggling to keep button text accurate

## Testing
- `npx prettier frontend/src/posapp/components/pos/ItemsTable.vue frontend/src/posapp/components/pos/invoiceOfferMethods.js --write`
- `npx eslint frontend/src/posapp/components/pos/ItemsTable.vue frontend/src/posapp/components/pos/invoiceOfferMethods.js`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b81b6ef5d88326839ffbbe30d48237