### PR TITLE
Handle scanned items immediately

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2372,15 +2372,13 @@ export default {
 						oEvent.preventDefault();
 						return onScan.decodeKeyEvent(oEvent);
 					},
-					onScan: function (sCode) {
-						if (vm.scannerLocked) {
-							vm.playScanTone("error");
-							return;
-						}
-						setTimeout(() => {
-							vm.trigger_onscan(sCode);
-						}, 300);
-					},
+                                        onScan: function (sCode) {
+                                                if (vm.scannerLocked) {
+                                                        vm.playScanTone("error");
+                                                        return;
+                                                }
+                                                vm.trigger_onscan(sCode);
+                                        },
 				});
 
 				// Mark document as having scanner attached
@@ -2623,11 +2621,9 @@ export default {
 				2,
 			);
 
-			// Enhanced item search and submission logic
-			setTimeout(() => {
-				this.processScannedItem(scannedCode);
-			}, 300);
-		},
+                        // Enhanced item search and submission logic
+                        this.processScannedItem(scannedCode);
+                },
 		async processScannedItem(scannedCode) {
 			this.pendingScanCode = scannedCode;
 			// Handle scale barcodes by extracting the item code and quantity


### PR DESCRIPTION
## Summary
- trigger keyboard wedge scans without the previous 300ms delay
- process camera scans immediately instead of waiting for a timeout

## Testing
- not run (manual camera/keyboard scan validation required)

------
https://chatgpt.com/codex/tasks/task_e_68cb0f6c587883269d678a2f11a90ba5