### PR TITLE
fix: ensure dark theme styling for items table

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -188,11 +188,15 @@
 			<!-- Expanded row content using Vuetify's built-in system -->
 			<template v-slot:expanded-row="{ item }">
 				<td :colspan="headers.length" class="ma-0 pa-0 expanded-row-cell">
-					<div class="expanded-content responsive-expanded-content">
-						<!-- Item Details Form -->
-						<div class="item-details-form">
-							<!-- Basic Information Section -->
-							<div class="form-section">
+                                       <div
+                                               class="expanded-content responsive-expanded-content"
+                                               v-theme="isDarkTheme ? 'dark' : 'light'"
+                                               :data-theme="isDarkTheme ? 'dark' : undefined"
+                                       >
+                                                <!-- Item Details Form -->
+                                                <div class="item-details-form">
+                                                        <!-- Basic Information Section -->
+                                                        <div class="form-section">
 								<div class="section-header">
 									<v-icon size="small" class="section-icon">mdi-information-outline</v-icon>
 									<span class="section-title">{{ __("Basic Information") }}</span>
@@ -867,8 +871,8 @@ export default {
 	background: #ffffff;
 }
 
-:deep([data-theme="dark"]) .modern-items-table,
-:deep(.v-theme--dark) .modern-items-table {
+:deep([data-theme="dark"] .modern-items-table),
+:deep(.modern-items-table.v-theme--dark) {
 	background: #1a202c;
 	border: 1px solid rgba(255, 255, 255, 0.1);
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -896,9 +900,9 @@ export default {
 	letter-spacing: 0.3px;
 	padding: 12px;
 	transition: background-color 0.2s ease;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-	background-color: #f8f9fa;
-	color: #495057;
+	border-bottom: 1px solid rgba(0, 0, 0, 0.1) !important;
+	background-color: #f8f9fa !important;
+	color: #495057 !important;
 	position: sticky;
 	top: 0;
 	z-index: 1;
@@ -913,11 +917,11 @@ export default {
 	height: 40px;
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(th),
-:deep(.v-theme--dark) .modern-items-table :deep(th) {
-	background-color: #2d3748;
-	color: #e2e8f0;
-	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+:deep([data-theme="dark"] .modern-items-table th),
+:deep(.modern-items-table.v-theme--dark th) {
+	background-color: #2d3748 !important;
+	color: #e2e8f0 !important;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.1) !important;
 }
 
 /* Header text wrapper for better control */
@@ -956,11 +960,13 @@ export default {
 	background-color: rgba(0, 0, 0, 0.02);
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(tr) {
+:deep([data-theme="dark"] .modern-items-table tr),
+:deep(.modern-items-table.v-theme--dark tr) {
 	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(tr:hover) {
+:deep([data-theme="dark"] .modern-items-table tr:hover),
+:deep(.modern-items-table.v-theme--dark tr:hover) {
 	background-color: rgba(255, 255, 255, 0.03);
 }
 
@@ -984,8 +990,8 @@ export default {
 	box-sizing: border-box;
 }
 
-:deep([data-theme="dark"]) .modern-items-table :deep(td),
-:deep(.v-theme--dark) .modern-items-table :deep(td) {
+:deep([data-theme="dark"] .modern-items-table td),
+:deep(.modern-items-table.v-theme--dark td) {
 	color: #e5e7eb;
 }
 
@@ -1242,11 +1248,16 @@ export default {
 }
 
 .section-title {
-	font-weight: 600;
-	font-size: 0.9rem;
-	text-transform: uppercase;
-	letter-spacing: 0.5px;
-	color: var(--text-primary);
+        font-weight: 600;
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--text-primary);
+}
+
+:deep([data-theme="dark"]) .section-title,
+:deep(.v-theme--dark) .section-title {
+        color: #e2e8f0;
 }
 
 /* Form rows - flexible and responsive */
@@ -1273,9 +1284,10 @@ export default {
 /* Dark theme */
 :deep([data-theme="dark"]) .form-section,
 :deep(.v-theme--dark) .form-section {
-	background: #1a202c;
-	border-color: rgba(255, 255, 255, 0.1);
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        background: #1a202c;
+        border-color: rgba(255, 255, 255, 0.1);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        color: #e2e8f0;
 }
 
 :deep([data-theme="dark"]) .form-section:hover,
@@ -1717,6 +1729,35 @@ body[dir="rtl"] .expanded-content .qty-display {
 		0 4px 20px rgba(59, 130, 246, 0.25) !important;
 	border-color: rgba(59, 130, 246, 0.5) !important;
 	background: rgba(30, 30, 30, 0.95) !important;
+}
+
+:deep([data-theme="dark"]) .dark-field,
+:deep(.v-theme--dark) .dark-field,
+::v-deep([data-theme="dark"]) .dark-field,
+::v-deep(.v-theme--dark) .dark-field {
+	background-color: #1e1e1e !important;
+}
+
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
+:deep([data-theme="dark"]) .dark-field :deep(input),
+:deep(.v-theme--dark) .dark-field :deep(input),
+:deep([data-theme="dark"]) .dark-field :deep(.v-label),
+:deep(.v-theme--dark) .dark-field :deep(.v-label),
+::v-deep([data-theme="dark"]) .dark-field .v-field__input,
+::v-deep(.v-theme--dark) .dark-field .v-field__input,
+::v-deep([data-theme="dark"]) .dark-field input,
+::v-deep(.v-theme--dark) .dark-field input,
+::v-deep([data-theme="dark"]) .dark-field .v-label,
+::v-deep(.v-theme--dark) .dark-field .v-label {
+	color: #fff !important;
+}
+
+:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
+:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
+::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
+::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
+	background-color: #1e1e1e !important;
 }
 
 /* Currency and amount display with enhanced Arabic number support */

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -188,15 +188,15 @@
 			<!-- Expanded row content using Vuetify's built-in system -->
 			<template v-slot:expanded-row="{ item }">
 				<td :colspan="headers.length" class="ma-0 pa-0 expanded-row-cell">
-                                       <div
-                                               class="expanded-content responsive-expanded-content"
-                                               v-theme="isDarkTheme ? 'dark' : 'light'"
-                                               :data-theme="isDarkTheme ? 'dark' : undefined"
-                                       >
-                                                <!-- Item Details Form -->
-                                                <div class="item-details-form">
-                                                        <!-- Basic Information Section -->
-                                                        <div class="form-section">
+					<div
+						class="expanded-content responsive-expanded-content"
+						v-theme="isDarkTheme ? 'dark' : 'light'"
+						:data-theme="isDarkTheme ? 'dark' : undefined"
+					>
+						<!-- Item Details Form -->
+						<div class="item-details-form">
+							<!-- Basic Information Section -->
+							<div class="form-section">
 								<div class="section-header">
 									<v-icon size="small" class="section-icon">mdi-information-outline</v-icon>
 									<span class="section-title">{{ __("Basic Information") }}</span>
@@ -1248,16 +1248,16 @@ export default {
 }
 
 .section-title {
-        font-weight: 600;
-        font-size: 0.9rem;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        color: var(--text-primary);
+	font-weight: 600;
+	font-size: 0.9rem;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var(--text-primary);
 }
 
 :deep([data-theme="dark"]) .section-title,
 :deep(.v-theme--dark) .section-title {
-        color: #e2e8f0;
+	color: #e2e8f0;
 }
 
 /* Form rows - flexible and responsive */
@@ -1284,10 +1284,10 @@ export default {
 /* Dark theme */
 :deep([data-theme="dark"]) .form-section,
 :deep(.v-theme--dark) .form-section {
-        background: #1a202c;
-        border-color: rgba(255, 255, 255, 0.1);
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-        color: #e2e8f0;
+	background: #1a202c;
+	border-color: rgba(255, 255, 255, 0.1);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+	color: #e2e8f0;
 }
 
 :deep([data-theme="dark"]) .form-section:hover,


### PR DESCRIPTION
## Summary
- apply dark theme styles when items table itself carries `v-theme--dark`
- override Vuetify inline colors so headers honor custom dark palette
- ensure expanded row form fields adopt dark mode inputs, labels and overlays
- apply dark theme to expanded item detail sections and titles
- use Vuetify `v-theme` directive on expanded rows so nested fields inherit dark mode correctly

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68bfdc5e9c388326ad634ef747936128