### PR TITLE
fix: remove duplicate actions slot

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -176,20 +176,6 @@
 			<template v-slot:item.actions="{ item }">
 				<v-btn
 					:disabled="!!item.posa_is_replace"
-					size="default"
-					color="error"
-					variant="tonal"
-					class="delete-action-btn"
-					@click.stop="removeItem(item)"
-				>
-					<v-icon size="small">mdi-delete-outline</v-icon>
-				</v-btn>
-			</template>
-
-			<!-- Actions column -->
-			<template v-slot:item.actions="{ item }">
-				<v-btn
-					:disabled="!!item.posa_is_replace"
 					size="small"
 					variant="flat"
 					class="pos-table__delete-btn"


### PR DESCRIPTION
## Summary
- remove duplicate actions slot in ItemsTable to avoid Vue build failure

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c1a5687a088326a649b7d743a69654