### PR TITLE
feat: centralize dark theme tokens and utilities

### DIFF
--- a/dark-theme-audit.md
+++ b/dark-theme-audit.md
@@ -1,0 +1,19 @@
+# Dark Theme Audit
+
+- frontend/tailwind.config.js
+    - No explicit dark mode config; relies on Tailwind's default `media` strategy.
+- posawesome/public/css/responsive.css
+    - Core tokens only cover surfaces; missing aliases for bg/fg, table states, focus ring, and scrollbars.
+- frontend/src/posapp/components/pos/Invoice.vue
+    - Inline hardcoded colors (`#121212`, `#1E1E1E`, `white`) bypass theme variables.
+    - Selected checkbox uses fixed `color: white`.
+- frontend/src/posapp/components/pos/ItemsTable.vue
+    - Hardcoded light/dark colors throughout style block.
+    - Quantity stepper lacks tokenized background/border; contrast breaks in dark mode.
+    - Expanded row uses fixed colors instead of tokens.
+    - Scroll container has no themed scrollbar styling.
+- frontend/src/posapp/components/pos/Payments.vue
+    - Multiple fields conditionally set `:bg-color` with `#1E1E1E` or `white` and rely on `dark-field` class.
+    - Card wrapper toggles classes via `isDarkTheme` instead of token utilities.
+- frontend/src/posapp/components/pos/InvoiceSummary.vue
+    - Card background switches between `bg-grey-lighten-4` and `#1E1E1E` via inline bindings.

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -10,15 +10,11 @@
 			:style="{
 				height: invoiceHeight || 'var(--container-height)',
 				maxHeight: invoiceHeight || 'var(--container-height)',
-				backgroundColor: isDarkTheme ? '#121212' : '',
+				backgroundColor: 'var(--card)',
 				resize: 'vertical',
 				overflow: 'auto',
 			}"
-			:class="[
-				'cards my-0 py-0 mt-3 resizable',
-				isDarkTheme ? '' : 'bg-grey-lighten-5',
-				{ 'return-mode': isReturnInvoice },
-			]"
+			:class="['cards my-0 py-0 mt-3 resizable u-card', { 'return-mode': isReturnInvoice }]"
 			@mouseup="saveInvoiceHeight"
 			@touchend="saveInvoiceHeight"
 		>
@@ -45,7 +41,7 @@
 							hide-details
 							variant="solo"
 							color="primary"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							:bg-color="'var(--input-bg)'"
 							class="dark-field sleek-field"
 							:items="invoiceTypes"
 							:label="frappe._('Type')"
@@ -1366,7 +1362,7 @@ export default {
 /* Style for selected checkbox button */
 .v-checkbox-btn.v-selected {
 	background-color: var(--submit-start) !important;
-	color: white;
+	color: var(--fg-inverted);
 }
 
 /* Bottom border for elements */
@@ -1411,7 +1407,7 @@ export default {
 	top: 0;
 	right: 0;
 	background-color: rgb(var(--v-theme-error));
-	color: white;
+	color: var(--fg-inverted);
 	padding: 4px 12px;
 	font-weight: bold;
 	border-bottom-left-radius: 8px;

--- a/frontend/src/posapp/components/pos/InvoiceSummary.vue
+++ b/frontend/src/posapp/components/pos/InvoiceSummary.vue
@@ -1,7 +1,7 @@
 <template>
 	<v-card
-		:class="['cards mb-0 mt-3 py-2 px-3 rounded-lg resizable', isDarkTheme ? '' : 'bg-grey-lighten-4']"
-		:style="(isDarkTheme ? 'background-color:#1E1E1E;' : '') + 'resize: vertical; overflow: auto;'"
+		class="cards mb-0 mt-3 py-2 px-3 rounded-lg resizable u-card"
+		style="resize: vertical; overflow: auto"
 	>
 		<v-row dense>
 			<!-- Summary Info -->
@@ -232,9 +232,6 @@ export default {
 		"show-payment",
 	],
 	computed: {
-		isDarkTheme() {
-			return this.$theme?.current === "dark";
-		},
 		hide_qty_decimals() {
 			try {
 				const saved = localStorage.getItem("posawesome_item_selector_settings");

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -209,7 +209,7 @@
 											color="primary"
 											:label="frappe._('Item Code')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											v-model="item.item_code"
 											disabled
@@ -223,7 +223,7 @@
 											color="primary"
 											:label="frappe._('QTY')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="
 												formatFloat(item.qty, hide_qty_decimals ? 0 : undefined)
@@ -248,7 +248,7 @@
 										<v-select
 											density="compact"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											:label="frappe._('UOM')"
 											v-model="item.uom"
 											:items="item.item_uoms"
@@ -282,7 +282,7 @@
 											id="rate"
 											:label="frappe._('Rate')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="formatCurrency(item.rate)"
 											@change="[
@@ -305,7 +305,7 @@
 											id="discount_percentage"
 											:label="frappe._('Discount %')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="formatFloat(item.discount_percentage || 0)"
 											@change="[
@@ -334,7 +334,7 @@
 											id="discount_amount"
 											:label="frappe._('Discount Amount')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="formatCurrency(item.discount_amount || 0)"
 											@change="[
@@ -364,7 +364,7 @@
 											color="primary"
 											:label="frappe._('Price List Rate')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="formatCurrency(item.price_list_rate || 0)"
 											:disabled="!pos_profile.posa_allow_price_list_rate_change"
@@ -380,7 +380,7 @@
 											color="primary"
 											:label="frappe._('Total Amount')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="formatCurrency(item.qty * item.rate)"
 											disabled
@@ -419,7 +419,7 @@
 											color="primary"
 											:label="frappe._('Available QTY')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="formatFloat(item.actual_qty)"
 											disabled
@@ -433,7 +433,7 @@
 											color="primary"
 											:label="frappe._('Stock QTY')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="formatFloat(item.stock_qty)"
 											disabled
@@ -447,7 +447,7 @@
 											color="primary"
 											:label="frappe._('Stock UOM')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											v-model="item.stock_uom"
 											disabled
@@ -463,7 +463,7 @@
 											color="primary"
 											:label="frappe._('Warehouse')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											v-model="item.warehouse"
 											disabled
@@ -477,7 +477,7 @@
 											color="primary"
 											:label="frappe._('Group')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											v-model="item.item_group"
 											disabled
@@ -512,7 +512,7 @@
 											color="primary"
 											:label="frappe._('Serial No QTY')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											v-model="item.serial_no_selected_count"
 											type="number"
@@ -533,7 +533,7 @@
 											chips
 											color="primary"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											:label="frappe._('Serial No')"
 											multiple
 											@update:model-value="setSerialNo(item)"
@@ -559,7 +559,7 @@
 											color="primary"
 											:label="frappe._('Batch No. Available QTY')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											:model-value="formatFloat(item.actual_batch_qty)"
 											disabled
@@ -573,7 +573,7 @@
 											color="primary"
 											:label="frappe._('Batch No Expiry Date')"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											hide-details
 											v-model="item.batch_no_expiry_date"
 											disabled
@@ -589,7 +589,7 @@
 											density="compact"
 											color="primary"
 											bg-color="var(--input-bg)"
-											class="sleek-field u-input"
+											class="u-input"
 											:label="frappe._('Batch No')"
 											@update:model-value="setBatchQty(item, $event)"
 											hide-details

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -208,8 +208,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Item Code')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											v-model="item.item_code"
 											disabled
@@ -222,8 +222,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('QTY')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="
 												formatFloat(item.qty, hide_qty_decimals ? 0 : undefined)
@@ -247,8 +247,8 @@
 									<div class="form-field">
 										<v-select
 											density="compact"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											:label="frappe._('UOM')"
 											v-model="item.uom"
 											:items="item.item_uoms"
@@ -281,8 +281,8 @@
 											color="primary"
 											id="rate"
 											:label="frappe._('Rate')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="formatCurrency(item.rate)"
 											@change="[
@@ -304,8 +304,8 @@
 											color="primary"
 											id="discount_percentage"
 											:label="frappe._('Discount %')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="formatFloat(item.discount_percentage || 0)"
 											@change="[
@@ -333,8 +333,8 @@
 											color="primary"
 											id="discount_amount"
 											:label="frappe._('Discount Amount')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="formatCurrency(item.discount_amount || 0)"
 											@change="[
@@ -363,8 +363,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Price List Rate')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="formatCurrency(item.price_list_rate || 0)"
 											:disabled="!pos_profile.posa_allow_price_list_rate_change"
@@ -379,8 +379,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Total Amount')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="formatCurrency(item.qty * item.rate)"
 											disabled
@@ -418,8 +418,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Available QTY')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="formatFloat(item.actual_qty)"
 											disabled
@@ -432,8 +432,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Stock QTY')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="formatFloat(item.stock_qty)"
 											disabled
@@ -446,8 +446,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Stock UOM')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											v-model="item.stock_uom"
 											disabled
@@ -462,8 +462,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Warehouse')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											v-model="item.warehouse"
 											disabled
@@ -476,8 +476,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Group')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											v-model="item.item_group"
 											disabled
@@ -511,8 +511,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Serial No QTY')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											v-model="item.serial_no_selected_count"
 											type="number"
@@ -532,8 +532,8 @@
 											density="compact"
 											chips
 											color="primary"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											:label="frappe._('Serial No')"
 											multiple
 											@update:model-value="setSerialNo(item)"
@@ -558,8 +558,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Batch No. Available QTY')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											:model-value="formatFloat(item.actual_batch_qty)"
 											disabled
@@ -572,8 +572,8 @@
 											variant="outlined"
 											color="primary"
 											:label="frappe._('Batch No Expiry Date')"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											hide-details
 											v-model="item.batch_no_expiry_date"
 											disabled
@@ -588,8 +588,8 @@
 											variant="outlined"
 											density="compact"
 											color="primary"
-											:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-											class="dark-field"
+											bg-color="var(--input-bg)"
+											class="sleek-field u-input"
 											:label="frappe._('Batch No')"
 											@update:model-value="setBatchQty(item, $event)"
 											hide-details

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="my-0 py-0 overflow-y-auto items-table-container"
+		class="my-0 py-0 overflow-y-auto items-table-container u-scrollbar"
 		:style="{ height: 'calc(100% - 80px)', maxHeight: 'calc(100% - 80px)' }"
 		@dragover="onDragOverFromSelector($event)"
 		@drop="onDropFromSelector($event)"
@@ -14,7 +14,7 @@
 			:expanded="expanded"
 			show-expand
 			item-value="posa_row_id"
-			class="modern-items-table elevation-2"
+			class="modern-items-table elevation-2 u-table"
 			:items-per-page="itemsPerPage"
 			expand-on-click
 			density="compact"
@@ -60,7 +60,11 @@
 
 			<!-- Quantity column -->
 			<template v-slot:item.qty="{ item }">
-				<div class="qty-counter-container" :class="{ 'rtl-layout': isRTL }" :title="`RTL: ${isRTL}`">
+				<div
+					class="qty-counter-container u-input"
+					:class="{ 'rtl-layout': isRTL }"
+					:title="`RTL: ${isRTL}`"
+				>
 					<v-btn
 						:disabled="!!item.posa_is_replace"
 						size="small"
@@ -188,7 +192,7 @@
 			<!-- Expanded row content using Vuetify's built-in system -->
 			<template v-slot:expanded-row="{ item }">
 				<td :colspan="headers.length" class="ma-0 pa-0 expanded-row-cell">
-					<div class="expanded-content responsive-expanded-content">
+					<div class="expanded-content responsive-expanded-content u-card">
 						<!-- Item Details Form -->
 						<div class="item-details-form">
 							<!-- Basic Information Section -->
@@ -706,7 +710,7 @@ export default {
 	},
 	computed: {
 		headerProps() {
-			return this.isDarkTheme ? { style: "background-color:#121212;color:#fff" } : {};
+			return { style: "background-color:var(--table-header);color:var(--fg)" };
 		},
 		isDarkTheme() {
 			return this.$theme.current === "dark";
@@ -859,24 +863,36 @@ export default {
 	border-radius: 8px;
 	overflow: hidden;
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-	border: 1px solid rgba(0, 0, 0, 0.1);
+	border: 1px solid var(--border);
 	height: 100%;
 	display: flex;
 	flex-direction: column;
 	transition: all 0.3s ease;
-	background: #ffffff;
-}
-
-:deep([data-theme="dark"]) .modern-items-table,
-:deep(.v-theme--dark) .modern-items-table {
-	background: #1a202c;
-	border: 1px solid rgba(255, 255, 255, 0.1);
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+	background: var(--card);
 }
 
 /* Ensure items table can scroll when many rows exist */
 .items-table-container {
 	overflow-y: auto;
+}
+
+.qty-counter-container {
+	display: flex;
+	align-items: center;
+}
+
+.qty-counter-container.u-input {
+	padding: 0;
+}
+
+.qty-counter-container.u-input:focus-within {
+	outline: 2px solid var(--focus-ring);
+	outline-offset: 2px;
+}
+
+.qty-control-btn {
+	border-left: 1px solid var(--input-border);
+	border-radius: 0;
 }
 
 /* Table wrapper styling */
@@ -896,9 +912,9 @@ export default {
 	letter-spacing: 0.3px;
 	padding: 12px;
 	transition: background-color 0.2s ease;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-	background-color: #f8f9fa;
-	color: #495057;
+	border-bottom: 1px solid var(--divider);
+	background-color: var(--table-header);
+	color: var(--fg);
 	position: sticky;
 	top: 0;
 	z-index: 1;
@@ -911,13 +927,6 @@ export default {
 	vertical-align: middle !important;
 	line-height: 1.2 !important;
 	height: 40px;
-}
-
-:deep([data-theme="dark"]) .modern-items-table :deep(th),
-:deep(.v-theme--dark) .modern-items-table :deep(th) {
-	background-color: #2d3748;
-	color: #e2e8f0;
-	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 /* Header text wrapper for better control */
@@ -949,19 +958,11 @@ export default {
 /* Table row styling */
 .modern-items-table :deep(tr) {
 	transition: background-color 0.2s ease;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+	border-bottom: 1px solid var(--divider);
 }
 
 .modern-items-table :deep(tr:hover) {
-	background-color: rgba(0, 0, 0, 0.02);
-}
-
-:deep([data-theme="dark"]) .modern-items-table :deep(tr) {
-	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-:deep([data-theme="dark"]) .modern-items-table :deep(tr:hover) {
-	background-color: rgba(255, 255, 255, 0.03);
+	background-color: var(--table-row-hover);
 }
 
 /* Table cell styling */
@@ -970,7 +971,7 @@ export default {
 	vertical-align: middle;
 	height: 60px;
 	text-align: center;
-	color: #374151;
+	color: var(--fg);
 	position: relative;
 }
 
@@ -982,11 +983,6 @@ export default {
 	align-items: center;
 	justify-content: center;
 	box-sizing: border-box;
-}
-
-:deep([data-theme="dark"]) .modern-items-table :deep(td),
-:deep(.v-theme--dark) .modern-items-table :deep(td) {
-	color: #e5e7eb;
 }
 
 /* =================================================================
@@ -1005,10 +1001,9 @@ export default {
 	padding: 24px;
 	width: 100%;
 	box-sizing: border-box;
-	background: #f8f9fa;
+	background: var(--card);
 	border-radius: 0 0 8px 8px;
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	border-top: none;
+	border-top: 1px solid var(--divider);
 	animation: expandIn 0.3s ease forwards;
 
 	/* Enable container queries */
@@ -1017,11 +1012,6 @@ export default {
 }
 
 /* Dark theme */
-:deep([data-theme="dark"]) .expanded-content,
-:deep(.v-theme--dark) .expanded-content {
-	background: #2d3748;
-	border-color: rgba(255, 255, 255, 0.1);
-}
 
 @keyframes expandIn {
 	from {
@@ -1198,9 +1188,9 @@ export default {
 	padding: 24px;
 	box-sizing: border-box;
 
-	background: #ffffff;
+	background: var(--card);
 	border-radius: 12px;
-	border: 1px solid rgba(0, 0, 0, 0.1);
+	border: 1px solid var(--divider);
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 
 	/* Smooth transitions */

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1,11 +1,7 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
 	<div class="pa-0">
-		<v-card
-			:class="['selection mx-auto pa-1 my-0 mt-3', isDarkTheme ? '' : 'bg-grey-lighten-5']"
-			:style="isDarkTheme ? 'background-color:#1E1E1E' : ''"
-			style="max-height: 68vh; height: 68vh"
-		>
+		<v-card class="selection mx-auto pa-1 my-0 mt-3 u-card" style="max-height: 68vh; height: 68vh">
 			<v-progress-linear
 				:active="loading"
 				:indeterminate="loading"
@@ -13,7 +9,7 @@
 				location="top"
 				color="info"
 			></v-progress-linear>
-			<div ref="paymentContainer" class="overflow-y-auto pa-2" style="max-height: 67vh">
+			<div ref="paymentContainer" class="overflow-y-auto pa-2 u-scrollbar" style="max-height: 67vh">
 				<!-- Payment Summary (Paid, To Be Paid, Change) -->
 				<v-row v-if="invoice_doc" class="pa-1" dense>
 					<v-col cols="7">
@@ -21,8 +17,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Paid Amount')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							v-model="total_payments_display"
 							readonly
@@ -36,8 +32,8 @@
 							variant="solo"
 							color="primary"
 							label="To Be Paid"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							v-model="diff_payment_display"
 							:prefix="currencySymbol(invoice_doc.currency)"
@@ -53,8 +49,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Paid Change')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							:model-value="formatCurrency(paid_change)"
 							:prefix="currencySymbol(invoice_doc.currency)"
 							:rules="paid_change_rules"
@@ -71,8 +67,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Credit Change')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							:model-value="formatCurrency(credit_change)"
 							:prefix="currencySymbol(invoice_doc.currency)"
 							density="compact"
@@ -96,8 +92,8 @@
 								variant="solo"
 								color="primary"
 								:label="frappe._(payment.mode_of_payment)"
-								:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-								class="dark-field sleek-field"
+								bg-color="var(--input-bg)"
+								class="sleek-field u-input"
 								hide-details
 								:model-value="formatCurrency(payment.amount)"
 								@change="setFormatedCurrency(payment, 'amount', null, false, $event)"
@@ -159,8 +155,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Redeem Loyalty Points')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatCurrency(loyalty_amount)"
 							type="text"
@@ -174,8 +170,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('You can redeem up to')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatFloat(available_points_amount)"
 							:prefix="currencySymbol(invoice_doc.currency)"
@@ -200,8 +196,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Redeemed Customer Credit')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatCurrency(redeemed_customer_credit)"
 							type="text"
@@ -218,8 +214,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('You can redeem credit up to')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatCurrency(available_customer_credit)"
 							:prefix="currencySymbol(invoice_doc.currency)"
@@ -238,8 +234,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Net Total')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							:model-value="formatCurrency(invoice_doc.net_total, displayCurrency)"
 							readonly
 							:prefix="currencySymbol()"
@@ -252,8 +248,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Tax and Charges')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="
 								formatCurrency(invoice_doc.total_taxes_and_charges, displayCurrency)
@@ -269,8 +265,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Total Amount')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatCurrency(invoice_doc.total, displayCurrency)"
 							readonly
@@ -284,8 +280,8 @@
 							variant="solo"
 							color="primary"
 							:label="diff_label"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatCurrency(diff_payment, displayCurrency)"
 							readonly
@@ -299,8 +295,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Discount Amount')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatCurrency(invoice_doc.discount_amount)"
 							readonly
@@ -314,8 +310,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Grand Total')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatCurrency(invoice_doc.grand_total)"
 							readonly
@@ -329,8 +325,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Rounded Total')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							:model-value="formatCurrency(invoice_doc.rounded_total)"
 							readonly
@@ -348,7 +344,7 @@
 							:min-date="new Date()"
 							auto-apply
 							:dark="isDarkTheme"
-							class="dark-field sleek-field"
+							class="sleek-field u-input"
 							@update:model-value="update_delivery_date()"
 						/>
 					</v-col>
@@ -365,8 +361,8 @@
 							:items="addresses"
 							item-title="address_title"
 							item-value="name"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							:no-data-text="__('Address not found')"
 							hide-details
 							:customFilter="addressFilter"
@@ -407,10 +403,10 @@
 					<!-- Additional Notes (if enabled in POS profile) -->
 					<v-col cols="12" v-if="pos_profile.posa_display_additional_notes">
 						<v-textarea
-							class="pa-0 dark-field sleek-field"
+							class="pa-0 sleek-field u-input"
 							variant="solo"
 							density="compact"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							bg-color="var(--input-bg)"
 							clearable
 							color="primary"
 							auto-grow
@@ -431,8 +427,8 @@
 								:label="frappe._('Purchase Order')"
 								variant="solo"
 								density="compact"
-								:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-								class="dark-field sleek-field"
+								bg-color="var(--input-bg)"
+								class="sleek-field u-input"
 								clearable
 								color="primary"
 								hide-details
@@ -446,7 +442,7 @@
 								:min-date="new Date()"
 								auto-apply
 								:dark="isDarkTheme"
-								class="dark-field sleek-field"
+								class="sleek-field u-input"
 								@update:model-value="update_po_date()"
 							/>
 							<v-text-field
@@ -508,17 +504,17 @@
 							:min-date="new Date()"
 							auto-apply
 							:dark="isDarkTheme"
-							class="dark-field sleek-field"
+							class="sleek-field u-input"
 							@update:model-value="update_credit_due_date()"
 						/>
 						<v-text-field
-							class="mt-2 dark-field sleek-field"
+							class="mt-2 sleek-field u-input"
 							density="compact"
 							variant="solo"
 							type="number"
 							min="0"
 							max="365"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							bg-color="var(--input-bg)"
 							v-model.number="credit_due_days"
 							:label="frappe._('Days until due')"
 							hide-details
@@ -568,8 +564,8 @@
 								variant="solo"
 								color="primary"
 								:label="frappe._('Available Credit')"
-								:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-								class="dark-field sleek-field"
+								bg-color="var(--input-bg)"
+								class="sleek-field u-input"
 								hide-details
 								:model-value="formatCurrency(row.total_credit)"
 								readonly
@@ -582,8 +578,8 @@
 								variant="solo"
 								color="primary"
 								:label="frappe._('Redeem Credit')"
-								:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-								class="dark-field sleek-field"
+								bg-color="var(--input-bg)"
+								class="sleek-field u-input"
 								hide-details
 								type="text"
 								:model-value="formatCurrency(row.credit_to_redeem)"
@@ -613,8 +609,8 @@
 							:items="sales_persons"
 							item-title="title"
 							item-value="value"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							:no-data-text="__('Sales Person not found')"
 							hide-details
 							:disabled="readonly"
@@ -683,8 +679,8 @@
 							type="number"
 							min="0"
 							max="365"
-							class="dark-field sleek-field"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
+							class="sleek-field u-input"
+							bg-color="var(--input-bg)"
 							v-model.number="custom_days_value"
 							:label="frappe._('Days')"
 							hide-details
@@ -716,8 +712,8 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Mobile Number')"
-							:bg-color="isDarkTheme ? '#1E1E1E' : 'white'"
-							class="dark-field sleek-field"
+							bg-color="var(--input-bg)"
+							class="sleek-field u-input"
 							hide-details
 							v-model="invoice_doc.contact_mobile"
 							type="number"
@@ -2090,32 +2086,32 @@ export default {
 }
 
 /* Dark mode styling for input fields */
-:deep([data-theme="dark"]) .dark-field,
-:deep(.v-theme--dark) .dark-field,
-::v-deep([data-theme="dark"]) .dark-field,
-::v-deep(.v-theme--dark) .dark-field {
+:deep([data-theme="dark"]) .,
+:deep(.v-theme--dark) .,
+::v-deep([data-theme="dark"]) .,
+::v-deep(.v-theme--dark) . {
 	background-color: #1e1e1e !important;
 }
 
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep([data-theme="dark"]) .dark-field :deep(input),
-:deep(.v-theme--dark) .dark-field :deep(input),
-:deep([data-theme="dark"]) .dark-field :deep(.v-label),
-:deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep([data-theme="dark"]) .dark-field .v-field__input,
-::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep([data-theme="dark"]) .dark-field input,
-::v-deep(.v-theme--dark) .dark-field input,
-::v-deep([data-theme="dark"]) .dark-field .v-label,
-::v-deep(.v-theme--dark) .dark-field .v-label {
+:deep([data-theme="dark"]) .:deep(.v-field__input),
+:deep(.v-theme--dark) .:deep(.v-field__input),
+:deep([data-theme="dark"]) .:deep(input),
+:deep(.v-theme--dark) .:deep(input),
+:deep([data-theme="dark"]) .:deep(.v-label),
+:deep(.v-theme--dark) .:deep(.v-label),
+::v-deep([data-theme="dark"]) ..v-field__input,
+::v-deep(.v-theme--dark) ..v-field__input,
+::v-deep([data-theme="dark"]) .input,
+::v-deep(.v-theme--dark) .input,
+::v-deep([data-theme="dark"]) ..v-label,
+::v-deep(.v-theme--dark) ..v-label {
 	color: #fff !important;
 }
 
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
-::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
+:deep([data-theme="dark"]) .:deep(.v-field__overlay),
+:deep(.v-theme--dark) .:deep(.v-field__overlay),
+::v-deep([data-theme="dark"]) ..v-field__overlay,
+::v-deep(.v-theme--dark) ..v-field__overlay {
 	background-color: #1e1e1e !important;
 }
 </style>

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -2084,34 +2084,4 @@ export default {
 	box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
 	transition: box-shadow 0.3s ease-in-out;
 }
-
-/* Dark mode styling for input fields */
-:deep([data-theme="dark"]) .,
-:deep(.v-theme--dark) .,
-::v-deep([data-theme="dark"]) .,
-::v-deep(.v-theme--dark) . {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .:deep(.v-field__input),
-:deep(.v-theme--dark) .:deep(.v-field__input),
-:deep([data-theme="dark"]) .:deep(input),
-:deep(.v-theme--dark) .:deep(input),
-:deep([data-theme="dark"]) .:deep(.v-label),
-:deep(.v-theme--dark) .:deep(.v-label),
-::v-deep([data-theme="dark"]) ..v-field__input,
-::v-deep(.v-theme--dark) ..v-field__input,
-::v-deep([data-theme="dark"]) .input,
-::v-deep(.v-theme--dark) .input,
-::v-deep([data-theme="dark"]) ..v-label,
-::v-deep(.v-theme--dark) ..v-label {
-	color: #fff !important;
-}
-
-:deep([data-theme="dark"]) .:deep(.v-field__overlay),
-:deep(.v-theme--dark) .:deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) ..v-field__overlay,
-::v-deep(.v-theme--dark) ..v-field__overlay {
-	background-color: #1e1e1e !important;
-}
 </style>

--- a/frontend/src/posapp/styles/utilities.css
+++ b/frontend/src/posapp/styles/utilities.css
@@ -10,7 +10,20 @@
 	border: 1px solid var(--input-border);
 	border-radius: var(--border-radius-md);
 }
-.u-input::placeholder {
+.u-input .v-field__overlay {
+	background: var(--input-bg);
+	border-color: var(--input-border);
+}
+.u-input .v-field__outline {
+	border-color: var(--input-border);
+}
+.u-input .v-field__input,
+.u-input .v-field__field,
+.u-input input,
+.u-input .v-select__selection-text {
+	color: var(--input-fg);
+}
+.u-input input::placeholder {
 	color: var(--input-placeholder);
 }
 .u-input:focus-within {

--- a/frontend/src/posapp/styles/utilities.css
+++ b/frontend/src/posapp/styles/utilities.css
@@ -1,0 +1,49 @@
+.u-card {
+	background: var(--card);
+	color: var(--fg);
+	border: 1px solid var(--border);
+}
+
+.u-input {
+	background: var(--input-bg);
+	color: var(--input-fg);
+	border: 1px solid var(--input-border);
+	border-radius: var(--border-radius-md);
+}
+.u-input::placeholder {
+	color: var(--input-placeholder);
+}
+.u-input:focus-within {
+	outline: 2px solid var(--focus-ring);
+	outline-offset: 2px;
+}
+
+.u-table thead {
+	background: var(--table-header);
+	color: var(--fg);
+}
+.u-table tbody tr {
+	background: var(--table-row);
+	border-bottom: 1px solid var(--divider);
+}
+.u-table tbody tr:hover {
+	background: var(--table-row-hover);
+}
+.u-table tbody tr.selected {
+	background: var(--table-row-selected);
+}
+
+.u-scrollbar {
+	scrollbar-color: var(--border) transparent;
+}
+.u-scrollbar::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+.u-scrollbar::-webkit-scrollbar-track {
+	background: transparent;
+}
+.u-scrollbar::-webkit-scrollbar-thumb {
+	background-color: var(--border);
+	border-radius: 4px;
+}

--- a/frontend/src/posapp/styles/utilities.css
+++ b/frontend/src/posapp/styles/utilities.css
@@ -18,6 +18,10 @@
 	border-color: var(--input-border);
 }
 .u-input .v-field__input,
+.u-input .v-field__field {
+	background: var(--input-bg);
+}
+.u-input .v-field__input,
 .u-input .v-field__field,
 .u-input input,
 .u-input .v-select__selection-text {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,3 +1,5 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import "./posapp/styles/utilities.css";

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,5 +1,4 @@
+@import "./posapp/styles/utilities.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import "./posapp/styles/utilities.css";

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 export default {
+	darkMode: ["class", '[data-theme="dark"]'],
 	content: ["./src/**/*.{vue,js,ts,jsx,tsx,html}"],
 	theme: {
 		extend: {},

--- a/posawesome/public/css/responsive.css
+++ b/posawesome/public/css/responsive.css
@@ -60,6 +60,28 @@
 	--field-bg: var(--surface-secondary);
 	--field-border: #e0e0e0;
 	--field-focus: rgba(25, 118, 210, 0.1);
+
+	/* Alias design tokens */
+	--bg: var(--surface-primary);
+	--fg: var(--text-primary);
+	--card: var(--surface-elevated);
+	--popover: var(--surface-elevated);
+	--border: var(--field-border);
+	--divider: var(--field-border);
+	--hover: var(--table-row-hover);
+	--active: var(--table-row-hover);
+	--selected: rgba(25, 118, 210, 0.15);
+	--focus-ring: var(--primary-start);
+	--table-header: var(--table-header-bg);
+	--table-row: var(--surface-primary);
+	--table-row-hover: var(--table-row-hover);
+	--table-row-selected: var(--selected);
+	--input-bg: var(--field-bg);
+	--input-fg: var(--text-primary);
+	--input-border: var(--field-border);
+	--input-placeholder: var(--text-disabled);
+	--backdrop: rgba(0, 0, 0, 0.5);
+	--fg-inverted: #ffffff;
 }
 
 /* Ensure the main viewport fills the screen without scroll */
@@ -115,6 +137,28 @@ body {
 	--field-bg: var(--surface-secondary);
 	--field-border: #373737;
 	--field-focus: rgba(187, 134, 252, 0.1);
+
+	/* Alias design tokens */
+	--bg: var(--background);
+	--fg: var(--text-primary);
+	--card: var(--surface-secondary);
+	--popover: var(--surface-elevated);
+	--border: var(--field-border);
+	--divider: var(--divider);
+	--hover: rgba(255, 255, 255, 0.06);
+	--active: rgba(255, 255, 255, 0.12);
+	--selected: rgba(187, 134, 252, 0.2);
+	--focus-ring: var(--primary-start);
+	--table-header: var(--table-header-bg);
+	--table-row: var(--surface-primary);
+	--table-row-hover: var(--table-row-hover);
+	--table-row-selected: var(--selected);
+	--input-bg: var(--field-bg);
+	--input-fg: var(--text-primary);
+	--input-border: var(--field-border);
+	--input-placeholder: var(--text-disabled);
+	--backdrop: rgba(0, 0, 0, 0.7);
+	--fg-inverted: #000000;
 }
 
 /* ===== SPACING UTILITIES ===== */


### PR DESCRIPTION
## Summary
- document remaining dark-mode toggles in payments and summary components
- replace inline isDarkTheme styles with tokenized u-card/u-input utilities

## Testing
- `npx prettier --check dark-theme-audit.md frontend/src/posapp/components/pos/Payments.vue frontend/src/posapp/components/pos/InvoiceSummary.vue`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd8151adfc8326a69416675610a77d