### PR TITLE
Fix return payment rounding when consolidating POS invoices

### DIFF
--- a/posawesome/posawesome/overrides/pos_invoice_merge_log.py
+++ b/posawesome/posawesome/overrides/pos_invoice_merge_log.py
@@ -56,13 +56,17 @@ class CustomPOSInvoiceMergeLog(ERPNextPOSInvoiceMergeLog):
             invoice.set_paid_amount()
             return
 
+        min_unit = 1 / (10 ** precision_paid) if precision_paid is not None else 0
+
         for payment in payments:
             abs_amount = abs(flt(payment.amount))
             if not abs_amount and payment.base_amount:
                 abs_amount = abs(flt(payment.base_amount)) / conversion_rate if conversion_rate else 0
 
             payment.amount = invoice_sign * flt(abs_amount, precision_paid)
-            payment.base_amount = invoice_sign * flt(abs_amount * conversion_rate, precision_base_paid)
+            payment.base_amount = invoice_sign * flt(
+                abs_amount * conversion_rate, precision_base_paid
+            )
 
         invoice.set_paid_amount()
 
@@ -79,6 +83,7 @@ class CustomPOSInvoiceMergeLog(ERPNextPOSInvoiceMergeLog):
                 precision_paid,
                 precision_base_paid,
                 tolerance,
+                min_unit,
             )
 
         self._cleanup_zero_amount_payments(invoice, tolerance, precision_base_paid)
@@ -93,9 +98,18 @@ class CustomPOSInvoiceMergeLog(ERPNextPOSInvoiceMergeLog):
             adjustment = min(current_abs, remaining_diff)
             new_abs = current_abs - adjustment
 
-            last_payment.amount = invoice_sign * flt(new_abs, precision_paid)
+            new_amount = invoice_sign * flt(new_abs, precision_paid)
+            if (
+                abs(flt(new_amount)) >= current_abs - tolerance
+                and min_unit
+                and current_abs > min_unit
+            ):
+                new_amount = invoice_sign * flt(current_abs - min_unit, precision_paid)
+
+            last_payment.amount = new_amount
             last_payment.base_amount = invoice_sign * flt(
-                new_abs * conversion_rate, precision_base_paid
+                abs(flt(last_payment.amount)) * conversion_rate,
+                precision_base_paid,
             )
 
             self._cleanup_zero_amount_payments(invoice, tolerance, precision_base_paid)
@@ -110,6 +124,7 @@ class CustomPOSInvoiceMergeLog(ERPNextPOSInvoiceMergeLog):
         precision_paid: int,
         precision_base_paid: int,
         tolerance: float,
+        min_unit: float,
     ) -> None:
         """Distribute the excess paid amount across existing payment rows."""
 
@@ -122,12 +137,23 @@ class CustomPOSInvoiceMergeLog(ERPNextPOSInvoiceMergeLog):
             deduction = min(current_abs, remaining)
             new_abs = current_abs - deduction
 
-            payment.amount = invoice_sign * flt(new_abs, precision_paid)
+            new_amount = invoice_sign * flt(new_abs, precision_paid)
+            new_abs_after = abs(flt(new_amount))
+
+            if (
+                new_abs_after >= current_abs - tolerance
+                and min_unit
+                and current_abs > min_unit
+            ):
+                new_amount = invoice_sign * flt(current_abs - min_unit, precision_paid)
+                new_abs_after = abs(flt(new_amount))
+
+            payment.amount = new_amount
             payment.base_amount = invoice_sign * flt(
-                new_abs * conversion_rate, precision_base_paid
+                new_abs_after * conversion_rate, precision_base_paid
             )
 
-            remaining -= deduction
+            remaining -= current_abs - new_abs_after
             if remaining <= tolerance:
                 break
 


### PR DESCRIPTION
## Summary
- clamp return payment adjustments to the minimum currency unit when normalizing consolidated credit notes
- recalculate base amounts after applying the reduced payment values so that rounding cannot exceed the grand total

## Testing
- python -m compileall posawesome/posawesome/overrides/pos_invoice_merge_log.py

------
https://chatgpt.com/codex/tasks/task_e_68ca964cbfe08326b1648347d312b75c