### PR TITLE
Fix consolidated return payment validation during closing shift

### DIFF
--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -154,6 +154,7 @@ doc_events = {
 # Override standard DocTypes with custom classes
 override_doctype_class = {
     "POS Invoice": "posawesome.posawesome.overrides.pos_invoice.CustomPOSInvoice",
+    "POS Invoice Merge Log": "posawesome.posawesome.overrides.pos_invoice_merge_log.CustomPOSInvoiceMergeLog",
 }
 
 # exempt linked doctypes from being automatically cancelled

--- a/posawesome/posawesome/overrides/pos_invoice_merge_log.py
+++ b/posawesome/posawesome/overrides/pos_invoice_merge_log.py
@@ -1,0 +1,154 @@
+"""Override POS Invoice Merge Log to stabilise consolidated return payments."""
+
+from __future__ import annotations
+
+from erpnext.accounts.doctype.pos_invoice_merge_log.pos_invoice_merge_log import (
+    POSInvoiceMergeLog as ERPNextPOSInvoiceMergeLog,
+)
+from frappe.utils import flt
+
+
+class CustomPOSInvoiceMergeLog(ERPNextPOSInvoiceMergeLog):
+    """Ensure consolidated credit notes keep payment totals within tolerance."""
+
+    def merge_pos_invoice_into(self, invoice, data):
+        invoice = super().merge_pos_invoice_into(invoice, data)
+
+        if getattr(invoice, "is_return", 0):
+            self._normalize_return_payments(invoice)
+
+        return invoice
+
+    def _normalize_return_payments(self, invoice) -> None:
+        """Clamp aggregated payment totals for consolidated return invoices."""
+
+        invoice_total = flt(invoice.rounded_total or invoice.grand_total)
+        conversion_rate = invoice.conversion_rate or 1
+
+        if not invoice_total:
+            invoice.write_off_amount = 0
+            invoice.base_write_off_amount = 0
+            invoice.set("payments", [])
+            invoice.set_paid_amount()
+            return
+
+        invoice_sign = -1 if invoice_total < 0 else 1
+        invoice_total_abs = abs(invoice_total)
+
+        precision_total = invoice.precision("grand_total") or 2
+        precision_paid = invoice.precision("paid_amount") or 2
+        precision_base_paid = invoice.precision("base_paid_amount") or 2
+        precision_write_off = invoice.precision("write_off_amount") or 2
+        precision_base_write_off = invoice.precision("base_write_off_amount") or 2
+        tolerance = 1 / (10 ** (precision_total + 1))
+
+        write_off_abs = abs(flt(invoice.write_off_amount))
+        if write_off_abs > invoice_total_abs:
+            write_off_abs = invoice_total_abs
+
+        invoice.write_off_amount = invoice_sign * flt(write_off_abs, precision_write_off)
+        invoice.base_write_off_amount = invoice_sign * flt(
+            write_off_abs * conversion_rate, precision_base_write_off
+        )
+
+        payments = invoice.get("payments", [])
+        if not payments:
+            invoice.set_paid_amount()
+            return
+
+        for payment in payments:
+            abs_amount = abs(flt(payment.amount))
+            if not abs_amount and payment.base_amount:
+                abs_amount = abs(flt(payment.base_amount)) / conversion_rate if conversion_rate else 0
+
+            payment.amount = invoice_sign * flt(abs_amount, precision_paid)
+            payment.base_amount = invoice_sign * flt(abs_amount * conversion_rate, precision_base_paid)
+
+        invoice.set_paid_amount()
+
+        difference = (
+            abs(flt(invoice.paid_amount)) + abs(flt(invoice.write_off_amount)) - invoice_total_abs
+        )
+
+        if difference > tolerance:
+            self._reduce_payment_difference(
+                invoice,
+                difference,
+                invoice_sign,
+                conversion_rate,
+                precision_paid,
+                precision_base_paid,
+                tolerance,
+            )
+
+        self._cleanup_zero_amount_payments(invoice, tolerance, precision_base_paid)
+        invoice.set_paid_amount()
+
+        remaining_diff = (
+            abs(flt(invoice.paid_amount)) + abs(flt(invoice.write_off_amount)) - invoice_total_abs
+        )
+        if remaining_diff > tolerance and invoice.payments:
+            last_payment = invoice.payments[-1]
+            current_abs = abs(flt(last_payment.amount))
+            adjustment = min(current_abs, remaining_diff)
+            new_abs = current_abs - adjustment
+
+            last_payment.amount = invoice_sign * flt(new_abs, precision_paid)
+            last_payment.base_amount = invoice_sign * flt(
+                new_abs * conversion_rate, precision_base_paid
+            )
+
+            self._cleanup_zero_amount_payments(invoice, tolerance, precision_base_paid)
+            invoice.set_paid_amount()
+
+    def _reduce_payment_difference(
+        self,
+        invoice,
+        difference: float,
+        invoice_sign: int,
+        conversion_rate: float,
+        precision_paid: int,
+        precision_base_paid: int,
+        tolerance: float,
+    ) -> None:
+        """Distribute the excess paid amount across existing payment rows."""
+
+        remaining = difference
+        for payment in reversed(invoice.payments):
+            current_abs = abs(flt(payment.amount))
+            if current_abs <= tolerance:
+                continue
+
+            deduction = min(current_abs, remaining)
+            new_abs = current_abs - deduction
+
+            payment.amount = invoice_sign * flt(new_abs, precision_paid)
+            payment.base_amount = invoice_sign * flt(
+                new_abs * conversion_rate, precision_base_paid
+            )
+
+            remaining -= deduction
+            if remaining <= tolerance:
+                break
+
+    def _cleanup_zero_amount_payments(
+        self,
+        invoice,
+        tolerance: float,
+        precision_base_paid: int,
+    ) -> None:
+        """Drop zeroed payment rows and keep indices tidy."""
+
+        conversion_rate = invoice.conversion_rate or 1
+        cleaned = []
+        for idx, payment in enumerate(invoice.get("payments", []), start=1):
+            if abs(flt(payment.amount)) <= tolerance:
+                continue
+
+            payment.idx = idx
+            payment.base_amount = flt(payment.amount * conversion_rate, precision_base_paid)
+            cleaned.append(payment)
+
+        if len(cleaned) != len(invoice.get("payments", [])):
+            invoice.set("payments", cleaned)
+


### PR DESCRIPTION
## Summary
- register a custom override for POS Invoice Merge Log so consolidated returns go through our validation layer
- normalise merged credit note payments and write-off amounts to keep totals within ERPNext's tolerance and avoid POS validation failures

## Testing
- python -m compileall posawesome

------
https://chatgpt.com/codex/tasks/task_e_68c9a22d45808326913793df10177b04