### PR TITLE
fix: convert delivery charges for multi currency

### DIFF
--- a/frontend/src/posapp/components/pos/DeliveryCharges.vue
+++ b/frontend/src/posapp/components/pos/DeliveryCharges.vue
@@ -40,7 +40,7 @@
 				class="pos-themed-input sleek-field"
 				hide-details
 				:model-value="formatCurrency(delivery_charges_rate)"
-				:prefix="currencySymbol(pos_profile.currency)"
+				:prefix="currencySymbol()"
 				disabled
 			></v-text-field>
 		</v-col>

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -371,6 +371,7 @@ export default {
 			available_stock_cache: {},
 			brand_cache: {},
 			delivery_charges: [], // List of delivery charges
+			base_delivery_charges_rate: 0, // Delivery charge in company currency
 			delivery_charges_rate: 0, // Selected delivery charge rate
 			selected_delivery_charge: "", // Selected delivery charge object
 			invoice_posting_date: false, // Posting date dialog
@@ -617,10 +618,12 @@ export default {
 			var vm = this;
 			if (!this.pos_profile || !this.customer || !this.pos_profile.posa_use_delivery_charges) {
 				this.delivery_charges = [];
+				this.base_delivery_charges_rate = 0;
 				this.delivery_charges_rate = 0;
 				this.selected_delivery_charge = "";
 				return;
 			}
+			this.base_delivery_charges_rate = 0;
 			this.delivery_charges_rate = 0;
 			this.selected_delivery_charge = "";
 			try {
@@ -649,7 +652,18 @@ export default {
 		},
 		update_delivery_charges() {
 			if (this.selected_delivery_charge) {
-				this.delivery_charges_rate = this.selected_delivery_charge.rate;
+				this.base_delivery_charges_rate = this.selected_delivery_charge.rate;
+			} else {
+				this.base_delivery_charges_rate = 0;
+			}
+			this.update_delivery_charges_rate();
+		},
+		update_delivery_charges_rate() {
+			if (this.base_delivery_charges_rate) {
+				this.delivery_charges_rate = this.flt(
+					this.base_delivery_charges_rate / (this.conversion_rate || 1),
+					this.currency_precision,
+				);
 			} else {
 				this.delivery_charges_rate = 0;
 			}
@@ -1070,6 +1084,7 @@ export default {
 			});
 
 			this.update_item_rates();
+			this.update_delivery_charges_rate();
 		},
 
 		// Add new rounding function

--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -196,6 +196,11 @@ def calc_delivery_charges(doc):
         charges_profile = next((i for i in charges_doc.profiles if i.pos_profile == doc.pos_profile), None)
         if charges_profile:
             doc.posa_delivery_charges_rate = charges_profile.rate
+        conversion_rate = doc.conversion_rate or 1
+        doc.posa_delivery_charges_rate = flt(
+            doc.posa_delivery_charges_rate / conversion_rate,
+            doc.precision("posa_delivery_charges_rate"),
+        )
 
     if old_doc and old_doc.posa_delivery_charges:
         old_charges = next(


### PR DESCRIPTION
## Summary
- convert delivery charge rate to selected currency using current exchange rate
- ensure UI reflects selected currency for delivery charges

## Testing
- `npx prettier --write frontend/src/posapp/components/pos/Invoice.vue frontend/src/posapp/components/pos/DeliveryCharges.vue`
- `black posawesome/posawesome/api/invoice.py`
- `pytest posawesome/posawesome/doctype/delivery_charges/test_delivery_charges.py`

------
https://chatgpt.com/codex/tasks/task_e_68c28c86430483268afbef6ddd6f4f91