### PR TITLE
Stabilize item add animation and optimize selector

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1698,12 +1698,15 @@ export default {
 			await this.add_item(item);
 			await this.$nextTick();
 
-			const rows = document.querySelectorAll(".items-table-container tbody tr");
-			const destRow = rows[rows.length - 1];
+			const destRow = document.querySelector(".items-table-container tbody tr:last-child");
 			if (destRow) {
 				const destRect = destRow.getBoundingClientRect();
 				const translateX = destRect.left - startRect.left;
 				const translateY = destRect.top - startRect.top;
+
+				const distance = Math.hypot(translateX, translateY);
+				const duration = Math.min(distance / 1000, 1);
+				table.style.transition = `transform ${duration}s cubic-bezier(0.4, 0, 0.2, 1), opacity ${duration}s`;
 
 				requestAnimationFrame(() => {
 					table.style.transform = `translate(${translateX}px, ${translateY}px)`;
@@ -1740,12 +1743,15 @@ export default {
 			await this.add_item(item);
 			await this.$nextTick();
 
-			const rows = document.querySelectorAll(".items-table-container tbody tr");
-			const destRow = rows[rows.length - 1];
+			const destRow = document.querySelector(".items-table-container tbody tr:last-child");
 			if (destRow) {
 				const destRect = destRow.getBoundingClientRect();
 				const translateX = destRect.left - startRect.left;
 				const translateY = destRect.top - startRect.top;
+
+				const distance = Math.hypot(translateX, translateY);
+				const duration = Math.min(distance / 1000, 1);
+				clone.style.transition = `transform ${duration}s cubic-bezier(0.4, 0, 0.2, 1), opacity ${duration}s`;
 
 				requestAnimationFrame(() => {
 					clone.style.transform = `translate(${translateX}px, ${translateY}px)`;

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -1380,4 +1380,18 @@ export default {
 .expanded-row {
 	background-color: var(--surface-secondary);
 }
+
+/* Row highlight animation */
+.row-highlight {
+	animation: rowHighlight 0.5s ease-out;
+}
+
+@keyframes rowHighlight {
+	from {
+		background-color: #fff9c4;
+	}
+	to {
+		background-color: inherit;
+	}
+}
 </style>


### PR DESCRIPTION
## Summary
- ensure item rows highlight with a dedicated animation
- keep item-add animation speed consistent regardless of table size
- query only the last row to keep item selector responsive

## Testing
- `yarn prettier frontend/src/posapp/components/pos/ItemsSelector.vue frontend/src/posapp/components/pos/ItemsTable.vue`
- `npx eslint frontend/src/posapp/components/pos/ItemsSelector.vue frontend/src/posapp/components/pos/ItemsTable.vue`


------
https://chatgpt.com/codex/tasks/task_e_68b9268e1ae88326a9a143add75e30b6