### PR TITLE
fix: find open POS shifts

### DIFF
--- a/posawesome/posawesome/api/shifts.py
+++ b/posawesome/posawesome/api/shifts.py
@@ -86,7 +86,7 @@ def check_opening_shift(user):
         "POS Opening Shift",
         filters={
             "user": user,
-            "pos_closing_shift": ["in", ["", None]],
+            "pos_closing_shift": ["is", "not set"],
             "docstatus": 1,
             "status": "Open",
         },


### PR DESCRIPTION
## Summary
- ensure open POS shifts are detected even when closing shift field is unset

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68c288e56d0c8326b46efacdd045e941