### PR TITLE
fix: retain manual uom prices on repeat scans

### DIFF
--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -321,9 +321,12 @@ export function useItemAddition() {
 			if (context.setSerialNo) context.setSerialNo(cur_item);
 
 			// Recalculate rates if UOM differs from stock UOM
-			if (context.calc_uom && cur_item.uom) {
-				await context.calc_uom(cur_item, cur_item.uom);
-			}
+                        if (context.calc_uom && cur_item.uom) {
+                                const shouldRecalculate = !cur_item._manual_rate_set;
+                                if (shouldRecalculate) {
+                                        await context.calc_uom(cur_item, cur_item.uom);
+                                }
+                        }
 
 			if (context.fetch_available_qty) {
 				context.fetch_available_qty(cur_item);

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -271,9 +271,14 @@ export function useItemAddition() {
 
 				if (context.setSerialNo) context.setSerialNo(cur_item);
 
-				if (context.calc_uom && cur_item.uom) {
-					await context.calc_uom(cur_item, cur_item.uom);
-				}
+                                if (context.calc_uom && cur_item.uom) {
+                                        // Preserve manually fetched UOM prices when the same item is scanned again.
+                                        // Only trigger a fresh UOM calculation when the rate hasn't been overridden.
+                                        const shouldRecalculate = !cur_item._manual_rate_set;
+                                        if (shouldRecalculate) {
+                                                await context.calc_uom(cur_item, cur_item.uom);
+                                        }
+                                }
 
 				if (context.fetch_available_qty) {
 					context.fetch_available_qty(cur_item);


### PR DESCRIPTION
## Summary
- skip recalculating UOM pricing when an item's rate has already been manually fetched, preserving barcode-specific prices on repeated scans
- document the intent with inline comments to clarify why recalculation is bypassed for manual prices

## Testing
- `yarn lint` *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caf65c184883268e04c65a53421f22