### PR TITLE
refactor: remove legacy loading overlay

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -1,14 +1,7 @@
 <template>
 	<v-app class="container1" :class="rtlClasses">
-		<LoadingOverlay
-			:loading="loadingActive"
-			:progress="loadingProgress"
-			:message="loadingMessage"
-			:sources="loadingSources"
-			:source-messages="loadingSourceMessages"
-		/>
-		<AppLoadingOverlay :visible="globalLoading" />
-		<v-main class="main-content">
+                <AppLoadingOverlay :visible="globalLoading" />
+                <v-main class="main-content">
 			<Navbar
 				:pos-profile="posProfile"
 				:pending-invoices="pendingInvoices"
@@ -46,11 +39,10 @@
 </template>
 
 <script>
-/* global frappe */
+/* global frappe, $ */
 import Navbar from "./components/Navbar.vue";
 import POS from "./components/pos/Pos.vue";
 import Payments from "./components/payments/Pay.vue";
-import LoadingOverlay from "./components/pos/LoadingOverlay.vue";
 import AppLoadingOverlay from "./components/ui/LoadingOverlay.vue";
 import { useLoading } from "./composables/useLoading.js";
 import { loadingState, initLoadingSources, setSourceProgress, markSourceLoaded } from "./utils/loading.js";
@@ -60,7 +52,6 @@ import {
 	checkDbHealth,
 	queueHealthCheck,
 	purgeOldQueueEntries,
-	MAX_QUEUE_ITEMS,
 	initPromise,
 	memoryInitPromise,
 	isCacheReady,
@@ -133,15 +124,9 @@ export default {
 		loadingActive() {
 			return loadingState.active;
 		},
-		loadingMessage() {
-			return loadingState.message;
-		},
-		loadingSources() {
-			return loadingState.sources;
-		},
-		loadingSourceMessages() {
-			return loadingState.sourceMessages;
-		},
+                loadingMessage() {
+                        return loadingState.message;
+                },
 	},
 	watch: {
 		networkOnline(newVal, oldVal) {
@@ -159,12 +144,11 @@ export default {
 		},
 	},
 	components: {
-		Navbar,
-		POS,
-		Payments,
-		LoadingOverlay,
-		AppLoadingOverlay,
-	},
+                Navbar,
+                POS,
+                Payments,
+                AppLoadingOverlay,
+        },
 	mounted() {
 		this.remove_frappe_nav();
 		// Initialize cache ready state early from stored value


### PR DESCRIPTION
## Summary
- remove outdated loading overlay component so new global loading screen shows
- clean up unused imports and declare global `$` for linting

## Testing
- `npx eslint frontend/src/posapp/Home.vue`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68b93aa254c08326aba6013f4221eeec