### PR TITLE
Fix submit button focus background

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -2067,14 +2067,15 @@ export default {
 	background-color: var(--surface-secondary) !important;
 }
 
-.submit-btn:focus,
-.submit-highlight {
-	background-color: rgb(var(--v-theme-primary)) !important;
-	color: rgb(var(--v-theme-on-primary)) !important;
+.submit-btn:focus {
+        background-color: transparent !important;
+        color: inherit !important;
 }
 
 .submit-highlight {
-	box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
-	transition: box-shadow 0.3s ease-in-out;
+        background-color: rgb(var(--v-theme-primary)) !important;
+        color: rgb(var(--v-theme-on-primary)) !important;
+        box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
+        transition: box-shadow 0.3s ease-in-out;
 }
 </style>


### PR DESCRIPTION
## Summary
- make the payment submit button focus state transparent so it no longer turns black after moving the mouse back to it
- ensure the highlight class solely manages the submit button emphasis styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca544a0f448326b8e3a9c8d1295eef