### PR TITLE
fix: remove duplicate slot in items table

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -171,20 +171,6 @@
 					{{ item.posa_offer_applied ? __("Remove Offer") : __("Apply Offer") }}
 				</v-btn>
 			</template>
-
-			<!-- Actions column -->
-			<template v-slot:item.actions="{ item }">
-				<v-btn
-					:disabled="!!item.posa_is_replace"
-					size="small"
-					variant="flat"
-					class="pos-table__delete-btn"
-					@click.stop="removeItem(item)"
-				>
-					<v-icon size="small">mdi-delete-outline</v-icon>
-				</v-btn>
-			</template>
-
 			<!-- Actions column -->
 			<template v-slot:item.actions="{ item }">
 				<v-btn


### PR DESCRIPTION
## Summary
- remove duplicated `item.actions` slot from ItemsTable.vue to prevent build failure

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c2f46d5be08326a03a33785c42e9db