### PR TITLE
fix: limit stock block to stock-updating invoices

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -681,8 +681,7 @@ export default {
 			// Enforce available stock limits
 			if (item.max_qty !== undefined && this.flt(item[field_name]) > this.flt(item.max_qty)) {
 				const blockSale =
-					!this.stock_settings.allow_negative_stock ||
-					this.pos_profile.posa_block_sale_beyond_available_qty;
+					!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
 				if (blockSale) {
 					item[field_name] = item.max_qty;
 					parsedValue = item.max_qty;
@@ -1112,8 +1111,7 @@ export default {
 			} else {
 				const proposed = item.qty + 1;
 				const blockSale =
-					!this.stock_settings.allow_negative_stock ||
-					this.pos_profile.posa_block_sale_beyond_available_qty;
+					!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
 				if (blockSale && item.max_qty !== undefined && proposed > item.max_qty) {
 					item.qty = item.max_qty;
 					this.calc_stock_qty(item, item.qty);

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -82,8 +82,7 @@
 					<v-btn
 						:disabled="
 							!!item.posa_is_replace ||
-							((!stock_settings.allow_negative_stock ||
-								pos_profile.posa_block_sale_beyond_available_qty) &&
+							((!stock_settings.allow_negative_stock || blockSaleBeyondAvailableQty) &&
 								item.max_qty !== undefined &&
 								item.qty >= item.max_qty)
 						"
@@ -651,6 +650,7 @@
 </template>
 
 <script>
+/* global process */
 import _ from "lodash";
 export default {
 	name: "ItemsTable",
@@ -739,6 +739,10 @@ export default {
 				[`expanded-${this.breakpoint}`]: true,
 				"compact-expanded": this.containerWidth < 600,
 			};
+		},
+
+		blockSaleBeyondAvailableQty() {
+			return this.invoiceType !== "Order" && this.pos_profile.posa_block_sale_beyond_available_qty;
 		},
 
 		// Responsive headers based on container size

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -777,6 +777,9 @@ export default {
 		displayCurrency() {
 			return this.invoice_doc ? this.invoice_doc.currency : "";
 		},
+		blockSaleBeyondAvailableQty() {
+			return this.invoiceType !== "Order" && this.pos_profile.posa_block_sale_beyond_available_qty;
+		},
 		// Calculate total payments (all methods, loyalty, credit)
 		total_payments() {
 			let total = 0;
@@ -1232,8 +1235,7 @@ export default {
 							)
 							.join("\n");
 						const blocking =
-							!this.stock_settings.allow_negative_stock ||
-							this.pos_profile.posa_block_sale_beyond_available_qty;
+							!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
 						this.eventBus.emit("show_message", {
 							title: blocking
 								? __("Insufficient stock:\n{0}", [msg])

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -1,3 +1,5 @@
+/* global flt, __, get_currency_symbol */
+
 export default {
 	// Calculate total quantity of all items
 	total_qty() {
@@ -85,6 +87,9 @@ export default {
 	// Determine if current invoice is a return
 	isReturnInvoice() {
 		return this.invoiceType === "Return" || (this.invoice_doc && this.invoice_doc.is_return);
+	},
+	blockSaleBeyondAvailableQty() {
+		return this.invoiceType !== "Order" && this.pos_profile.posa_block_sale_beyond_available_qty;
 	},
 	// Table headers for item table (for another table if needed)
 	itemTableHeaders() {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1765,9 +1765,7 @@ export default {
 			this.update_qty_limits(item);
 		}
 		if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
-			const blockSale =
-				!this.stock_settings.allow_negative_stock ||
-				this.pos_profile.posa_block_sale_beyond_available_qty;
+			const blockSale = !this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
 			if (blockSale) {
 				item.qty = item.max_qty;
 				calcStockQty(item, item.qty, this);
@@ -1794,8 +1792,7 @@ export default {
 
 			if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
 				const blockSale =
-					!this.stock_settings.allow_negative_stock ||
-					this.pos_profile.posa_block_sale_beyond_available_qty;
+					!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
 				if (blockSale) {
 					item.qty = item.max_qty;
 					calcStockQty(item, item.qty, this);
@@ -1815,8 +1812,7 @@ export default {
 			}
 
 			item.disable_increment =
-				(!this.stock_settings.allow_negative_stock ||
-					this.pos_profile.posa_block_sale_beyond_available_qty) &&
+				(!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty) &&
 				item.qty >= item.max_qty;
 		}
 	},

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -117,6 +117,9 @@ def _should_block(pos_profile):
 
 
 def _validate_stock_on_invoice(invoice_doc):
+    if invoice_doc.doctype == "Sales Invoice" and not cint(getattr(invoice_doc, "update_stock", 0)):
+        frappe.logger().debug("Skipping stock validation for Sales Invoice without stock update")
+        return
     items_to_check = [d.as_dict() for d in invoice_doc.items if d.get("is_stock_item")]
     if hasattr(invoice_doc, "packed_items"):
         items_to_check.extend([d.as_dict() for d in invoice_doc.packed_items])


### PR DESCRIPTION
## Summary
- skip stock validation when creating Sales Invoice without stock update
- dynamically toggle blocking stock sale when switching between Sales Order and Invoice
- drop regression tests and format code with Prettier and Black
