### PR TITLE
fix: update item selector stock on fetch

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2907,9 +2907,16 @@ export default {
 		this.eventBus.on("update_customer_price_list", (data) => {
 			this.customer_price_list = data;
 		});
-		this.eventBus.on("update_customer", (data) => {
-			this.customer = data;
-		});
+                this.eventBus.on("update_customer", (data) => {
+                        this.customer = data;
+                });
+
+                this.eventBus.on("update_item_stock", ({ item_code, actual_qty }) => {
+                        const item = this.items.find((it) => it.item_code === item_code);
+                        if (item) {
+                                item.actual_qty = actual_qty;
+                        }
+                });
 
 		// Manually trigger a full item reload when requested
 		this.eventBus.on("force_reload_items", async () => {
@@ -3066,12 +3073,13 @@ export default {
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("update_cur_items_details");
 		this.eventBus.off("update_offers_counters");
-		this.eventBus.off("update_coupons_counters");
-		this.eventBus.off("update_customer_price_list");
-		this.eventBus.off("update_customer");
-		this.eventBus.off("force_reload_items");
-		window.removeEventListener("resize", this.checkItemContainerOverflow);
-	},
+                this.eventBus.off("update_coupons_counters");
+                this.eventBus.off("update_customer_price_list");
+                this.eventBus.off("update_customer");
+                this.eventBus.off("update_item_stock");
+                this.eventBus.off("force_reload_items");
+                window.removeEventListener("resize", this.checkItemContainerOverflow);
+        },
 };
 </script>
 

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -230,16 +230,16 @@
 											:disabled="!!item.posa_is_replace"
 											prepend-inner-icon="mdi-numeric"
 										></v-text-field>
-										<div v-if="item.max_qty !== undefined" class="text-caption mt-1">
-											{{
-												__("In stock: {0}", [
-													formatFloat(
-														item.max_qty,
-														hide_qty_decimals ? 0 : undefined,
-													),
-												])
-											}}
-										</div>
+                                                                        <div v-if="hasInStockValue(item)" class="text-caption mt-1">
+                                                                                {{
+                                                                                        __("In stock: {0}", [
+                                                                                                formatFloat(
+                                                                                                        getDisplayInStockQty(item),
+                                                                                                        hide_qty_decimals ? 0 : undefined,
+                                                                                                ),
+                                                                                        ])
+                                                                                }}
+                                                                        </div>
 									</div>
 									<div class="form-field">
 										<v-select
@@ -939,11 +939,11 @@ export default {
 			return Math.max(config.min, Math.min(config.max, calculatedWidth));
 		},
 
-		calculateMinColumnWidth(header) {
-			const minWidths = {
-				item_name: 120,
-				qty: 100,
-				rate: 80,
+                calculateMinColumnWidth(header) {
+                        const minWidths = {
+                                item_name: 120,
+                                qty: 100,
+                                rate: 80,
 				amount: 80,
 				discount_value: 70,
 				discount_amount: 80,
@@ -952,14 +952,39 @@ export default {
 				posa_is_offer: 50,
 			};
 
-			return minWidths[header.key] || 60;
-		},
+                        return minWidths[header.key] || 60;
+                },
 
-		setupResizeObserver() {
-			if (typeof ResizeObserver !== "undefined") {
-				// Debounced resize handler for better performance
-				const debouncedResizeHandler = _.debounce((entries) => {
-					for (let entry of entries) {
+                hasInStockValue(item) {
+                        if (!item) return false;
+
+                        const sources = ["actual_qty", "available_qty", "max_qty"];
+                        return sources.some((key) => item[key] !== undefined && item[key] !== null);
+                },
+
+                getDisplayInStockQty(item) {
+                        if (!item) return 0;
+
+                        if (item.actual_qty !== undefined && item.actual_qty !== null) {
+                                return item.actual_qty;
+                        }
+
+                        if (item.available_qty !== undefined && item.available_qty !== null) {
+                                return item.available_qty;
+                        }
+
+                        if (item.max_qty !== undefined && item.max_qty !== null) {
+                                return item.max_qty;
+                        }
+
+                        return 0;
+                },
+
+                setupResizeObserver() {
+                        if (typeof ResizeObserver !== "undefined") {
+                                // Debounced resize handler for better performance
+                                const debouncedResizeHandler = _.debounce((entries) => {
+                                        for (let entry of entries) {
 						const { width, height } = entry.contentRect;
 
 						// Only update if dimensions actually changed

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1,13 +1,14 @@
 /* global __, frappe, flt */
 import {
-	isOffline,
-	saveCustomerBalance,
-	getCachedCustomerBalance,
-	getCachedPriceListItems,
-	getCustomerStorage,
-	getOfflineCustomers,
-	getTaxTemplate,
-	getTaxInclusiveSetting,
+        isOffline,
+        saveCustomerBalance,
+        getCachedCustomerBalance,
+        getCachedPriceListItems,
+        getCustomerStorage,
+        getOfflineCustomers,
+        getTaxTemplate,
+        getTaxInclusiveSetting,
+        updateLocalStockCache,
 } from "../../../offline/index.js";
 
 // Import composables
@@ -1845,14 +1846,19 @@ export default {
 					]),
 				},
 			});
-			const qty = r.message && r.message.length ? flt(r.message[0].available_qty) : 0;
-			this.available_stock_cache[key] = { qty, ts: now };
-			item.available_qty = qty;
-			this.update_qty_limits(item);
-		} catch (e) {
-			console.error("Failed to fetch available qty", e);
-		}
-	},
+                        const qty = r.message && r.message.length ? flt(r.message[0].available_qty) : 0;
+                        this.available_stock_cache[key] = { qty, ts: now };
+                        item.available_qty = qty;
+                        this.update_qty_limits(item);
+                        updateLocalStockCache([{ item_code: item.item_code, actual_qty: qty }]);
+                        this.eventBus?.emit("update_item_stock", {
+                                item_code: item.item_code,
+                                actual_qty: qty,
+                        });
+                } catch (e) {
+                        console.error("Failed to fetch available qty", e);
+                }
+        },
 
 	// Set serial numbers for an item (and update qty)
 	set_serial_no(item) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1313,9 +1313,10 @@ export default {
 					const updated_item = response.message.find(
 						(element) => element.posa_row_id == item.posa_row_id,
 					);
-					if (updated_item) {
-						item.actual_qty = updated_item.actual_qty;
-						item.item_uoms = updated_item.item_uoms;
+                                        if (updated_item) {
+                                                item.actual_qty = updated_item.actual_qty;
+                                                item.available_qty = updated_item.actual_qty;
+                                                item.item_uoms = updated_item.item_uoms;
 						item.has_batch_no = updated_item.has_batch_no;
 						item.has_serial_no = updated_item.has_serial_no;
 						item.batch_no_data = updated_item.batch_no_data;
@@ -1544,8 +1545,9 @@ export default {
 					item.projected_qty = data.projected_qty;
 					item.reserved_qty = data.reserved_qty;
 					item.conversion_factor = data.conversion_factor;
-					item.stock_qty = data.stock_qty;
-					item.actual_qty = data.actual_qty;
+                                        item.stock_qty = data.stock_qty;
+                                        item.actual_qty = data.actual_qty;
+                                        item.available_qty = data.actual_qty;
 					item.stock_uom = data.stock_uom;
 					item.has_serial_no = data.has_serial_no;
 					item.has_batch_no = data.has_batch_no;
@@ -1566,7 +1568,11 @@ export default {
 					});
 
 					// Force update UI immediately
-					vm.$forceUpdate();
+                                        if (vm.update_qty_limits) {
+                                                vm.update_qty_limits(item);
+                                        }
+
+                                        vm.$forceUpdate();
 				}
 			},
 		});
@@ -1849,6 +1855,7 @@ export default {
                         const qty = r.message && r.message.length ? flt(r.message[0].available_qty) : 0;
                         this.available_stock_cache[key] = { qty, ts: now };
                         item.available_qty = qty;
+                        item.actual_qty = qty;
                         this.update_qty_limits(item);
                         updateLocalStockCache([{ item_code: item.item_code, actual_qty: qty }]);
                         this.eventBus?.emit("update_item_stock", {


### PR DESCRIPTION
## Summary
- update local stock cache when fetching item quantity
- refresh item selector quantities via event bus

## Testing
- `npx eslint frontend/src/posapp/components/pos/invoiceItemMethods.js frontend/src/posapp/components/pos/ItemsSelector.vue >/tmp/eslint.log && tail -n 20 /tmp/eslint.log`
- `cat /tmp/eslint.log`
- `ls -l /tmp/eslint.log`


------
https://chatgpt.com/codex/tasks/task_e_68c80d7a0ed88326bda89cfac827b845