### PR TITLE
fix: ensure dark theme styling for items table

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -856,22 +856,22 @@ export default {
 <style scoped>
 /* Modern table styling with clean design */
 .modern-items-table {
-        border-radius: 8px;
-        overflow: hidden;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-        border: 1px solid rgba(0, 0, 0, 0.1);
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-        transition: all 0.3s ease;
-        background: #ffffff;
+	border-radius: 8px;
+	overflow: hidden;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	transition: all 0.3s ease;
+	background: #ffffff;
 }
 
 :deep([data-theme="dark"] .modern-items-table),
 :deep(.modern-items-table.v-theme--dark) {
-        background: #1a202c;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+	background: #1a202c;
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 /* Ensure items table can scroll when many rows exist */
@@ -890,34 +890,34 @@ export default {
 
 /* Table header styling */
 .modern-items-table :deep(th) {
-        font-weight: 600;
-        font-size: 0.8rem;
-        text-transform: uppercase;
-        letter-spacing: 0.3px;
-        padding: 12px;
-        transition: background-color 0.2s ease;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.1) !important;
-        background-color: #f8f9fa !important;
-        color: #495057 !important;
-        position: sticky;
-        top: 0;
-        z-index: 1;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        max-width: 150px;
-        min-width: 80px;
-        text-align: center;
-        vertical-align: middle !important;
-        line-height: 1.2 !important;
-        height: 40px;
+	font-weight: 600;
+	font-size: 0.8rem;
+	text-transform: uppercase;
+	letter-spacing: 0.3px;
+	padding: 12px;
+	transition: background-color 0.2s ease;
+	border-bottom: 1px solid rgba(0, 0, 0, 0.1) !important;
+	background-color: #f8f9fa !important;
+	color: #495057 !important;
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 150px;
+	min-width: 80px;
+	text-align: center;
+	vertical-align: middle !important;
+	line-height: 1.2 !important;
+	height: 40px;
 }
 
 :deep([data-theme="dark"] .modern-items-table th),
 :deep(.modern-items-table.v-theme--dark th) {
-        background-color: #2d3748 !important;
-        color: #e2e8f0 !important;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1) !important;
+	background-color: #2d3748 !important;
+	color: #e2e8f0 !important;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.1) !important;
 }
 
 /* Header text wrapper for better control */
@@ -958,12 +958,12 @@ export default {
 
 :deep([data-theme="dark"] .modern-items-table tr),
 :deep(.modern-items-table.v-theme--dark tr) {
-        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 :deep([data-theme="dark"] .modern-items-table tr:hover),
 :deep(.modern-items-table.v-theme--dark tr:hover) {
-        background-color: rgba(255, 255, 255, 0.03);
+	background-color: rgba(255, 255, 255, 0.03);
 }
 
 /* Table cell styling */
@@ -988,7 +988,7 @@ export default {
 
 :deep([data-theme="dark"] .modern-items-table td),
 :deep(.modern-items-table.v-theme--dark td) {
-        color: #e5e7eb;
+	color: #e5e7eb;
 }
 
 /* =================================================================

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -856,22 +856,22 @@ export default {
 <style scoped>
 /* Modern table styling with clean design */
 .modern-items-table {
-	border-radius: 8px;
-	overflow: hidden;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	height: 100%;
-	display: flex;
-	flex-direction: column;
-	transition: all 0.3s ease;
-	background: #ffffff;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        border: 1px solid rgba(0, 0, 0, 0.1);
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        transition: all 0.3s ease;
+        background: #ffffff;
 }
 
-:deep([data-theme="dark"]) .modern-items-table,
-:deep(.v-theme--dark) .modern-items-table {
-	background: #1a202c;
-	border: 1px solid rgba(255, 255, 255, 0.1);
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+:deep([data-theme="dark"] .modern-items-table),
+:deep(.modern-items-table.v-theme--dark) {
+        background: #1a202c;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 /* Ensure items table can scroll when many rows exist */
@@ -890,34 +890,34 @@ export default {
 
 /* Table header styling */
 .modern-items-table :deep(th) {
-	font-weight: 600;
-	font-size: 0.8rem;
-	text-transform: uppercase;
-	letter-spacing: 0.3px;
-	padding: 12px;
-	transition: background-color 0.2s ease;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-	background-color: #f8f9fa;
-	color: #495057;
-	position: sticky;
-	top: 0;
-	z-index: 1;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	max-width: 150px;
-	min-width: 80px;
-	text-align: center;
-	vertical-align: middle !important;
-	line-height: 1.2 !important;
-	height: 40px;
+        font-weight: 600;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+        padding: 12px;
+        transition: background-color 0.2s ease;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1) !important;
+        background-color: #f8f9fa !important;
+        color: #495057 !important;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 150px;
+        min-width: 80px;
+        text-align: center;
+        vertical-align: middle !important;
+        line-height: 1.2 !important;
+        height: 40px;
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(th),
-:deep(.v-theme--dark) .modern-items-table :deep(th) {
-	background-color: #2d3748;
-	color: #e2e8f0;
-	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+:deep([data-theme="dark"] .modern-items-table th),
+:deep(.modern-items-table.v-theme--dark th) {
+        background-color: #2d3748 !important;
+        color: #e2e8f0 !important;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1) !important;
 }
 
 /* Header text wrapper for better control */
@@ -956,12 +956,14 @@ export default {
 	background-color: rgba(0, 0, 0, 0.02);
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(tr) {
-	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+:deep([data-theme="dark"] .modern-items-table tr),
+:deep(.modern-items-table.v-theme--dark tr) {
+        border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(tr:hover) {
-	background-color: rgba(255, 255, 255, 0.03);
+:deep([data-theme="dark"] .modern-items-table tr:hover),
+:deep(.modern-items-table.v-theme--dark tr:hover) {
+        background-color: rgba(255, 255, 255, 0.03);
 }
 
 /* Table cell styling */
@@ -984,9 +986,9 @@ export default {
 	box-sizing: border-box;
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(td),
-:deep(.v-theme--dark) .modern-items-table :deep(td) {
-	color: #e5e7eb;
+:deep([data-theme="dark"] .modern-items-table td),
+:deep(.modern-items-table.v-theme--dark td) {
+        color: #e5e7eb;
 }
 
 /* =================================================================


### PR DESCRIPTION
## Summary
- apply dark theme styles when items table itself carries `v-theme--dark`
- override Vuetify inline colors so headers honor custom dark palette

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68bfdc5e9c388326ad634ef747936128