### PR TITLE
Fix submit button focus styling

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -2067,10 +2067,16 @@ export default {
 	background-color: var(--surface-secondary) !important;
 }
 
+.submit-btn {
+        position: relative;
+}
+
+.submit-btn:hover,
 .submit-btn:focus,
-.submit-btn:focus-visible {
-        background-color: transparent !important;
-        color: inherit !important;
+.submit-btn:focus-visible,
+.submit-btn:active {
+        background-color: rgb(var(--v-theme-primary)) !important;
+        color: rgb(var(--v-theme-on-primary)) !important;
         box-shadow: none;
 }
 
@@ -2079,9 +2085,15 @@ export default {
         outline-offset: 2px;
 }
 
+.submit-btn::before,
+.submit-btn:hover::before,
+.submit-btn:focus::before,
+.submit-btn:focus-visible::before,
+.submit-btn:active::before {
+        opacity: 0 !important;
+}
+
 .submit-highlight {
-        background-color: rgb(var(--v-theme-primary)) !important;
-        color: rgb(var(--v-theme-on-primary)) !important;
         box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
         transition: box-shadow 0.3s ease-in-out;
 }

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -2068,13 +2068,21 @@ export default {
 }
 
 .submit-btn:focus,
-.submit-highlight {
-	background-color: rgb(var(--v-theme-primary)) !important;
-	color: rgb(var(--v-theme-on-primary)) !important;
+.submit-btn:focus-visible {
+        background-color: transparent !important;
+        color: inherit !important;
+        box-shadow: none;
+}
+
+.submit-btn:focus-visible {
+        outline: 2px solid rgb(var(--v-theme-primary));
+        outline-offset: 2px;
 }
 
 .submit-highlight {
-	box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
-	transition: box-shadow 0.3s ease-in-out;
+        background-color: rgb(var(--v-theme-primary)) !important;
+        color: rgb(var(--v-theme-on-primary)) !important;
+        box-shadow: 0 0 0 4px rgb(var(--v-theme-primary));
+        transition: box-shadow 0.3s ease-in-out;
 }
 </style>


### PR DESCRIPTION
## Summary
- keep the payment submit button background transparent when it receives focus
- move the highlight styling to the submit-highlight class so the manual highlight still works
- add a focus outline to preserve accessibility when the button is focused

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca544a0f448326b8e3a9c8d1295eef