### PR TITLE
fix: keep submit button color on focus

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -610,7 +610,7 @@
 						@click="submit"
 						:loading="loading"
 						:disabled="loading || vaildatPayment"
-						:class="{ 'submit-highlight': highlightSubmit }"
+						:class="['submit-button', { 'submit-highlight': highlightSubmit }]"
 					>
 						{{ __("Submit") }}
 					</v-btn>
@@ -2061,8 +2061,23 @@ export default {
 	background-color: var(--surface-secondary) !important;
 }
 
+.submit-button:focus,
+.submit-button:focus-visible,
+.submit-button:hover,
+.submit-button:active {
+	outline: none;
+	box-shadow: none;
+}
+
+.submit-button:focus::before,
+.submit-button:focus-visible::before,
+.submit-button:hover::before,
+.submit-button:active::before {
+	opacity: 0;
+}
+
 .submit-highlight {
-	box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
+	box-shadow: 0 0 0 4px transparent;
 	transition: box-shadow 0.3s ease-in-out;
 }
 </style>


### PR DESCRIPTION
## Summary
- avoid submit button focus ring changing its color
- remove highlight color so button color stays consistent

## Testing
- `./node_modules/.bin/prettier -w frontend/src/posapp/components/pos/Payments.vue`
- `./node_modules/.bin/eslint frontend/src/posapp/components/pos/Payments.vue`


------
https://chatgpt.com/codex/tasks/task_e_68c5226552688326a4dd0c86dc4bc0d1