### PR TITLE
fix: apply dark theme row styles

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -956,11 +956,13 @@ export default {
 	background-color: rgba(0, 0, 0, 0.02);
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(tr) {
+:deep([data-theme="dark"]) .modern-items-table :deep(tr),
+:deep(.v-theme--dark) .modern-items-table :deep(tr) {
 	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(tr:hover) {
+:deep([data-theme="dark"]) .modern-items-table :deep(tr:hover),
+:deep(.v-theme--dark) .modern-items-table :deep(tr:hover) {
 	background-color: rgba(255, 255, 255, 0.03);
 }
 


### PR DESCRIPTION
## Summary
- include v-theme--dark selector for item table rows so dark theme styling applies consistently

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68bfd3fa760c8326a9d178f920697751