### PR TITLE
fix: align item table with global theme

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -1,21 +1,24 @@
 <template>
-	<div
-		class="my-0 py-0 overflow-y-auto items-table-container"
-		:style="{ height: 'calc(100% - 80px)', maxHeight: 'calc(100% - 80px)' }"
-		@dragover="onDragOverFromSelector($event)"
-		@drop="onDropFromSelector($event)"
-		@dragenter="onDragEnterFromSelector"
-		@dragleave="onDragLeaveFromSelector"
-	>
-		<v-data-table-virtual
-			:headers="headers"
-			:items="items"
-			:theme="$theme.current"
-			:expanded="expanded"
-			show-expand
-			item-value="posa_row_id"
-			class="modern-items-table elevation-2"
-			:items-per-page="itemsPerPage"
+        <div
+                :class="['my-0 py-0 overflow-y-auto items-table-container', isDarkTheme ? '' : 'bg-grey-lighten-5']"
+                :style="{
+                        height: 'calc(100% - 80px)',
+                        maxHeight: 'calc(100% - 80px)',
+                        backgroundColor: isDarkTheme ? '#1E1E1E' : ''
+                }"
+                @dragover="onDragOverFromSelector($event)"
+                @drop="onDropFromSelector($event)"
+                @dragenter="onDragEnterFromSelector"
+                @dragleave="onDragLeaveFromSelector"
+        >
+                <v-data-table-virtual
+                        :headers="headers"
+                        :items="items"
+                        :expanded="expanded"
+                        show-expand
+                        item-value="posa_row_id"
+                        class="modern-items-table elevation-2"
+                        :items-per-page="itemsPerPage"
 			expand-on-click
 			density="compact"
 			hide-default-footer

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -1,24 +1,24 @@
 <template>
-        <div
-                :class="['my-0 py-0 overflow-y-auto items-table-container', isDarkTheme ? '' : 'bg-grey-lighten-5']"
-                :style="{
-                        height: 'calc(100% - 80px)',
-                        maxHeight: 'calc(100% - 80px)',
-                        backgroundColor: isDarkTheme ? '#1E1E1E' : ''
-                }"
-                @dragover="onDragOverFromSelector($event)"
-                @drop="onDropFromSelector($event)"
-                @dragenter="onDragEnterFromSelector"
-                @dragleave="onDragLeaveFromSelector"
-        >
-                <v-data-table-virtual
-                        :headers="headers"
-                        :items="items"
-                        :expanded="expanded"
-                        show-expand
-                        item-value="posa_row_id"
-                        class="modern-items-table elevation-2"
-                        :items-per-page="itemsPerPage"
+	<div
+		:class="['my-0 py-0 overflow-y-auto items-table-container', isDarkTheme ? '' : 'bg-grey-lighten-5']"
+		:style="{
+			height: 'calc(100% - 80px)',
+			maxHeight: 'calc(100% - 80px)',
+			backgroundColor: isDarkTheme ? '#1E1E1E' : '',
+		}"
+		@dragover="onDragOverFromSelector($event)"
+		@drop="onDropFromSelector($event)"
+		@dragenter="onDragEnterFromSelector"
+		@dragleave="onDragLeaveFromSelector"
+	>
+		<v-data-table-virtual
+			:headers="headers"
+			:items="items"
+			:expanded="expanded"
+			show-expand
+			item-value="posa_row_id"
+			class="modern-items-table elevation-2"
+			:items-per-page="itemsPerPage"
 			expand-on-click
 			density="compact"
 			hide-default-footer


### PR DESCRIPTION
## Summary
- unify item table styling with the rest of the app
- let global theme control item table so dark mode works again

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68bfcdea4c08832691264fae38425aba