### PR TITLE
feat: reorder cart item on repeated scan

### DIFF
--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -64,6 +64,15 @@ export function useItemAddition() {
 		}
 	};
 
+	const moveItemToTop = (context, target) => {
+		if (!target) return;
+		const currentIndex = context.items.findIndex((item) => item.posa_row_id === target.posa_row_id);
+		if (currentIndex > 0) {
+			const [existing] = context.items.splice(currentIndex, 1);
+			context.items.unshift(existing);
+		}
+	};
+
 	// Add item to invoice
 	const addItem = async (item, context) => {
 		if (!item.uom) {
@@ -239,6 +248,7 @@ export function useItemAddition() {
 				}
 			} else {
 				const cur_item = context.items[index];
+				const previousQty = cur_item.qty;
 				if (context.update_items_details) context.update_items_details([cur_item]);
 				// Merge serial numbers if any
 				if (new_item.serial_no_selected && new_item.serial_no_selected.length) {
@@ -268,9 +278,13 @@ export function useItemAddition() {
 				if (context.fetch_available_qty) {
 					context.fetch_available_qty(cur_item);
 				}
+				if (cur_item.qty > previousQty) {
+					moveItemToTop(context, cur_item);
+				}
 			}
 		} else {
 			const cur_item = context.items[index];
+			const previousQty = cur_item.qty;
 			if (context.update_items_details) context.update_items_details([cur_item]);
 			// Serial number logic for existing item
 			if (item.has_serial_no && item.to_set_serial_no) {
@@ -308,6 +322,9 @@ export function useItemAddition() {
 
 			if (context.fetch_available_qty) {
 				context.fetch_available_qty(cur_item);
+			}
+			if (cur_item.qty > previousQty) {
+				moveItemToTop(context, cur_item);
 			}
 		}
 		if (context.forceUpdate) context.forceUpdate();


### PR DESCRIPTION
## Summary
- add a helper to move an existing cart line to the top of the list
- keep repeated scans of an item focused by moving the line when its quantity increases

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68c9383a7d8c8326ba98e1eee58f5463