### PR TITLE
feat: show per-component loading progress

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -1,6 +1,12 @@
 <template>
 	<v-app class="container1" :class="rtlClasses">
-		<LoadingOverlay :loading="loadingActive" :progress="loadingProgress" :message="loadingMessage" />
+                <LoadingOverlay
+                        :loading="loadingActive"
+                        :progress="loadingProgress"
+                        :message="loadingMessage"
+                        :sources="loadingSources"
+                        :source-messages="loadingSourceMessages"
+                />
 		<v-main class="main-content">
 			<Navbar
 				:pos-profile="posProfile"
@@ -118,20 +124,26 @@ export default {
 			// Loading progress handled via utility
 		};
 	},
-	computed: {
-		isDark() {
-			return this.$theme?.current === "dark";
-		},
-		loadingProgress() {
-			return loadingState.progress;
-		},
-		loadingActive() {
-			return loadingState.active;
-		},
-		loadingMessage() {
-			return loadingState.message;
-		},
-	},
+        computed: {
+                isDark() {
+                        return this.$theme?.current === "dark";
+                },
+                loadingProgress() {
+                        return loadingState.progress;
+                },
+                loadingActive() {
+                        return loadingState.active;
+                },
+                loadingMessage() {
+                        return loadingState.message;
+                },
+                loadingSources() {
+                        return loadingState.sources;
+                },
+                loadingSourceMessages() {
+                        return loadingState.sourceMessages;
+                },
+        },
 	watch: {
 		networkOnline(newVal, oldVal) {
 			if (newVal && !oldVal) {

--- a/frontend/src/posapp/components/pos/LoadingOverlay.vue
+++ b/frontend/src/posapp/components/pos/LoadingOverlay.vue
@@ -1,46 +1,65 @@
 <template>
-	<v-overlay
-		:model-value="loading"
-		class="d-flex flex-column align-center justify-center fancy-overlay"
-		contained
-	>
-		<v-progress-linear
-			:model-value="progress"
-			height="8"
-			color="primary"
-			rounded
-			class="elegant-progress"
-		/>
-		<div class="mt-4 text-subtitle-1">{{ message }}</div>
-	</v-overlay>
+        <v-overlay
+                :model-value="loading"
+                class="d-flex flex-column align-center justify-center fancy-overlay"
+                contained
+        >
+                <div v-for="(value, name) in sources" :key="name" class="mb-4 w-100">
+                        <div class="d-flex justify-space-between">
+                                <span class="text-subtitle-2">{{ getLabel(name) }}</span>
+                                <span v-if="value >= 100" class="text-caption text-success">{{ __('Ready') }}</span>
+                        </div>
+                        <v-progress-linear
+                                :model-value="value"
+                                height="8"
+                                color="primary"
+                                rounded
+                                class="elegant-progress"
+                        />
+                </div>
+                <div class="mt-4 text-subtitle-1">{{ message }}</div>
+        </v-overlay>
 </template>
 
 <script>
 export default {
-	name: "LoadingOverlay",
-	props: {
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		message: {
-			type: String,
-			default: "",
-		},
-		progress: {
-			type: Number,
-			default: 0,
-		},
-	},
+        name: "LoadingOverlay",
+        props: {
+                loading: {
+                        type: Boolean,
+                        default: false,
+                },
+                message: {
+                        type: String,
+                        default: "",
+                },
+                progress: {
+                        type: Number,
+                        default: 0,
+                },
+                sources: {
+                        type: Object,
+                        default: () => ({}),
+                },
+                sourceMessages: {
+                        type: Object,
+                        default: () => ({}),
+                },
+        },
+        methods: {
+                getLabel(name) {
+                        return this.sourceMessages[name] || name;
+                },
+        },
 };
 </script>
 
 <style scoped>
 .fancy-overlay {
-	backdrop-filter: blur(2px);
+        backdrop-filter: blur(2px);
 }
 .elegant-progress {
-	width: 60%;
-	max-width: 320px;
+        width: 100%;
+        max-width: 320px;
 }
 </style>


### PR DESCRIPTION
## Summary
- show individual progress bars for each loading source in overlay
- pass loading source data from Home to overlay with ready labels when complete

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b8666724f883268d3e88588cde7dea