### PR TITLE
feat: allow creating quotations from POS

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -359,7 +359,7 @@ export default {
 			isApplyingOffer: false, // Flag to prevent offer watcher loops
 			allItems: [], // All items for offer logic
 			discount_percentage_offer_name: null, // Track which offer is applied
-			invoiceTypes: ["Invoice", "Order"], // Types of invoices
+			invoiceTypes: ["Invoice", "Order", "Quotation"], // Types of invoices
 			invoiceType: "Invoice", // Current invoice type
 			itemsPerPage: 1000, // Items per page in table
 			expanded: [], // Array of expanded row IDs

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -596,7 +596,10 @@
 							<!-- Delivery Date Section -->
 							<div
 								class="form-section"
-								v-if="pos_profile.posa_allow_sales_order && invoiceType == 'Order'"
+								v-if="
+									pos_profile.posa_allow_sales_order &&
+									['Order', 'Quotation'].includes(invoiceType)
+								"
 							>
 								<div class="section-header">
 									<v-icon size="small" class="section-icon">mdi-calendar-check</v-icon>
@@ -742,7 +745,10 @@ export default {
 		},
 
 		blockSaleBeyondAvailableQty() {
-			return this.invoiceType !== "Order" && this.pos_profile.posa_block_sale_beyond_available_qty;
+			return (
+				!["Order", "Quotation"].includes(this.invoiceType) &&
+				this.pos_profile.posa_block_sale_beyond_available_qty
+			);
 		},
 
 		// Responsive headers based on container size

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -778,7 +778,10 @@ export default {
 			return this.invoice_doc ? this.invoice_doc.currency : "";
 		},
 		blockSaleBeyondAvailableQty() {
-			return this.invoiceType !== "Order" && this.pos_profile.posa_block_sale_beyond_available_qty;
+			return (
+				!["Order", "Quotation"].includes(this.invoiceType) &&
+				this.pos_profile.posa_block_sale_beyond_available_qty
+			);
 		},
 		// Calculate total payments (all methods, loyalty, credit)
 		total_payments() {
@@ -1315,7 +1318,9 @@ export default {
 				method:
 					this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
 						? "posawesome.posawesome.api.sales_orders.submit_sales_order"
-						: "posawesome.posawesome.api.invoices.submit_invoice",
+						: this.invoiceType === "Quotation"
+							? "posawesome.posawesome.api.quotations.submit_quotation"
+							: "posawesome.posawesome.api.invoices.submit_invoice",
 				args: {
 					data: data,
 					invoice: this.invoice_doc,
@@ -1375,7 +1380,9 @@ export default {
 						title:
 							vm.invoiceType === "Order" && vm.pos_profile.posa_create_only_sales_order
 								? __("Sales Order {0} is Submitted", [r.message.name])
-								: __("Invoice {0} is Submitted", [r.message.name]),
+								: vm.invoiceType === "Quotation"
+									? __("Quotation {0} is Submitted", [r.message.name])
+									: __("Invoice {0} is Submitted", [r.message.name]),
 						color: "success",
 					});
 					frappe.utils.play_sound("submit");

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -89,7 +89,10 @@ export default {
 		return this.invoiceType === "Return" || (this.invoice_doc && this.invoice_doc.is_return);
 	},
 	blockSaleBeyondAvailableQty() {
-		return this.invoiceType !== "Order" && this.pos_profile.posa_block_sale_beyond_available_qty;
+		return (
+			!["Order", "Quotation"].includes(this.invoiceType) &&
+			this.pos_profile.posa_block_sale_beyond_available_qty
+		);
 	},
 	// Table headers for item table (for another table if needed)
 	itemTableHeaders() {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -113,7 +113,7 @@ export default {
 	async cancel_invoice() {
 		const doc = this.get_invoice_doc();
 		this.invoiceType = this.pos_profile.posa_default_sales_order ? "Order" : "Invoice";
-		this.invoiceTypes = ["Invoice", "Order"];
+		this.invoiceTypes = ["Invoice", "Order", "Quotation"];
 		this.posting_date = frappe.datetime.nowdate();
 		var vm = this;
 		if (doc.name && this.pos_profile.posa_allow_delete) {
@@ -280,7 +280,7 @@ export default {
 			this.discount_amount = 0;
 			this.additional_discount_percentage = 0;
 			this.invoiceType = "Invoice";
-			this.invoiceTypes = ["Invoice", "Order"];
+			this.invoiceTypes = ["Invoice", "Order", "Quotation"];
 		} else {
 			if (data.is_return) {
 				// For return without invoice case, check if there's a return_against
@@ -334,7 +334,9 @@ export default {
 		}
 
 		// Always set these fields first
-		if (this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order) {
+		if (this.invoiceType === "Quotation") {
+			doc.doctype = "Quotation";
+		} else if (this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order) {
 			doc.doctype = "Sales Order";
 		} else if (this.pos_profile.create_pos_invoice_instead_of_sales_invoice) {
 			doc.doctype = "POS Invoice";
@@ -841,7 +843,9 @@ export default {
 			method:
 				doc.doctype === "Sales Order" && this.pos_profile.posa_create_only_sales_order
 					? "posawesome.posawesome.api.sales_orders.update_sales_order"
-					: "posawesome.posawesome.api.invoices.update_invoice",
+					: doc.doctype === "Quotation"
+						? "posawesome.posawesome.api.quotations.update_quotation"
+						: "posawesome.posawesome.api.invoices.update_invoice",
 			args: {
 				data: doc,
 			},

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -431,7 +431,7 @@ export function useItemAddition() {
 
 		context.eventBus.emit("set_customer_readonly", false);
 		context.invoiceType = context.pos_profile.posa_default_sales_order ? "Order" : "Invoice";
-		context.invoiceTypes = ["Invoice", "Order"];
+		context.invoiceTypes = ["Invoice", "Order", "Quotation"];
 	};
 
 	// Add this utility for grouping logic, matching ItemsTable.vue

--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -44,6 +44,10 @@ from .sales_orders import (
     submit_sales_order,
     update_sales_order,
 )
+from .quotations import (
+    submit_quotation,
+    update_quotation,
+)
 from .shifts import (
     check_opening_shift,
     create_opening_voucher,

--- a/posawesome/posawesome/api/quotations.py
+++ b/posawesome/posawesome/api/quotations.py
@@ -1,0 +1,64 @@
+import json
+import frappe
+from frappe.utils import getdate
+
+
+def _map_delivery_dates(data):
+    """Ensure mandatory delivery_date fields are populated."""
+
+    def parse_date(value):
+        if not value:
+            return None
+        try:
+            return str(getdate(value))
+        except Exception:
+            return None
+
+    if not data.get("delivery_date") and data.get("posa_delivery_date"):
+        parsed = parse_date(data.get("posa_delivery_date"))
+        if parsed:
+            data["delivery_date"] = parsed
+
+    for item in data.get("items", []):
+        if not item.get("delivery_date"):
+            delivery = item.get("posa_delivery_date") or data.get("delivery_date")
+            parsed = parse_date(delivery)
+            if parsed:
+                item["delivery_date"] = parsed
+
+
+@frappe.whitelist()
+def update_quotation(data):
+    """Create or update a Quotation document."""
+    data = json.loads(data)
+    _map_delivery_dates(data)
+    if data.get("name") and frappe.db.exists("Quotation", data.get("name")):
+        doc = frappe.get_doc("Quotation", data.get("name"))
+        doc.update(data)
+    else:
+        doc = frappe.get_doc(data)
+
+    doc.flags.ignore_permissions = True
+    frappe.flags.ignore_account_permission = True
+    doc.docstatus = 0
+    doc.save()
+    return doc
+
+
+@frappe.whitelist()
+def submit_quotation(order):
+    """Submit quotation document."""
+    order = json.loads(order)
+    _map_delivery_dates(order)
+    if order.get("name") and frappe.db.exists("Quotation", order.get("name")):
+        doc = frappe.get_doc("Quotation", order.get("name"))
+        doc.update(order)
+    else:
+        doc = frappe.get_doc(order)
+
+    doc.flags.ignore_permissions = True
+    frappe.flags.ignore_account_permission = True
+    doc.save()
+    doc.submit()
+
+    return {"name": doc.name, "status": doc.docstatus}


### PR DESCRIPTION
## Summary
- add quotation option to POS invoice types
- support quotation CRUD via new backend API
- handle quotation submission in payment flow

## Testing
- `python -m py_compile posawesome/posawesome/api/quotations.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*
- `yarn lint` *(fails: Command "lint" not found)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c42783c5fc8326b7e7b6a0a8f9b05e