### PR TITLE
refactor: unify dark mode styling with theme

### DIFF
--- a/frontend/src/posapp/components/OfflineInvoices.vue
+++ b/frontend/src/posapp/components/OfflineInvoices.vue
@@ -277,11 +277,11 @@ export default {
 
 /* Main Card Styling */
 .offline-invoices-card {
-	border-radius: 20px !important;
-	overflow: hidden;
-	background: linear-gradient(145deg, #ffffff 0%, #f8f9fa 100%) !important;
-	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15) !important;
-	border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 20px !important;
+        overflow: hidden;
+        background-color: var(--pos-card-bg) !important;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15) !important;
+        border: 1px solid var(--pos-border);
 }
 
 /* ========== REVAMPED HEADER SECTION ========== */
@@ -494,13 +494,14 @@ export default {
 }
 
 /* Content containers */
+
 .white-background {
-	background: var(--surface-primary);
+        background: var(--pos-card-bg);
 }
 
 .empty-state {
-	padding: var(--dynamic-xl) var(--dynamic-md);
-	background: var(--surface-primary);
+        padding: var(--dynamic-xl) var(--dynamic-md);
+        background: var(--pos-card-bg);
 }
 
 .empty-icon-wrapper {
@@ -514,50 +515,59 @@ export default {
 	filter: drop-shadow(0 2px 8px rgba(76, 175, 80, 0.3));
 }
 
+
 .table-container {
-	background: var(--surface-primary);
+        background: var(--pos-card-bg);
 }
+
 
 .table-header {
-	padding: 0 var(--dynamic-xs);
-	color: var(--text-secondary);
+        padding: 0 var(--dynamic-xs);
+        color: var(--pos-text-secondary);
 }
 
+
 .white-table {
-	background: var(--surface-primary);
-	border: 1px solid var(--field-border);
-	border-radius: var(--border-radius-lg);
-	overflow: hidden;
+        background: var(--pos-card-bg);
+        border: 1px solid var(--pos-border);
+        border-radius: var(--border-radius-lg);
+        overflow: hidden;
 }
+
 
 .white-table :deep(th),
 .white-table :deep(td) {
-	border-bottom: 1px solid var(--field-border);
+        border-bottom: 1px solid var(--pos-border);
 }
+
 
 :deep(.v-data-table-header) {
-	background: var(--table-header-bg);
-	border-bottom: 2px solid var(--field-border);
+        background: var(--pos-table-header-bg);
+        border-bottom: 2px solid var(--pos-border);
 }
+
 
 :deep(.v-data-table-header th) {
-	font-weight: 600;
-	color: var(--table-header-text);
-	font-size: 0.875rem;
-	padding: var(--dynamic-md);
+        font-weight: 600;
+        color: var(--pos-text-primary);
+        font-size: 0.875rem;
+        padding: var(--dynamic-md);
 }
+
 
 :deep(.v-data-table__tr) {
-	border-bottom: 1px solid var(--field-border);
+        border-bottom: 1px solid var(--pos-border);
 }
+
 
 :deep(.v-data-table__tr:hover) {
-	background-color: var(--table-row-hover);
+        background-color: var(--pos-table-row-hover);
 }
 
+
 :deep(.v-data-table__td) {
-	padding: var(--dynamic-md);
-	border-bottom: 1px solid var(--field-border);
+        padding: var(--dynamic-md);
+        border-bottom: 1px solid var(--pos-border);
 }
 
 /* Enhanced Cell Styling */
@@ -673,17 +683,17 @@ export default {
 
 /* ========== REVAMPED FOOTER ACTIONS ========== */
 .dialog-actions-container-revamped {
-	background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%) !important;
-	border-top: 1px solid rgba(25, 118, 210, 0.1) !important;
-	padding: 24px 32px !important;
-	display: flex !important;
-	align-items: center !important;
-	justify-content: space-between !important;
-	gap: 24px !important;
-	min-height: 80px !important;
-	width: 100% !important;
-	visibility: visible !important;
-	opacity: 1 !important;
+        background-color: var(--pos-card-bg) !important;
+        border-top: 1px solid var(--pos-border) !important;
+        padding: 24px 32px !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: space-between !important;
+        gap: 24px !important;
+        min-height: 80px !important;
+        width: 100% !important;
+        visibility: visible !important;
+        opacity: 1 !important;
 }
 
 .actions-left-section {
@@ -727,12 +737,12 @@ export default {
 
 /* Close Button - Neutral with Red Text and Icon */
 .close-action-btn-revamped {
-	background: white !important;
-	color: #f44336 !important;
-	border: 2px solid #f44336 !important;
-	border-radius: 14px !important;
-	text-transform: none !important;
-	font-weight: 600 !important;
+        background: var(--pos-button-bg) !important;
+        color: #f44336 !important;
+        border: 2px solid #f44336 !important;
+        border-radius: 14px !important;
+        text-transform: none !important;
+        font-weight: 600 !important;
 	padding: 12px 24px !important;
 	min-width: 120px !important;
 	height: 48px !important;

--- a/frontend/src/posapp/components/navbar/NavbarDrawer.vue
+++ b/frontend/src/posapp/components/navbar/NavbarDrawer.vue
@@ -188,19 +188,16 @@ export default {
 	border-right: 3px solid #1976d2;
 }
 
-/* Dark Theme Adjustments */
-:deep([data-theme="dark"]) .drawer-custom,
-:deep(.v-theme--dark) .drawer-custom {
-	background-color: var(--surface-primary, #1e1e1e) !important;
-	color: var(--text-primary, #ffffff) !important;
+/* Theme-aware drawer styling */
+.drawer-custom {
+	background-color: var(--pos-navbar-bg) !important;
+	color: var(--pos-text-primary) !important;
 }
 
-:deep([data-theme="dark"]) .drawer-header,
-:deep([data-theme="dark"]) .drawer-header-mini,
-:deep(.v-theme--dark) .drawer-header,
-:deep(.v-theme--dark) .drawer-header-mini {
-	background: linear-gradient(135deg, #2d2d2d 0%, #1e1e1e 100%);
-	border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+.drawer-header,
+.drawer-header-mini {
+	background: var(--pos-navbar-bg) !important;
+	border-bottom: 1px solid var(--pos-border);
 }
 
 :deep([data-theme="dark"]) .drawer-item-title,
@@ -269,9 +266,8 @@ export default {
 }
 
 @media (max-width: 1024px) {
-	:deep([data-theme="dark"]) .drawer-custom.drawer-visible,
-	:deep(.v-theme--dark) .drawer-custom.drawer-visible {
-		background-color: var(--surface-primary, #1e1e1e) !important;
+	.drawer-custom.drawer-visible {
+		background-color: var(--pos-navbar-bg) !important;
 	}
 }
 </style>

--- a/frontend/src/posapp/components/navbar/NavbarMenu.vue
+++ b/frontend/src/posapp/components/navbar/NavbarMenu.vue
@@ -807,56 +807,48 @@ export default {
 }
 
 /* Dark Theme Adjustments */
-:deep([data-theme="dark"]) .menu-btn-compact,
-:deep(.v-theme--dark) .menu-btn-compact {
+/* Theme-aware compact menu styling */
+.menu-btn-compact {
 	background: linear-gradient(135deg, #90caf9 0%, #42a5f5 100%);
-	color: #1e1e1e !important;
+	color: var(--pos-text-primary) !important;
 }
 
-:deep([data-theme="dark"]) .menu-btn-compact:hover,
-:deep(.v-theme--dark) .menu-btn-compact:hover {
+.menu-btn-compact:hover {
 	background: linear-gradient(135deg, #64b5f6 0%, #1976d2 100%);
 	box-shadow: 0 4px 12px rgba(144, 202, 249, 0.3);
 }
 
-:deep([data-theme="dark"]) .menu-card-compact,
-:deep(.v-theme--dark) .menu-card-compact {
-	background: var(--surface-primary, #1e1e1e) !important;
-	border: 1px solid rgba(255, 255, 255, 0.12);
+.menu-card-compact {
+	background: var(--pos-card-bg) !important;
+	border: 1px solid var(--pos-border);
 	box-shadow:
-		0 8px 24px rgba(0, 0, 0, 0.4),
-		0 2px 6px rgba(0, 0, 0, 0.2);
+		0 8px 24px var(--pos-shadow-dark),
+		0 2px 6px var(--pos-shadow);
 }
 
-:deep([data-theme="dark"]) .menu-header-compact,
-:deep(.v-theme--dark) .menu-header-compact {
-	background: linear-gradient(135deg, #2d2d2d 0%, #1e1e1e 100%) !important;
-	border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+.menu-header-compact {
+	background: var(--pos-navbar-bg) !important;
+	border-bottom: 1px solid var(--pos-border);
 }
 
-:deep([data-theme="dark"]) .menu-header-text-compact,
-:deep(.v-theme--dark) .menu-header-text-compact {
-	color: var(--primary-light, #90caf9) !important;
+.menu-header-text-compact {
+	color: var(--pos-primary) !important;
 }
 
-:deep([data-theme="dark"]) .menu-list-compact,
-:deep(.v-theme--dark) .menu-list-compact {
-	background: var(--surface-primary, #1e1e1e) !important;
+.menu-list-compact {
+	background: var(--pos-card-bg) !important;
 }
 
-:deep([data-theme="dark"]) .menu-item-title-compact,
-:deep(.v-theme--dark) .menu-item-title-compact {
-	color: var(--text-primary, #ffffff) !important;
+.menu-item-title-compact {
+	color: var(--pos-text-primary) !important;
 }
 
-:deep([data-theme="dark"]) .menu-item-subtitle-compact,
-:deep(.v-theme--dark) .menu-item-subtitle-compact {
-	color: var(--pos-text-secondary, #e0e0e0) !important;
+.menu-item-subtitle-compact {
+	color: var(--pos-text-secondary) !important;
 }
 
-:deep([data-theme="dark"]) .menu-section-divider-compact,
-:deep(.v-theme--dark) .menu-section-divider-compact {
-	border-color: rgba(255, 255, 255, 0.12) !important;
+.menu-section-divider-compact {
+	border-color: var(--pos-border) !important;
 }
 
 :deep([data-theme="dark"]) .menu-item-compact:hover::before,

--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -38,7 +38,7 @@
 									variant="outlined"
 									hide-details
 									clearable
-									class="dark-field pos-themed-input"
+									class="pos-themed-input"
 									v-model="pos_profile_search"
 									:items="pos_profiles_list"
 									item-value="name"
@@ -172,7 +172,7 @@
 									variant="outlined"
 									color="primary"
 									:label="frappe._('Search by Name')"
-									class="pos-themed-input dark-field"
+									class="pos-themed-input"
 									hide-details
 									v-model="mpesa_search_name"
 									clearable
@@ -184,7 +184,7 @@
 									variant="outlined"
 									color="primary"
 									:label="frappe._('Search by Mobile')"
-									class="pos-themed-input dark-field"
+									class="pos-themed-input"
 									hide-details
 									v-model="mpesa_search_mobile"
 									clearable
@@ -235,7 +235,7 @@
 							</v-col>
 							<v-col md="5">
 								<v-text-field
-									class="p-0 m-0 dark-field pos-themed-input"
+									class="p-0 m-0 pos-themed-input"
 									density="compact"
 									color="primary"
 									hide-details
@@ -256,7 +256,7 @@
 							>
 							<v-col md="5">
 								<v-text-field
-									class="p-0 m-0 dark-field pos-themed-input"
+									class="p-0 m-0 pos-themed-input"
 									density="compact"
 									color="primary"
 									hide-details
@@ -274,7 +274,7 @@
 							>
 							<v-col md="5">
 								<v-text-field
-									class="p-0 m-0 dark-field pos-themed-input"
+									class="p-0 m-0 pos-themed-input"
 									density="compact"
 									color="primary"
 									hide-details
@@ -303,7 +303,7 @@
 											{{ currencySymbol(pos_profile.currency) }}
 										</div>
 										<v-text-field
-											class="p-0 m-0 dark-field pos-themed-input"
+											class="p-0 m-0 pos-themed-input"
 											density="compact"
 											color="primary"
 											hide-details
@@ -324,7 +324,7 @@
 							</v-col>
 							<v-col md="5">
 								<v-text-field
-									class="p-0 m-0 dark-field pos-themed-input"
+									class="p-0 m-0 pos-themed-input"
 									density="compact"
 									color="primary"
 									hide-details
@@ -1215,36 +1215,6 @@ export default {
 </script>
 
 <style>
-/* Dark mode input styling */
-:deep([data-theme="dark"]) .dark-field,
-:deep(.v-theme--dark) .dark-field,
-::v-deep([data-theme="dark"]) .dark-field,
-::v-deep(.v-theme--dark) .dark-field {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep([data-theme="dark"]) .dark-field :deep(input),
-:deep(.v-theme--dark) .dark-field :deep(input),
-:deep([data-theme="dark"]) .dark-field :deep(.v-label),
-:deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep([data-theme="dark"]) .dark-field .v-field__input,
-::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep([data-theme="dark"]) .dark-field input,
-::v-deep(.v-theme--dark) .dark-field input,
-::v-deep([data-theme="dark"]) .dark-field .v-label,
-::v-deep(.v-theme--dark) .dark-field .v-label {
-	color: #fff !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
-::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
-	background-color: #1e1e1e !important;
-}
-
 input[total_of_diff] {
 	text-align: right;
 }

--- a/frontend/src/posapp/components/pos/ClosingDialog.vue
+++ b/frontend/src/posapp/components/pos/ClosingDialog.vue
@@ -313,43 +313,22 @@ export default {
 	transform: none;
 }
 
-/* Dark theme overrides */
-:deep([data-theme="dark"]) .closing-dialog-card,
-:deep(.v-theme--dark) .closing-dialog-card,
-::v-deep([data-theme="dark"]) .closing-dialog-card,
-::v-deep(.v-theme--dark) .closing-dialog-card {
-	background: #1e1e1e !important;
+/* Theme-aware dialog styling */
+.closing-dialog-card,
+.closing-header,
+.white-background,
+.white-table,
+.dialog-actions-container {
+	background: var(--pos-card-bg) !important;
+	color: var(--pos-text-primary) !important;
 }
 
-:deep([data-theme="dark"]) .closing-header,
-:deep(.v-theme--dark) .closing-header,
-::v-deep([data-theme="dark"]) .closing-header,
-::v-deep(.v-theme--dark) .closing-header {
-	background: #1e1e1e !important;
-	color: #fff !important;
-	border-bottom: 1px solid #373737;
+.closing-header {
+	border-bottom: 1px solid var(--pos-border);
 }
 
-:deep([data-theme="dark"]) .white-background,
-:deep(.v-theme--dark) .white-background,
-::v-deep([data-theme="dark"]) .white-background,
-::v-deep(.v-theme--dark) .white-background {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .white-table,
-:deep(.v-theme--dark) .white-table,
-::v-deep([data-theme="dark"]) .white-table,
-::v-deep(.v-theme--dark) .white-table {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .dialog-actions-container,
-:deep(.v-theme--dark) .dialog-actions-container,
-::v-deep([data-theme="dark"]) .dialog-actions-container,
-::v-deep(.v-theme--dark) .dialog-actions-container {
-	background: #1e1e1e !important;
-	border-top: 1px solid #373737;
+.dialog-actions-container {
+	border-top: 1px solid var(--pos-border);
 }
 
 /* And the responsive section: */

--- a/frontend/src/posapp/components/pos/Customer.vue
+++ b/frontend/src/posapp/components/pos/Customer.vue
@@ -108,42 +108,22 @@
 	border-radius: 12px;
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
 	transition: box-shadow 0.3s ease;
-	background-color: #fff;
+	background-color: var(--pos-input-bg);
 }
 
 .customer-autocomplete:hover {
 	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
 }
 
-/* Dark mode styling */
-:deep([data-theme="dark"]) .customer-autocomplete,
-:deep(.v-theme--dark) .customer-autocomplete,
-::v-deep([data-theme="dark"]) .customer-autocomplete,
-::v-deep(.v-theme--dark) .customer-autocomplete {
-	/* Use surface color for dark mode */
-	background-color: #1e1e1e !important;
+/* Theme-aware internal field colors */
+.customer-autocomplete :deep(.v-field__input),
+.customer-autocomplete :deep(input),
+.customer-autocomplete :deep(.v-label) {
+	color: var(--pos-text-primary) !important;
 }
 
-:deep([data-theme="dark"]) .customer-autocomplete :deep(.v-field__input),
-:deep(.v-theme--dark) .customer-autocomplete :deep(.v-field__input),
-:deep([data-theme="dark"]) .customer-autocomplete :deep(input),
-:deep(.v-theme--dark) .customer-autocomplete :deep(input),
-:deep([data-theme="dark"]) .customer-autocomplete :deep(.v-label),
-:deep(.v-theme--dark) .customer-autocomplete :deep(.v-label),
-::v-deep([data-theme="dark"]) .customer-autocomplete .v-field__input,
-::v-deep(.v-theme--dark) .customer-autocomplete .v-field__input,
-::v-deep([data-theme="dark"]) .customer-autocomplete input,
-::v-deep(.v-theme--dark) .customer-autocomplete input,
-::v-deep([data-theme="dark"]) .customer-autocomplete .v-label,
-::v-deep(.v-theme--dark) .customer-autocomplete .v-label {
-	color: #fff !important;
-}
-
-:deep([data-theme="dark"]) .customer-autocomplete :deep(.v-field__overlay),
-:deep(.v-theme--dark) .customer-autocomplete :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .customer-autocomplete .v-field__overlay,
-::v-deep(.v-theme--dark) .customer-autocomplete .v-field__overlay {
-	background-color: #1e1e1e !important;
+.customer-autocomplete :deep(.v-field__overlay) {
+	background-color: var(--pos-input-bg) !important;
 }
 
 .icon-button {

--- a/frontend/src/posapp/components/pos/DeliveryCharges.vue
+++ b/frontend/src/posapp/components/pos/DeliveryCharges.vue
@@ -78,33 +78,4 @@ export default {
 };
 </script>
 
-<style scoped>
-:deep([data-theme="dark"]) .dark-field,
-:deep(.v-theme--dark) .dark-field,
-::v-deep([data-theme="dark"]) .dark-field,
-::v-deep(.v-theme--dark) .dark-field {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep([data-theme="dark"]) .dark-field :deep(input),
-:deep(.v-theme--dark) .dark-field :deep(input),
-:deep([data-theme="dark"]) .dark-field :deep(.v-label),
-:deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep([data-theme="dark"]) .dark-field .v-field__input,
-::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep([data-theme="dark"]) .dark-field input,
-::v-deep(.v-theme--dark) .dark-field input,
-::v-deep([data-theme="dark"]) .dark-field .v-label,
-::v-deep(.v-theme--dark) .dark-field .v-label {
-	color: #fff !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
-::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
-	background-color: #1e1e1e !important;
-}
-</style>
+<style scoped></style>

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -40,7 +40,7 @@
 							hide-details
 							variant="solo"
 							color="primary"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							:items="invoiceTypes"
 							:label="frappe._('Type')"
 							v-model="invoiceType"
@@ -1486,9 +1486,8 @@ export default {
 	transform: translateY(-100%);
 }
 
-:deep([data-theme="dark"]) .column-selector-container,
-:deep(.v-theme--dark) .column-selector-container {
-	background-color: #1e1e1e;
+.column-selector-container {
+	background-color: var(--pos-card-bg);
 }
 
 .column-selector-btn {

--- a/frontend/src/posapp/components/pos/InvoiceSummary.vue
+++ b/frontend/src/posapp/components/pos/InvoiceSummary.vue
@@ -323,31 +323,16 @@ export default {
 
 <style scoped>
 .cards {
-	background-color: #f5f5f5 !important;
+	background-color: var(--pos-card-bg) !important;
 	transition: all 0.3s ease;
 }
 
-:deep([data-theme="dark"]) .cards,
-:deep([data-theme="dark"]) .cards .v-card__underlay,
-:deep(.v-theme--dark) .cards,
-:deep(.v-theme--dark) .cards .v-card__underlay,
-:deep(.cards.v-theme--dark),
-:deep(.cards.v-theme--dark) .v-card__underlay,
-::v-deep([data-theme="dark"]) .cards,
-::v-deep([data-theme="dark"]) .cards .v-card__underlay,
-::v-deep(.v-theme--dark) .cards,
-::v-deep(.v-theme--dark) .cards .v-card__underlay,
-::v-deep(.cards.v-theme--dark),
-::v-deep(.cards.v-theme--dark) .v-card__underlay {
-	background-color: #1e1e1e !important;
-}
-
 .white-text-btn {
-	color: white !important;
+	color: var(--pos-text-primary) !important;
 }
 
 .white-text-btn :deep(.v-btn__content) {
-	color: white !important;
+	color: var(--pos-text-primary) !important;
 }
 
 /* Enhanced button styling with better performance */

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -163,7 +163,7 @@
 												color="primary"
 												hide-details
 												:label="__('Items per page')"
-												class="mb-2 dark-field pos-themed-input"
+												class="mb-2 pos-themed-input"
 											>
 											</v-text-field>
 										</v-card-text>
@@ -3098,9 +3098,9 @@ export default {
 		border-color 0.15s ease;
 }
 
-[data-theme="dark"] .sticky-header {
-	background-color: var(--surface-primary, #1e1e1e);
-	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+.sticky-header {
+	background-color: var(--pos-card-bg);
+	border-bottom: 1px solid var(--pos-border);
 }
 
 .dynamic-scroll {

--- a/frontend/src/posapp/components/pos/MultiCurrencyRow.vue
+++ b/frontend/src/posapp/components/pos/MultiCurrencyRow.vue
@@ -86,33 +86,4 @@ export default {
 };
 </script>
 
-<style scoped>
-:deep([data-theme="dark"]) .dark-field,
-:deep(.v-theme--dark) .dark-field,
-::v-deep([data-theme="dark"]) .dark-field,
-::v-deep(.v-theme--dark) .dark-field {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep([data-theme="dark"]) .dark-field :deep(input),
-:deep(.v-theme--dark) .dark-field :deep(input),
-:deep([data-theme="dark"]) .dark-field :deep(.v-label),
-:deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep([data-theme="dark"]) .dark-field .v-field__input,
-::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep([data-theme="dark"]) .dark-field input,
-::v-deep(.v-theme--dark) .dark-field input,
-::v-deep([data-theme="dark"]) .dark-field .v-label,
-::v-deep(.v-theme--dark) .dark-field .v-label {
-	color: #fff !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
-::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
-	background-color: #1e1e1e !important;
-}
-</style>
+<style scoped></style>

--- a/frontend/src/posapp/components/pos/NewAddress.vue
+++ b/frontend/src/posapp/components/pos/NewAddress.vue
@@ -117,34 +117,4 @@ export default {
 };
 </script>
 
-<style scoped>
-/* Dark mode input styling */
-:deep([data-theme="dark"]) .dark-field,
-:deep(.v-theme--dark) .dark-field,
-::v-deep([data-theme="dark"]) .dark-field,
-::v-deep(.v-theme--dark) .dark-field {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep([data-theme="dark"]) .dark-field :deep(input),
-:deep(.v-theme--dark) .dark-field :deep(input),
-:deep([data-theme="dark"]) .dark-field :deep(.v-label),
-:deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep([data-theme="dark"]) .dark-field .v-field__input,
-::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep([data-theme="dark"]) .dark-field input,
-::v-deep(.v-theme--dark) .dark-field input,
-::v-deep([data-theme="dark"]) .dark-field .v-label,
-::v-deep(.v-theme--dark) .dark-field .v-label {
-	color: #fff !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
-::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
-	background-color: #1e1e1e !important;
-}
-</style>
+<style scoped></style>

--- a/frontend/src/posapp/components/pos/OpeningDialog.vue
+++ b/frontend/src/posapp/components/pos/OpeningDialog.vue
@@ -664,35 +664,20 @@ export default {
 	transform: none;
 }
 
-/* Dark theme overrides */
-:deep([data-theme="dark"]) .opening-dialog-card,
-:deep(.v-theme--dark) .opening-dialog-card,
-::v-deep([data-theme="dark"]) .opening-dialog-card,
-::v-deep(.v-theme--dark) .opening-dialog-card {
-	background: #1e1e1e !important;
+/* Theme-aware dialog styling */
+.opening-dialog-card,
+.opening-dialog-header,
+.opening-dialog-content,
+.dialog-actions-container {
+	background: var(--pos-card-bg) !important;
+	color: var(--pos-text-primary) !important;
 }
 
-:deep([data-theme="dark"]) .opening-dialog-header,
-:deep(.v-theme--dark) .opening-dialog-header,
-::v-deep([data-theme="dark"]) .opening-dialog-header,
-::v-deep(.v-theme--dark) .opening-dialog-header {
-	background: #1e1e1e !important;
-	color: #fff !important;
-	border-bottom: 1px solid #373737;
+.opening-dialog-header {
+	border-bottom: 1px solid var(--pos-border);
 }
 
-:deep([data-theme="dark"]) .opening-dialog-content,
-:deep(.v-theme--dark) .opening-dialog-content,
-::v-deep([data-theme="dark"]) .opening-dialog-content,
-::v-deep(.v-theme--dark) .opening-dialog-content {
-	background: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .dialog-actions-container,
-:deep(.v-theme--dark) .dialog-actions-container,
-::v-deep([data-theme="dark"]) .dialog-actions-container,
-::v-deep(.v-theme--dark) .dialog-actions-container {
-	background: #1e1e1e !important;
-	border-top: 1px solid #373737;
+.dialog-actions-container {
+	border-top: 1px solid var(--pos-border);
 }
 </style>

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -20,7 +20,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Paid Amount')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							v-model="total_payments_display"
 							readonly
@@ -34,7 +34,7 @@
 							variant="solo"
 							color="primary"
 							label="To Be Paid"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							v-model="diff_payment_display"
 							:prefix="currencySymbol(invoice_doc.currency)"
@@ -50,7 +50,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Paid Change')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							:model-value="formatCurrency(paid_change)"
 							:prefix="currencySymbol(invoice_doc.currency)"
 							:rules="paid_change_rules"
@@ -67,7 +67,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Credit Change')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							:model-value="formatCurrency(credit_change)"
 							:prefix="currencySymbol(invoice_doc.currency)"
 							density="compact"
@@ -91,7 +91,7 @@
 								variant="solo"
 								color="primary"
 								:label="frappe._(payment.mode_of_payment)"
-								class="dark-field sleek-field pos-themed-input"
+								class="sleek-field pos-themed-input"
 								hide-details
 								:model-value="formatCurrency(payment.amount)"
 								@change="setFormatedCurrency(payment, 'amount', null, false, $event)"
@@ -153,7 +153,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Redeem Loyalty Points')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatCurrency(loyalty_amount)"
 							type="text"
@@ -167,7 +167,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('You can redeem up to')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatFloat(available_points_amount)"
 							:prefix="currencySymbol(invoice_doc.currency)"
@@ -192,7 +192,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Redeemed Customer Credit')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatCurrency(redeemed_customer_credit)"
 							type="text"
@@ -209,7 +209,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('You can redeem credit up to')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatCurrency(available_customer_credit)"
 							:prefix="currencySymbol(invoice_doc.currency)"
@@ -228,7 +228,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Net Total')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							:model-value="formatCurrency(invoice_doc.net_total, displayCurrency)"
 							readonly
 							:prefix="currencySymbol()"
@@ -241,7 +241,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Tax and Charges')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="
 								formatCurrency(invoice_doc.total_taxes_and_charges, displayCurrency)
@@ -257,7 +257,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Total Amount')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatCurrency(invoice_doc.total, displayCurrency)"
 							readonly
@@ -271,7 +271,7 @@
 							variant="solo"
 							color="primary"
 							:label="diff_label"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatCurrency(diff_payment, displayCurrency)"
 							readonly
@@ -285,7 +285,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Discount Amount')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatCurrency(invoice_doc.discount_amount)"
 							readonly
@@ -299,7 +299,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Grand Total')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatCurrency(invoice_doc.grand_total)"
 							readonly
@@ -313,7 +313,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Rounded Total')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							:model-value="formatCurrency(invoice_doc.rounded_total)"
 							readonly
@@ -330,7 +330,7 @@
 							format="dd-MM-yyyy"
 							:min-date="new Date()"
 							auto-apply
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							@update:model-value="update_delivery_date()"
 						/>
 					</v-col>
@@ -347,7 +347,7 @@
 							:items="addresses"
 							item-title="address_title"
 							item-value="name"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							:no-data-text="__('Address not found')"
 							hide-details
 							:customFilter="addressFilter"
@@ -388,7 +388,7 @@
 					<!-- Additional Notes (if enabled in POS profile) -->
 					<v-col cols="12" v-if="pos_profile.posa_display_additional_notes">
 						<v-textarea
-							class="pa-0 dark-field sleek-field"
+							class="pa-0 sleek-field"
 							variant="solo"
 							density="compact"
 							clearable
@@ -411,7 +411,7 @@
 								:label="frappe._('Purchase Order')"
 								variant="solo"
 								density="compact"
-								class="dark-field sleek-field pos-themed-input"
+								class="sleek-field pos-themed-input"
 								clearable
 								color="primary"
 								hide-details
@@ -424,7 +424,7 @@
 								format="dd-MM-yyyy"
 								:min-date="new Date()"
 								auto-apply
-								class="dark-field sleek-field pos-themed-input"
+								class="sleek-field pos-themed-input"
 								@update:model-value="update_po_date()"
 							/>
 							<v-text-field
@@ -485,11 +485,11 @@
 							format="dd-MM-yyyy"
 							:min-date="new Date()"
 							auto-apply
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							@update:model-value="update_credit_due_date()"
 						/>
 						<v-text-field
-							class="mt-2 dark-field sleek-field"
+							class="mt-2 sleek-field"
 							density="compact"
 							variant="solo"
 							type="number"
@@ -544,7 +544,7 @@
 								variant="solo"
 								color="primary"
 								:label="frappe._('Available Credit')"
-								class="dark-field sleek-field pos-themed-input"
+								class="sleek-field pos-themed-input"
 								hide-details
 								:model-value="formatCurrency(row.total_credit)"
 								readonly
@@ -557,7 +557,7 @@
 								variant="solo"
 								color="primary"
 								:label="frappe._('Redeem Credit')"
-								class="dark-field sleek-field pos-themed-input"
+								class="sleek-field pos-themed-input"
 								hide-details
 								type="text"
 								:model-value="formatCurrency(row.credit_to_redeem)"
@@ -587,7 +587,7 @@
 							:items="sales_persons"
 							item-title="title"
 							item-value="value"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							:no-data-text="__('Sales Person not found')"
 							hide-details
 							:disabled="readonly"
@@ -656,7 +656,7 @@
 							type="number"
 							min="0"
 							max="365"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							v-model.number="custom_days_value"
 							:label="frappe._('Days')"
 							hide-details
@@ -688,7 +688,7 @@
 							variant="solo"
 							color="primary"
 							:label="frappe._('Mobile Number')"
-							class="dark-field sleek-field pos-themed-input"
+							class="sleek-field pos-themed-input"
 							hide-details
 							v-model="invoice_doc.contact_mobile"
 							type="number"
@@ -2057,35 +2057,5 @@ export default {
 .submit-highlight {
 	box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
 	transition: box-shadow 0.3s ease-in-out;
-}
-
-/* Dark mode styling for input fields */
-:deep([data-theme="dark"]) .dark-field,
-:deep(.v-theme--dark) .dark-field,
-::v-deep([data-theme="dark"]) .dark-field,
-::v-deep(.v-theme--dark) .dark-field {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep([data-theme="dark"]) .dark-field :deep(input),
-:deep(.v-theme--dark) .dark-field :deep(input),
-:deep([data-theme="dark"]) .dark-field :deep(.v-label),
-:deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep([data-theme="dark"]) .dark-field .v-field__input,
-::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep([data-theme="dark"]) .dark-field input,
-::v-deep(.v-theme--dark) .dark-field input,
-::v-deep([data-theme="dark"]) .dark-field .v-label,
-::v-deep(.v-theme--dark) .dark-field .v-label {
-	color: #fff !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
-::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
-	background-color: #1e1e1e !important;
 }
 </style>

--- a/frontend/src/posapp/components/pos/PostingDateRow.vue
+++ b/frontend/src/posapp/components/pos/PostingDateRow.vue
@@ -7,7 +7,7 @@
 				format="dd-MM-yyyy"
 				auto-apply
 				:placeholder="frappe._('Posting Date')"
-				class="dark-field sleek-field posting-date-input pos-themed-input"
+				class="sleek-field posting-date-input pos-themed-input"
 				@update:model-value="onUpdate"
 			/>
 		</v-col>
@@ -84,54 +84,26 @@ export default {
 </script>
 
 <style scoped>
-/* Dark mode styling for input wrapper */
-:deep([data-theme="dark"]) .dark-field,
-:deep(.v-theme--dark) .dark-field,
-::v-deep([data-theme="dark"]) .dark-field,
-::v-deep(.v-theme--dark) .dark-field {
-	background-color: #1e1e1e !important;
+/* Theme-aware input styling */
+.posting-date-input :deep(.v-field__input),
+.posting-date-input :deep(input),
+.posting-date-input :deep(.v-label) {
+	color: var(--pos-text-primary) !important;
 }
 
-/* Ensure input text and label are readable */
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep([data-theme="dark"]) .dark-field :deep(input),
-:deep(.v-theme--dark) .dark-field :deep(input),
-:deep([data-theme="dark"]) .dark-field :deep(.v-label),
-:deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep([data-theme="dark"]) .dark-field .v-field__input,
-::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep([data-theme="dark"]) .dark-field input,
-::v-deep(.v-theme--dark) .dark-field input,
-::v-deep([data-theme="dark"]) .dark-field .v-label,
-::v-deep(.v-theme--dark) .dark-field .v-label {
-	color: #fff !important;
+.posting-date-input :deep(.v-field__overlay) {
+	background-color: var(--pos-input-bg) !important;
 }
 
-/* Overlay background in dark mode */
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
-::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
-	background-color: #1e1e1e !important;
+/* Theme-aware date picker elements */
+:deep(.dp__input) {
+	background-color: var(--pos-input-bg) !important;
+	color: var(--pos-text-primary) !important;
 }
 
-/* Dark mode styling for date picker input */
-:deep([data-theme="dark"]) .dp__input,
-:deep(.v-theme--dark) .dp__input,
-::v-deep([data-theme="dark"]) .dp__input,
-::v-deep(.v-theme--dark) .dp__input {
-	background-color: #1e1e1e !important;
-	color: #fff !important;
-}
-
-/* Dark mode styling for date picker calendar dropdown */
-:deep([data-theme="dark"]) .dp__menu,
-:deep(.v-theme--dark) .dp__menu,
-::v-deep([data-theme="dark"]) .dp__menu,
-::v-deep(.v-theme--dark) .dp__menu {
-	background-color: #1e1e1e !important;
-	color: #fff !important;
+:deep(.dp__menu) {
+	background-color: var(--pos-card-bg) !important;
+	color: var(--pos-text-primary) !important;
 }
 
 /* Sleek design for VueDatePicker */

--- a/frontend/src/posapp/components/pos/PostingDateRow.vue
+++ b/frontend/src/posapp/components/pos/PostingDateRow.vue
@@ -102,8 +102,14 @@ export default {
 }
 
 :deep(.dp__menu) {
-	background-color: var(--pos-card-bg) !important;
-	color: var(--pos-text-primary) !important;
+        background-color: var(--pos-card-bg) !important;
+        color: var(--pos-text-primary) !important;
+}
+
+/* Ensure calendar numbers remain visible across themes */
+.posting-date-input :deep(.dp__calendar_header_item),
+.posting-date-input :deep(.dp__cell_inner) {
+        color: var(--pos-text-primary) !important;
 }
 
 /* Sleek design for VueDatePicker */

--- a/frontend/src/posapp/components/pos/UpdateCustomer.vue
+++ b/frontend/src/posapp/components/pos/UpdateCustomer.vue
@@ -681,34 +681,4 @@ export default {
 };
 </script>
 
-<style scoped>
-/* Dark mode input styling */
-:deep([data-theme="dark"]) .dark-field,
-:deep(.v-theme--dark) .dark-field,
-::v-deep([data-theme="dark"]) .dark-field,
-::v-deep(.v-theme--dark) .dark-field {
-	background-color: #1e1e1e !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__input),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__input),
-:deep([data-theme="dark"]) .dark-field :deep(input),
-:deep(.v-theme--dark) .dark-field :deep(input),
-:deep([data-theme="dark"]) .dark-field :deep(.v-label),
-:deep(.v-theme--dark) .dark-field :deep(.v-label),
-::v-deep([data-theme="dark"]) .dark-field .v-field__input,
-::v-deep(.v-theme--dark) .dark-field .v-field__input,
-::v-deep([data-theme="dark"]) .dark-field input,
-::v-deep(.v-theme--dark) .dark-field input,
-::v-deep([data-theme="dark"]) .dark-field .v-label,
-::v-deep(.v-theme--dark) .dark-field .v-label {
-	color: #fff !important;
-}
-
-:deep([data-theme="dark"]) .dark-field :deep(.v-field__overlay),
-:deep(.v-theme--dark) .dark-field :deep(.v-field__overlay),
-::v-deep([data-theme="dark"]) .dark-field .v-field__overlay,
-::v-deep(.v-theme--dark) .dark-field .v-field__overlay {
-	background-color: #1e1e1e !important;
-}
-</style>
+<style scoped></style>

--- a/frontend/src/posapp/styles/theme.css
+++ b/frontend/src/posapp/styles/theme.css
@@ -262,6 +262,17 @@
 	border-color: var(--pos-border);
 }
 
+/* Ensure inputs adapt to the active theme without per-component overrides */
+.posapp .pos-themed-input :deep(.v-field__input),
+.posapp .pos-themed-input :deep(input),
+.posapp .pos-themed-input :deep(.v-label) {
+	color: var(--pos-text-primary) !important;
+}
+
+.posapp .pos-themed-input :deep(.v-field__overlay) {
+	background-color: var(--pos-input-bg) !important;
+}
+
 /* Fix for Frappe navbar collapse elements being hidden by POSAwesome CSS */
 /* This overrides the problematic .collapse { visibility: collapse; } rule */
 .navbar-collapse,


### PR DESCRIPTION
## Summary
- remove hard-coded dark mode CSS from POS components
- add global theme-aware input styles
- align dialogs, forms and menus with shared theme variables

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c3c0547b4083269e6941691d134abf