### PR TITLE
feat: animate item card to table row

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1698,12 +1698,15 @@ export default {
 			await this.add_item(item);
 			await this.$nextTick();
 
-			const rows = document.querySelectorAll(".items-table-container tbody tr");
-			const destRow = rows[rows.length - 1];
+			const destRow = document.querySelector(".items-table-container tbody tr:last-child");
 			if (destRow) {
 				const destRect = destRow.getBoundingClientRect();
 				const translateX = destRect.left - startRect.left;
 				const translateY = destRect.top - startRect.top;
+
+				const distance = Math.hypot(translateX, translateY);
+				const duration = Math.min(distance / 1000, 1);
+				table.style.transition = `transform ${duration}s cubic-bezier(0.4, 0, 0.2, 1), opacity ${duration}s`;
 
 				requestAnimationFrame(() => {
 					table.style.transform = `translate(${translateX}px, ${translateY}px)`;
@@ -1740,12 +1743,15 @@ export default {
 			await this.add_item(item);
 			await this.$nextTick();
 
-			const rows = document.querySelectorAll(".items-table-container tbody tr");
-			const destRow = rows[rows.length - 1];
+			const destRow = document.querySelector(".items-table-container tbody tr:last-child");
 			if (destRow) {
 				const destRect = destRow.getBoundingClientRect();
 				const translateX = destRect.left - startRect.left;
 				const translateY = destRect.top - startRect.top;
+
+				const distance = Math.hypot(translateX, translateY);
+				const duration = Math.min(distance / 1000, 1);
+				clone.style.transition = `transform ${duration}s cubic-bezier(0.4, 0, 0.2, 1), opacity ${duration}s`;
 
 				requestAnimationFrame(() => {
 					clone.style.transform = `translate(${translateX}px, ${translateY}px)`;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -198,7 +198,7 @@
 									v-for="item in filtered_items"
 									:key="item.item_code"
 									class="card-item-card"
-                                                                        @click="onItemClick($event, item)"
+									@click="onItemClick($event, item)"
 									:draggable="true"
 									@dragstart="onDragStart($event, item)"
 									@dragend="onDragEnd"
@@ -1677,53 +1677,53 @@ export default {
 
 			return items_headers;
 		},
-                async click_item_row(event, { item }) {
-                        await this.add_item(item);
-                },
-                async onItemClick(event, item) {
-                        const target = event.currentTarget;
-                        const clone = target.cloneNode(true);
-                        clone.classList.add('flying-item');
+		async click_item_row(event, { item }) {
+			await this.add_item(item);
+		},
+		async onItemClick(event, item) {
+			const target = event.currentTarget;
+			const clone = target.cloneNode(true);
+			clone.classList.add("flying-item");
 
-                        const startRect = target.getBoundingClientRect();
-                        Object.assign(clone.style, {
-                                left: `${startRect.left}px`,
-                                top: `${startRect.top}px`,
-                                width: `${startRect.width}px`,
-                                height: `${startRect.height}px`,
-                        });
-                        document.body.appendChild(clone);
+			const startRect = target.getBoundingClientRect();
+			Object.assign(clone.style, {
+				left: `${startRect.left}px`,
+				top: `${startRect.top}px`,
+				width: `${startRect.width}px`,
+				height: `${startRect.height}px`,
+			});
+			document.body.appendChild(clone);
 
-                        await this.add_item(item);
-                        await this.$nextTick();
+			await this.add_item(item);
+			await this.$nextTick();
 
-                        const rows = document.querySelectorAll('.items-table-container tbody tr');
-                        const destRow = rows[rows.length - 1];
-                        if (destRow) {
-                                const destRect = destRow.getBoundingClientRect();
-                                const translateX = destRect.left - startRect.left;
-                                const translateY = destRect.top - startRect.top;
+			const rows = document.querySelectorAll(".items-table-container tbody tr");
+			const destRow = rows[rows.length - 1];
+			if (destRow) {
+				const destRect = destRow.getBoundingClientRect();
+				const translateX = destRect.left - startRect.left;
+				const translateY = destRect.top - startRect.top;
 
-                                requestAnimationFrame(() => {
-                                        clone.style.transform = `translate(${translateX}px, ${translateY}px)`;
-                                        clone.style.opacity = '0';
-                                });
+				requestAnimationFrame(() => {
+					clone.style.transform = `translate(${translateX}px, ${translateY}px)`;
+					clone.style.opacity = "0";
+				});
 
-                                clone.addEventListener(
-                                        'transitionend',
-                                        () => {
-                                                clone.remove();
-                                                destRow.classList.add('row-highlight');
-                                                setTimeout(() => destRow.classList.remove('row-highlight'), 300);
-                                        },
-                                        { once: true },
-                                );
-                        } else {
-                                clone.remove();
-                        }
-                },
-                async add_item(item) {
-                        item = { ...item };
+				clone.addEventListener(
+					"transitionend",
+					() => {
+						clone.remove();
+						destRow.classList.add("row-highlight");
+						setTimeout(() => destRow.classList.remove("row-highlight"), 300);
+					},
+					{ once: true },
+				);
+			} else {
+				clone.remove();
+			}
+		},
+		async add_item(item) {
+			item = { ...item };
 			if (item.has_variants) {
 				let variants = this.items.filter((it) => it.variant_of == item.item_code);
 				let attrsMeta = {};
@@ -3076,29 +3076,31 @@ export default {
 <style scoped>
 /* Flying item animation */
 .flying-item {
-        position: fixed;
-        pointer-events: none;
-        transition: transform 0.3s ease, opacity 0.3s;
-        z-index: 1000;
+	position: fixed;
+	pointer-events: none;
+	transition:
+		transform 0.3s ease,
+		opacity 0.3s;
+	z-index: 1000;
 }
 
 :deep(.row-highlight) {
-        animation: rowHighlight 0.3s ease;
+	animation: rowHighlight 0.3s ease;
 }
 
 @keyframes rowHighlight {
-        from {
-                background-color: #fff9c4;
-        }
-        to {
-                background-color: inherit;
-        }
+	from {
+		background-color: #fff9c4;
+	}
+	to {
+		background-color: inherit;
+	}
 }
 
 /* "dynamic-card" no longer composes from pos-card; the pos-card class is added directly in the template */
 .dynamic-padding {
-        /* Equal spacing on all sides for consistent alignment */
-        padding: var(--dynamic-sm);
+	/* Equal spacing on all sides for consistent alignment */
+	padding: var(--dynamic-sm);
 }
 
 .sticky-header {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1678,7 +1678,50 @@ export default {
 			return items_headers;
 		},
 		async click_item_row(event, { item }) {
+			const target = event.currentTarget;
+			const row = target.cloneNode(true);
+			const table = document.createElement("table");
+			const tbody = document.createElement("tbody");
+			table.appendChild(tbody);
+			tbody.appendChild(row);
+			table.classList.add("flying-item");
+
+			const startRect = target.getBoundingClientRect();
+			Object.assign(table.style, {
+				left: `${startRect.left}px`,
+				top: `${startRect.top}px`,
+				width: `${startRect.width}px`,
+				height: `${startRect.height}px`,
+			});
+			document.body.appendChild(table);
+
 			await this.add_item(item);
+			await this.$nextTick();
+
+			const rows = document.querySelectorAll(".items-table-container tbody tr");
+			const destRow = rows[rows.length - 1];
+			if (destRow) {
+				const destRect = destRow.getBoundingClientRect();
+				const translateX = destRect.left - startRect.left;
+				const translateY = destRect.top - startRect.top;
+
+				requestAnimationFrame(() => {
+					table.style.transform = `translate(${translateX}px, ${translateY}px)`;
+					table.style.opacity = "0";
+				});
+
+				table.addEventListener(
+					"transitionend",
+					() => {
+						table.remove();
+						destRow.classList.add("row-highlight");
+						setTimeout(() => destRow.classList.remove("row-highlight"), 300);
+					},
+					{ once: true },
+				);
+			} else {
+				table.remove();
+			}
 		},
 		async onItemClick(event, item) {
 			const target = event.currentTarget;
@@ -3079,13 +3122,13 @@ export default {
 	position: fixed;
 	pointer-events: none;
 	transition:
-		transform 0.3s ease,
-		opacity 0.3s;
+		transform 0.5s cubic-bezier(0.4, 0, 0.2, 1),
+		opacity 0.5s;
 	z-index: 1000;
 }
 
 :deep(.row-highlight) {
-	animation: rowHighlight 0.3s ease;
+	animation: rowHighlight 0.5s ease-out;
 }
 
 @keyframes rowHighlight {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1686,6 +1686,12 @@ export default {
 			tbody.appendChild(row);
 			table.classList.add("flying-item");
 
+			// copy vue's scoped style attribute so animation styles apply
+			const scopeAttr = target.getAttributeNames().find((name) => name.startsWith("data-v-"));
+			if (scopeAttr) {
+				table.setAttribute(scopeAttr, "");
+			}
+
 			const startRect = target.getBoundingClientRect();
 			Object.assign(table.style, {
 				left: `${startRect.left}px`,

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -1380,4 +1380,18 @@ export default {
 .expanded-row {
 	background-color: var(--surface-secondary);
 }
+
+/* Row highlight animation */
+.row-highlight {
+	animation: rowHighlight 0.5s ease-out;
+}
+
+@keyframes rowHighlight {
+	from {
+		background-color: #fff9c4;
+	}
+	to {
+		background-color: inherit;
+	}
+}
 </style>


### PR DESCRIPTION
## Summary
- animate item cards to fly to table row when clicked
- add CSS for flying item clone and destination row highlight

## Testing
- `yarn build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b86b7c51348326990316d44bd07015