### PR TITLE
Optimize item filtering and detail refresh

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -530,9 +530,10 @@ export default {
 		refresh_interval: null,
 		abortController: null,
 		itemDetailsRequestCache: { key: null, promise: null, result: null },
-		itemDetailsRetryCount: 0,
-		itemDetailsRetryTimeout: null,
-		items_loaded: false,
+                itemDetailsRetryCount: 0,
+                itemDetailsRetryTimeout: null,
+                lastItemDetailsSignature: null,
+                items_loaded: false,
 		selected_currency: "",
 		exchange_rate: 1,
 		prePopulateInProgress: false,
@@ -676,22 +677,23 @@ export default {
 					cached.forEach((ci) => {
 						map[ci.item_code] = ci;
 					});
-					this.items.forEach((it) => {
-						const ci = map[it.item_code];
-						if (ci) {
-							const force =
-								this.pos_profile?.posa_force_price_from_customer_price_list !== false;
-							const price = ci.price_list_rate ?? ci.rate ?? 0;
-							if (force || price) {
-								it.rate = price;
-								it.price_list_rate = price;
-							}
-						}
-					});
-					this.eventBus.emit("set_all_items", this.items);
-					this.update_items_details(this.items);
-					return;
-				}
+                                        this.items.forEach((it) => {
+                                                const ci = map[it.item_code];
+                                                if (ci) {
+                                                        const force =
+                                                                this.pos_profile?.posa_force_price_from_customer_price_list !== false;
+                                                        const price = ci.price_list_rate ?? ci.rate ?? 0;
+                                                        if (force || price) {
+                                                                it.rate = price;
+                                                                it.price_list_rate = price;
+                                                        }
+                                                }
+                                        });
+                                        this.eventBus.emit("set_all_items", this.items);
+                                        this.lastItemDetailsSignature = null;
+                                        this.update_items_details(this.items);
+                                        return;
+                                }
 			}
 			// No cache found - force a reload so prices are updated
 			this.items_loaded = false;
@@ -723,17 +725,26 @@ export default {
 				}
 			}
 		},
-		filtered_items(new_value, old_value) {
-			// Update item details if items changed
-			if (
-				this.pos_profile &&
-				!this.pos_profile.pose_use_limit_search &&
-				new_value.length !== old_value.length
-			) {
-				this.update_items_details(new_value);
-			}
-			this.$nextTick(this.checkItemContainerOverflow);
-		},
+                filtered_items(new_value, old_value) {
+                        if (this.pos_profile && !this.pos_profile.pose_use_limit_search && Array.isArray(new_value)) {
+                                const newItems = Array.isArray(new_value) ? new_value : [];
+                                const oldItems = Array.isArray(old_value) ? old_value : [];
+                                const newCodes = newItems.map((it) => it.item_code).filter(Boolean);
+                                const oldCodes = oldItems.map((it) => it.item_code).filter(Boolean);
+                                const newSet = new Set(newCodes);
+                                const oldSet = new Set(oldCodes);
+                                const codesChanged =
+                                        newItems.length !== oldItems.length ||
+                                        newCodes.some((code) => !oldSet.has(code)) ||
+                                        oldCodes.some((code) => !newSet.has(code));
+
+                                if (codesChanged) {
+                                        this.lastItemDetailsSignature = null;
+                                        this.update_items_details(newItems);
+                                }
+                        }
+                        this.$nextTick(this.checkItemContainerOverflow);
+                },
 		// Automatically search when the query has at least 3 characters
 		first_search: _.debounce(function (val, oldVal) {
 			const newLen = (val || "").trim().length;
@@ -803,12 +814,12 @@ export default {
 			return result;
 		},
 
-		performSearch(searchTerm, itemGroup) {
-			if (!this.items || !this.items.length) {
-				return [];
-			}
+                performSearch(searchTerm, itemGroup) {
+                        if (!this.items || !this.items.length) {
+                                return [];
+                        }
 
-			let filtered = this.items;
+                        let filtered = this.items;
 
 			// Filter by item group
 			if (itemGroup !== "ALL") {
@@ -839,8 +850,91 @@ export default {
 				});
 			}
 
-			return filtered;
-		},
+                        return filtered;
+                },
+
+                getItemSearchCache(item) {
+                        if (!item) {
+                                return {
+                                        searchFieldsLower: [],
+                                        serialsLower: [],
+                                        batchesLower: [],
+                                        itemGroupLower: "",
+                                };
+                        }
+
+                        const barcodeValues = [];
+                        if (Array.isArray(item.item_barcode)) {
+                                barcodeValues.push(
+                                        ...item.item_barcode
+                                                .map((b) => b && b.barcode)
+                                                .filter((val) => val != null && val !== "")
+                                                .map((val) => String(val)),
+                                );
+                        } else if (item.item_barcode) {
+                                barcodeValues.push(String(item.item_barcode));
+                        }
+                        if (Array.isArray(item.barcodes)) {
+                                barcodeValues.push(
+                                        ...item.barcodes
+                                                .filter((val) => val != null && val !== "")
+                                                .map((val) => String(val)),
+                                );
+                        }
+
+                        const serialValues = Array.isArray(item.serial_no_data)
+                                ? item.serial_no_data
+                                          .map((s) => s && s.serial_no)
+                                          .filter((val) => val != null && val !== "")
+                                          .map((val) => String(val))
+                                : [];
+
+                        const batchValues = Array.isArray(item.batch_no_data)
+                                ? item.batch_no_data
+                                          .map((b) => b && b.batch_no)
+                                          .filter((val) => val != null && val !== "")
+                                          .map((val) => String(val))
+                                : [];
+
+                        const signature = JSON.stringify({
+                                item_code: item.item_code || "",
+                                item_name: item.item_name || "",
+                                barcode: item.barcode || "",
+                                description: item.description || "",
+                                item_group: item.item_group || "",
+                                barcodes: barcodeValues,
+                                serials: serialValues,
+                                batches: batchValues,
+                        });
+
+                        if (item._posaLowerCache && item._posaLowerCache.signature === signature) {
+                                return item._posaLowerCache;
+                        }
+
+                        const searchFieldsLower = [
+                                item.item_code,
+                                item.item_name,
+                                item.barcode,
+                                item.description,
+                                ...barcodeValues,
+                        ]
+                                .filter((val) => val != null && val !== "")
+                                .map((val) => String(val).toLowerCase());
+
+                        const serialsLower = serialValues.map((val) => val.toLowerCase());
+                        const batchesLower = batchValues.map((val) => val.toLowerCase());
+
+                        const cache = {
+                                signature,
+                                searchFieldsLower,
+                                serialsLower,
+                                batchesLower,
+                                itemGroupLower: (item.item_group || "").toLowerCase(),
+                        };
+
+                        item._posaLowerCache = cache;
+                        return cache;
+                },
 
 		async fetchServerItemsTimestamp() {
 			try {
@@ -948,15 +1042,16 @@ export default {
 			}
 			return dbHealthy;
 		},
-		async loadVisibleItems(reset = false) {
-			this.loadProgress = 0;
-			this.eventBus.emit("data-load-progress", { name: "items", progress: 0 });
-			await initPromise;
-			await this.ensureStorageHealth();
-			if (reset) {
-				this.currentPage = 0;
-				this.items = [];
-			}
+                async loadVisibleItems(reset = false) {
+                        this.loadProgress = 0;
+                        this.eventBus.emit("data-load-progress", { name: "items", progress: 0 });
+                        await initPromise;
+                        await this.ensureStorageHealth();
+                        if (reset) {
+                                this.currentPage = 0;
+                                this.items = [];
+                                this.lastItemDetailsSignature = null;
+                        }
 			const search = this.get_search(this.first_search);
 			const itemGroup = this.item_group !== "ALL" ? this.item_group.toLowerCase() : "";
 			const pageItems = await searchStoredItems({
@@ -1373,10 +1468,11 @@ export default {
 					if (item.actual_qty === undefined) {
 						item.actual_qty = 0;
 					}
-				});
+                                });
 
-				vm.items = items;
-				vm.items_loaded = true;
+                                vm.items = items;
+                                vm.lastItemDetailsSignature = null;
+                                vm.items_loaded = true;
 				vm.eventBus.emit("set_all_items", vm.items);
 				console.log("[ItemsSelector] set_all_items emitted", { itemsLength: vm.items.length });
 
@@ -2033,15 +2129,16 @@ export default {
 				// When local storage is disabled, always fetch items
 				// from the server so searches aren't limited to the
 				// initially loaded set.
-				await vm.get_items(true);
-				vm.enter_event();
+                                await vm.get_items(true);
+                                vm.enter_event();
 
-				if (vm.filtered_items && vm.filtered_items.length > 0) {
-					setTimeout(() => {
-						vm.update_items_details(vm.filtered_items);
-					}, 300);
-				}
-			}
+                                if (vm.filtered_items && vm.filtered_items.length > 0) {
+                                        setTimeout(() => {
+                                                vm.lastItemDetailsSignature = null;
+                                                vm.update_items_details(vm.filtered_items);
+                                        }, 300);
+                                }
+                        }
 
 			// Clear the input only when triggered via scanner
 			if (fromScanner) {
@@ -2096,22 +2193,30 @@ export default {
 			this.qty = 1;
 			this.$refs.debounce_search.focus();
 		},
-		async update_items_details(items) {
-			const vm = this;
-			if (!items || !items.length) return;
+                async update_items_details(items) {
+                        const vm = this;
+                        if (!items || !items.length) return;
 
-			// reset any pending retry timer
-			if (vm.itemDetailsRetryTimeout) {
-				clearTimeout(vm.itemDetailsRetryTimeout);
-				vm.itemDetailsRetryTimeout = null;
-			}
+                        // reset any pending retry timer
+                        if (vm.itemDetailsRetryTimeout) {
+                                clearTimeout(vm.itemDetailsRetryTimeout);
+                                vm.itemDetailsRetryTimeout = null;
+                        }
 
-			const itemCodes = items.map((it) => it.item_code);
-			const cacheResult = await getCachedItemDetails(
-				vm.pos_profile.name,
-				vm.active_price_list,
-				itemCodes,
-			);
+                        const itemCodes = items.map((it) => it.item_code);
+                        const signature = `${Array.from(new Set(itemCodes.filter(Boolean)))
+                                .sort()
+                                .join("|")}::${items.length}`;
+                        if (vm.lastItemDetailsSignature === signature) {
+                                return;
+                        }
+                        vm.lastItemDetailsSignature = signature;
+
+                        const cacheResult = await getCachedItemDetails(
+                                vm.pos_profile.name,
+                                vm.active_price_list,
+                                itemCodes,
+                        );
 			cacheResult.cached.forEach((det) => {
 				const item = items.find((it) => it.item_code === det.item_code);
 				if (item) {
@@ -2272,14 +2377,15 @@ export default {
 						}
 					});
 
-					if (!isOffline()) {
-						vm.itemDetailsRetryCount += 1;
-						const delay = Math.min(32000, 1000 * Math.pow(2, vm.itemDetailsRetryCount - 1));
-						vm.itemDetailsRetryTimeout = setTimeout(() => {
-							vm.update_items_details(items);
-						}, delay);
-					}
-				}
+                                        if (!isOffline()) {
+                                                vm.itemDetailsRetryCount += 1;
+                                                const delay = Math.min(32000, 1000 * Math.pow(2, vm.itemDetailsRetryCount - 1));
+                                                vm.lastItemDetailsSignature = null;
+                                                vm.itemDetailsRetryTimeout = setTimeout(() => {
+                                                        vm.update_items_details(items);
+                                                }, delay);
+                                        }
+                                }
 			}
 
 			// Cleanup on component destroy
@@ -2289,11 +2395,12 @@ export default {
 				}
 			};
 		},
-		update_cur_items_details() {
-			if (this.filtered_items && this.filtered_items.length > 0) {
-				this.update_items_details(this.filtered_items);
-			}
-		},
+                update_cur_items_details() {
+                        if (this.filtered_items && this.filtered_items.length > 0) {
+                                this.lastItemDetailsSignature = null;
+                                this.update_items_details(this.filtered_items);
+                        }
+                },
 		async prePopulateStockCache(items) {
 			if (this.prePopulateInProgress) {
 				return;
@@ -2934,18 +3041,19 @@ export default {
 		},
 
 		// Force load quantities for all visible items
-		forceLoadQuantities() {
-			if (this.filtered_items && this.filtered_items.length > 0) {
-				// Set default quantities if not available
-				this.filtered_items.forEach((item) => {
-					if (item.actual_qty === undefined || item.actual_qty === null) {
-						item.actual_qty = 0;
-					}
-				});
-				// Force update quantities from server
-				this.update_items_details(this.filtered_items);
-			}
-		},
+                forceLoadQuantities() {
+                        if (this.filtered_items && this.filtered_items.length > 0) {
+                                // Set default quantities if not available
+                                this.filtered_items.forEach((item) => {
+                                        if (item.actual_qty === undefined || item.actual_qty === null) {
+                                                item.actual_qty = 0;
+                                        }
+                                });
+                                // Force update quantities from server
+                                this.lastItemDetailsSignature = null;
+                                this.update_items_details(this.filtered_items);
+                        }
+                },
 
 		// Ensure all items have quantities set
 		ensureAllItemsHaveQuantities() {
@@ -3067,78 +3175,74 @@ export default {
 		headers() {
 			return this.getItemsHeaders();
 		},
-		filtered_items() {
-			if (!this.items || this.items.length === 0) {
-				return [];
-			}
+                filtered_items() {
+                        if (!this.items || this.items.length === 0) {
+                                return [];
+                        }
 
-			const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
-			let filteredItems = [...this.items];
+                        const rawLimit = this.enable_custom_items_per_page
+                                ? Number(this.items_per_page)
+                                : Number(this.itemsPerPage);
+                        const limit = Number.isFinite(rawLimit) ? rawLimit : this.itemsPerPage;
+                        const effectiveLimit = limit > 0 ? limit : this.items.length;
+                        const workingLimit = Math.min(
+                                this.items.length,
+                                Math.max(effectiveLimit * 2, effectiveLimit, this.items.length ? 1 : 0),
+                        );
 
-			// Apply search filter only for queries with at least three characters
-			if (searchTerm.length >= 3) {
-				filteredItems = filteredItems.filter((item) => {
-					const barcodeList = [];
-					if (Array.isArray(item.item_barcode)) {
-						barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
-					} else if (item.item_barcode) {
-						barcodeList.push(String(item.item_barcode));
-					}
-					if (Array.isArray(item.barcodes)) {
-						barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
-					}
+                        const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
+                        let filteredItems = this.items.slice(0, workingLimit);
 
-					const searchFields = [
-						item.item_code,
-						item.item_name,
-						item.barcode,
-						item.description,
-						...barcodeList,
-						...(this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)
-							? item.serial_no_data.map((s) => s.serial_no)
-							: []),
-						...(this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
-							? item.batch_no_data.map((b) => b.batch_no)
-							: []),
-					]
-						.filter(Boolean)
-						.map((field) => field.toLowerCase());
+                        if (searchTerm.length >= 3) {
+                                filteredItems = filteredItems.filter((item) => {
+                                        const cache = this.getItemSearchCache(item);
+                                        if (cache.searchFieldsLower.some((field) => field.includes(searchTerm))) {
+                                                return true;
+                                        }
+                                        if (
+                                                this.pos_profile?.posa_search_serial_no &&
+                                                cache.serialsLower.some((field) => field.includes(searchTerm))
+                                        ) {
+                                                return true;
+                                        }
+                                        if (
+                                                this.pos_profile?.posa_search_batch_no &&
+                                                cache.batchesLower.some((field) => field.includes(searchTerm))
+                                        ) {
+                                                return true;
+                                        }
+                                        return false;
+                                });
+                        } else {
+                                filteredItems = filteredItems.slice();
+                        }
 
-					return searchFields.some((field) => field.includes(searchTerm));
-				});
-			}
+                        if (this.item_group !== "ALL") {
+                                const targetGroup = this.item_group.toLowerCase();
+                                filteredItems = filteredItems.filter(
+                                        (item) => this.getItemSearchCache(item).itemGroupLower === targetGroup,
+                                );
+                        }
 
-			// Apply item group filter
-			if (this.item_group !== "ALL") {
-				filteredItems = filteredItems.filter(
-					(item) =>
-						item.item_group && item.item_group.toLowerCase() === this.item_group.toLowerCase(),
-				);
-			}
+                        if (this.hide_zero_rate_items) {
+                                filteredItems = filteredItems.filter((item) => parseFloat(item.rate || 0) > 0);
+                        }
 
-			// Apply zero rate filter
-			if (this.hide_zero_rate_items) {
-				filteredItems = filteredItems.filter((item) => parseFloat(item.rate || 0) > 0);
-			}
+                        if (this.pos_profile?.posa_hide_variants_items) {
+                                filteredItems = filteredItems.filter((item) => !item.variant_of);
+                        }
 
-			// Apply template/variant filter
-			if (this.pos_profile?.posa_hide_variants_items) {
-				filteredItems = filteredItems.filter((item) => !item.variant_of);
-			}
+                        const finalLimit = limit > 0 ? limit : filteredItems.length;
+                        const limitedItems = filteredItems.slice(0, finalLimit);
 
-			// Apply pagination
-			const limit = this.enable_custom_items_per_page ? this.items_per_page : this.itemsPerPage;
-			filteredItems = filteredItems.slice(0, limit);
+                        limitedItems.forEach((item) => {
+                                if (item.actual_qty === undefined || item.actual_qty === null) {
+                                        item.actual_qty = 0;
+                                }
+                        });
 
-			// Ensure quantities are defined
-			filteredItems.forEach((item) => {
-				if (item.actual_qty === undefined || item.actual_qty === null) {
-					item.actual_qty = 0;
-				}
-			});
-
-			return filteredItems;
-		},
+                        return limitedItems;
+                },
 		debounce_search: {
 			get() {
 				return this.first_search;
@@ -3264,12 +3368,13 @@ export default {
 			}
 		});
 
-		// Refresh item quantities when connection to server is restored
-		this.eventBus.on("server-online", async () => {
-			if (this.items && this.items.length > 0) {
-				await this.update_items_details(this.items);
-			}
-		});
+                // Refresh item quantities when connection to server is restored
+                this.eventBus.on("server-online", async () => {
+                        if (this.items && this.items.length > 0) {
+                                this.lastItemDetailsSignature = null;
+                                await this.update_items_details(this.items);
+                        }
+                });
 
 		if (typeof Worker !== "undefined") {
 			try {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -220,32 +220,34 @@
                                                        <DynamicScroller
                                                                v-else
                                                                ref="itemsContainer"
-                                                               class="items-card-grid"
+                                                               class="items-card-scroller"
                                                                :class="{ 'item-container': isOverflowing }"
-                                                               :items="filtered_items"
-                                                               key-field="item_code"
+                                                               :style="cardScrollerStyle"
+                                                               :items="cardRows"
+                                                               key-field="rowKey"
                                                                :min-item-size="cardItemMinSize"
                                                        >
-                                                               <template #default="{ item, index, active }">
+                                                               <template #default="{ item: row, index, active }">
                                                                        <DynamicScrollerItem
-                                                                               :key="item.item_code"
-                                                                               :item="item"
+                                                                               :key="row.rowKey"
+                                                                               :item="row"
                                                                                :active="active"
                                                                                :data-index="index"
-                                                                               :size-dependencies="[
-                                                                                       item.actual_qty,
-                                                                                       item.rate,
-                                                                                       selected_currency,
-                                                                                       hide_qty_decimals,
-                                                                               ]"
+                                                                               :size-dependencies="row.sizeDependencies"
                                                                        >
                                                                                <div
-                                                                                       class="card-item-card"
-                                                                                       @click="select_item($event, item)"
-                                                                                       :draggable="true"
-                                                                                       @dragstart="onDragStart($event, item)"
-                                                                                       @dragend="onDragEnd"
+                                                                                       class="items-card-row"
+                                                                                       :style="getCardRowStyle(index)"
                                                                                >
+                                                                                       <div
+                                                                                               v-for="item in row.items"
+                                                                                               :key="item.item_code"
+                                                                                               class="card-item-card"
+                                                                                               @click="select_item($event, item)"
+                                                                                               :draggable="true"
+                                                                                               @dragstart="onDragStart($event, item)"
+                                                                                               @dragend="onDragEnd"
+                                                                                       >
                                                                                        <div class="card-item-image-container">
                                                                                                <v-img
                                                                                                        :src="item.image || placeholderImage"
@@ -336,10 +338,11 @@
                                                                                                </div>
                                                                                        </div>
                                                                                </div>
+                                                                               </div>
                                                                        </DynamicScrollerItem>
                                                                </template>
                                                        </DynamicScroller>
-                                                </div>
+                                               </div>
                                                 <div v-else class="items-table-container">
 							<v-data-table-virtual
 								:headers="headers"
@@ -538,7 +541,8 @@ export default {
                 // Limit the displayed items to avoid overly large lists
                 itemsPerPage: 50,
                 cardItemMinSize: 180,
-		offersCount: 0,
+                cardSizeMeasureHandle: null,
+                offersCount: 0,
 		appliedOffersCount: 0,
 		couponsCount: 0,
 		appliedCouponsCount: 0,
@@ -768,6 +772,8 @@ export default {
                                 if (this.items_view === "card") {
                                         this.attachCardScrollListener();
                                         this.checkItemContainerOverflow();
+                                        this.refreshCardScroller();
+                                        this.scheduleCardMeasurement();
                                 }
                         });
                 },
@@ -785,22 +791,38 @@ export default {
 		}, 300),
 
 		// Refresh item prices whenever the user changes currency
-		selected_currency() {
-			this.applyCurrencyConversionToItems();
-		},
+                selected_currency() {
+                        this.applyCurrencyConversionToItems();
+                        if (this.items_view === "card") {
+                                this.refreshCardScroller();
+                                this.scheduleCardMeasurement();
+                        }
+                },
 
-		// Also react when exchange rate is adjusted manually
-		exchange_rate() {
-			this.applyCurrencyConversionToItems();
-		},
-		windowWidth() {
-			// Keep the configured items per page on resize
-			this.itemsPerPage = this.items_per_page;
-		},
-		windowHeight() {
-			// Maintain the configured items per page on resize
-			this.itemsPerPage = this.items_per_page;
-		},
+                // Also react when exchange rate is adjusted manually
+                exchange_rate() {
+                        this.applyCurrencyConversionToItems();
+                        if (this.items_view === "card") {
+                                this.refreshCardScroller();
+                                this.scheduleCardMeasurement();
+                        }
+                },
+                windowWidth() {
+                        // Keep the configured items per page on resize
+                        this.itemsPerPage = this.items_per_page;
+                        if (this.items_view === "card") {
+                                this.refreshCardScroller();
+                                this.scheduleCardMeasurement();
+                        }
+                },
+                windowHeight() {
+                        // Maintain the configured items per page on resize
+                        this.itemsPerPage = this.items_per_page;
+                        if (this.items_view === "card") {
+                                this.refreshCardScroller();
+                                this.scheduleCardMeasurement();
+                        }
+                },
 		items_loaded(val) {
 			if (val) {
 				this.eventBus.emit("items_loaded");
@@ -812,13 +834,27 @@ export default {
                                 if (this.items_view === "card") {
                                         this.attachCardScrollListener();
                                         this.checkItemContainerOverflow();
+                                        this.refreshCardScroller();
+                                        this.scheduleCardMeasurement();
                                 } else {
                                         this.detachCardScrollListener();
                                         this.isOverflowing = false;
                                 }
                         });
                 },
-	},
+                cardLayoutColumns() {
+                        if (this.items_view === "card") {
+                                this.refreshCardScroller();
+                                this.scheduleCardMeasurement();
+                        }
+                },
+                hide_qty_decimals() {
+                        if (this.items_view === "card") {
+                                this.refreshCardScroller();
+                                this.scheduleCardMeasurement();
+                        }
+                },
+        },
 
 	methods: {
 		// Performance optimization: Memoized search function
@@ -988,6 +1024,62 @@ export default {
                                 return null;
                         }
                         return ref.$el || ref;
+                },
+
+                getCardRowStyle(index) {
+                        const { columns, gap } = this.cardLayoutConfig;
+                        const style = {
+                                display: "grid",
+                                gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                                gap: `${gap}px`,
+                        };
+
+                        if (index === this.cardRows.length - 1) {
+                                style.marginBottom = "0px";
+                        } else {
+                                style.marginBottom = `${gap}px`;
+                        }
+
+                        return style;
+                },
+
+                refreshCardScroller() {
+                        this.$nextTick(() => {
+                                const scroller = this.$refs.itemsContainer;
+                                if (scroller && typeof scroller.forceUpdate === "function") {
+                                        scroller.forceUpdate(false);
+                                }
+                        });
+                },
+
+                scheduleCardMeasurement() {
+                        if (this.cardSizeMeasureHandle) {
+                                cancelAnimationFrame(this.cardSizeMeasureHandle);
+                                this.cardSizeMeasureHandle = null;
+                        }
+
+                        this.cardSizeMeasureHandle = requestAnimationFrame(() => {
+                                this.cardSizeMeasureHandle = null;
+                                this.measureCardRowSize();
+                        });
+                },
+
+                measureCardRowSize() {
+                        if (this.items_view !== "card" || this.loading) {
+                                return;
+                        }
+
+                        this.$nextTick(() => {
+                                const row = this.$el.querySelector(".items-card-row");
+                                if (!row) {
+                                        return;
+                                }
+
+                                const height = row.offsetHeight;
+                                if (height && Math.abs(height - this.cardItemMinSize) > 1) {
+                                        this.cardItemMinSize = height;
+                                }
+                        });
                 },
 
                 attachCardScrollListener() {
@@ -3310,10 +3402,58 @@ export default {
 
                         return limitedItems;
                 },
-		debounce_search: {
-			get() {
-				return this.first_search;
-			},
+                cardLayoutConfig() {
+                        if (this.windowWidth <= 768) {
+                                return { columns: 1, gap: 10, padding: 10 };
+                        }
+                        if (this.windowWidth <= 1200) {
+                                return { columns: 2, gap: 12, padding: 12 };
+                        }
+                        return { columns: 3, gap: 16, padding: 16 };
+                },
+                cardLayoutColumns() {
+                        return this.cardLayoutConfig.columns;
+                },
+                cardRows() {
+                        const items = Array.isArray(this.filtered_items) ? this.filtered_items : [];
+                        const columns = Math.max(this.cardLayoutColumns || 1, 1);
+                        const rows = [];
+
+                        for (let index = 0; index < items.length; index += columns) {
+                                const rowIndex = Math.floor(index / columns);
+                                const slice = items.slice(index, index + columns);
+                                const dependencies = slice.flatMap((card) => [
+                                        card.item_code,
+                                        card.item_name,
+                                        card.actual_qty,
+                                        card.rate,
+                                        card.image,
+                                        card.stock_uom,
+                                        this.selected_currency,
+                                        this.hide_qty_decimals,
+                                ]);
+
+                                rows.push({
+                                        rowKey: `row-${rowIndex}`,
+                                        items: slice,
+                                        sizeDependencies: dependencies,
+                                });
+                        }
+
+                        return rows;
+                },
+                cardScrollerStyle() {
+                        const padding = this.cardLayoutConfig.padding;
+                        return {
+                                height: "calc(100% - 80px)",
+                                overflowY: "auto",
+                                padding: `${padding}px`,
+                        };
+                },
+                debounce_search: {
+                        get() {
+                                return this.first_search;
+                        },
 			set: _.debounce(function (newValue) {
 				this.first_search = (newValue || "").trim();
 			}, 200),
@@ -3537,10 +3677,14 @@ export default {
                 this.$nextTick(() => {
                         this.attachCardScrollListener();
                         this.checkItemContainerOverflow();
+                        if (this.items_view === "card") {
+                                this.refreshCardScroller();
+                                this.scheduleCardMeasurement();
+                        }
                 });
-	},
+        },
 
-	beforeUnmount() {
+        beforeUnmount() {
 		// Clear interval when component is destroyed
 		if (this.refresh_interval) {
 			clearInterval(this.refresh_interval);
@@ -3591,6 +3735,10 @@ export default {
 		this.eventBus.off("focus_item_search");
                 window.removeEventListener("resize", this.checkItemContainerOverflow);
                 this.detachCardScrollListener();
+                if (this.cardSizeMeasureHandle) {
+                        cancelAnimationFrame(this.cardSizeMeasureHandle);
+                        this.cardSizeMeasureHandle = null;
+                }
         },
 };
 </script>
@@ -3783,31 +3931,47 @@ export default {
 
 /* Enhanced Card View Grid Layout - 3 items per row */
 .items-card-grid {
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	gap: 16px;
-	padding: 16px;
-	height: calc(100% - 80px);
-	overflow-y: auto;
-	scrollbar-width: thin;
-	scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
-	/* Performance optimizations */
-	contain: layout style;
-	will-change: scroll-position;
-	transform: translate3d(0, 0, 0);
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        padding: 16px;
+        height: calc(100% - 80px);
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+        contain: layout style;
+        will-change: scroll-position;
+        transform: translate3d(0, 0, 0);
 }
 
-.items-card-grid::-webkit-scrollbar {
-	width: 8px;
+.items-card-scroller {
+        height: calc(100% - 80px);
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+        contain: layout style;
+        will-change: scroll-position;
+        transform: translate3d(0, 0, 0);
 }
 
-.items-card-grid::-webkit-scrollbar-track {
-	background: transparent;
+.items-card-row {
+        width: 100%;
 }
 
-.items-card-grid::-webkit-scrollbar-thumb {
-	background-color: rgba(0, 0, 0, 0.2);
-	border-radius: 4px;
+.items-card-grid::-webkit-scrollbar,
+.items-card-scroller::-webkit-scrollbar {
+        width: 8px;
+}
+
+.items-card-grid::-webkit-scrollbar-track,
+.items-card-scroller::-webkit-scrollbar-track {
+        background: transparent;
+}
+
+.items-card-grid::-webkit-scrollbar-thumb,
+.items-card-scroller::-webkit-scrollbar-thumb {
+        background-color: rgba(0, 0, 0, 0.2);
+        border-radius: 4px;
 }
 
 .card-item-card {
@@ -4203,11 +4367,11 @@ export default {
 
 /* Responsive breakpoints */
 @media (max-width: 1200px) {
-	.items-card-grid {
-		grid-template-columns: repeat(2, 1fr);
-		gap: 12px;
-		padding: 12px;
-	}
+        .items-card-grid {
+                grid-template-columns: repeat(2, 1fr);
+                gap: 12px;
+                padding: 12px;
+        }
 }
 
 @media (max-width: 768px) {
@@ -4225,11 +4389,11 @@ export default {
 		font-size: 0.875rem !important;
 	}
 
-	.items-card-grid {
-		grid-template-columns: 1fr;
-		gap: 10px;
-		padding: 10px;
-	}
+        .items-card-grid {
+                grid-template-columns: 1fr;
+                gap: 10px;
+                padding: 10px;
+        }
 
 	.card-item-image-container {
 		height: 100px;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -217,115 +217,130 @@
 							<div v-if="loading" class="items-card-grid">
 								<Skeleton v-for="n in 8" :key="n" class="mb-4" height="120" />
 							</div>
-							<div
-								v-else
-								class="items-card-grid"
-								ref="itemsContainer"
-								@scroll.passive="onCardScroll"
-								:class="{ 'item-container': isOverflowing }"
-							>
-								<div
-									v-for="item in filtered_items"
-									:key="item.item_code"
-									class="card-item-card"
-									@click="select_item($event, item)"
-									:draggable="true"
-									@dragstart="onDragStart($event, item)"
-									@dragend="onDragEnd"
-								>
-									<div class="card-item-image-container">
-										<v-img
-											:src="item.image || placeholderImage"
-											class="card-item-image"
-											aspect-ratio="1"
-											:alt="item.item_name"
-										>
-											<template v-slot:placeholder>
-												<div class="image-placeholder">
-													<v-icon size="40" color="grey-lighten-2"
-														>mdi-image</v-icon
-													>
-												</div>
-											</template>
-										</v-img>
-									</div>
-									<div class="card-item-content">
-										<div class="card-item-header">
-											<h4 class="card-item-name">{{ item.item_name }}</h4>
-											<span class="card-item-code">{{ item.item_code }}</span>
-										</div>
-										<div class="card-item-details">
-											<div class="card-item-price">
-												<div class="primary-price">
-													<span class="currency-symbol">
-														{{
-															currencySymbol(
-																item.original_currency ||
-																	pos_profile.currency,
-															)
-														}}
-													</span>
-													<span class="price-amount">
-														{{
-															format_currency(
-																item.base_price_list_rate ?? item.rate ?? 0,
-																item.original_currency ||
-																	pos_profile.currency,
-																ratePrecision(
-																	item.base_price_list_rate ??
-																		item.rate ??
-																		0,
-																),
-															)
-														}}
-													</span>
-												</div>
-												<div
-													v-if="
-														pos_profile.posa_allow_multi_currency &&
-														selected_currency !== pos_profile.currency
-													"
-													class="secondary-price"
-												>
-													<span class="currency-symbol">{{
-														currencySymbol(selected_currency)
-													}}</span>
-													<span class="price-amount">
-														{{
-															format_currency(
-																item.rate,
-																selected_currency,
-																ratePrecision(item.rate),
-															)
-														}}
-													</span>
-												</div>
-											</div>
-											<div class="card-item-stock">
-												<v-icon size="small" class="stock-icon"
-													>mdi-package-variant</v-icon
-												>
-												<span
-													class="stock-amount"
-													:class="{
-														'negative-number': isNegative(item.actual_qty),
-													}"
-												>
-													{{
-														format_number(
-															item.actual_qty,
-															hide_qty_decimals ? 0 : 4,
-														) || 0
-													}}
-												</span>
-												<span class="stock-uom">{{ item.stock_uom || "" }}</span>
-											</div>
-										</div>
-									</div>
-								</div>
-							</div>
-						</div>
-						<div v-else class="items-table-container">
+                                                       <DynamicScroller
+                                                               v-else
+                                                               ref="itemsContainer"
+                                                               class="items-card-grid"
+                                                               :class="{ 'item-container': isOverflowing }"
+                                                               :items="filtered_items"
+                                                               key-field="item_code"
+                                                               :min-item-size="cardItemMinSize"
+                                                       >
+                                                               <template #default="{ item, index, active }">
+                                                                       <DynamicScrollerItem
+                                                                               :key="item.item_code"
+                                                                               :item="item"
+                                                                               :active="active"
+                                                                               :data-index="index"
+                                                                               :size-dependencies="[
+                                                                                       item.actual_qty,
+                                                                                       item.rate,
+                                                                                       selected_currency,
+                                                                                       hide_qty_decimals,
+                                                                               ]"
+                                                                       >
+                                                                               <div
+                                                                                       class="card-item-card"
+                                                                                       @click="select_item($event, item)"
+                                                                                       :draggable="true"
+                                                                                       @dragstart="onDragStart($event, item)"
+                                                                                       @dragend="onDragEnd"
+                                                                               >
+                                                                                       <div class="card-item-image-container">
+                                                                                               <v-img
+                                                                                                       :src="item.image || placeholderImage"
+                                                                                                       class="card-item-image"
+                                                                                                       aspect-ratio="1"
+                                                                                                       :alt="item.item_name"
+                                                                                               >
+                                                                                                       <template v-slot:placeholder>
+                                                                                                               <div class="image-placeholder">
+                                                                                                                       <v-icon size="40" color="grey-lighten-2"
+                                                                                                                               >mdi-image</v-icon
+                                                                                                                       >
+                                                                                                               </div>
+                                                                                                       </template>
+                                                                                               </v-img>
+                                                                                       </div>
+                                                                                       <div class="card-item-content">
+                                                                                               <div class="card-item-header">
+                                                                                                       <h4 class="card-item-name">{{ item.item_name }}</h4>
+                                                                                                       <span class="card-item-code">{{ item.item_code }}</span>
+                                                                                               </div>
+                                                                                               <div class="card-item-details">
+                                                                                                       <div class="card-item-price">
+                                                                                                               <div class="primary-price">
+                                                                                                                       <span class="currency-symbol">
+                                                                                                                               {{
+                                                                                                                                       currencySymbol(
+                                                                                                                                               item.original_currency ||
+                                                                                                                                                       pos_profile.currency,
+                                                                                                                                       )
+                                                                                                                               }}
+                                                                                                                       </span>
+                                                                                                                       <span class="price-amount">
+                                                                                                                               {{
+                                                                                                                                       format_currency(
+                                                                                                                                               item.base_price_list_rate ?? item.rate ?? 0,
+                                                                                                                                               item.original_currency ||
+                                                                                                                                                       pos_profile.currency,
+                                                                                                                                               ratePrecision(
+                                                                                                                                                       item.base_price_list_rate ??
+                                                                                                                                                               item.rate ??
+                                                                                                                                                               0,
+                                                                                                                                               ),
+                                                                                                                                       )
+                                                                                                                               }}
+                                                                                                                       </span>
+                                                                                                               </div>
+                                                                                                               <div
+                                                                                                                       v-if="
+                                                                                                                               pos_profile.posa_allow_multi_currency &&
+                                                                                                                               selected_currency !== pos_profile.currency
+                                                                                                                       "
+                                                                                                                       class="secondary-price"
+                                                                                                               >
+                                                                                                                       <span class="currency-symbol">{{
+                                                                                                                               currencySymbol(selected_currency)
+                                                                                                                       }}</span>
+                                                                                                                       <span class="price-amount">
+                                                                                                                               {{
+                                                                                                                                       format_currency(
+                                                                                                                                               item.rate,
+                                                                                                                                               selected_currency,
+                                                                                                                                               ratePrecision(item.rate),
+                                                                                                                                       )
+                                                                                                                               }}
+                                                                                                                       </span>
+                                                                                                               </div>
+                                                                                                       </div>
+                                                                                                       <div class="card-item-stock">
+                                                                                                               <v-icon size="small" class="stock-icon"
+                                                                                                                       >mdi-package-variant</v-icon
+                                                                                                               >
+                                                                                                               <span
+                                                                                                                       class="stock-amount"
+                                                                                                                       :class="{
+                                                                                                                               'negative-number': isNegative(item.actual_qty),
+                                                                                                                       }"
+                                                                                                               >
+                                                                                                                       {{
+                                                                                                                                       format_number(
+                                                                                                                                               item.actual_qty,
+                                                                                                                                               hide_qty_decimals ? 0 : 4,
+                                                                                                                                       ) || 0
+                                                                                                                       }}
+                                                                                                               </span>
+                                                                                                               <span class="stock-uom">{{ item.stock_uom || "" }}</span>
+                                                                                                       </div>
+                                                                                               </div>
+                                                                                       </div>
+                                                                               </div>
+                                                                       </DynamicScrollerItem>
+                                                               </template>
+                                                       </DynamicScroller>
+                                                </div>
+                                                <div v-else class="items-table-container">
 							<v-data-table-virtual
 								:headers="headers"
 								:items="filtered_items"
@@ -492,6 +507,7 @@ import { useRtl } from "../../composables/useRtl.js";
 import { useFlyAnimation } from "../../composables/useFlyAnimation.js";
 import placeholderImage from "./placeholder-image.png";
 import Skeleton from "../ui/Skeleton.vue";
+import { DynamicScroller, DynamicScrollerItem } from "vue-virtual-scroller";
 
 export default {
 	mixins: [format],
@@ -501,10 +517,12 @@ export default {
 		const { fly } = useFlyAnimation();
 		return { ...responsive, ...rtl, fly };
 	},
-	components: {
-		CameraScanner,
-		Skeleton,
-	},
+        components: {
+                CameraScanner,
+                Skeleton,
+                DynamicScroller,
+                DynamicScrollerItem,
+        },
 	data: () => ({
 		pos_profile: {},
 		stock_settings: {},
@@ -517,8 +535,9 @@ export default {
 		search: "",
 		first_search: "",
 		search_backup: "",
-		// Limit the displayed items to avoid overly large lists
-		itemsPerPage: 50,
+                // Limit the displayed items to avoid overly large lists
+                itemsPerPage: 50,
+                cardItemMinSize: 180,
 		offersCount: 0,
 		appliedOffersCount: 0,
 		couponsCount: 0,
@@ -561,9 +580,11 @@ export default {
 		itemCache: new Map(),
 		virtualScrollEnabled: true,
 		renderBuffer: 10,
-		lastScrollTop: 0,
-		scrollThrottle: null,
-		searchDebounce: null,
+                lastScrollTop: 0,
+                scrollThrottle: null,
+                cardScrollEl: null,
+                boundCardScrollHandler: null,
+                searchDebounce: null,
 		// Prevent repeated server fetches when local storage is empty
 		fallbackAttempted: false,
 		// Fixed page size for incremental item loading to avoid
@@ -743,7 +764,12 @@ export default {
                                         this.update_items_details(newItems);
                                 }
                         }
-                        this.$nextTick(this.checkItemContainerOverflow);
+                        this.$nextTick(() => {
+                                if (this.items_view === "card") {
+                                        this.attachCardScrollListener();
+                                        this.checkItemContainerOverflow();
+                                }
+                        });
                 },
 		// Automatically search when the query has at least 3 characters
 		first_search: _.debounce(function (val, oldVal) {
@@ -781,15 +807,17 @@ export default {
 				this.eventBus.emit("data-loaded", "items");
 			}
 		},
-		items_view() {
-			this.$nextTick(() => {
-				if (this.items_view === "card") {
-					this.checkItemContainerOverflow();
-				} else {
-					this.isOverflowing = false;
-				}
-			});
-		},
+                items_view() {
+                        this.$nextTick(() => {
+                                if (this.items_view === "card") {
+                                        this.attachCardScrollListener();
+                                        this.checkItemContainerOverflow();
+                                } else {
+                                        this.detachCardScrollListener();
+                                        this.isOverflowing = false;
+                                }
+                        });
+                },
 	},
 
 	methods: {
@@ -936,12 +964,12 @@ export default {
                         return cache;
                 },
 
-		async fetchServerItemsTimestamp() {
-			try {
-				const { message } = await frappe.call({
-					method: "frappe.client.get_list",
-					args: {
-						doctype: "Item",
+                async fetchServerItemsTimestamp() {
+                        try {
+                                const { message } = await frappe.call({
+                                        method: "frappe.client.get_list",
+                                        args: {
+                                                doctype: "Item",
 						fields: ["modified"],
 						order_by: "modified desc",
 						limit_page_length: 1,
@@ -949,21 +977,60 @@ export default {
 				});
 				return message && message[0] && message[0].modified;
 			} catch (e) {
-				console.error("Failed to fetch server items timestamp", e);
-				return null;
-			}
-		},
+                                console.error("Failed to fetch server items timestamp", e);
+                                return null;
+                        }
+                },
 
-		// Optimized scroll handler with throttling
-		onCardScroll() {
-			if (this.scrollThrottle) return;
+                getItemsContainerEl() {
+                        const ref = this.$refs.itemsContainer;
+                        if (!ref) {
+                                return null;
+                        }
+                        return ref.$el || ref;
+                },
 
-			this.scrollThrottle = requestAnimationFrame(() => {
-				try {
-					const el = this.$refs.itemsContainer;
-					if (!el) return;
+                attachCardScrollListener() {
+                        if (this.items_view !== "card") {
+                                this.detachCardScrollListener();
+                                return;
+                        }
 
-					const scrollTop = el.scrollTop;
+                        const el = this.getItemsContainerEl();
+                        if (!el) {
+                                return;
+                        }
+
+                        if (!this.boundCardScrollHandler) {
+                                this.boundCardScrollHandler = () => this.onCardScroll();
+                        }
+
+                        if (this.cardScrollEl === el) {
+                                return;
+                        }
+
+                        this.detachCardScrollListener();
+                        this.cardScrollEl = el;
+                        this.cardScrollEl.addEventListener("scroll", this.boundCardScrollHandler, { passive: true });
+                },
+
+                detachCardScrollListener() {
+                        if (this.cardScrollEl && this.boundCardScrollHandler) {
+                                this.cardScrollEl.removeEventListener("scroll", this.boundCardScrollHandler);
+                        }
+                        this.cardScrollEl = null;
+                },
+
+                // Optimized scroll handler with throttling
+                onCardScroll() {
+                        if (this.scrollThrottle) return;
+
+                        this.scrollThrottle = requestAnimationFrame(() => {
+                                try {
+                                        const el = this.getItemsContainerEl();
+                                        if (!el) return;
+
+                                        const scrollTop = el.scrollTop;
 					const clientHeight = el.clientHeight;
 					const scrollHeight = el.scrollHeight;
 
@@ -1091,12 +1158,12 @@ export default {
 			});
 		},
 
-		checkItemContainerOverflow() {
-			const el = this.$refs.itemsContainer;
-			if (!el) {
-				this.isOverflowing = false;
-				return;
-			}
+                checkItemContainerOverflow() {
+                        const el = this.getItemsContainerEl();
+                        if (!el) {
+                                this.isOverflowing = false;
+                                return;
+                        }
 
 			const containerHeight = parseFloat(getComputedStyle(el).getPropertyValue("--container-height"));
 			if (isNaN(containerHeight)) {
@@ -3466,8 +3533,11 @@ export default {
 
 		// Apply the configured items per page on mount
 		this.itemsPerPage = this.items_per_page;
-		window.addEventListener("resize", this.checkItemContainerOverflow);
-		this.$nextTick(this.checkItemContainerOverflow);
+                window.addEventListener("resize", this.checkItemContainerOverflow);
+                this.$nextTick(() => {
+                        this.attachCardScrollListener();
+                        this.checkItemContainerOverflow();
+                });
 	},
 
 	beforeUnmount() {
@@ -3519,8 +3589,9 @@ export default {
 		this.eventBus.off("update_customer");
 		this.eventBus.off("force_reload_items");
 		this.eventBus.off("focus_item_search");
-		window.removeEventListener("resize", this.checkItemContainerOverflow);
-	},
+                window.removeEventListener("resize", this.checkItemContainerOverflow);
+                this.detachCardScrollListener();
+        },
 };
 </script>
 


### PR DESCRIPTION
## Summary
- cache lower-cased item search fields and limit filtering to a small working set before paging
- track the last detail request signature and reset it when the visible item set changes to skip redundant fetches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccdc5ee9508326907a949de245f919