### PR TITLE
feat: replace item offer checkbox with apply/remove buttons

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -442,7 +442,7 @@ export default {
 				{ title: __("Discount Amount"), key: "discount_amount", align: "start", required: false },
 				{ title: __("Rate"), key: "rate", align: "start", required: true },
 				{ title: __("Amount"), key: "amount", align: "start", required: true },
-				{ title: __("Offer?"), key: "posa_is_offer", align: "center", required: false },
+				{ title: __("Offer"), key: "posa_is_offer", align: "center", required: false },
 			];
 
 			// Initialize selected columns if empty

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -128,7 +128,7 @@
 			<!-- Offer action column -->
 			<template v-slot:item.posa_is_offer="{ item }">
 				<v-btn
-					v-if="!item.posa_is_offer && !item.posa_offer_applied"
+					v-if="!item.posa_offer_applied"
 					color="green"
 					@mousedown.stop
 					@click.stop="applyOffer(item)"
@@ -833,12 +833,10 @@ export default {
 		},
 		applyOffer(item) {
 			item.posa_offer_disabled = false;
-			item.posa_is_offer = 1;
 			this.toggleOffer(item);
 		},
 		removeOffer(item) {
 			item.posa_offer_disabled = true;
-			item.posa_is_offer = 0;
 			this.toggleOffer(item);
 		},
 	},

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -832,10 +832,12 @@ export default {
 			}
 		},
 		applyOffer(item) {
+			item.posa_offer_disabled = false;
 			item.posa_is_offer = 1;
 			this.toggleOffer(item);
 		},
 		removeOffer(item) {
+			item.posa_offer_disabled = true;
 			item.posa_is_offer = 0;
 			this.toggleOffer(item);
 		},

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -125,13 +125,19 @@
 				</div>
 			</template>
 
-			<!-- Offer checkbox column -->
+			<!-- Offer action column -->
 			<template v-slot:item.posa_is_offer="{ item }">
-				<v-checkbox-btn
-					v-model="item.posa_is_offer"
-					class="center"
-					@change="toggleOffer(item)"
-				></v-checkbox-btn>
+				<v-btn
+					v-if="!item.posa_is_offer && !item.posa_offer_applied"
+					color="green"
+					@mousedown.stop
+					@click.stop="applyOffer(item)"
+				>
+					{{ __("Apply Offer") }}
+				</v-btn>
+				<v-btn v-else color="red" @mousedown.stop @click.stop="removeOffer(item)">
+					{{ __("Remove Offer") }}
+				</v-btn>
 			</template>
 
 			<!-- Expanded row content using Vuetify's built-in system -->
@@ -824,6 +830,14 @@ export default {
 			if (this.editNameTarget === item) {
 				this.editedName = item.item_name;
 			}
+		},
+		applyOffer(item) {
+			item.posa_is_offer = 1;
+			this.toggleOffer(item);
+		},
+		removeOffer(item) {
+			item.posa_is_offer = 0;
+			this.toggleOffer(item);
 		},
 	},
 };

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -180,7 +180,8 @@ export default {
 			if (this.checkOfferCoupon(offer)) {
 				const combined = [...this.items, ...this.packed_items];
 				combined.forEach((item) => {
-					if (!item.posa_is_offer && !item.posa_offer_disabled && item.item_code === offer.item) {
+					if (!item.posa_is_offer && item.item_code === offer.item) {
+						const auto = !item.posa_offer_disabled;
 						if (
 							offer.offer === "Item Price" &&
 							item.posa_offer_applied &&
@@ -194,6 +195,7 @@ export default {
 						if (res.apply) {
 							items.push(item.posa_row_id);
 							offer.items = items;
+							offer.auto = auto;
 							apply_offer = offer;
 						}
 					}
@@ -1141,7 +1143,7 @@ export default {
 
 	toggleOffer(item) {
 		this.$nextTick(() => {
-			if (!item.posa_is_offer) {
+			if (item.posa_offer_applied) {
 				this.isApplyingOffer = true;
 				const offerIds = item.posa_offers ? JSON.parse(item.posa_offers) : [];
 				offerIds.forEach((id) => {

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1133,16 +1133,19 @@ export default {
 	toggleOffer(item) {
 		this.$nextTick(() => {
 			if (!item.posa_is_offer) {
+				this.isApplyingOffer = true;
 				item.posa_offers = JSON.stringify([]);
 				item.posa_offer_applied = 0;
 				item.discount_percentage = 0;
 				item.discount_amount = 0;
 				item.rate = item.price_list_rate;
 				this.calc_item_price(item);
+				this.isApplyingOffer = false;
+			} else {
 				this.handelOffers();
 			}
 			// Ensure Vue reactivity
 			this.$forceUpdate();
 		});
-	}, // Added missing comma here
+	},
 };

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -52,6 +52,7 @@ export function useItemAddition() {
 				posa_offers: JSON.stringify([]),
 				posa_offer_applied: 0,
 				posa_is_offer: 0,
+				posa_offer_disabled: 0,
 			};
 			context.packed_items.push(child);
 			if (context.update_item_detail) {
@@ -385,6 +386,7 @@ export function useItemAddition() {
 		new_item.posa_offers = JSON.stringify([]);
 		new_item.posa_offer_applied = 0;
 		new_item.posa_is_offer = item.posa_is_offer;
+		new_item.posa_offer_disabled = 0;
 		new_item.posa_is_replace = item.posa_is_replace || null;
 		new_item.is_free_item = 0;
 		new_item.is_bundle = 0;


### PR DESCRIPTION
## Summary
- switch item table offer checkbox to Apply Offer/Remove Offer buttons
- label offer column without question mark
- shift button to "Remove Offer" automatically when offers apply
- stop row expansion when toggling offers
- allow removing offers without auto reapplying

## Testing
- `npx prettier frontend/src/posapp/components/pos/ItemsTable.vue frontend/src/posapp/components/pos/invoiceOfferMethods.js --write`
- `npx eslint frontend/src/posapp/components/pos/ItemsTable.vue frontend/src/posapp/components/pos/invoiceOfferMethods.js`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b81b6ef5d88326839ffbbe30d48237