### PR TITLE
fix: preserve barcode UOM pricing on rescan

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -776,7 +776,16 @@ def get_items_details(pos_profile, items_data, price_list=None, customer=None):
 
         item_price = {}
         if price_map.get(item_code):
-            item_price = price_map[item_code].get(stock_uom) or price_map[item_code].get("None") or {}
+            requested_uom = item.get("uom")
+            if requested_uom:
+                item_price = price_map[item_code].get(requested_uom) or {}
+
+            if not item_price:
+                item_price = (
+                    price_map[item_code].get(stock_uom)
+                    or price_map[item_code].get("None")
+                    or {}
+                )
 
         row = {}
         row.update(item)


### PR DESCRIPTION
## Summary
- ensure `get_items_details` returns price list rows for the requested UOM when present
- fall back to stock or default pricing only when the requested UOM price is unavailable

## Testing
- python -m compileall posawesome/posawesome/api/items.py

------
https://chatgpt.com/codex/tasks/task_e_68cb0234c2f08326aa098de7a2a4f963