### PR TITLE
fix: remove forced loading timeout

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -50,13 +50,7 @@ import Navbar from "./components/Navbar.vue";
 import POS from "./components/pos/Pos.vue";
 import Payments from "./components/payments/Pay.vue";
 import LoadingOverlay from "./components/pos/LoadingOverlay.vue";
-import {
-	loadingState,
-	initLoadingSources,
-	setSourceProgress,
-	markSourceLoaded,
-	clearLoadingTimeout,
-} from "./utils/loading.js";
+import { loadingState, initLoadingSources, setSourceProgress, markSourceLoaded } from "./utils/loading.js";
 import {
 	getOpeningStorage,
 	getCacheUsageEstimate,
@@ -490,8 +484,6 @@ export default {
 			this.eventBus.off("pending_invoices_changed");
 			this.eventBus.off("data-loaded");
 		}
-		// Clear loading timeout when component unmounts
-		clearLoadingTimeout();
 	},
 	created: function () {
 		setTimeout(() => {

--- a/frontend/src/posapp/utils/loading.js
+++ b/frontend/src/posapp/utils/loading.js
@@ -37,9 +37,6 @@ export function initLoadingSources(list) {
 
 	loadingState.progress = 0;
 	loadingState.active = true;
-
-	// Start the fallback timeout
-	startLoadingTimeout();
 }
 
 export function setSourceProgress(name, value) {
@@ -105,8 +102,6 @@ function completeLoading() {
 	if (isCompleting) return;
 	isCompleting = true;
 
-	clearLoadingTimeout(); // Clear the fallback timeout
-
 	loadingState.progress = 100;
 	loadingState.message = __("Setup complete!");
 
@@ -127,30 +122,6 @@ function completeLoading() {
 	}, 400);
 }
 
-// Add fallback timeout to ensure loading bar disappears
-let loadingTimeout = null;
-
-export function startLoadingTimeout() {
-	// Clear any existing timeout
-	if (loadingTimeout) {
-		clearTimeout(loadingTimeout);
-	}
-
-	// Set a maximum loading time of 30 seconds
-	loadingTimeout = setTimeout(() => {
-		console.warn("Loading timeout reached, forcing loading state to complete");
-		loadingState.message = __("Taking longer than expected...");
-		completeLoading();
-	}, 30000);
-}
-
-export function clearLoadingTimeout() {
-	if (loadingTimeout) {
-		clearTimeout(loadingTimeout);
-		loadingTimeout = null;
-	}
-}
-
 export function markSourceLoaded(name) {
 	console.log(`Loading source marked as loaded: ${name}`);
 	setSourceProgress(name, 100);
@@ -158,7 +129,6 @@ export function markSourceLoaded(name) {
 
 // Utility function to manually reset loading state
 export function resetLoadingState() {
-	clearLoadingTimeout();
 	loadingState.active = false;
 	loadingState.progress = 0;
 	loadingState.message = __("Loading app data...");


### PR DESCRIPTION
## Summary
- remove forced 30s loading timeout to rely on actual progress
- drop unused timeout cleanup in Home component

## Testing
- `npx prettier --write src/posapp/utils/loading.js src/posapp/Home.vue`
- `npx eslint frontend/src/posapp/utils/loading.js frontend/src/posapp/Home.vue` *(fails: 'MAX_QUEUE_ITEMS' is defined but never used; '$' is not defined)*
- `npx eslint frontend/src/posapp/utils/loading.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8699152d0832692ee4392106cbf65