### PR TITLE
Refactor scanner search handling for immediate execution

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1281,10 +1281,10 @@ export default {
 		this.eventBus.on("update_invoice_offers", (data) => {
 			this.updateInvoiceOffers(data);
 		});
-		this.eventBus.on("update_invoice_coupons", (data) => {
-			this.posa_coupons = data;
-			this.handelOffers();
-		});
+                this.eventBus.on("update_invoice_coupons", (data) => {
+                        this.posa_coupons = data;
+                        this.queueOfferRecalculation(null, { forceFull: true });
+                });
 		this.eventBus.on("set_all_items", (data) => {
 			this.allItems = data;
 			this.items.forEach((item) => {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -562,7 +562,9 @@ export default {
 		renderBuffer: 10,
 		lastScrollTop: 0,
 		scrollThrottle: null,
-		searchDebounce: null,
+                searchDebounce: null,
+                manualSearchRunner: null,
+                firstSearchSetter: null,
 		// Prevent repeated server fetches when local storage is empty
 		fallbackAttempted: false,
 		// Fixed page size for incremental item loading to avoid
@@ -734,18 +736,25 @@ export default {
 			}
 			this.$nextTick(this.checkItemContainerOverflow);
 		},
-		// Automatically search when the query has at least 3 characters
-		first_search: _.debounce(function (val, oldVal) {
-			const newLen = (val || "").trim().length;
-			const oldLen = (oldVal || "").trim().length;
-			if (newLen >= 3) {
-				// Call without arguments so search_onchange treats it like an Enter key
-				this.search_onchange();
-			} else if (oldLen >= 3 && newLen === 0) {
-				// Reset items only when search is fully cleared
-				this.clearSearch();
-			}
-		}, 300),
+                // Automatically search when the query has at least 3 characters
+                first_search(val, oldVal) {
+                        const trimmedVal = (val || "").trim();
+                        const trimmedOldVal = (oldVal || "").trim();
+
+                        if (this.search_from_scanner) {
+                                this.cancelManualSearchRunner();
+                                this.search_onchange(trimmedVal);
+                                return;
+                        }
+
+                        if (trimmedVal.length >= 3) {
+                                const runner = this.ensureManualSearchRunner();
+                                runner(trimmedVal);
+                        } else if (trimmedOldVal.length >= 3 && trimmedVal.length === 0) {
+                                // Reset items only when search is fully cleared
+                                this.clearSearch();
+                        }
+                },
 
 		// Refresh item prices whenever the user changes currency
 		selected_currency() {
@@ -781,10 +790,36 @@ export default {
 		},
 	},
 
-	methods: {
-		// Performance optimization: Memoized search function
-		memoizedSearch(searchTerm, itemGroup) {
-			const cacheKey = `${searchTerm || ""}_${itemGroup || "ALL"}`;
+        methods: {
+                ensureManualSearchRunner() {
+                        if (!this.manualSearchRunner) {
+                                this.manualSearchRunner = _.debounce((searchTerm) => {
+                                        this.search_onchange(searchTerm);
+                                }, 300);
+                        }
+                        return this.manualSearchRunner;
+                },
+                cancelManualSearchRunner() {
+                        if (this.manualSearchRunner && typeof this.manualSearchRunner.cancel === "function") {
+                                this.manualSearchRunner.cancel();
+                        }
+                },
+                ensureFirstSearchSetter() {
+                        if (!this.firstSearchSetter) {
+                                this.firstSearchSetter = _.debounce((value) => {
+                                        this.first_search = value;
+                                }, 200);
+                        }
+                        return this.firstSearchSetter;
+                },
+                cancelFirstSearchSetter() {
+                        if (this.firstSearchSetter && typeof this.firstSearchSetter.cancel === "function") {
+                                this.firstSearchSetter.cancel();
+                        }
+                },
+                // Performance optimization: Memoized search function
+                memoizedSearch(searchTerm, itemGroup) {
+                        const cacheKey = `${searchTerm || ""}_${itemGroup || "ALL"}`;
 
 			// Check if we have a cached result
 			if (this.searchCache && this.searchCache.has(cacheKey)) {
@@ -1427,15 +1462,12 @@ export default {
 		finishBackgroundLoad() {
 			this.isBackgroundLoading = false;
 
-			const pendingSearch = this.pendingItemSearch;
-			this.pendingItemSearch = null;
-			if (pendingSearch) {
-				this.search_onchange(pendingSearch);
-				if (this.search_onchange.flush) {
-					this.search_onchange.flush();
-				}
-				return;
-			}
+                        const pendingSearch = this.pendingItemSearch;
+                        this.pendingItemSearch = null;
+                        if (pendingSearch) {
+                                this.search_onchange(pendingSearch);
+                                return;
+                        }
 
 			if (this.pendingGetItems) {
 				const { force_server: forceServer } = this.pendingGetItems;
@@ -1991,65 +2023,75 @@ export default {
 				}
 			}
 		},
-		search_onchange: _.debounce(async function (newSearchTerm) {
-			const vm = this;
+                async search_onchange(newSearchTerm) {
+                        let incoming = newSearchTerm;
 
-			vm.cancelItemDetailsRequest();
+                        if (incoming && typeof incoming === "object" && typeof incoming.preventDefault === "function") {
+                                incoming.preventDefault();
+                                if (typeof incoming.stopPropagation === "function") {
+                                        incoming.stopPropagation();
+                                }
+                                incoming = this.first_search;
+                        }
 
-			// Determine the actual query string and trim whitespace
-			const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
-			const trimmedQuery = (query || "").trim();
+                        await this.executeImmediateSearch(incoming);
+                },
+                async executeImmediateSearch(newSearchTerm) {
+                        this.cancelItemDetailsRequest();
 
-			// Require a minimum of three characters before running a search
-			if (!trimmedQuery || trimmedQuery.length < 3) {
-				vm.search_from_scanner = false;
-				return;
-			}
+                        const query = typeof newSearchTerm === "string" ? newSearchTerm : this.first_search;
+                        const trimmedQuery = (query || "").trim();
 
-			// If background loading is in progress, defer the search without changing the active query
-			if (vm.isBackgroundLoading) {
-				vm.pendingItemSearch = trimmedQuery;
-				return;
-			}
+                        // Require a minimum of three characters before running a search
+                        if (!trimmedQuery || trimmedQuery.length < 3) {
+                                this.search_from_scanner = false;
+                                return;
+                        }
 
-			vm.search = trimmedQuery;
+                        // If background loading is in progress, defer the search without changing the active query
+                        if (this.isBackgroundLoading) {
+                                this.pendingItemSearch = trimmedQuery;
+                                return;
+                        }
 
-			const fromScanner = vm.search_from_scanner;
+                        this.search = trimmedQuery;
 
-			if (vm.pos_profile && vm.pos_profile.pose_use_limit_search) {
-				if (vm.pos_profile && (!vm.pos_profile.posa_local_storage || !vm.storageAvailable)) {
-					vm.get_items(true);
-				} else {
-					vm.get_items();
-				}
-			} else if (vm.pos_profile && vm.pos_profile.posa_local_storage) {
-				if (vm.storageAvailable) {
-					await vm.loadVisibleItems(true);
-					vm.enter_event();
-				} else {
-					vm.get_items(true);
-				}
-			} else {
-				// When local storage is disabled, always fetch items
-				// from the server so searches aren't limited to the
-				// initially loaded set.
-				await vm.get_items(true);
-				vm.enter_event();
+                        const fromScanner = this.search_from_scanner;
 
-				if (vm.filtered_items && vm.filtered_items.length > 0) {
-					setTimeout(() => {
-						vm.update_items_details(vm.filtered_items);
-					}, 300);
-				}
-			}
+                        if (this.pos_profile && this.pos_profile.pose_use_limit_search) {
+                                if (this.pos_profile && (!this.pos_profile.posa_local_storage || !this.storageAvailable)) {
+                                        this.get_items(true);
+                                } else {
+                                        this.get_items();
+                                }
+                        } else if (this.pos_profile && this.pos_profile.posa_local_storage) {
+                                if (this.storageAvailable) {
+                                        await this.loadVisibleItems(true);
+                                        this.enter_event();
+                                } else {
+                                        this.get_items(true);
+                                }
+                        } else {
+                                // When local storage is disabled, always fetch items
+                                // from the server so searches aren't limited to the
+                                // initially loaded set.
+                                await this.get_items(true);
+                                this.enter_event();
 
-			// Clear the input only when triggered via scanner
-			if (fromScanner) {
-				vm.clearSearch();
-				vm.$refs.debounce_search && vm.$refs.debounce_search.focus();
-				vm.search_from_scanner = false;
-			}
-		}, 300),
+                                if (this.filtered_items && this.filtered_items.length > 0) {
+                                        setTimeout(() => {
+                                                this.update_items_details(this.filtered_items);
+                                        }, 300);
+                                }
+                        }
+
+                        // Clear the input only when triggered via scanner
+                        if (fromScanner) {
+                                this.clearSearch();
+                                this.$refs.debounce_search && this.$refs.debounce_search.focus();
+                                this.search_from_scanner = false;
+                        }
+                },
 		get_item_qty(first_search) {
 			const qtyVal = this.qty != null ? this.qty : 1;
 			let scal_qty = Math.abs(qtyVal);
@@ -2389,40 +2431,51 @@ export default {
 				console.warn("Scanner initialization error:", error.message);
 			}
 		},
-		trigger_onscan(sCode) {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
-				return;
-			}
-			// indicate this search came from a scanner
+                async trigger_onscan(sCode) {
+                        if (this.scannerLocked) {
+                                this.playScanTone("error");
+                                return;
+                        }
+                        // indicate this search came from a scanner
 			this.search_from_scanner = true;
 			// apply scanned code as search term
 			this.first_search = sCode;
 			this.search = sCode;
-			this.pendingScanCode = sCode;
+                        this.pendingScanCode = sCode;
 
-			this.$nextTick(() => {
-				if (this.filtered_items.length == 0) {
-					this.eventBus.emit("show_message", {
-						title: `No Item has this barcode "${sCode}"`,
-						color: "error",
-					});
-					this.showScanError({
-						message: `${this.__("Item not found")}: ${sCode}`,
-						code: sCode,
-						details: this.__("Please verify the barcode or search manually."),
-					});
-				} else {
-					this.enter_event();
-				}
+                        let handled = false;
+                        try {
+                                handled = await this.processScannedItem(sCode);
+                        } catch (error) {
+                                console.error("Failed to process hardware scan", error);
+                        }
 
-				// clear search field for next scan and refocus input
-				if (!this.scanErrorDialog) {
-					this.clearSearch();
-					this.$refs.debounce_search && this.$refs.debounce_search.focus();
-				}
-			});
-		},
+                        if (handled) {
+                                return;
+                        }
+
+                        this.$nextTick(() => {
+                                if (this.filtered_items.length == 0) {
+                                        this.eventBus.emit("show_message", {
+                                                title: `No Item has this barcode "${sCode}"`,
+                                                color: "error",
+                                        });
+                                        this.showScanError({
+                                                message: `${this.__("Item not found")}: ${sCode}`,
+                                                code: sCode,
+                                                details: this.__("Please verify the barcode or search manually."),
+                                        });
+                                } else {
+                                        this.enter_event();
+                                }
+
+                                // clear search field for next scan and refocus input
+                                if (!this.scanErrorDialog) {
+                                        this.clearSearch();
+                                        this.$refs.debounce_search && this.$refs.debounce_search.focus();
+                                }
+                        });
+                },
 		generateWordCombinations(inputString) {
 			const words = inputString.split(" ");
 			const wordCount = words.length;
@@ -2623,13 +2676,13 @@ export default {
 			);
 
 			// Enhanced item search and submission logic
-			this.processScannedItem(scannedCode);
-		},
-		async processScannedItem(scannedCode) {
-			this.pendingScanCode = scannedCode;
-			// Handle scale barcodes by extracting the item code and quantity
-			let searchCode = scannedCode;
-			let qtyFromBarcode = null;
+                        return this.processScannedItem(scannedCode);
+                },
+                async processScannedItem(scannedCode) {
+                        this.pendingScanCode = scannedCode;
+                        // Handle scale barcodes by extracting the item code and quantity
+                        let searchCode = scannedCode;
+                        let qtyFromBarcode = null;
 			if (
 				this.pos_profile?.posa_scale_barcode_start &&
 				scannedCode.startsWith(this.pos_profile.posa_scale_barcode_start)
@@ -2648,14 +2701,14 @@ export default {
 				return barcodeMatch || item.item_code === searchCode;
 			});
 
-			if (foundItem) {
-				console.log("Found item by processed code:", foundItem);
-				await this.addScannedItemToInvoice(foundItem, searchCode, qtyFromBarcode);
-				return;
-			}
+                        if (foundItem) {
+                                console.log("Found item by processed code:", foundItem);
+                                await this.addScannedItemToInvoice(foundItem, searchCode, qtyFromBarcode);
+                                return true;
+                        }
 
-			// If not found locally, attempt to fetch from server using processed code
-			try {
+                        // If not found locally, attempt to fetch from server using processed code
+                        try {
 				const res = await frappe.call({
 					method: "posawesome.posawesome.api.items.get_items_from_barcode",
 					args: {
@@ -2665,42 +2718,44 @@ export default {
 					},
 				});
 
-				if (res && res.message) {
-					const newItem = res.message;
-					this.items.push(newItem);
+                                if (res && res.message) {
+                                        const newItem = res.message;
+                                        this.items.push(newItem);
 
-					if (this.searchCache) {
-						this.searchCache.clear();
+                                        if (this.searchCache) {
+                                                this.searchCache.clear();
 					}
 
 					await saveItems(this.items);
 					await savePriceListItems(this.customer_price_list, this.items);
 					this.eventBus.emit("set_all_items", this.items);
 					await this.update_items_details([newItem]);
-					await this.addScannedItemToInvoice(newItem, searchCode, qtyFromBarcode);
-					return;
-				}
+                                        await this.addScannedItemToInvoice(newItem, searchCode, qtyFromBarcode);
+                                        return true;
+                                }
 
-				this.first_search = scannedCode;
-				this.search = scannedCode;
-				this.showScanError({
-					message: `${this.__("Item not found")}: ${scannedCode}`,
-					code: scannedCode,
-					details: this.__("Please verify the barcode or check the item's availability."),
-				});
-				return;
-			} catch (e) {
-				console.error("Error fetching item from barcode:", e);
-				this.first_search = scannedCode;
-				this.search = scannedCode;
-				this.showScanError({
-					message: `${this.__("Item not found")}: ${scannedCode}`,
-					code: scannedCode,
-					details: this.__("The system could not retrieve the item details. Please try again."),
-				});
-				return;
-			}
-		},
+                                this.first_search = scannedCode;
+                                this.search = scannedCode;
+                                this.showScanError({
+                                        message: `${this.__("Item not found")}: ${scannedCode}`,
+                                        code: scannedCode,
+                                        details: this.__("Please verify the barcode or check the item's availability."),
+                                });
+                                return false;
+                        } catch (e) {
+                                console.error("Error fetching item from barcode:", e);
+                                this.first_search = scannedCode;
+                                this.search = scannedCode;
+                                this.showScanError({
+                                        message: `${this.__("Item not found")}: ${scannedCode}`,
+                                        code: scannedCode,
+                                        details: this.__("The system could not retrieve the item details. Please try again."),
+                                });
+                                return false;
+                        }
+
+                        return false;
+                },
 		searchItemsByCode(code) {
 			return this.items.filter((item) => {
 				const searchTerm = code.toLowerCase();
@@ -3139,14 +3194,24 @@ export default {
 
 			return filteredItems;
 		},
-		debounce_search: {
-			get() {
-				return this.first_search;
-			},
-			set: _.debounce(function (newValue) {
-				this.first_search = (newValue || "").trim();
-			}, 200),
-		},
+                debounce_search: {
+                        get() {
+                                return this.first_search;
+                        },
+                        set(newValue) {
+                                const trimmedValue = (newValue || "").trim();
+
+                                if (this.search_from_scanner) {
+                                        this.cancelFirstSearchSetter();
+                                        this.cancelManualSearchRunner();
+                                        this.first_search = trimmedValue;
+                                        return;
+                                }
+
+                                const setter = this.ensureFirstSearchSetter();
+                                setter(trimmedValue);
+                        },
+                },
 		debounce_qty: {
 			get() {
 				// Display the raw quantity while typing to avoid forced decimal format
@@ -3170,12 +3235,15 @@ export default {
 	},
 
 	created() {
-		console.log("ItemsSelector created - starting initialization");
+                console.log("ItemsSelector created - starting initialization");
 
-		// Setup search debounce
-		this.searchDebounce = _.debounce(() => {
-			this.get_items();
-		}, 300);
+                // Setup search debounce
+                this.searchDebounce = _.debounce(() => {
+                        this.get_items();
+                }, 300);
+
+                this.ensureManualSearchRunner();
+                this.ensureFirstSearchSetter();
 
 		// Load settings
 		this.loadItemSettings();

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -3,7 +3,6 @@
 export default {
 	// Calculate total quantity of all items
 	total_qty() {
-		this.close_payments();
 		let qty = 0;
 		this.items.forEach((item) => {
 			qty += flt(item.qty);
@@ -23,7 +22,6 @@ export default {
 	},
 	// Calculate subtotal after discounts and delivery charges
 	subtotal() {
-		this.close_payments();
 		let sum = 0;
 		this.items.forEach((item) => {
 			// For returns, use absolute value for correct calculation

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -47,6 +47,7 @@ export default {
 
 	// Reset all invoice fields to default/empty values
 	clear_invoice() {
+		this.close_payments();
 		return clearInvoice(this);
 	},
 

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1766,11 +1766,11 @@ export default {
 	},
 
 	// Calculate stock quantity for an item with stock validation
-	calc_stock_qty(item, value) {
-		calcStockQty(item, value, this);
-		if (this.update_qty_limits) {
-			this.update_qty_limits(item);
-		}
+        calc_stock_qty(item, value) {
+                calcStockQty(item, value, this);
+                if (this.update_qty_limits) {
+                        this.update_qty_limits(item);
+                }
 		if (item.max_qty !== undefined && flt(item.qty) > flt(item.max_qty)) {
 			const blockSale = !this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
 			if (blockSale) {
@@ -1784,13 +1784,17 @@ export default {
 					color: "error",
 				});
 			} else {
-				this.eventBus.emit("show_message", {
-					title: __("Stock is lower than requested. Proceeding may create negative stock."),
-					color: "warning",
-				});
-			}
-		}
-	},
+                                this.eventBus.emit("show_message", {
+                                        title: __("Stock is lower than requested. Proceeding may create negative stock."),
+                                        color: "warning",
+                                });
+                        }
+                }
+
+                if (this.queueOfferRecalculation) {
+                        this.queueOfferRecalculation(item);
+                }
+        },
 
 	// Update quantity limits based on available stock
 	update_qty_limits(item) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -45,11 +45,15 @@ export default {
 		return getNewItem(item, this);
 	},
 
-	// Reset all invoice fields to default/empty values
-	clear_invoice() {
-		this.close_payments();
-		return clearInvoice(this);
-	},
+        // Reset all invoice fields to default/empty values
+        clear_invoice() {
+                this.close_payments();
+                const result = clearInvoice(this);
+                if (this.queueOfferRecalculation) {
+                        this.queueOfferRecalculation(null, { forceFull: true });
+                }
+                return result;
+        },
 
 	// Fetch customer balance from backend or cache
 	async fetch_customer_balance() {
@@ -225,16 +229,21 @@ export default {
 			});
 		}
 
-		if (data.is_return) {
-			this.return_doc = data;
-		} else {
-			this.eventBus.emit("set_pos_coupons", data.posa_coupons);
-		}
+                if (data.is_return) {
+                        this.return_doc = data;
+                } else {
+                        this.eventBus.emit("set_pos_coupons", data.posa_coupons);
+                }
 
-		console.log("load_invoice completed, invoice state:", {
-			invoiceType: this.invoiceType,
-			is_return: this.invoice_doc.is_return,
-			items: this.items.length,
+                if (this.queueOfferRecalculation) {
+                        this.queueOfferRecalculation(null, { forceFull: true });
+                }
+                this.close_payments();
+
+                console.log("load_invoice completed, invoice state:", {
+                        invoiceType: this.invoiceType,
+                        is_return: this.invoice_doc.is_return,
+                        items: this.items.length,
 			customer: this.customer,
 		});
 	},
@@ -276,11 +285,11 @@ export default {
 		this.eventBus.emit("set_pos_coupons", []);
 		this.posa_coupons = [];
 		this.return_doc = "";
-		if (!data.name && !data.is_return) {
-			this.items = [];
-			this.customer = this.pos_profile.customer;
-			this.invoice_doc = "";
-			this.discount_amount = 0;
+                if (!data.name && !data.is_return) {
+                        this.items = [];
+                        this.customer = this.pos_profile.customer;
+                        this.invoice_doc = "";
+                        this.discount_amount = 0;
 			this.additional_discount_percentage = 0;
 			this.invoiceType = "Invoice";
 			this.invoiceTypes = ["Invoice", "Order", "Quotation"];
@@ -311,23 +320,28 @@ export default {
 			});
 			this.customer = data.customer;
 			this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
-			this.discount_amount = data.discount_amount;
-			this.additional_discount_percentage = data.additional_discount_percentage;
-			this.items.forEach((item) => {
-				if (item.serial_no) {
-					item.serial_no_selected = [];
-					const serial_list = item.serial_no.split("\n");
-					serial_list.forEach((element) => {
-						if (element.length) {
-							item.serial_no_selected.push(element);
-						}
-					});
-					item.serial_no_selected_count = item.serial_no_selected.length;
-				}
-			});
-		}
-		return old_invoice;
-	},
+                        this.discount_amount = data.discount_amount;
+                        this.additional_discount_percentage = data.additional_discount_percentage;
+                        this.items.forEach((item) => {
+                                if (item.serial_no) {
+                                        item.serial_no_selected = [];
+                                        const serial_list = item.serial_no.split("\n");
+                                        serial_list.forEach((element) => {
+                                                if (element.length) {
+                                                        item.serial_no_selected.push(element);
+                                                }
+                                        });
+                                        item.serial_no_selected_count = item.serial_no_selected.length;
+                                }
+                        });
+                }
+
+                if (this.queueOfferRecalculation) {
+                        this.queueOfferRecalculation(null, { forceFull: true });
+                }
+                this.close_payments();
+                return old_invoice;
+        },
 
 	// Build the invoice document object for backend submission
 	get_invoice_doc() {

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -42,35 +42,98 @@ export default {
 		return applied;
 	},
 
-	handelOffers() {
-		const offers = [];
-		this.posOffers.forEach((offer) => {
-			if (offer.apply_on === "Item Code") {
-				const itemOffer = this.getItemOffer(offer);
-				if (itemOffer) {
-					offers.push(itemOffer);
-				}
-			} else if (offer.apply_on === "Item Group") {
-				const groupOffer = this.getGroupOffer(offer);
-				if (groupOffer) {
-					offers.push(groupOffer);
-				}
-			} else if (offer.apply_on === "Brand") {
-				const brandOffer = this.getBrandOffer(offer);
-				if (brandOffer) {
-					offers.push(brandOffer);
-				}
-			} else if (offer.apply_on === "Transaction") {
-				const transactionOffer = this.getTransactionOffer(offer);
-				if (transactionOffer) {
-					offers.push(transactionOffer);
-				}
-			}
-		});
+        queueOfferRecalculation(changedItems = null, options = {}) {
+                if (this.isApplyingOffer) {
+                        return;
+                }
 
-		this.setItemGiveOffer(offers);
-		this.updatePosOffers(offers);
-	},
+                if (!this._offerRecalcState) {
+                        this._offerRecalcState = { full: false, ids: new Set() };
+                }
+
+                const state = this._offerRecalcState;
+                const { forceFull = false } = options || {};
+                if (forceFull || !changedItems) {
+                        state.full = true;
+                        state.ids.clear();
+                } else if (!state.full) {
+                        const entries = Array.isArray(changedItems) ? changedItems : [changedItems];
+                        entries.forEach((entry) => {
+                                if (!entry) return;
+                                if (typeof entry === "string") {
+                                        state.ids.add(entry);
+                                } else if (entry.posa_row_id) {
+                                        state.ids.add(entry.posa_row_id);
+                                }
+                        });
+                        if (!state.ids.size) {
+                                state.full = true;
+                        }
+                }
+
+                if (this._offerRecalcScheduled) {
+                        return;
+                }
+
+                this._offerRecalcScheduled = true;
+                const schedule =
+                        typeof window !== "undefined" && typeof window.requestAnimationFrame === "function"
+                                ? (cb) => window.requestAnimationFrame(() => cb())
+                                : (cb) => Promise.resolve().then(cb);
+
+                schedule(() => {
+                        this._offerRecalcScheduled = false;
+                        const payload = this._offerRecalcState || { full: true, ids: new Set() };
+                        this._offerRecalcState = { full: false, ids: new Set() };
+
+                        if (payload.full || !payload.ids.size) {
+                                this.handelOffers();
+                        } else {
+                                this.handelOffers({ affectedRows: Array.from(payload.ids) });
+                        }
+                });
+        },
+
+        handelOffers(options = {}) {
+                const affectedRows =
+                        Array.isArray(options?.affectedRows) && options.affectedRows.length
+                                ? new Set(options.affectedRows)
+                                : null;
+
+                const offers = [];
+                if (!Array.isArray(this.posOffers)) {
+                        this.updatePosOffers(offers);
+                        return;
+                }
+
+                this.posOffers.forEach((offer) => {
+                        if (!offer) return;
+                        if (offer.apply_on === "Item Code") {
+                                const itemOffer = this.getItemOffer(offer, affectedRows);
+                                if (itemOffer) {
+                                        offers.push(itemOffer);
+                                }
+                        } else if (offer.apply_on === "Item Group") {
+                                const groupOffer = this.getGroupOffer(offer, affectedRows);
+                                if (groupOffer) {
+                                        offers.push(groupOffer);
+                                }
+                        } else if (offer.apply_on === "Brand") {
+                                const brandOffer = this.getBrandOffer(offer, affectedRows);
+                                if (brandOffer) {
+                                        offers.push(brandOffer);
+                                }
+                        } else if (offer.apply_on === "Transaction") {
+                                const transactionOffer = this.getTransactionOffer(offer, affectedRows);
+                                if (transactionOffer) {
+                                        offers.push(transactionOffer);
+                                }
+                        }
+                });
+
+                this.setItemGiveOffer(offers);
+                this.updatePosOffers(offers);
+        },
 
 	setItemGiveOffer(offers) {
 		// Set item give offer for replace
@@ -174,17 +237,20 @@ export default {
 		}
 	},
 
-	getItemOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Item Code") {
-			if (this.checkOfferCoupon(offer)) {
-				const combined = [...this.items, ...this.packed_items];
-				combined.forEach((item) => {
-					if (!item.posa_is_offer && item.item_code === offer.item) {
-						if (
-							offer.offer === "Item Price" &&
-							item.posa_offer_applied &&
-							!this.checkOfferIsAppley(item, offer)
+        getItemOffer(offer, affectedRows) {
+                let apply_offer = null;
+                if (offer.apply_on === "Item Code") {
+                        if (this.checkOfferCoupon(offer)) {
+                                const combined = [...this.items, ...this.packed_items];
+                                combined.forEach((item) => {
+                                        if (affectedRows && !affectedRows.has(item.posa_row_id)) {
+                                                return;
+                                        }
+                                        if (!item.posa_is_offer && item.item_code === offer.item) {
+                                                if (
+                                                        offer.offer === "Item Price" &&
+                                                        item.posa_offer_applied &&
+                                                        !this.checkOfferIsAppley(item, offer)
 						) {
 							return;
 						}
@@ -203,19 +269,30 @@ export default {
 		return apply_offer;
 	},
 
-	getGroupOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Item Group") {
-			if (this.checkOfferCoupon(offer)) {
-				const items = [];
-				let total_count = 0;
-				let total_amount = 0;
-				const combined = [...this.items, ...this.packed_items];
-				combined.forEach((item) => {
-					if (!item.posa_is_offer && item.item_group === offer.item_group) {
-						if (
-							offer.offer === "Item Price" &&
-							item.posa_offer_applied &&
+        getGroupOffer(offer, affectedRows) {
+                let apply_offer = null;
+                if (offer.apply_on === "Item Group") {
+                        if (this.checkOfferCoupon(offer)) {
+                                const items = [];
+                                let total_count = 0;
+                                let total_amount = 0;
+                                const combined = [...this.items, ...this.packed_items];
+                                if (
+                                        affectedRows &&
+                                        !combined.some((item) => {
+                                                if (!affectedRows.has(item.posa_row_id) || item.posa_is_offer) {
+                                                        return false;
+                                                }
+                                                return item.item_group === offer.item_group;
+                                        })
+                                ) {
+                                        return null;
+                                }
+                                combined.forEach((item) => {
+                                        if (!item.posa_is_offer && item.item_group === offer.item_group) {
+                                                if (
+                                                        offer.offer === "Item Price" &&
+                                                        item.posa_offer_applied &&
 							!this.checkOfferIsAppley(item, offer)
 						) {
 							return;
@@ -238,20 +315,32 @@ export default {
 		return apply_offer;
 	},
 
-	getBrandOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Brand") {
-			if (this.checkOfferCoupon(offer)) {
-				const items = [];
-				let total_count = 0;
-				let total_amount = 0;
-				const offer_brand = this.normalizeBrand(offer.brand);
-				const combined = [...this.items, ...this.packed_items];
-				combined.forEach((item) => {
-					const item_brand = this.getItemBrand(item);
-					if (!item.posa_is_offer && item_brand && item_brand === offer_brand) {
-						if (
-							offer.offer === "Item Price" &&
+        getBrandOffer(offer, affectedRows) {
+                let apply_offer = null;
+                if (offer.apply_on === "Brand") {
+                        if (this.checkOfferCoupon(offer)) {
+                                const items = [];
+                                let total_count = 0;
+                                let total_amount = 0;
+                                const offer_brand = this.normalizeBrand(offer.brand);
+                                const combined = [...this.items, ...this.packed_items];
+                                if (
+                                        affectedRows &&
+                                        !combined.some((item) => {
+                                                if (!affectedRows.has(item.posa_row_id) || item.posa_is_offer) {
+                                                        return false;
+                                                }
+                                                const item_brand = this.getItemBrand(item);
+                                                return item_brand && item_brand === offer_brand;
+                                        })
+                                ) {
+                                        return null;
+                                }
+                                combined.forEach((item) => {
+                                        const item_brand = this.getItemBrand(item);
+                                        if (!item.posa_is_offer && item_brand && item_brand === offer_brand) {
+                                                if (
+                                                        offer.offer === "Item Price" &&
 							item.posa_offer_applied &&
 							!this.checkOfferIsAppley(item, offer)
 						) {
@@ -274,16 +363,22 @@ export default {
 		}
 		return apply_offer;
 	},
-	getTransactionOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Transaction") {
-			if (this.checkOfferCoupon(offer)) {
-				const combined = [...this.items, ...this.packed_items];
-				let total_qty = 0;
-				let total_amount = 0;
-				const items = [];
-				combined.forEach((item) => {
-					if (!item.posa_is_offer && !item.posa_is_replace) {
+        getTransactionOffer(offer, affectedRows) {
+                let apply_offer = null;
+                if (offer.apply_on === "Transaction") {
+                        if (this.checkOfferCoupon(offer)) {
+                                const combined = [...this.items, ...this.packed_items];
+                                if (
+                                        affectedRows &&
+                                        !combined.some((item) => affectedRows.has(item.posa_row_id))
+                                ) {
+                                        return null;
+                                }
+                                let total_qty = 0;
+                                let total_amount = 0;
+                                const items = [];
+                                combined.forEach((item) => {
+                                        if (!item.posa_is_offer && !item.posa_is_replace) {
 						total_qty += item.stock_qty;
 						const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
 						total_amount += item.stock_qty * rate;
@@ -1118,18 +1213,18 @@ export default {
 				item.original_rate = null;
 				item.original_price_list_rate = null;
 				item.original_base_rate = null;
-				item.original_base_price_list_rate = null;
+                                item.original_base_price_list_rate = null;
 
-				this.calc_item_price(item);
-				this.handelOffers();
-			} else {
-				// Allow offers to be applied
-				item.posa_is_offer = 0;
-				this.handelOffers();
-			}
+                                this.calc_item_price(item);
+                                this.queueOfferRecalculation(null, { forceFull: true });
+                        } else {
+                                // Allow offers to be applied
+                                item.posa_is_offer = 0;
+                                this.queueOfferRecalculation(null, { forceFull: true });
+                        }
 
-			// Ensure Vue reactivity
-			this.$forceUpdate();
-		});
+                        // Ensure Vue reactivity
+                        this.$forceUpdate();
+                });
 	},
 };

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -34,6 +34,7 @@ export default {
 	items: {
 		deep: true,
 		handler() {
+			this.close_payments();
 			if (this.isApplyingOffer) return;
 			this.handelOffers();
 			this.$forceUpdate();
@@ -42,6 +43,7 @@ export default {
 	packed_items: {
 		deep: true,
 		handler() {
+			this.close_payments();
 			if (this.isApplyingOffer) return;
 			this.handelOffers();
 			this.$forceUpdate();

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -30,25 +30,15 @@ export default {
 			value: this.discount_percentage_offer_name,
 		});
 	},
-	// Watch for items array changes (deep) and re-handle offers
-	items: {
-		deep: true,
-		handler() {
-			this.close_payments();
-			if (this.isApplyingOffer) return;
-			this.handelOffers();
-			this.$forceUpdate();
-		},
-	},
-	packed_items: {
-		deep: true,
-		handler() {
-			this.close_payments();
-			if (this.isApplyingOffer) return;
-			this.handelOffers();
-			this.$forceUpdate();
-		},
-	},
+        // Watch for structural changes in the cart collections
+        items() {
+                this.close_payments();
+                this.queueOfferRecalculation(null, { forceFull: true });
+        },
+        packed_items() {
+                this.close_payments();
+                this.queueOfferRecalculation(null, { forceFull: true });
+        },
 	// Watch for invoice type change and emit
 	invoiceType() {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -31,13 +31,15 @@ export default {
 		});
 	},
         // Watch for structural changes in the cart collections
-        items() {
-                this.close_payments();
-                this.queueOfferRecalculation(null, { forceFull: true });
+        items(newItems) {
+                if (!Array.isArray(newItems) || newItems.length === 0) {
+                        this.close_payments();
+                }
         },
-        packed_items() {
-                this.close_payments();
-                this.queueOfferRecalculation(null, { forceFull: true });
+        packed_items(newPackedItems) {
+                if (!Array.isArray(newPackedItems) || newPackedItems.length === 0) {
+                        this.close_payments();
+                }
         },
 	// Watch for invoice type change and emit
 	invoiceType() {

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -17,6 +17,10 @@ export function useItemAddition() {
                 // Remove from expanded if present
                 context.expanded = context.expanded.filter((id) => id !== item.posa_row_id);
 
+                if (context.close_payments && context.items.length === 0) {
+                        context.close_payments();
+                }
+
                 if (context.queueOfferRecalculation) {
                         context.queueOfferRecalculation(null, { forceFull: true });
                 }
@@ -24,24 +28,25 @@ export function useItemAddition() {
 
 	const { getBundleComponents } = useBundles();
 
-	const expandBundle = async (parent, context) => {
-		const components = await getBundleComponents(parent.item_code);
-		if (!components || !components.length) {
-			return;
-		}
-		parent.is_bundle = 1;
-		parent.is_bundle_parent = 1;
-		parent.is_stock_item = 0;
-		parent.warehouse = null;
-		parent.stock_qty = 0;
-		parent.bundle_id = context.makeid ? context.makeid(10) : Math.random().toString(36).substr(2, 10);
-		// Force reactivity so the bundle badge appears immediately
-		context.items = [...context.items];
-		for (const comp of components) {
-			const child = {
-				parent_item: parent.item_code,
-				bundle_id: parent.bundle_id,
-				item_code: comp.item_code,
+        const expandBundle = async (parent, context) => {
+                const components = await getBundleComponents(parent.item_code);
+                if (!components || !components.length) {
+                        return [];
+                }
+                parent.is_bundle = 1;
+                parent.is_bundle_parent = 1;
+                parent.is_stock_item = 0;
+                parent.warehouse = null;
+                parent.stock_qty = 0;
+                parent.bundle_id = context.makeid ? context.makeid(10) : Math.random().toString(36).substr(2, 10);
+                // Force reactivity so the bundle badge appears immediately
+                context.items = [...context.items];
+                const childRowIds = [];
+                for (const comp of components) {
+                        const child = {
+                                parent_item: parent.item_code,
+                                bundle_id: parent.bundle_id,
+                                item_code: comp.item_code,
 				item_name: comp.item_name || comp.item_code,
 				qty: (parent.qty || 1) * comp.qty,
 				stock_qty: (parent.qty || 1) * comp.qty,
@@ -55,18 +60,20 @@ export function useItemAddition() {
 				posa_row_id: context.makeid ? context.makeid(20) : Math.random().toString(36).substr(2, 20),
 				posa_offers: JSON.stringify([]),
 				posa_offer_applied: 0,
-				posa_is_offer: 0,
-			};
-			context.packed_items.push(child);
-			if (context.update_item_detail) {
-				context.update_item_detail(child, false);
-				context.calc_stock_qty && context.calc_stock_qty(child, child.qty);
-			}
-			if (context.fetch_available_qty) {
-				context.fetch_available_qty(child);
-			}
-		}
-	};
+                                posa_is_offer: 0,
+                        };
+                        context.packed_items.push(child);
+                        childRowIds.push(child.posa_row_id);
+                        if (context.update_item_detail) {
+                                context.update_item_detail(child, false);
+                                context.calc_stock_qty && context.calc_stock_qty(child, child.qty);
+                        }
+                        if (context.fetch_available_qty) {
+                                context.fetch_available_qty(child);
+                        }
+                }
+                return childRowIds;
+        };
 
 	const moveItemToTop = (context, target) => {
 		if (!target) return;
@@ -192,13 +199,13 @@ export function useItemAddition() {
 			}
 
 			if (index === -1 || context.new_line) {
-				context.items.unshift(new_item);
-				await expandBundle(new_item, context);
-				// Skip recalculation to preserve the manually set rate
-				if (context.update_item_detail) context.update_item_detail(new_item, false);
+                                context.items.unshift(new_item);
+                                const bundleChildRows = await expandBundle(new_item, context);
+                                // Skip recalculation to preserve the manually set rate
+                                if (context.update_item_detail) context.update_item_detail(new_item, false);
 
-				if (context.fetch_available_qty) {
-					context.fetch_available_qty(new_item);
+                                if (context.fetch_available_qty) {
+                                        context.fetch_available_qty(new_item);
 				}
 
 				if (
@@ -252,7 +259,11 @@ export function useItemAddition() {
                                 }
 
                                 if (context.queueOfferRecalculation) {
-                                        context.queueOfferRecalculation(new_item);
+                                        const targets =
+                                                bundleChildRows && bundleChildRows.length
+                                                        ? [new_item.posa_row_id, ...bundleChildRows]
+                                                        : new_item;
+                                        context.queueOfferRecalculation(targets);
                                 }
                         } else {
                                 const cur_item = context.items[index];

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -6,17 +6,21 @@ import { useBundles } from "./useBundles.js";
 
 export function useItemAddition() {
 	// Remove item from invoice
-	const removeItem = (item, context) => {
-		const index = context.items.findIndex((el) => el.posa_row_id == item.posa_row_id);
-		if (index >= 0) {
-			context.items.splice(index, 1);
-		}
-		if (item.is_bundle) {
-			context.packed_items = context.packed_items.filter((it) => it.bundle_id !== item.bundle_id);
-		}
-		// Remove from expanded if present
-		context.expanded = context.expanded.filter((id) => id !== item.posa_row_id);
-	};
+        const removeItem = (item, context) => {
+                const index = context.items.findIndex((el) => el.posa_row_id == item.posa_row_id);
+                if (index >= 0) {
+                        context.items.splice(index, 1);
+                }
+                if (item.is_bundle) {
+                        context.packed_items = context.packed_items.filter((it) => it.bundle_id !== item.bundle_id);
+                }
+                // Remove from expanded if present
+                context.expanded = context.expanded.filter((id) => id !== item.posa_row_id);
+
+                if (context.queueOfferRecalculation) {
+                        context.queueOfferRecalculation(null, { forceFull: true });
+                }
+        };
 
 	const { getBundleComponents } = useBundles();
 
@@ -238,19 +242,23 @@ export function useItemAddition() {
 				}
 
 				// Expand new item if it has batch or serial number
-				if (
-					(!context.pos_profile.posa_auto_set_batch && new_item.has_batch_no) ||
-					new_item.has_serial_no
-				) {
-					nextTick(() => {
-						context.expanded = [new_item.posa_row_id];
-					});
-				}
-			} else {
-				const cur_item = context.items[index];
-				const previousQty = cur_item.qty;
-				if (context.update_items_details) context.update_items_details([cur_item]);
-				// Merge serial numbers if any
+                                if (
+                                        (!context.pos_profile.posa_auto_set_batch && new_item.has_batch_no) ||
+                                        new_item.has_serial_no
+                                ) {
+                                        nextTick(() => {
+                                                context.expanded = [new_item.posa_row_id];
+                                        });
+                                }
+
+                                if (context.queueOfferRecalculation) {
+                                        context.queueOfferRecalculation(new_item);
+                                }
+                        } else {
+                                const cur_item = context.items[index];
+                                const previousQty = cur_item.qty;
+                                if (context.update_items_details) context.update_items_details([cur_item]);
+                                // Merge serial numbers if any
 				if (new_item.serial_no_selected && new_item.serial_no_selected.length) {
 					new_item.serial_no_selected.forEach((sn) => {
 						if (!cur_item.serial_no_selected.includes(sn)) {
@@ -275,16 +283,20 @@ export function useItemAddition() {
 					await context.calc_uom(cur_item, cur_item.uom);
 				}
 
-				if (context.fetch_available_qty) {
-					context.fetch_available_qty(cur_item);
-				}
-				if (cur_item.qty > previousQty) {
-					moveItemToTop(context, cur_item);
-				}
-			}
-		} else {
-			const cur_item = context.items[index];
-			const previousQty = cur_item.qty;
+                                if (context.fetch_available_qty) {
+                                        context.fetch_available_qty(cur_item);
+                                }
+                                if (cur_item.qty > previousQty) {
+                                        moveItemToTop(context, cur_item);
+                                }
+
+                                if (context.queueOfferRecalculation) {
+                                        context.queueOfferRecalculation(cur_item);
+                                }
+                        }
+                } else {
+                        const cur_item = context.items[index];
+                        const previousQty = cur_item.qty;
 			if (context.update_items_details) context.update_items_details([cur_item]);
 			// Serial number logic for existing item
 			if (item.has_serial_no && item.to_set_serial_no) {
@@ -320,23 +332,28 @@ export function useItemAddition() {
 				await context.calc_uom(cur_item, cur_item.uom);
 			}
 
-			if (context.fetch_available_qty) {
-				context.fetch_available_qty(cur_item);
-			}
-			if (cur_item.qty > previousQty) {
-				moveItemToTop(context, cur_item);
-			}
-		}
-		if (context.forceUpdate) context.forceUpdate();
+                        if (context.fetch_available_qty) {
+                                context.fetch_available_qty(cur_item);
+                        }
+                        if (cur_item.qty > previousQty) {
+                                moveItemToTop(context, cur_item);
+                        }
 
-		// Only try to expand if new_item exists and should be expanded
-		if (
-			new_item &&
-			((!context.pos_profile.posa_auto_set_batch && new_item.has_batch_no) || new_item.has_serial_no)
-		) {
-			context.expanded = [new_item.posa_row_id];
-		}
-	};
+                        if (context.queueOfferRecalculation) {
+                                context.queueOfferRecalculation(cur_item);
+                        }
+                }
+                if (context.forceUpdate) context.forceUpdate();
+
+                // Only try to expand if new_item exists and should be expanded
+                if (
+                        new_item &&
+                        ((!context.pos_profile.posa_auto_set_batch && new_item.has_batch_no) || new_item.has_serial_no)
+                ) {
+                        context.expanded = [new_item.posa_row_id];
+                }
+
+        };
 
 	// Create a new item object with default and calculated fields
 	const getNewItem = (item, context) => {


### PR DESCRIPTION
## Summary
- split manual typing and scanner-driven search flows so scanner input bypasses debounced setters
- replace the debounced `search_onchange` with an immediate search routine shared by keyboard and scanner triggers
- ensure hardware and camera scans await `processScannedItem` so barcode additions run promptly with existing safeguards

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68cc2faef57083269e7504168a8e2df5