### PR TITLE
feat: improve scan error feedback

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1242,9 +1242,24 @@ export default {
 			this.fetch_price_lists();
 			this.update_price_list();
 		});
-		this.eventBus.on("add_item", (item) => {
-			this.add_item(item);
-		});
+                this.eventBus.on("add_item", (payload) => {
+                        const hasMeta = payload && typeof payload === "object" && "item" in payload;
+                        const item = hasMeta ? payload.item : payload;
+                        const meta = hasMeta ? payload.meta : null;
+
+                        const result = this.add_item(item);
+
+                        if (meta && typeof meta.onResult === "function") {
+                                Promise.resolve(result)
+                                        .then((response) => {
+                                                meta.onResult(response);
+                                        })
+                                        .catch((error) => {
+                                                console.error("Failed to add item from event bus:", error);
+                                                meta.onResult({ success: false, error });
+                                        });
+                        }
+                });
 		this.eventBus.on("update_customer", (customer) => {
 			this.customer = customer;
 		});

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1801,12 +1801,29 @@ export default {
 					}
 					item.qty = qtyVal;
 				}
-				const payload = { ...item };
-				delete payload._barcode_qty;
-				this.eventBus.emit("add_item", payload);
-				this.qty = 1;
-			}
-		},
+                                const payload = { ...item };
+                                delete payload._barcode_qty;
+                                this.qty = 1;
+
+                                return await new Promise((resolve) => {
+                                        let settled = false;
+                                        const finalize = (result) => {
+                                                if (!settled) {
+                                                        settled = true;
+                                                        resolve(result);
+                                                }
+                                        };
+
+                                        this.eventBus.emit("add_item", {
+                                                item: payload,
+                                                meta: {
+                                                        source: this.search_from_scanner ? "scanner" : "selector",
+                                                        onResult: finalize,
+                                                },
+                                        });
+                                });
+                        }
+                },
 		async enter_event() {
 			if (!this.filtered_items.length || !this.first_search) {
 				return;
@@ -2416,26 +2433,40 @@ export default {
 					return;
 				}
 
-				frappe.show_alert(
-					{
-						message: `${this.__("Item not found")}: ${scannedCode}`,
-						indicator: "red",
-					},
-					5,
-				);
-				return;
-			} catch (e) {
-				console.error("Error fetching item from barcode:", e);
-				frappe.show_alert(
-					{
-						message: `${this.__("Item not found")}: ${scannedCode}`,
-						indicator: "red",
-					},
-					5,
-				);
-				return;
-			}
-		},
+                                frappe.show_alert(
+                                        {
+                                                message: `${this.__("Item not found")}: ${scannedCode}`,
+                                                indicator: "red",
+                                        },
+                                        5,
+                                );
+                                if (
+                                        typeof frappe !== "undefined" &&
+                                        frappe.utils &&
+                                        typeof frappe.utils.play_sound === "function"
+                                ) {
+                                        frappe.utils.play_sound("error");
+                                }
+                                return;
+                        } catch (e) {
+                                console.error("Error fetching item from barcode:", e);
+                                frappe.show_alert(
+                                        {
+                                                message: `${this.__("Item not found")}: ${scannedCode}`,
+                                                indicator: "red",
+                                        },
+                                        5,
+                                );
+                                if (
+                                        typeof frappe !== "undefined" &&
+                                        frappe.utils &&
+                                        typeof frappe.utils.play_sound === "function"
+                                ) {
+                                        frappe.utils.play_sound("error");
+                                }
+                                return;
+                        }
+                },
 		searchItemsByCode(code) {
 			return this.items.filter((item) => {
 				const searchTerm = code.toLowerCase();
@@ -2497,22 +2528,41 @@ export default {
 				newItem._barcode_qty = true;
 			}
 
-			// Use existing add_item method with enhanced feedback
-			await this.add_item(newItem);
+                        // Use existing add_item method with enhanced feedback
+                        const additionResult = await this.add_item(newItem);
 
-			// Show success message
-			frappe.show_alert(
-				{
-					message: `Added: ${item.item_name}`,
-					indicator: "green",
-				},
-				3,
-			);
+                        if (!additionResult || !additionResult.success) {
+                                const reason = additionResult?.reason;
+                                if (!reason || (reason !== "no_stock" && reason !== "unchanged")) {
+                                        frappe.show_alert(
+                                                {
+                                                        message: this.__(
+                                                                "Unable to add item to invoice. Please try again.",
+                                                        ),
+                                                        indicator: "red",
+                                                },
+                                                5,
+                                        );
+                                }
 
-			// Clear search after successful addition and refocus input
-			this.clearSearch();
-			this.$refs.debounce_search && this.$refs.debounce_search.focus();
-		},
+                                this.clearSearch();
+                                this.$refs.debounce_search && this.$refs.debounce_search.focus();
+                                return;
+                        }
+
+                        // Show success message
+                        frappe.show_alert(
+                                {
+                                        message: `Added: ${item.item_name}`,
+                                        indicator: "green",
+                                },
+                                3,
+                        );
+
+                        // Clear search after successful addition and refocus input
+                        this.clearSearch();
+                        this.$refs.debounce_search && this.$refs.debounce_search.focus();
+                },
 		showMultipleItemsDialog(items, scannedCode) {
 			// Create a dialog to let user choose from multiple matches
 			const dialog = new frappe.ui.Dialog({

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -26,19 +26,96 @@ export default {
 		return removeItem(item, this);
 	},
 
-	async add_item(item) {
-		const res = await addItem(item, this);
-		const target = this.items.find(
-			(it) =>
-				it.item_code === item.item_code &&
-				it.uom === (item.uom || it.uom) &&
-				(!it.batch_no || it.batch_no === item.batch_no),
-		);
-		if (target && this.fetch_available_qty) {
-			this.fetch_available_qty(target);
-		}
-		return res;
-	},
+        async add_item(item) {
+                const findMatchingItem = (candidate) => {
+                        if (!candidate) {
+                                return null;
+                        }
+
+                        const candidateUom = candidate.uom || null;
+                        const candidateBatch = candidate.batch_no || candidate.to_set_batch_no || "";
+
+                        return this.items.find((invoiceItem) => {
+                                if (!invoiceItem || invoiceItem.posa_is_offer || invoiceItem.posa_is_replace) {
+                                        return false;
+                                }
+                                if (invoiceItem.item_code !== candidate.item_code) {
+                                        return false;
+                                }
+
+                                if (candidateUom && invoiceItem.uom !== candidateUom) {
+                                        return false;
+                                }
+
+                                if (this.pos_profile?.posa_auto_set_batch && candidate.has_batch_no) {
+                                        return true;
+                                }
+
+                                const invoiceBatch = invoiceItem.batch_no || "";
+                                if (candidateBatch && invoiceBatch) {
+                                        return invoiceBatch === candidateBatch;
+                                }
+
+                                return !candidateBatch && !invoiceBatch;
+                        });
+                };
+
+                const toNumber = (value) => {
+                        if (value === undefined || value === null || value === "") {
+                                return null;
+                        }
+                        const numeric = parseFloat(value);
+                        return Number.isNaN(numeric) ? null : numeric;
+                };
+
+                const previousMatch = findMatchingItem(item);
+                const previousQty = previousMatch ? toNumber(previousMatch.qty) : null;
+                const previousAbsQty = previousQty !== null ? Math.abs(previousQty) : null;
+                const previousLength = this.items.length;
+
+                const response = await addItem(item, this);
+
+                const target = findMatchingItem(item);
+                const newQty = target ? toNumber(target.qty) : null;
+                const newAbsQty = newQty !== null ? Math.abs(newQty) : null;
+                const addedNewLine = this.items.length > previousLength && Boolean(target);
+
+                let success = false;
+                if (target) {
+                        if (!previousMatch || addedNewLine) {
+                                success = newAbsQty !== null && newAbsQty > 0;
+                        } else if (newAbsQty !== null) {
+                                success = previousAbsQty === null ? newAbsQty > 0 : newAbsQty > previousAbsQty;
+                        }
+                }
+
+                let reason = null;
+                if (!success) {
+                        if (!target) {
+                                reason = "not_added";
+                        } else if (
+                                target.max_qty !== undefined &&
+                                target.max_qty !== null &&
+                                flt(target.max_qty) <= 0
+                        ) {
+                                reason = "no_stock";
+                        } else if (previousAbsQty !== null && newAbsQty === previousAbsQty) {
+                                reason = "unchanged";
+                        } else if (!newAbsQty) {
+                                reason = "no_qty";
+                        }
+                }
+
+                return {
+                        success,
+                        target,
+                        previousQty,
+                        newQty,
+                        reason,
+                        addedNewLine,
+                        response,
+                };
+        },
 
 	// Create a new item object with default and calculated fields
 	get_new_item(item) {
@@ -1758,33 +1835,66 @@ export default {
 	},
 
 	// Update UOM (unit of measure) for an item and recalculate prices
-	calc_uom(item, value) {
-		return calcUom(item, value, this);
-	},
+        calc_uom(item, value) {
+                return calcUom(item, value, this);
+        },
 
-	// Calculate stock quantity for an item with stock validation
-	calc_stock_qty(item, value) {
-		calcStockQty(item, value, this);
-		if (this.update_qty_limits) {
-			this.update_qty_limits(item);
-		}
-		if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
-			const blockSale = !this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
-			if (blockSale) {
-				item.qty = item.max_qty;
-				calcStockQty(item, item.qty, this);
-				this.$forceUpdate();
-				this.eventBus.emit("show_message", {
-					title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
-						this.formatFloat(item.max_qty),
-					]),
-					color: "error",
-				});
-			} else {
-				this.eventBus.emit("show_message", {
-					title: __("Stock is lower than requested. Proceeding may create negative stock."),
-					color: "warning",
-				});
+        notify_quantity_issue(item, limitedQty) {
+                const qtyValue =
+                        limitedQty !== undefined && limitedQty !== null ? flt(limitedQty) : 0;
+                const isOutOfStock = qtyValue <= 0;
+                const itemLabel =
+                        (item && (item.item_name || item.item_code)) || __("Item");
+                const formattedQty =
+                        typeof this.formatFloat === "function" ? this.formatFloat(qtyValue) : qtyValue;
+                const message = isOutOfStock
+                        ? __(`Quantity not available for {0}.`, [itemLabel])
+                        : __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
+                                  formattedQty,
+                          ]);
+
+                this.eventBus.emit("show_message", {
+                        title: message,
+                        color: "error",
+                });
+
+                if (typeof frappe !== "undefined" && typeof frappe.show_alert === "function") {
+                        frappe.show_alert(
+                                {
+                                        message,
+                                        indicator: isOutOfStock ? "red" : "orange",
+                                },
+                                5,
+                        );
+                }
+
+                if (
+                        typeof frappe !== "undefined" &&
+                        frappe.utils &&
+                        typeof frappe.utils.play_sound === "function"
+                ) {
+                        frappe.utils.play_sound("error");
+                }
+        },
+
+        // Calculate stock quantity for an item with stock validation
+        calc_stock_qty(item, value) {
+                calcStockQty(item, value, this);
+                if (this.update_qty_limits) {
+                        this.update_qty_limits(item);
+                }
+                if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
+                        const blockSale = !this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
+                        if (blockSale) {
+                                item.qty = item.max_qty;
+                                calcStockQty(item, item.qty, this);
+                                this.$forceUpdate();
+                                this.notify_quantity_issue(item, item.max_qty);
+                        } else {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Stock is lower than requested. Proceeding may create negative stock."),
+                                        color: "warning",
+                                });
 			}
 		}
 	},
@@ -1794,24 +1904,19 @@ export default {
 		if (item && item.available_qty !== undefined) {
 			item.max_qty = flt(item.available_qty / (item.conversion_factor || 1));
 
-			if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
-				const blockSale =
-					!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
-				if (blockSale) {
-					item.qty = item.max_qty;
-					calcStockQty(item, item.qty, this);
-					this.$forceUpdate();
-					this.eventBus.emit("show_message", {
-						title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
-							this.formatFloat(item.max_qty),
-						]),
-						color: "error",
-					});
-				} else {
-					this.eventBus.emit("show_message", {
-						title: __("Stock is lower than requested. Proceeding may create negative stock."),
-						color: "warning",
-					});
+                        if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
+                                const blockSale =
+                                        !this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
+                                if (blockSale) {
+                                        item.qty = item.max_qty;
+                                        calcStockQty(item, item.qty, this);
+                                        this.$forceUpdate();
+                                        this.notify_quantity_issue(item, item.max_qty);
+                                } else {
+                                        this.eventBus.emit("show_message", {
+                                                title: __("Stock is lower than requested. Proceeding may create negative stock."),
+                                                color: "warning",
+                                        });
 				}
 			}
 

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -193,9 +193,9 @@ export function useItemAddition() {
 				// Skip recalculation to preserve the manually set rate
 				if (context.update_item_detail) context.update_item_detail(new_item, false);
 
-				if (context.fetch_available_qty) {
-					context.fetch_available_qty(new_item);
-				}
+                                if (context.fetch_available_qty) {
+                                        await context.fetch_available_qty(new_item);
+                                }
 
 				if (
 					context.isReturnInvoice &&
@@ -275,9 +275,9 @@ export function useItemAddition() {
 					await context.calc_uom(cur_item, cur_item.uom);
 				}
 
-				if (context.fetch_available_qty) {
-					context.fetch_available_qty(cur_item);
-				}
+                                if (context.fetch_available_qty) {
+                                        await context.fetch_available_qty(cur_item);
+                                }
 				if (cur_item.qty > previousQty) {
 					moveItemToTop(context, cur_item);
 				}
@@ -320,9 +320,9 @@ export function useItemAddition() {
 				await context.calc_uom(cur_item, cur_item.uom);
 			}
 
-			if (context.fetch_available_qty) {
-				context.fetch_available_qty(cur_item);
-			}
+                        if (context.fetch_available_qty) {
+                                await context.fetch_available_qty(cur_item);
+                        }
 			if (cur_item.qty > previousQty) {
 				moveItemToTop(context, cur_item);
 			}


### PR DESCRIPTION
## Summary
- await quantity lookups during item additions and return success metadata through the invoice event bus
- surface "quantity not available" alerts with audio feedback and suppress false success messages when scanning
- add scanner error sounds for missing items to make barcode failures more obvious

## Testing
- yarn install --frozen-lockfile
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68c96122a394832680104208337ba731