### PR TITLE
fix: skip stock check for sales orders

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1217,14 +1217,17 @@ export default {
 				return;
 			}
 			// Validate stock availability before submitting
-			if (!isOffline()) {
-				try {
-					const itemsToCheck = this.invoice_doc.items.filter((it) => !it.is_bundle);
-					const stockCheck = await frappe.call({
-						method: "posawesome.posawesome.api.invoices.validate_cart_items",
-						args: { items: JSON.stringify(itemsToCheck) },
-					});
-					if (stockCheck.message && stockCheck.message.length) {
+                        if (!isOffline() && this.invoice_doc.doctype !== "Sales Order") {
+                                try {
+                                        const itemsToCheck = this.invoice_doc.items.filter((it) => !it.is_bundle);
+                                        const stockCheck = await frappe.call({
+                                                method: "posawesome.posawesome.api.invoices.validate_cart_items",
+                                                args: {
+                                                        items: JSON.stringify(itemsToCheck),
+                                                        doctype: this.invoice_doc.doctype,
+                                                },
+                                        });
+                                        if (stockCheck.message && stockCheck.message.length) {
 						const msg = stockCheck.message
 							.map(
 								(e) =>

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -163,12 +163,18 @@ def _auto_set_return_batches(invoice_doc):
 
 
 @frappe.whitelist()
-def validate_cart_items(items, pos_profile=None):
+def validate_cart_items(items, pos_profile=None, doctype=None):
     """Validate cart items for available stock.
 
     Returns a list of item dicts where requested quantity exceeds availability.
     This can be used on the front-end for pre-submission checks.
     """
+
+    if doctype and doctype.lower() == "sales order":
+        frappe.logger("posawesome").debug(
+            "Skipping stock validation for doctype %s", doctype
+        )
+        return []
 
     if isinstance(items, str):
         items = json.loads(items)


### PR DESCRIPTION
## Summary
- avoid server-side stock validation when processing Sales Orders
- skip client-side stock check for Sales Orders and pass doctype when validating other docs

## Testing
- `python -m py_compile posawesome/posawesome/api/invoices.py`
- `cd frontend && yarn build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68c3172e4a688326967b1d7a2ef3430b