### PR TITLE
fix: preserve submit button color on focus

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -607,6 +607,7 @@
 						size="large"
 						color="primary"
 						theme="dark"
+						class="submit-btn"
 						@click="submit"
 						:loading="loading"
 						:disabled="loading || vaildatPayment"
@@ -2059,6 +2060,12 @@ export default {
 
 .cards {
 	background-color: var(--surface-secondary) !important;
+}
+
+.submit-btn:focus,
+.submit-highlight {
+	background-color: rgb(var(--v-theme-primary)) !important;
+	color: rgb(var(--v-theme-on-primary)) !important;
 }
 
 .submit-highlight {


### PR DESCRIPTION
## Summary
- ensure submit button keeps primary color when focused or highlighted

## Testing
- `npx prettier frontend/src/posapp/components/pos/Payments.vue --write`
- `npx eslint frontend/src/posapp/components/pos/Payments.vue`


------
https://chatgpt.com/codex/tasks/task_e_68c830cfd3e8832680d5aa211a3bf13b