### PR TITLE
Ensure item search refocus after clearing sales

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1264,9 +1264,10 @@ export default {
 		this.eventBus.on("fetch_customer_details", () => {
 			this.fetch_customer_details();
 		});
-		this.eventBus.on("clear_invoice", () => {
-			this.clear_invoice();
-		});
+                this.eventBus.on("clear_invoice", () => {
+                        this.clear_invoice();
+                        this.eventBus.emit("focus_item_search");
+                });
 		this.eventBus.on("load_invoice", (data) => {
 			this.load_invoice(data);
 		});

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2444,12 +2444,21 @@ export default {
 				// No need to reload items when focus is lost
 			}
 		},
-		handleItemSearchFocus() {
-			this.first_search = "";
-			this.search = "";
-			// Optionally, you might want to also clear search_backup if the behaviour should be a full reset on focus
-			// this.search_backup = "";
-		},
+                handleItemSearchFocus() {
+                        this.first_search = "";
+                        this.search = "";
+                        // Optionally, you might want to also clear search_backup if the behaviour should be a full reset on focus
+                        // this.search_backup = "";
+                },
+
+                focusItemSearch() {
+                        this.$nextTick(() => {
+                                const input = this.$refs.debounce_search;
+                                if (input && typeof input.focus === "function") {
+                                        input.focus();
+                                }
+                        });
+                },
 
 		clearQty() {
 			this.qty = null;
@@ -3195,13 +3204,17 @@ export default {
 		this.eventBus.on("update_customer_price_list", (data) => {
 			this.customer_price_list = data;
 		});
-		this.eventBus.on("update_customer", (data) => {
-			this.customer = data;
-		});
+                this.eventBus.on("update_customer", (data) => {
+                        this.customer = data;
+                });
 
-		// Manually trigger a full item reload when requested
-		this.eventBus.on("force_reload_items", async () => {
-			await this.ensureStorageHealth();
+                this.eventBus.on("focus_item_search", () => {
+                        this.focusItemSearch();
+                });
+
+                // Manually trigger a full item reload when requested
+                this.eventBus.on("force_reload_items", async () => {
+                        await this.ensureStorageHealth();
 			this.items_loaded = false;
 			if (!isOffline()) {
 				if (this.pos_profile && (!this.pos_profile.posa_local_storage || !this.storageAvailable)) {
@@ -3363,12 +3376,13 @@ export default {
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("update_cur_items_details");
 		this.eventBus.off("update_offers_counters");
-		this.eventBus.off("update_coupons_counters");
-		this.eventBus.off("update_customer_price_list");
-		this.eventBus.off("update_customer");
-		this.eventBus.off("force_reload_items");
-		window.removeEventListener("resize", this.checkItemContainerOverflow);
-	},
+                this.eventBus.off("update_coupons_counters");
+                this.eventBus.off("update_customer_price_list");
+                this.eventBus.off("update_customer");
+                this.eventBus.off("force_reload_items");
+                this.eventBus.off("focus_item_search");
+                window.removeEventListener("resize", this.checkItemContainerOverflow);
+        },
 };
 </script>
 

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1298,15 +1298,16 @@ export default {
 						title: __("Invoice saved offline"),
 						color: "warning",
 					});
-					if (print) {
-						this.print_offline_invoice(this.invoice_doc);
-					}
-					vm.eventBus.emit("clear_invoice");
-					vm.eventBus.emit("reset_posting_date");
-					vm.back_to_invoice();
-					vm.loading = false;
-					return;
-				} catch (error) {
+                                        if (print) {
+                                                this.print_offline_invoice(this.invoice_doc);
+                                        }
+                                        vm.eventBus.emit("clear_invoice");
+                                        vm.eventBus.emit("focus_item_search");
+                                        vm.eventBus.emit("reset_posting_date");
+                                        vm.back_to_invoice();
+                                        vm.loading = false;
+                                        return;
+                                } catch (error) {
 					vm.eventBus.emit("show_message", {
 						title: __("Cannot Save Offline Invoice: ") + (error.message || __("Unknown error")),
 						color: "error",
@@ -1389,14 +1390,15 @@ export default {
 					frappe.utils.play_sound("submit");
 					// Update local stock quantities immediately after successful
 					// invoice submission so item availability reflects changes
-					updateLocalStock(vm.invoice_doc.items || []);
-					vm.addresses = [];
-					vm.eventBus.emit("clear_invoice");
-					vm.eventBus.emit("reset_posting_date");
-					vm.back_to_invoice();
-					vm.loading = false;
-				},
-			});
+                                        updateLocalStock(vm.invoice_doc.items || []);
+                                        vm.addresses = [];
+                                        vm.eventBus.emit("clear_invoice");
+                                        vm.eventBus.emit("focus_item_search");
+                                        vm.eventBus.emit("reset_posting_date");
+                                        vm.back_to_invoice();
+                                        vm.loading = false;
+                                },
+                        });
 		},
 		// Set full amount for a payment method (or negative for returns)
 		set_full_amount(idx) {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1041,10 +1041,13 @@ export default {
 	},
 	methods: {
 		// Go back to invoice view and reset customer readonly
-		back_to_invoice() {
-			this.eventBus.emit("show_payment", "false");
-			this.eventBus.emit("set_customer_readonly", false);
-		},
+                back_to_invoice() {
+                        this.eventBus.emit("show_payment", "false");
+                        this.eventBus.emit("set_customer_readonly", false);
+                        this.$nextTick(() => {
+                                this.eventBus.emit("focus_item_search");
+                        });
+                },
 		// Highlight and focus the submit button when payment screen opens
 		handleShowPayment(data) {
 			if (data === "true") {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -116,11 +116,11 @@ export default {
 		this.invoiceTypes = ["Invoice", "Order", "Quotation"];
 		this.posting_date = frappe.datetime.nowdate();
 		var vm = this;
-		if (doc.name && this.pos_profile.posa_allow_delete) {
-			await frappe.call({
-				method: "posawesome.posawesome.api.invoices.delete_invoice",
-				args: { invoice: doc.name },
-				async: true,
+                if (doc.name && this.pos_profile.posa_allow_delete) {
+                        await frappe.call({
+                                method: "posawesome.posawesome.api.invoices.delete_invoice",
+                                args: { invoice: doc.name },
+                                async: true,
 				callback: function (r) {
 					if (r.message) {
 						vm.eventBus.emit("show_message", {
@@ -129,11 +129,12 @@ export default {
 						});
 					}
 				},
-			});
-		}
-		this.clear_invoice();
-		this.cancel_dialog = false;
-	},
+                        });
+                }
+                this.clear_invoice();
+                this.eventBus.emit("focus_item_search");
+                this.cancel_dialog = false;
+        },
 
 	// Load an invoice (or return invoice) from data, set all fields accordingly
 	async load_invoice(data = {}) {
@@ -253,16 +254,17 @@ export default {
 				});
 			}
 		}
-		if (!old_invoice) {
-			this.eventBus.emit("show_message", {
-				title: `Error saving the current invoice`,
-				color: "error",
-			});
-		} else {
-			this.clear_invoice();
-			return old_invoice;
-		}
-	},
+                if (!old_invoice) {
+                        this.eventBus.emit("show_message", {
+                                title: `Error saving the current invoice`,
+                                color: "error",
+                        });
+                } else {
+                        this.clear_invoice();
+                        this.eventBus.emit("focus_item_search");
+                        return old_invoice;
+                }
+        },
 
 	// Start a new order (or return order) with provided data
 	async new_order(data = {}) {


### PR DESCRIPTION
## Summary
- add an event-driven helper in ItemsSelector to refocus the search field on demand
- emit the new focus event after save & clear, cancel sale, and successful invoice submission flows

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4095eff8832683e0917c032c765f