### PR TITLE
Set Sales Invoice update outstanding default to unchecked

### DIFF
--- a/posawesome/fixtures/property_setter.json
+++ b/posawesome/fixtures/property_setter.json
@@ -43,9 +43,26 @@
   "is_system_generated": 0,
   "modified": "2024-01-01 00:00:00",
   "module": null,
-  "name": "Sales Invoice Reference-sales_invoice-reqd",
-  "property": "reqd",
-  "property_type": "Check",
+ "name": "Sales Invoice Reference-sales_invoice-reqd",
+ "property": "reqd",
+ "property_type": "Check",
+ "row_name": null,
+ "value": "0"
+}
+,
+ {
+  "default_value": null,
+  "doc_type": "Sales Invoice",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "update_outstanding_for_self",
+  "is_system_generated": 0,
+  "modified": "2024-05-15 00:00:00",
+  "module": null,
+  "name": "Sales Invoice-update_outstanding_for_self-default",
+  "property": "default",
+  "property_type": "Text",
   "row_name": null,
   "value": "0"
  }

--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -305,6 +305,7 @@ fixtures = [
                     "Sales Invoice-posa_pos_opening_shift-no_copy",
                     "POS Invoice-posa_pos_opening_shift-no_copy",
                     "Sales Invoice Reference-sales_invoice-reqd",
+                    "Sales Invoice-update_outstanding_for_self-default",
                 ),
             ]
         ],


### PR DESCRIPTION
## Summary
- add a property setter fixture to default Sales Invoice `update_outstanding_for_self` to unchecked
- include the property setter in the fixtures export list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c913389d6c832680c7fb702ccfcc7b