### PR TITLE
Optimize item filtering and detail refresh

### DIFF
--- a/frontend/src/offline.js
+++ b/frontend/src/offline.js
@@ -1,4 +1,5 @@
 import Dexie from "dexie/dist/dexie.mjs";
+import { prepareItemsForStorage } from "./offline/item-utils.js";
 
 // --- Dexie initialization ---------------------------------------------------
 const db = new Dexie("posawesome_offline");
@@ -992,39 +993,88 @@ export async function getStoredItems() {
 }
 
 export async function searchStoredItems({ search = "", itemGroup = "", limit = 100, offset = 0 } = {}) {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		let collection = db.table("items");
-		if (itemGroup && itemGroup.toLowerCase() !== "all") {
-			collection = collection.where("item_group").equalsIgnoreCase(itemGroup);
-		}
-		if (search) {
-			const term = search.toLowerCase();
-			collection = collection.filter((it) => {
-				const nameMatch = it.item_name && it.item_name.toLowerCase().includes(term);
-				const codeMatch = it.item_code && it.item_code.toLowerCase().includes(term);
-				const barcodeMatch = Array.isArray(it.item_barcode)
-					? it.item_barcode.some((b) => b.barcode && b.barcode.toLowerCase() === term)
-					: it.item_barcode && String(it.item_barcode).toLowerCase().includes(term);
-				return nameMatch || codeMatch || barcodeMatch;
-			});
-		}
-		return await collection.offset(offset).limit(limit).toArray();
-	} catch (e) {
-		console.error("Failed to query stored items", e);
-		return [];
-	}
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) await db.open();
+                const term = search ? search.trim().toLowerCase() : "";
+                const hasGroupFilter = itemGroup && itemGroup.toLowerCase() !== "all";
+                const groupTerm = hasGroupFilter ? itemGroup.toLowerCase() : "";
+                const safeLower = (value) => (value != null ? String(value).toLowerCase() : "");
+                const matchesGroup = (item) => {
+                        if (!hasGroupFilter) {
+                                return true;
+                        }
+                        const group = item.item_group_lower || safeLower(item.item_group);
+                        return group === groupTerm;
+                };
+
+                if (term) {
+                        const matchesTerm = (item) => {
+                                const nameLower = item.item_name_lower || safeLower(item.item_name);
+                                const codeLower = item.item_code_lower || safeLower(item.item_code);
+                                const barcodeMatch = Array.isArray(item.barcodes)
+                                        ? item.barcodes.some((bc) => safeLower(bc).includes(term))
+                                        : false;
+                                const keywordMatch = Array.isArray(item.name_keywords)
+                                        ? item.name_keywords.some((kw) => safeLower(kw).includes(term))
+                                        : false;
+                                return (
+                                        (nameLower && nameLower.includes(term)) ||
+                                        (codeLower && codeLower.includes(term)) ||
+                                        barcodeMatch ||
+                                        keywordMatch
+                                );
+                        };
+
+                        let collection = db
+                                .table("items")
+                                .where("item_code_lower")
+                                .startsWith(term)
+                                .or("item_name_lower")
+                                .startsWith(term)
+                                .or("barcodes")
+                                .equals(term)
+                                .or("name_keywords")
+                                .startsWith(term)
+                                .filter(matchesGroup);
+                        let results = await collection.toArray();
+                        if (!results.length) {
+                                results = await db
+                                        .table("items")
+                                        .filter((item) => matchesGroup(item) && matchesTerm(item))
+                                        .toArray();
+                        }
+                        const map = new Map();
+                        results.forEach((item) => {
+                                if (!map.has(item.item_code)) {
+                                        map.set(item.item_code, item);
+                                }
+                        });
+                        const unique = Array.from(map.values());
+                        return unique.slice(offset, offset + limit);
+                }
+
+                return await db
+                        .table("items")
+                        .filter(matchesGroup)
+                        .offset(offset)
+                        .limit(limit)
+                        .toArray();
+        } catch (e) {
+                console.error("Failed to query stored items", e);
+                return [];
+        }
 }
 
 export async function saveItems(items) {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		await db.table("items").bulkPut(items);
-	} catch (e) {
-		console.error("Failed to save items", e);
-	}
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) await db.open();
+                const normalized = Array.isArray(items) ? prepareItemsForStorage(items) : [];
+                await db.table("items").bulkPut(normalized);
+        } catch (e) {
+                console.error("Failed to save items", e);
+        }
 }
 
 export async function clearStoredItems() {

--- a/frontend/src/offline/cache.js
+++ b/frontend/src/offline/cache.js
@@ -10,6 +10,159 @@ import { clearPriceListCache } from "./items.js";
 import Dexie from "dexie/dist/dexie.mjs";
 import { prepareItemsForStorage } from "./item-utils.js";
 
+const IMMEDIATE_HYDRATION_KEYS = [
+        "cache_version",
+        "cache_ready",
+        "manual_offline",
+        "tax_inclusive",
+        "offline_invoices",
+        "offline_customers",
+        "offline_payments",
+        "pos_last_sync_totals",
+        "pos_opening_storage",
+        "opening_dialog_storage",
+        "sales_persons_storage",
+        "customer_balance_cache",
+        "customer_storage",
+        "items_last_sync",
+        "customers_last_sync",
+        "tax_template_cache",
+        "print_template",
+        "terms_and_conditions",
+        "item_groups_cache",
+];
+
+const POST_UI_HYDRATION_KEYS = ["uom_cache", "item_details_cache", "coupons_cache"];
+
+const BACKGROUND_HYDRATION_KEYS = [
+        "local_stock_cache",
+        "stock_cache_ready",
+        "offers_cache",
+        "translation_cache",
+];
+
+function runAfterFirstPaint(callback) {
+        if (typeof window === "undefined") {
+                callback();
+                return;
+        }
+
+        const raf = window.requestAnimationFrame?.bind(window);
+        if (typeof raf === "function") {
+                raf(() => raf(() => callback()));
+        } else {
+                setTimeout(callback, 16);
+        }
+}
+
+function runWhenIdle(callback, timeout = 2000) {
+        if (typeof window === "undefined") {
+                callback();
+                return;
+        }
+
+        const ric = window.requestIdleCallback?.bind(window);
+        if (typeof ric === "function") {
+                ric(callback, { timeout });
+        } else {
+                setTimeout(callback, timeout);
+        }
+}
+
+function resolveFeatureFlag(flagName) {
+        if (typeof window === "undefined") {
+                return undefined;
+        }
+
+        const globalFlags = window.posawesomeFeatureFlags || window.posawesomeFeatures;
+        if (globalFlags && Object.prototype.hasOwnProperty.call(globalFlags, flagName)) {
+                return !!globalFlags[flagName];
+        }
+
+        const bootFlags = window.frappe?.boot?.posawesome_features;
+        if (bootFlags && Object.prototype.hasOwnProperty.call(bootFlags, flagName)) {
+                return !!bootFlags[flagName];
+        }
+
+        return undefined;
+}
+
+function shouldHydrateOptionalCache(key) {
+        switch (key) {
+                case "offers_cache": {
+                        const explicit = resolveFeatureFlag("offersCache");
+                        if (typeof explicit === "boolean") {
+                                return explicit;
+                        }
+                        const profile = typeof window !== "undefined" ? window.frappe?.boot?.pos_profile : null;
+                        if (profile && Object.prototype.hasOwnProperty.call(profile, "posa_enable_offers")) {
+                                return !!profile.posa_enable_offers;
+                        }
+                        return true;
+                }
+                case "translation_cache": {
+                        const explicit = resolveFeatureFlag("translationCache");
+                        if (typeof explicit === "boolean") {
+                                return explicit;
+                        }
+                        const lang = typeof window !== "undefined" ? window.frappe?.boot?.lang : null;
+                        return !!(lang && lang !== "en");
+                }
+                default:
+                        return true;
+        }
+}
+
+async function hydrateKeys(keys, { guard } = {}) {
+        if (!Array.isArray(keys) || keys.length === 0) {
+                return;
+        }
+
+        let dbReady = false;
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) {
+                        await db.open();
+                }
+                dbReady = true;
+        } catch (err) {
+                console.error("Failed to prepare IndexedDB for hydration", err);
+        }
+
+        for (const key of keys) {
+                if (guard && guard(key) === false) {
+                        continue;
+                }
+
+                let loaded = false;
+
+                if (dbReady) {
+                        try {
+                                const stored = await db.table(tableForKey(key)).get(key);
+                                if (stored && stored.value !== undefined) {
+                                        memory[key] = stored.value;
+                                        loaded = true;
+                                }
+                        } catch (err) {
+                                console.error(`Failed to hydrate ${key} from IndexedDB`, err);
+                        }
+                }
+
+                if (!loaded && typeof localStorage !== "undefined") {
+                        try {
+                                const raw = localStorage.getItem(`posa_${key}`);
+                                if (raw) {
+                                        memory[key] = JSON.parse(raw);
+                                        loaded = true;
+                                }
+                        } catch (err) {
+                                console.error(`Failed to hydrate ${key} from localStorage`, err);
+                        }
+                }
+
+        }
+}
+
 // Increment this number whenever the cache data structure changes
 export const CACHE_VERSION = 1;
 
@@ -17,10 +170,10 @@ export const MAX_QUEUE_ITEMS = 1000;
 
 // Memory cache object
 export const memory = {
-	offline_invoices: [],
-	offline_customers: [],
-	offline_payments: [],
-	pos_last_sync_totals: { pending: 0, synced: 0, drafted: 0 },
+        offline_invoices: [],
+        offline_customers: [],
+        offline_payments: [],
+        pos_last_sync_totals: { pending: 0, synced: 0, drafted: 0 },
 	uom_cache: {},
 	offers_cache: [],
 	customer_balance_cache: {},
@@ -42,56 +195,64 @@ export const memory = {
 	cache_ready: false,
 	tax_inclusive: false,
 	manual_offline: false,
-	print_template: "",
-	terms_and_conditions: "",
+        print_template: "",
+        terms_and_conditions: "",
 };
+
+const ALL_HYDRATION_KEYS = new Set([
+        ...IMMEDIATE_HYDRATION_KEYS,
+        ...POST_UI_HYDRATION_KEYS,
+        ...BACKGROUND_HYDRATION_KEYS,
+]);
+
+for (const key of Object.keys(memory)) {
+        if (!ALL_HYDRATION_KEYS.has(key)) {
+                IMMEDIATE_HYDRATION_KEYS.push(key);
+                ALL_HYDRATION_KEYS.add(key);
+        }
+}
 
 // Initialize memory from IndexedDB and expose a promise for consumers
 export const memoryInitPromise = (async () => {
-	try {
-		await checkDbHealth();
-		for (const key of Object.keys(memory)) {
-			const stored = await db.table(tableForKey(key)).get(key);
-			if (stored && stored.value !== undefined) {
-				memory[key] = stored.value;
-				continue;
-			}
-			if (typeof localStorage !== "undefined") {
-				const ls = localStorage.getItem(`posa_${key}`);
-				if (ls) {
-					try {
-						memory[key] = JSON.parse(ls);
-						continue;
-					} catch (err) {
-						console.error("Failed to parse localStorage for", key, err);
-					}
-				}
-			}
-		}
+        try {
+                await hydrateKeys(IMMEDIATE_HYDRATION_KEYS);
 
-		// Verify cache version and clear outdated caches
-		const versionEntry = await db.table(tableForKey("cache_version")).get("cache_version");
-		let storedVersion = versionEntry ? versionEntry.value : null;
-		if (!storedVersion && typeof localStorage !== "undefined") {
-			const v = localStorage.getItem("posa_cache_version");
-			if (v) storedVersion = parseInt(v, 10);
-		}
-		if (storedVersion !== CACHE_VERSION) {
-			await forceClearAllCache();
-			memory.cache_version = CACHE_VERSION;
-			if (typeof localStorage !== "undefined") {
-				localStorage.setItem("posa_cache_version", CACHE_VERSION);
-			}
-			persist("cache_version", CACHE_VERSION);
-		} else {
-			memory.cache_version = storedVersion || CACHE_VERSION;
-		}
-		// Mark caches initialized
-		memory.cache_ready = true;
-		persist("cache_ready", true);
-	} catch (e) {
-		console.error("Failed to initialize memory from DB", e);
-	}
+                let storedVersion = memory.cache_version;
+                if ((storedVersion === undefined || storedVersion === null) && typeof localStorage !== "undefined") {
+                        const v = localStorage.getItem("posa_cache_version");
+                        if (v) {
+                                storedVersion = parseInt(v, 10);
+                        }
+                }
+
+                if (storedVersion !== CACHE_VERSION) {
+                        await forceClearAllCache();
+                        memory.cache_version = CACHE_VERSION;
+                        if (typeof localStorage !== "undefined") {
+                                localStorage.setItem("posa_cache_version", CACHE_VERSION);
+                        }
+                        persist("cache_version", CACHE_VERSION);
+                } else {
+                        memory.cache_version = storedVersion || CACHE_VERSION;
+                }
+
+                memory.cache_ready = true;
+                persist("cache_ready", true);
+
+                runAfterFirstPaint(() => {
+                        hydrateKeys(POST_UI_HYDRATION_KEYS).catch((err) => {
+                                console.error("Failed to hydrate post-UI caches", err);
+                        });
+                });
+
+                runWhenIdle(() => {
+                        hydrateKeys(BACKGROUND_HYDRATION_KEYS, { guard: shouldHydrateOptionalCache }).catch((err) => {
+                                console.error("Failed to hydrate background caches", err);
+                        });
+                });
+        } catch (e) {
+                console.error("Failed to initialize memory from DB", e);
+        }
 })();
 
 // Reset cached invoices and customers after syncing

--- a/frontend/src/offline/cache.js
+++ b/frontend/src/offline/cache.js
@@ -6,7 +6,6 @@ import {
 	initPersistWorker,
 	tableForKey,
 } from "./core.js";
-import { getAllByCursor } from "./db-utils.js";
 import { clearPriceListCache } from "./items.js";
 import Dexie from "dexie/dist/dexie.mjs";
 import { prepareItemsForStorage } from "./item-utils.js";
@@ -572,12 +571,53 @@ export async function forceClearAllCache() {
  * Estimates the current cache usage size in bytes and percentage
  * @returns {Promise<Object>} Object containing total, localStorage, and indexedDB sizes in bytes, and usage percentage
  */
+const TABLE_SAMPLE_LIMIT = 25;
+
+function estimateSerializedSize(value) {
+        try {
+                const serialized = JSON.stringify(value);
+                return serialized ? serialized.length * 2 : 0;
+        } catch (e) {
+                console.warn("Failed to serialize value while estimating size", e);
+                return 0;
+        }
+}
+
+async function estimateTableUsage(table) {
+        try {
+                const totalCount = await table.count();
+                if (!totalCount) {
+                        return 0;
+                }
+
+                const sampleSize = Math.min(totalCount, TABLE_SAMPLE_LIMIT);
+                const sample = await table
+                        .toCollection()
+                        .limit(sampleSize)
+                        .toArray();
+
+                if (!sample.length) {
+                        return 0;
+                }
+
+                const totalSampleBytes = sample.reduce((size, item) => {
+                        return size + estimateSerializedSize(item);
+                }, 0);
+
+                const averageItemSize = totalSampleBytes / sample.length;
+                return Math.round(averageItemSize * totalCount);
+        } catch (e) {
+                        console.error(`Failed to estimate usage for table ${table.name}`, e);
+                return 0;
+        }
+}
+
 export async function getCacheUsageEstimate() {
-	try {
-		await checkDbHealth();
-		// Calculate localStorage size
-		let localStorageSize = 0;
-		if (typeof localStorage !== "undefined") {
+        try {
+                await checkDbHealth();
+                // Calculate localStorage size
+                let localStorageSize = 0;
+                if (typeof localStorage !== "undefined") {
 			for (let i = 0; i < localStorage.length; i++) {
 				const key = localStorage.key(i);
 				if (key && key.startsWith("posa_")) {
@@ -587,21 +627,17 @@ export async function getCacheUsageEstimate() {
 			}
 		}
 
-		// Estimate IndexedDB size using cursor to avoid loading everything in memory
-		let indexedDBSize = 0;
-		try {
-			if (db.isOpen()) {
-				for (const table of db.tables) {
-					const entries = await getAllByCursor(table.name);
-					indexedDBSize += entries.reduce((size, item) => {
-						const itemSize = JSON.stringify(item).length * 2; // UTF-16 characters
-						return size + itemSize;
-					}, 0);
-				}
-			}
-		} catch (e) {
-			console.error("Failed to calculate IndexedDB size", e);
-		}
+                // Estimate IndexedDB size using record counts with sampled averages
+                let indexedDBSize = 0;
+                try {
+                        if (db.isOpen()) {
+                                for (const table of db.tables) {
+                                        indexedDBSize += await estimateTableUsage(table);
+                                }
+                        }
+                } catch (e) {
+                        console.error("Failed to calculate IndexedDB size", e);
+                }
 
 		const totalSize = localStorageSize + indexedDBSize;
 		const maxSize = 50 * 1024 * 1024; // Assume 50MB as max size

--- a/frontend/src/offline/cache.js
+++ b/frontend/src/offline/cache.js
@@ -9,6 +9,7 @@ import {
 import { getAllByCursor } from "./db-utils.js";
 import { clearPriceListCache } from "./items.js";
 import Dexie from "dexie/dist/dexie.mjs";
+import { prepareItemsForStorage } from "./item-utils.js";
 
 // Increment this number whenever the cache data structure changes
 export const CACHE_VERSION = 1;
@@ -163,7 +164,8 @@ export async function saveItems(items) {
 			console.error("Failed to serialize items", err);
 			cleanItems = [];
 		}
-		await db.table("items").bulkPut(cleanItems);
+                cleanItems = prepareItemsForStorage(cleanItems);
+                await db.table("items").bulkPut(cleanItems);
 	} catch (e) {
 		console.error("Failed to save items", e);
 	}

--- a/frontend/src/offline/core.js
+++ b/frontend/src/offline/core.js
@@ -1,38 +1,26 @@
 import Dexie from "dexie/dist/dexie.mjs";
 import { withWriteLock } from "./db-utils.js";
+import { prepareItemForStorage } from "./item-utils.js";
 
 // --- Dexie initialization ---------------------------------------------------
 export const db = new Dexie("posawesome_offline");
-db.version(7)
-	.stores({
-		keyval: "&key",
-		queue: "&key",
-		cache: "&key",
-		items: "&item_code,item_name,item_group,*barcodes,*name_keywords,*serials,*batches",
-		item_prices: "&[price_list+item_code],price_list,item_code",
-		customers: "&name,customer_name,mobile_no,email_id,tax_id",
-	})
-	.upgrade((tx) =>
-		tx
-			.table("items")
-			.toCollection()
-			.modify((item) => {
-				item.barcodes = Array.isArray(item.item_barcode)
-					? item.item_barcode.map((b) => b.barcode).filter(Boolean)
-					: item.item_barcode
-						? [String(item.item_barcode)]
-						: [];
-				item.name_keywords = item.item_name
-					? item.item_name.toLowerCase().split(/\s+/).filter(Boolean)
-					: [];
-				item.serials = Array.isArray(item.serial_no_data)
-					? item.serial_no_data.map((s) => s.serial_no).filter(Boolean)
-					: [];
-				item.batches = Array.isArray(item.batch_no_data)
-					? item.batch_no_data.map((b) => b.batch_no).filter(Boolean)
-					: [];
-			}),
-	);
+db.version(8)
+        .stores({
+                keyval: "&key",
+                queue: "&key",
+                cache: "&key",
+                items: "&item_code,item_name,item_group,item_code_lower,item_name_lower,item_group_lower,*barcodes,*name_keywords,*serials,*batches",
+                item_prices: "&[price_list+item_code],price_list,item_code",
+                customers: "&name,customer_name,mobile_no,email_id,tax_id",
+        })
+        .upgrade((tx) =>
+                tx
+                        .table("items")
+                        .toCollection()
+                        .modify((item) => {
+                                prepareItemForStorage(item);
+                        }),
+        );
 
 export const KEY_TABLE_MAP = {
 	offline_invoices: "queue",

--- a/frontend/src/offline/item-utils.js
+++ b/frontend/src/offline/item-utils.js
@@ -1,0 +1,76 @@
+export function prepareItemForStorage(item) {
+        if (!item || typeof item !== "object") {
+                return item;
+        }
+
+        const normalized = item;
+        const lower = (value) => (value != null ? String(value).toLowerCase() : "");
+        const toCleanArray = (collection, extractor) => {
+                if (!Array.isArray(collection)) {
+                        return [];
+                }
+                return collection
+                        .map((entry) => {
+                                try {
+                                        const value = extractor(entry);
+                                        return value != null ? String(value) : "";
+                                } catch {
+                                        return "";
+                                }
+                        })
+                        .map((value) => value.trim())
+                        .filter(Boolean);
+        };
+
+        normalized.item_code_lower = lower(normalized.item_code);
+        normalized.item_name_lower = lower(normalized.item_name);
+        normalized.item_group_lower = lower(normalized.item_group);
+
+        if (Array.isArray(normalized.item_barcode)) {
+                        normalized.barcodes = toCleanArray(normalized.item_barcode, (b) =>
+                                typeof b === "object" && b !== null ? b.barcode : b,
+                        );
+        } else if (normalized.item_barcode) {
+                normalized.barcodes = [String(normalized.item_barcode)];
+        } else if (Array.isArray(normalized.barcodes)) {
+                normalized.barcodes = toCleanArray(normalized.barcodes, (b) => b);
+        } else {
+                normalized.barcodes = [];
+        }
+
+        const nameLower = normalized.item_name_lower;
+        if (nameLower) {
+                normalized.name_keywords = nameLower.split(/\s+/).map((kw) => kw.trim()).filter(Boolean);
+        } else if (Array.isArray(normalized.name_keywords)) {
+                normalized.name_keywords = toCleanArray(normalized.name_keywords, (kw) =>
+                        typeof kw === "string" ? kw.toLowerCase() : kw,
+                );
+        } else {
+                normalized.name_keywords = [];
+        }
+
+        if (Array.isArray(normalized.serial_no_data)) {
+                normalized.serials = toCleanArray(normalized.serial_no_data, (s) => s && s.serial_no);
+        } else if (Array.isArray(normalized.serials)) {
+                normalized.serials = toCleanArray(normalized.serials, (s) => s);
+        } else {
+                normalized.serials = [];
+        }
+
+        if (Array.isArray(normalized.batch_no_data)) {
+                normalized.batches = toCleanArray(normalized.batch_no_data, (b) => b && b.batch_no);
+        } else if (Array.isArray(normalized.batches)) {
+                normalized.batches = toCleanArray(normalized.batches, (b) => b);
+        } else {
+                normalized.batches = [];
+        }
+
+        return normalized;
+}
+
+export function prepareItemsForStorage(items) {
+        if (!Array.isArray(items)) {
+                return [];
+        }
+        return items.map((item) => prepareItemForStorage(item));
+}

--- a/frontend/src/offline/items.js
+++ b/frontend/src/offline/items.js
@@ -1,5 +1,6 @@
 import { memory } from "./cache.js";
 import { persist, db, checkDbHealth } from "./core.js";
+import { prepareItemsForStorage } from "./item-utils.js";
 
 export function saveItemUOMs(itemCode, uoms) {
 	try {
@@ -210,21 +211,7 @@ export async function saveItemsBulk(items) {
 			console.error("Failed to serialize items", err);
 			cleanItems = [];
 		}
-		cleanItems = cleanItems.map((it) => ({
-			...it,
-			barcodes: Array.isArray(it.item_barcode)
-				? it.item_barcode.map((b) => b.barcode).filter(Boolean)
-				: it.item_barcode
-					? [String(it.item_barcode)]
-					: [],
-			name_keywords: it.item_name ? it.item_name.toLowerCase().split(/\s+/).filter(Boolean) : [],
-			serials: Array.isArray(it.serial_no_data)
-				? it.serial_no_data.map((s) => s.serial_no).filter(Boolean)
-				: [],
-			batches: Array.isArray(it.batch_no_data)
-				? it.batch_no_data.map((b) => b.batch_no).filter(Boolean)
-				: [],
-		}));
+                cleanItems = prepareItemsForStorage(cleanItems);
 		const CHUNK_SIZE = 1000;
 		await db.transaction("rw", db.table("items"), async () => {
 			for (let i = 0; i < cleanItems.length; i += CHUNK_SIZE) {
@@ -249,96 +236,85 @@ export async function getAllStoredItems() {
 }
 
 export async function searchStoredItems({ search = "", itemGroup = "", limit = 100, offset = 0 } = {}) {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		const term = search.toLowerCase();
-		if (term) {
-			let collection = db
-				.table("items")
-				.where("item_code")
-				.startsWithIgnoreCase(term)
-				.or("item_name")
-				.startsWithIgnoreCase(term)
-				.or("barcodes")
-				.equalsIgnoreCase(term)
-				.or("name_keywords")
-				.startsWithIgnoreCase(term)
-				.or("serials")
-				.equalsIgnoreCase(term)
-				.or("batches")
-				.equalsIgnoreCase(term);
-			if (itemGroup && itemGroup.toLowerCase() !== "all") {
-				const group = itemGroup.toLowerCase();
-				collection = collection.and((it) => it.item_group && it.item_group.toLowerCase() === group);
-			}
-			let results = await collection.toArray();
-			if (!results.length) {
-				let fallback = db.table("items");
-				if (itemGroup && itemGroup.toLowerCase() !== "all") {
-					fallback = fallback.where("item_group").equalsIgnoreCase(itemGroup);
-				}
-				results = await fallback
-					.filter((it) => {
-						const nameMatch = it.item_name && it.item_name.toLowerCase().includes(term);
-						const codeMatch = it.item_code && it.item_code.toLowerCase().includes(term);
-						const barcodeMatch = Array.isArray(it.item_barcode)
-							? it.item_barcode.some((b) => b.barcode && b.barcode.toLowerCase() === term)
-							: it.item_barcode && String(it.item_barcode).toLowerCase().includes(term);
-						const serialMatch = Array.isArray(it.serial_no_data)
-							? it.serial_no_data.some((s) => s.serial_no && s.serial_no.toLowerCase() === term)
-							: Array.isArray(it.serials)
-								? it.serials.some((s) => s && s.toLowerCase() === term)
-								: false;
-						const batchMatch = Array.isArray(it.batch_no_data)
-							? it.batch_no_data.some((b) => b.batch_no && b.batch_no.toLowerCase() === term)
-							: Array.isArray(it.batches)
-								? it.batches.some((b) => b && b.toLowerCase() === term)
-								: false;
-						return nameMatch || codeMatch || barcodeMatch || serialMatch || batchMatch;
-					})
-					.toArray();
-			}
-			const map = new Map();
-			results.forEach((it) => {
-				if (!map.has(it.item_code)) {
-					map.set(it.item_code, it);
-				}
-			});
-			const unique = Array.from(map.values());
-			return unique.slice(offset, offset + limit);
-		}
-		let collection = db.table("items");
-		if (itemGroup && itemGroup.toLowerCase() !== "all") {
-			collection = collection.where("item_group").equalsIgnoreCase(itemGroup);
-		}
-		if (search) {
-			const term = search.toLowerCase();
-			collection = collection.filter((it) => {
-				const nameMatch = it.item_name && it.item_name.toLowerCase().includes(term);
-				const codeMatch = it.item_code && it.item_code.toLowerCase().includes(term);
-				const barcodeMatch = Array.isArray(it.item_barcode)
-					? it.item_barcode.some((b) => b.barcode && b.barcode.toLowerCase() === term)
-					: it.item_barcode && String(it.item_barcode).toLowerCase().includes(term);
-				const serialMatch = Array.isArray(it.serial_no_data)
-					? it.serial_no_data.some((s) => s.serial_no && s.serial_no.toLowerCase() === term)
-					: Array.isArray(it.serials)
-						? it.serials.some((s) => s && s.toLowerCase() === term)
-						: false;
-				const batchMatch = Array.isArray(it.batch_no_data)
-					? it.batch_no_data.some((b) => b.batch_no && b.batch_no.toLowerCase() === term)
-					: Array.isArray(it.batches)
-						? it.batches.some((b) => b && b.toLowerCase() === term)
-						: false;
-				return nameMatch || codeMatch || barcodeMatch || serialMatch || batchMatch;
-			});
-		}
-		const res = await collection.offset(offset).limit(limit).toArray();
-		return res;
-	} catch (e) {
-		console.error("Failed to query stored items", e);
-		return [];
-	}
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) await db.open();
+                const term = search ? search.trim().toLowerCase() : "";
+                const hasGroupFilter = itemGroup && itemGroup.toLowerCase() !== "all";
+                const groupTerm = hasGroupFilter ? itemGroup.toLowerCase() : "";
+                const table = db.table("items");
+                const safeLower = (value) => (value != null ? String(value).toLowerCase() : "");
+                const matchesGroup = (item) => {
+                        if (!hasGroupFilter) {
+                                return true;
+                        }
+                        const group = item.item_group_lower || safeLower(item.item_group);
+                        return group === groupTerm;
+                };
+
+                if (term) {
+                        const matchesTerm = (item) => {
+                                const nameLower = item.item_name_lower || safeLower(item.item_name);
+                                const codeLower = item.item_code_lower || safeLower(item.item_code);
+                                const barcodeMatch = Array.isArray(item.barcodes)
+                                        ? item.barcodes.some((bc) => safeLower(bc).includes(term))
+                                        : false;
+                                const serialMatch = Array.isArray(item.serials)
+                                        ? item.serials.some((s) => safeLower(s) === term)
+                                        : false;
+                                const batchMatch = Array.isArray(item.batches)
+                                        ? item.batches.some((b) => safeLower(b) === term)
+                                        : false;
+                                const keywordMatch = Array.isArray(item.name_keywords)
+                                        ? item.name_keywords.some((kw) => safeLower(kw).includes(term))
+                                        : false;
+                                return (
+                                        (nameLower && nameLower.includes(term)) ||
+                                        (codeLower && codeLower.includes(term)) ||
+                                        barcodeMatch ||
+                                        serialMatch ||
+                                        batchMatch ||
+                                        keywordMatch
+                                );
+                        };
+
+                        let collection = table
+                                .where("item_code_lower")
+                                .startsWith(term)
+                                .or("item_name_lower")
+                                .startsWith(term)
+                                .or("barcodes")
+                                .equals(term)
+                                .or("name_keywords")
+                                .startsWith(term)
+                                .or("serials")
+                                .equals(term)
+                                .or("batches")
+                                .equals(term)
+                                .filter(matchesGroup);
+
+                        let results = await collection.toArray();
+                        if (!results.length) {
+                                results = await table.filter((item) => matchesGroup(item) && matchesTerm(item)).toArray();
+                        }
+
+                        const map = new Map();
+                        results.forEach((item) => {
+                                if (!map.has(item.item_code)) {
+                                        map.set(item.item_code, item);
+                                }
+                        });
+                        const unique = Array.from(map.values());
+                        return unique.slice(offset, offset + limit);
+                }
+
+                let collection = table.filter(matchesGroup);
+                const results = await collection.offset(offset).limit(limit).toArray();
+                return results;
+        } catch (e) {
+                console.error("Failed to query stored items", e);
+                return [];
+        }
 }
 
 export async function clearStoredItems() {

--- a/frontend/src/offline/sync.js
+++ b/frontend/src/offline/sync.js
@@ -1,10 +1,431 @@
 /* global frappe */
-import { memory, resetOfflineState, setLastSyncTotals, MAX_QUEUE_ITEMS, reduceCacheUsage } from "./cache.js";
+import {
+        memory,
+        resetOfflineState,
+        setLastSyncTotals,
+        MAX_QUEUE_ITEMS,
+        reduceCacheUsage,
+        getLastSyncTotals,
+} from "./cache.js";
 import { persist } from "./core.js";
 import { updateLocalStock } from "./stock.js";
 
 // Flag to avoid concurrent invoice syncs which can cause duplicate submissions
 let invoiceSyncInProgress = false;
+
+// --- Cross-tab invoice sync coordination -----------------------------------
+
+const SYNC_CHANNEL_NAME = "posawesome:invoice-sync";
+const SYNC_REQUEST_TIMEOUT_MS = 12_000;
+const SYNC_HEARTBEAT_INTERVAL_MS = 5_000;
+const SYNC_HEARTBEAT_STALE_MS = SYNC_HEARTBEAT_INTERVAL_MS * 3;
+
+const tabId = (() => {
+        if (typeof crypto !== "undefined") {
+                if (typeof crypto.randomUUID === "function") {
+                        return crypto.randomUUID();
+                }
+                try {
+                        const buf = new Uint32Array(4);
+                        crypto.getRandomValues(buf);
+                        return Array.from(buf, (n) => n.toString(16).padStart(8, "0")).join("-");
+                } catch (e) {
+                        // Fall through to timestamp-based id
+                }
+        }
+        return `${Date.now().toString(36)}-${Math.random().toString(16).slice(2)}`;
+})();
+
+const syncChannel = typeof BroadcastChannel !== "undefined" ? new BroadcastChannel(SYNC_CHANNEL_NAME) : null;
+
+let syncLeaderId = null;
+let isSyncLeader = false;
+let heartbeatTimer = null;
+let heartbeatLastReceived = 0;
+let leaderProbeTimeout = null;
+let currentSyncPromise = null;
+let remoteSyncInProgress = false;
+
+const pendingSyncResolvers = new Map();
+const broadcastResultListeners = new Set();
+const outstandingRemoteRequests = new Map();
+
+function broadcast(message) {
+        if (!syncChannel || !message) {
+                return;
+        }
+        syncChannel.postMessage({ ...message, scope: SYNC_CHANNEL_NAME });
+}
+
+function shouldYieldTo(remoteId) {
+        if (!remoteId) {
+                return false;
+        }
+        return tabId.localeCompare(remoteId) > 0;
+}
+
+function isHeartbeatStale() {
+        if (!heartbeatLastReceived) {
+                return true;
+        }
+        return Date.now() - heartbeatLastReceived > SYNC_HEARTBEAT_STALE_MS;
+}
+
+function startHeartbeat() {
+        if (!syncChannel || heartbeatTimer) {
+                return;
+        }
+        heartbeatLastReceived = Date.now();
+        broadcast({ type: "leader-announcement", leaderId: tabId });
+        broadcast({ type: "heartbeat", leaderId: tabId, timestamp: heartbeatLastReceived });
+        heartbeatTimer = setInterval(() => {
+                const timestamp = Date.now();
+                broadcast({ type: "heartbeat", leaderId: tabId, timestamp });
+        }, SYNC_HEARTBEAT_INTERVAL_MS);
+}
+
+function stopHeartbeat() {
+        if (heartbeatTimer) {
+                clearInterval(heartbeatTimer);
+                heartbeatTimer = null;
+        }
+}
+
+function becomeLeader() {
+        if (isSyncLeader) {
+                return;
+        }
+        isSyncLeader = true;
+        syncLeaderId = tabId;
+        remoteSyncInProgress = false;
+        stopHeartbeat();
+        startHeartbeat();
+}
+
+function scheduleLeaderProbe(delay = 200) {
+        if (!syncChannel) {
+                becomeLeader();
+                return;
+        }
+        if (leaderProbeTimeout) {
+                clearTimeout(leaderProbeTimeout);
+        }
+        leaderProbeTimeout = setTimeout(() => {
+                leaderProbeTimeout = null;
+                if (!syncLeaderId) {
+                        becomeLeader();
+                }
+        }, delay);
+}
+
+function releaseLeadership() {
+        if (!isSyncLeader) {
+                return;
+        }
+        stopHeartbeat();
+        broadcast({ type: "leader-release", leaderId: tabId });
+        isSyncLeader = false;
+        syncLeaderId = null;
+        remoteSyncInProgress = false;
+}
+
+function handleSyncResultMessage(message) {
+        const { requestId, requesterId, totals, leaderId } = message;
+        if (totals) {
+                setLastSyncTotals(totals);
+        }
+        if (leaderId && leaderId !== tabId) {
+                syncLeaderId = leaderId;
+                isSyncLeader = false;
+                heartbeatLastReceived = Date.now();
+        }
+        if (requestId && requesterId === tabId && pendingSyncResolvers.has(requestId)) {
+                const entry = pendingSyncResolvers.get(requestId);
+                pendingSyncResolvers.delete(requestId);
+                if (entry.timeoutId) {
+                        clearTimeout(entry.timeoutId);
+                }
+                entry.resolve(totals || getFallbackTotals());
+        }
+        if (!requestId) {
+                const listeners = Array.from(broadcastResultListeners);
+                broadcastResultListeners.clear();
+                listeners.forEach((listener) => {
+                        try {
+                                listener(totals || getFallbackTotals());
+                        } catch (err) {
+                                console.error("Failed to deliver broadcast sync result", err);
+                        }
+                });
+        }
+        if (leaderId && leaderId !== tabId) {
+                remoteSyncInProgress = false;
+        }
+}
+
+function handleChannelMessage(event) {
+        const message = event?.data;
+        if (!message || message.scope !== SYNC_CHANNEL_NAME) {
+                return;
+        }
+        switch (message.type) {
+                case "leader-announcement": {
+                        const { leaderId } = message;
+                        if (leaderId === tabId) {
+                                becomeLeader();
+                                break;
+                        }
+                        if (shouldYieldTo(leaderId)) {
+                                syncLeaderId = leaderId;
+                                isSyncLeader = false;
+                                heartbeatLastReceived = Date.now();
+                                stopHeartbeat();
+                        } else {
+                                syncLeaderId = tabId;
+                                if (!isSyncLeader) {
+                                        becomeLeader();
+                                } else {
+                                        broadcast({ type: "leader-announcement", leaderId: tabId });
+                                }
+                        }
+                        break;
+                }
+                case "leader-release": {
+                        if (message.leaderId !== tabId && syncLeaderId === message.leaderId) {
+                                syncLeaderId = null;
+                                heartbeatLastReceived = 0;
+                                remoteSyncInProgress = false;
+                                scheduleLeaderProbe();
+                        }
+                        break;
+                }
+                case "leader-query": {
+                        if (isSyncLeader) {
+                                broadcast({ type: "leader-announcement", leaderId: tabId });
+                        }
+                        break;
+                }
+                case "heartbeat": {
+                        if (message.leaderId !== tabId && shouldYieldTo(message.leaderId)) {
+                                syncLeaderId = message.leaderId;
+                                heartbeatLastReceived = Date.now();
+                                isSyncLeader = false;
+                                stopHeartbeat();
+                        } else if (message.leaderId === tabId) {
+                                becomeLeader();
+                        }
+                        break;
+                }
+                case "sync-request": {
+                        const { requestId, requesterId } = message;
+                        if (!requestId) {
+                                break;
+                        }
+                        if (
+                                !isSyncLeader &&
+                                (!syncLeaderId || isHeartbeatStale() || !shouldYieldTo(syncLeaderId))
+                        ) {
+                                becomeLeader();
+                        }
+                        if (isSyncLeader) {
+                                outstandingRemoteRequests.set(requestId, requesterId);
+                                runLeaderSync();
+                        }
+                        break;
+                }
+                case "sync-status": {
+                        if (message.leaderId !== tabId) {
+                                if (message.leaderId) {
+                                        syncLeaderId = message.leaderId;
+                                        heartbeatLastReceived = Date.now();
+                                }
+                                remoteSyncInProgress = message.status === "running";
+                                if (!remoteSyncInProgress && message.status === "idle") {
+                                        heartbeatLastReceived = Date.now();
+                                }
+                        }
+                        break;
+                }
+                case "sync-result": {
+                        handleSyncResultMessage(message);
+                        break;
+                }
+                default:
+                        break;
+        }
+}
+
+function ensureSyncLeadership(force = false) {
+        if (!syncChannel) {
+                if (!isSyncLeader) {
+                        becomeLeader();
+                }
+                return true;
+        }
+        if (isSyncLeader) {
+                return true;
+        }
+        if (!syncLeaderId || force || isHeartbeatStale()) {
+                        becomeLeader();
+                        return true;
+        }
+        return false;
+}
+
+function getFallbackTotals() {
+        return (
+                getLastSyncTotals() || {
+                        pending: getPendingOfflineInvoiceCount(),
+                        synced: 0,
+                        drafted: 0,
+                }
+        );
+}
+
+function waitForBroadcastResult() {
+        return new Promise((resolve) => {
+                let timeoutId = null;
+                const listener = (totals) => {
+                        if (timeoutId !== null) {
+                                clearTimeout(timeoutId);
+                        }
+                        if (broadcastResultListeners.has(listener)) {
+                                broadcastResultListeners.delete(listener);
+                        }
+                        remoteSyncInProgress = false;
+                        resolve(totals);
+                };
+                broadcastResultListeners.add(listener);
+                timeoutId = setTimeout(async () => {
+                        if (broadcastResultListeners.has(listener)) {
+                                broadcastResultListeners.delete(listener);
+                        }
+                        if (ensureSyncLeadership(true)) {
+                                try {
+                                        const totals = await runLeaderSync();
+                                        remoteSyncInProgress = false;
+                                        resolve(totals);
+                                        return;
+                                } catch (err) {
+                                        console.error("Failed to run fallback sync", err);
+                                }
+                        }
+                        remoteSyncInProgress = false;
+                        resolve(getFallbackTotals());
+                }, SYNC_REQUEST_TIMEOUT_MS);
+        });
+}
+
+function requestLeaderSync() {
+        const requestId = `${tabId}:${Date.now().toString(36)}:${Math.random().toString(16).slice(2)}`;
+        if (!syncChannel) {
+                return Promise.resolve(getFallbackTotals());
+        }
+        return new Promise((resolve) => {
+                const entry = {
+                        resolve: (totals) => {
+                                if (entry.timeoutId) {
+                                        clearTimeout(entry.timeoutId);
+                                }
+                                if (pendingSyncResolvers.has(requestId)) {
+                                        pendingSyncResolvers.delete(requestId);
+                                }
+                                remoteSyncInProgress = false;
+                                resolve(totals);
+                        },
+                        timeoutId: null,
+                };
+                pendingSyncResolvers.set(requestId, entry);
+                remoteSyncInProgress = true;
+                broadcast({ type: "sync-request", requestId, requesterId: tabId });
+                entry.timeoutId = setTimeout(async () => {
+                        if (!pendingSyncResolvers.has(requestId)) {
+                                return;
+                        }
+                        pendingSyncResolvers.delete(requestId);
+                        if (ensureSyncLeadership(true)) {
+                                try {
+                                        const totals = await runLeaderSync();
+                                        remoteSyncInProgress = false;
+                                        resolve(totals);
+                                        return;
+                                } catch (err) {
+                                        console.error("Failed to run fallback leader sync", err);
+                                }
+                        }
+                        remoteSyncInProgress = false;
+                        resolve(getFallbackTotals());
+                }, SYNC_REQUEST_TIMEOUT_MS);
+        });
+}
+
+function broadcastSyncStatus(status) {
+        if (!syncChannel) {
+                return;
+        }
+        broadcast({ type: "sync-status", status, leaderId: tabId });
+}
+
+function broadcastSyncResult(totals) {
+        setLastSyncTotals(totals);
+        if (!syncChannel) {
+                outstandingRemoteRequests.clear();
+                return totals;
+        }
+        for (const [requestId, requesterId] of outstandingRemoteRequests.entries()) {
+                broadcast({ type: "sync-result", requestId, requesterId, totals, leaderId: tabId });
+        }
+        outstandingRemoteRequests.clear();
+        broadcast({ type: "sync-result", requestId: null, requesterId: null, totals, leaderId: tabId });
+        return totals;
+}
+
+function getOrCreateSyncPromise() {
+        if (currentSyncPromise) {
+                return currentSyncPromise;
+        }
+        currentSyncPromise = (async () => {
+                broadcastSyncStatus("running");
+                try {
+                        const totals = await performInvoiceSync();
+                        broadcastSyncResult(totals);
+                        return totals;
+                } finally {
+                        broadcastSyncStatus("idle");
+                        currentSyncPromise = null;
+                }
+        })();
+        return currentSyncPromise;
+}
+
+function runLeaderSync() {
+        const promise = getOrCreateSyncPromise();
+        if (syncChannel) {
+                promise
+                        .then((totals) => {
+                                if (outstandingRemoteRequests.size) {
+                                        broadcastSyncResult(totals);
+                                }
+                                return totals;
+                        })
+                        .catch((err) => {
+                                console.error("Failed to broadcast sync result", err);
+                        });
+        }
+        return promise;
+}
+
+if (syncChannel) {
+        syncChannel.addEventListener("message", handleChannelMessage);
+        broadcast({ type: "leader-query", from: tabId });
+        scheduleLeaderProbe();
+}
+
+if (typeof window !== "undefined") {
+        window.addEventListener("beforeunload", () => {
+                releaseLeadership();
+        });
+}
 
 export function saveOfflineInvoice(entry) {
 	// Validate that invoice has items before saving
@@ -188,86 +609,101 @@ export function clearOfflineCustomers() {
 
 // Add sync function to clear local cache when invoices are successfully synced
 export async function syncOfflineInvoices() {
-	// Prevent concurrent syncs which can lead to duplicate submissions
-	if (invoiceSyncInProgress) {
-		return { pending: getPendingOfflineInvoiceCount(), synced: 0, drafted: 0 };
-	}
-	invoiceSyncInProgress = true;
-	try {
-		// Ensure any offline customers are synced first so that invoices
-		// referencing them do not fail during submission
-		await syncOfflineCustomers();
+        if (ensureSyncLeadership()) {
+                return await runLeaderSync();
+        }
 
-		const invoices = getOfflineInvoices();
-		if (!invoices.length) {
-			// No invoices to sync; clear last totals to avoid repeated messages
-			const totals = { pending: 0, synced: 0, drafted: 0 };
-			setLastSyncTotals(totals);
-			return totals;
-		}
-		if (isOffline()) {
-			// When offline just return the pending count without attempting a sync
-			return { pending: invoices.length, synced: 0, drafted: 0 };
-		}
+        if (!syncChannel) {
+                return await performInvoiceSync();
+        }
 
-		const failures = [];
-		let synced = 0;
-		let drafted = 0;
+        if (remoteSyncInProgress) {
+                return await waitForBroadcastResult();
+        }
 
-		for (const inv of invoices) {
-			try {
-				await frappe.call({
-					method: "posawesome.posawesome.api.invoices.submit_invoice",
-					args: {
-						invoice: inv.invoice,
-						data: inv.data,
-					},
-				});
-				synced++;
-			} catch (error) {
-				console.error("Failed to submit invoice, saving as draft", error);
-				try {
-					await frappe.call({
-						method: "posawesome.posawesome.api.invoices.update_invoice",
-						args: { data: inv.invoice },
-					});
-					drafted += 1;
-				} catch (draftErr) {
-					console.error("Failed to save invoice as draft", draftErr);
-					failures.push(inv);
-				}
-			}
-		}
+        return await requestLeaderSync();
+}
 
-		// Reset saved invoices and totals after successful sync
-		if (synced > 0) {
-			resetOfflineState();
-		}
+async function performInvoiceSync() {
+        if (invoiceSyncInProgress) {
+                return { pending: getPendingOfflineInvoiceCount(), synced: 0, drafted: 0 };
+        }
+        invoiceSyncInProgress = true;
+        try {
+                // Ensure any offline customers are synced first so that invoices
+                // referencing them do not fail during submission
+                await syncOfflineCustomers();
 
-		const pendingLeft = failures.length;
+                const invoices = getOfflineInvoices();
+                if (!invoices.length) {
+                        // No invoices to sync; clear last totals to avoid repeated messages
+                        const totals = { pending: 0, synced: 0, drafted: 0 };
+                        setLastSyncTotals(totals);
+                        return totals;
+                }
+                if (isOffline()) {
+                        // When offline just return the pending count without attempting a sync
+                        return { pending: invoices.length, synced: 0, drafted: 0 };
+                }
 
-		if (pendingLeft) {
-			memory.offline_invoices = failures;
-			persist("offline_invoices", memory.offline_invoices);
-		} else {
-			clearOfflineInvoices();
-			if (synced > 0 && drafted === 0) {
-				reduceCacheUsage();
-			}
-		}
+                const failures = [];
+                let synced = 0;
+                let drafted = 0;
 
-		const totals = { pending: pendingLeft, synced, drafted };
-		if (pendingLeft || drafted) {
-			// Persist totals only if there are invoices still pending or drafted
-			setLastSyncTotals(totals);
-		} else {
-			// Clear totals so success message only shows once
-			setLastSyncTotals({ pending: 0, synced: 0, drafted: 0 });
-		}
-		return totals;
-	} finally {
-		invoiceSyncInProgress = false;
-	}
+                for (const inv of invoices) {
+                        try {
+                                await frappe.call({
+                                        method: "posawesome.posawesome.api.invoices.submit_invoice",
+                                        args: {
+                                                invoice: inv.invoice,
+                                                data: inv.data,
+                                        },
+                                });
+                                synced++;
+                        } catch (error) {
+                                console.error("Failed to submit invoice, saving as draft", error);
+                                try {
+                                        await frappe.call({
+                                                method: "posawesome.posawesome.api.invoices.update_invoice",
+                                                args: { data: inv.invoice },
+                                        });
+                                        drafted += 1;
+                                } catch (draftErr) {
+                                        console.error("Failed to save invoice as draft", draftErr);
+                                        failures.push(inv);
+                                }
+                        }
+                }
+
+                // Reset saved invoices and totals after successful sync
+                if (synced > 0) {
+                        resetOfflineState();
+                }
+
+                const pendingLeft = failures.length;
+
+                if (pendingLeft) {
+                        memory.offline_invoices = failures;
+                        persist("offline_invoices", memory.offline_invoices);
+                } else {
+                        clearOfflineInvoices();
+                        if (synced > 0 && drafted === 0) {
+                                reduceCacheUsage();
+                        }
+                }
+
+                const totals = { pending: pendingLeft, synced, drafted };
+                if (pendingLeft || drafted) {
+                        // Persist totals only if there are invoices still pending or drafted
+                        setLastSyncTotals(totals);
+                } else {
+                        // Clear totals so success message only shows once
+                        setLastSyncTotals({ pending: 0, synced: 0, drafted: 0 });
+                }
+                return totals;
+        } finally {
+                invoiceSyncInProgress = false;
+        }
 }
 
 export async function syncOfflineCustomers() {

--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -156,12 +156,12 @@ export default {
 		this.initializeData();
 		this.setupNetworkListeners();
 		this.setupEventListeners();
-		this.handleRefreshCacheUsage();
-	},
-	methods: {
-		setupNetworkListeners,
-		checkNetworkConnectivity,
-		detectHostType,
+                this.scheduleInitialCacheUsageEstimate();
+        },
+        methods: {
+                setupNetworkListeners,
+                checkNetworkConnectivity,
+                detectHostType,
 		performConnectivityChecks,
 		checkFrappePing,
 		checkCurrentOrigin,
@@ -191,15 +191,7 @@ export default {
 			}
 
 			this.pendingInvoices = getPendingOfflineInvoiceCount();
-			this.syncTotals = getLastSyncTotals();
-
-			getCacheUsageEstimate()
-				.then((usage) => {
-					if (usage.percentage > 90) {
-						alert("Local cache nearing capacity. Consider going online to sync.");
-					}
-				})
-				.catch(() => {});
+                        this.syncTotals = getLastSyncTotals();
 
 			// Check if running on IP host
 			this.isIpHost = /^\d+\.\d+\.\d+\.\d+/.test(window.location.hostname);
@@ -407,17 +399,57 @@ export default {
 			});
 		},
 
-		handleRefreshCacheUsage() {
-			this.cacheUsageLoading = true;
-			getCacheUsageEstimate()
-				.then((usage) => {
-					this.cacheUsage = usage.percentage || 0;
-					this.cacheUsageDetails = {
-						total: usage.total || 0,
-						indexedDB: usage.indexedDB || 0,
-						localStorage: usage.localStorage || 0,
-					};
-				})
+                scheduleInitialCacheUsageEstimate() {
+                        if (this.isWarmNavigation()) {
+                                return;
+                        }
+
+                        const runEstimate = () => {
+                                this.handleRefreshCacheUsage({ initial: true });
+                        };
+
+                        if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+                                window.requestIdleCallback(runEstimate, { timeout: 2000 });
+                        } else {
+                                window.setTimeout(runEstimate, 0);
+                        }
+                },
+
+                isWarmNavigation() {
+                        const hasPerformance = typeof performance !== "undefined";
+                        const navigationEntries = hasPerformance && performance.getEntriesByType
+                                ? performance.getEntriesByType("navigation")
+                                : [];
+                        if (navigationEntries && navigationEntries.length > 0) {
+                                return navigationEntries[0].type === "back_forward";
+                        }
+
+                        if (hasPerformance && performance.navigation) {
+                                return performance.navigation.type === performance.navigation.TYPE_BACK_FORWARD;
+                        }
+
+                        return false;
+                },
+
+                handleRefreshCacheUsage(options = {}) {
+                        let initial = false;
+                        if (options && typeof options === "object" && !("target" in options)) {
+                                ({ initial = false } = options);
+                        }
+
+                        this.cacheUsageLoading = true;
+                        getCacheUsageEstimate()
+                                .then((usage) => {
+                                        this.cacheUsage = usage.percentage || 0;
+                                        this.cacheUsageDetails = {
+                                                total: usage.total || 0,
+                                                indexedDB: usage.indexedDB || 0,
+                                                localStorage: usage.localStorage || 0,
+                                        };
+                                        if (initial && usage.percentage > 90) {
+                                                alert("Local cache nearing capacity. Consider going online to sync.");
+                                        }
+                                })
 				.catch((e) => {
 					console.error("Failed to refresh cache usage", e);
 				})

--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -39,9 +39,7 @@
 
 <script>
 /* global frappe, $ */
-import Navbar from "./components/Navbar.vue";
-import POS from "./components/pos/Pos.vue";
-import Payments from "./components/payments/Pay.vue";
+import { defineAsyncComponent } from "vue";
 import AppLoadingOverlay from "./components/ui/LoadingOverlay.vue";
 import { useLoading } from "./composables/useLoading.js";
 import { loadingState, initLoadingSources, setSourceProgress, markSourceLoaded } from "./utils/loading.js";
@@ -142,12 +140,18 @@ export default {
 			}
 		},
 	},
-	components: {
-		Navbar,
-		POS,
-		Payments,
-		AppLoadingOverlay,
-	},
+        components: {
+                Navbar: defineAsyncComponent(() =>
+                        import(/* webpackChunkName: "posapp-navbar" */ "./components/Navbar.vue")
+                ),
+                POS: defineAsyncComponent(() =>
+                        import(/* webpackChunkName: "posapp-pos" */ "./components/pos/Pos.vue")
+                ),
+                Payments: defineAsyncComponent(() =>
+                        import(/* webpackChunkName: "posapp-payments" */ "./components/payments/Pay.vue")
+                ),
+                AppLoadingOverlay,
+        },
 	mounted() {
 		this.remove_frappe_nav();
 		// Initialize cache ready state early from stored value

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -529,7 +529,13 @@ export default {
 		qty: 1,
 		refresh_interval: null,
 		abortController: null,
-		itemDetailsRequestCache: { key: null, promise: null, result: null },
+                itemDetailsRequestCache: {
+                        lastKey: null,
+                        lastPromise: null,
+                        lastResult: null,
+                        responses: new Map(),
+                        inflight: new Map(),
+                },
 		itemDetailsRetryCount: 0,
 		itemDetailsRetryTimeout: null,
 		items_loaded: false,
@@ -591,8 +597,9 @@ export default {
         }),
 
 	watch: {
-		customer: _.debounce(function () {
-			if (this.pos_profile.posa_force_reload_items) {
+                customer: _.debounce(function () {
+                        this.resetItemDetailsRequestCache();
+                        if (this.pos_profile.posa_force_reload_items) {
 				if (this.pos_profile.posa_smart_reload_mode) {
 					// When limit search is enabled there may be no items yet.
 					// Fallback to full reload if nothing is loaded
@@ -644,8 +651,9 @@ export default {
 				}
 			}
 		}, 300),
-		customer_price_list: _.debounce(async function () {
-			if (this.pos_profile.posa_force_reload_items) {
+                customer_price_list: _.debounce(async function () {
+                        this.resetItemDetailsRequestCache();
+                        if (this.pos_profile.posa_force_reload_items) {
 				if (this.pos_profile.posa_smart_reload_mode) {
 					// When limit search is enabled there may be no items yet.
 					// Fallback to full reload if nothing is loaded
@@ -961,6 +969,7 @@ export default {
                                 this.currentPage = 0;
                                 this.items = [];
                                 this.lastItemDetailsSignature = null;
+                                this.resetItemDetailsRequestCache();
                         }
                         const search = this.get_search(this.first_search);
 			const itemGroup = this.item_group !== "ALL" ? this.item_group.toLowerCase() : "";
@@ -1022,72 +1031,102 @@ export default {
 			this.isOverflowing = el.scrollHeight > availableHeight;
 		},
 
-		async fetchItemDetails(items) {
-			if (!items || items.length === 0) {
-				return [];
-			}
+                buildItemDetailsCacheKey(items) {
+                        const profile = this.pos_profile?.name || "";
+                        const priceList = this.active_price_list || "";
+                        const codes = Array.isArray(items)
+                                ? items
+                                          .map((it) => [it.item_code || "", it.uom || ""])
+                                          .filter((pair) => pair[0])
+                                          .sort((a, b) =>
+                                                  a[0] === b[0] ? a[1].localeCompare(b[1]) : a[0].localeCompare(b[0]),
+                                          )
+                                : [];
+                        return [profile, priceList, JSON.stringify(codes)].join("::");
+                },
+                async fetchItemDetails(items) {
+                        if (!items || items.length === 0) {
+                                return [];
+                        }
 
-			const key = [
-				this.pos_profile.name,
-				this.active_price_list,
-				items.map((i) => i.item_code).join(","),
-			].join(":");
+                        const key = this.buildItemDetailsCacheKey(items);
 
-			if (this.itemDetailsRequestCache.key === key && this.itemDetailsRequestCache.result) {
-				return this.itemDetailsRequestCache.result;
-			}
+                        if (this.itemDetailsRequestCache.responses.has(key)) {
+                                return this.itemDetailsRequestCache.responses.get(key);
+                        }
 
-			if (this.itemDetailsRequestCache.key === key && this.itemDetailsRequestCache.promise) {
-				return this.itemDetailsRequestCache.promise;
-			}
+                        if (this.itemDetailsRequestCache.inflight.has(key)) {
+                                return this.itemDetailsRequestCache.inflight.get(key).promise;
+                        }
 
-			this.cancelItemDetailsRequest();
-			this.itemDetailsRequestCache.key = key;
+                        const controller = new AbortController();
+                        this.abortController = controller;
 
-			this.abortController = new AbortController();
-			const requestPromise = frappe.call({
-				method: "posawesome.posawesome.api.items.get_items_details",
-				args: {
-					pos_profile: JSON.stringify(this.pos_profile),
-					items_data: JSON.stringify(items),
-					price_list: this.active_price_list,
-				},
-				freeze: false,
-				signal: this.abortController.signal,
-			});
+                        const requestPromise = frappe.call({
+                                method: "posawesome.posawesome.api.items.get_items_details",
+                                args: {
+                                        pos_profile: JSON.stringify(this.pos_profile),
+                                        items_data: JSON.stringify(items),
+                                        price_list: this.active_price_list,
+                                },
+                                freeze: false,
+                                signal: controller.signal,
+                        });
 
-			this.itemDetailsRequestCache.promise = requestPromise;
+                        this.itemDetailsRequestCache.inflight.set(key, {
+                                promise: requestPromise,
+                                controller,
+                        });
+                        this.itemDetailsRequestCache.lastKey = key;
+                        this.itemDetailsRequestCache.lastPromise = requestPromise;
 
-			try {
-				const r = await requestPromise;
-				const msg = (r && r.message) || [];
-				if (this.itemDetailsRequestCache.key === key) {
-					this.itemDetailsRequestCache.result = msg;
-				}
-				return msg;
-			} catch (err) {
-				if (err.name !== "AbortError") {
-					console.error("Error fetching item details:", err);
-				}
-				throw err;
-			} finally {
-				if (this.itemDetailsRequestCache.key === key) {
-					this.itemDetailsRequestCache.promise = null;
-				}
-				this.abortController = null;
-			}
-		},
-		cancelItemDetailsRequest() {
-			if (this.abortController) {
-				this.abortController.abort();
-				this.abortController = null;
-			}
-			if (this.itemDetailsRequestCache) {
-				this.itemDetailsRequestCache.key = null;
-				this.itemDetailsRequestCache.promise = null;
-				this.itemDetailsRequestCache.result = null;
-			}
-		},
+                        try {
+                                const r = await requestPromise;
+                                const msg = (r && r.message) || [];
+                                this.itemDetailsRequestCache.responses.set(key, msg);
+                                this.itemDetailsRequestCache.lastResult = msg;
+                                return msg;
+                        } catch (err) {
+                                if (err.name !== "AbortError") {
+                                        console.error("Error fetching item details:", err);
+                                }
+                                throw err;
+                        } finally {
+                                this.itemDetailsRequestCache.inflight.delete(key);
+                                if (this.abortController === controller) {
+                                        this.abortController = null;
+                                }
+                        }
+                },
+                cancelItemDetailsRequest() {
+                        if (!this.itemDetailsRequestCache) {
+                                return;
+                        }
+
+                        this.itemDetailsRequestCache.inflight.forEach(({ controller }) => {
+                                if (controller) {
+                                        try {
+                                                controller.abort();
+                                        } catch (err) {
+                                                console.warn("Failed to abort item details request", err);
+                                        }
+                                }
+                        });
+                        this.itemDetailsRequestCache.inflight.clear();
+                        this.itemDetailsRequestCache.lastKey = null;
+                        this.itemDetailsRequestCache.lastPromise = null;
+                        this.itemDetailsRequestCache.lastResult = null;
+                        this.abortController = null;
+                },
+                resetItemDetailsRequestCache() {
+                        if (!this.itemDetailsRequestCache) {
+                                return;
+                        }
+                        this.cancelItemDetailsRequest();
+                        if (this.itemDetailsRequestCache.responses) {
+                                this.itemDetailsRequestCache.responses.clear();
+                        }
+                },
 		async refreshPricesForVisibleItems() {
 			const vm = this;
 			if (!vm.filtered_items || vm.filtered_items.length === 0) return;
@@ -1233,6 +1272,7 @@ export default {
                         console.log("[ItemsSelector] storage health ensured");
                         this.items_loaded = false;
                         this.lastItemDetailsSignature = null;
+                        this.resetItemDetailsRequestCache();
 
                         // When no search term is entered, reset the search so
                         // we fetch the entire item list from the server.
@@ -2405,12 +2445,10 @@ export default {
                                 }
                         }
 
-			// Cleanup on component destroy
-			this.cleanupBeforeDestroy = () => {
-				if (vm.abortController) {
-					vm.abortController.abort();
-				}
-			};
+                        // Cleanup on component destroy
+                        this.cleanupBeforeDestroy = () => {
+                                vm.resetItemDetailsRequestCache();
+                        };
 		},
                 update_cur_items_details() {
                         if (this.filtered_items && this.filtered_items.length > 0) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -585,6 +585,8 @@ export default {
                 scanAudioContext: null,
                 pendingScanCode: "",
                 awaitingScanResult: false,
+                lastScanCompletedAt: 0,
+                scanCooldownMs: 600,
                 lastItemDetailsSignature: null,
         }),
 
@@ -2716,11 +2718,23 @@ export default {
 				this.$refs.cameraScanner.startScanning();
 			}
 		},
-		onBarcodeScanned(scannedCode) {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
-				return;
-			}
+                onBarcodeScanned(scannedCode) {
+                        if (this.awaitingScanResult) {
+                                this.playScanTone("error");
+                                return;
+                        }
+                        const now = Date.now();
+                        if (
+                                this.scanCooldownMs > 0 &&
+                                this.lastScanCompletedAt &&
+                                now - this.lastScanCompletedAt < this.scanCooldownMs
+                        ) {
+                                return;
+                        }
+                        if (this.scannerLocked) {
+                                this.playScanTone("error");
+                                return;
+                        }
 			console.log("Barcode scanned:", scannedCode);
 			this.pendingScanCode = scannedCode;
 
@@ -2844,119 +2858,129 @@ export default {
 		async addScannedItemToInvoice(item, scannedCode, qtyFromBarcode = null) {
 			console.log("Adding scanned item to invoice:", item, scannedCode);
 
-			// Clone the item to avoid mutating list data
-			const newItem = { ...item };
+                        try {
+                                // Clone the item to avoid mutating list data
+                                const newItem = { ...item };
 
-			// If the scanned barcode has a specific UOM, apply it
-			if (Array.isArray(newItem.item_barcode)) {
-				const barcodeMatch = newItem.item_barcode.find((b) => b.barcode === scannedCode);
-				if (barcodeMatch && barcodeMatch.posa_uom) {
-					newItem.uom = barcodeMatch.posa_uom;
+                                // If the scanned barcode has a specific UOM, apply it
+                                if (Array.isArray(newItem.item_barcode)) {
+                                        const barcodeMatch = newItem.item_barcode.find((b) => b.barcode === scannedCode);
+                                        if (barcodeMatch && barcodeMatch.posa_uom) {
+                                                newItem.uom = barcodeMatch.posa_uom;
 
-					// Try fetching the rate for this UOM from the active price list
-					try {
-						const res = await frappe.call({
-							method: "posawesome.posawesome.api.items.get_price_for_uom",
-							args: {
-								item_code: newItem.item_code,
-								price_list: this.active_price_list,
-								uom: barcodeMatch.posa_uom,
-							},
-						});
-						if (res.message) {
-							const price = parseFloat(res.message);
-							newItem.rate = price;
-							newItem.price_list_rate = price;
-							newItem.base_rate = price;
-							newItem.base_price_list_rate = price;
-							newItem._manual_rate_set = true;
-							newItem.skip_force_update = true;
-						}
-					} catch (e) {
-						console.error("Failed to fetch UOM price", e);
-					}
-				}
-			}
+                                                // Try fetching the rate for this UOM from the active price list
+                                                try {
+                                                        const res = await frappe.call({
+                                                                method: "posawesome.posawesome.api.items.get_price_for_uom",
+                                                                args: {
+                                                                        item_code: newItem.item_code,
+                                                                        price_list: this.active_price_list,
+                                                                        uom: barcodeMatch.posa_uom,
+                                                                },
+                                                        });
+                                                        if (res.message) {
+                                                                const price = parseFloat(res.message);
+                                                                newItem.rate = price;
+                                                                newItem.price_list_rate = price;
+                                                                newItem.base_rate = price;
+                                                                newItem.base_price_list_rate = price;
+                                                                newItem._manual_rate_set = true;
+                                                                newItem.skip_force_update = true;
+                                                        }
+                                                } catch (e) {
+                                                        console.error("Failed to fetch UOM price", e);
+                                                }
+                                        }
+                                }
 
-			// Apply quantity from scale barcode if available
-			if (qtyFromBarcode !== null && !isNaN(qtyFromBarcode)) {
-				newItem.qty = qtyFromBarcode;
-				newItem._barcode_qty = true;
-			}
+                                // Apply quantity from scale barcode if available
+                                if (qtyFromBarcode !== null && !isNaN(qtyFromBarcode)) {
+                                        newItem.qty = qtyFromBarcode;
+                                        newItem._barcode_qty = true;
+                                }
 
-			const requestedQtyRaw =
-				qtyFromBarcode !== null && !isNaN(qtyFromBarcode) ? qtyFromBarcode : (newItem.qty ?? 1);
-			const requestedQty = Math.abs(requestedQtyRaw || 1);
-			const availableQty =
-				typeof newItem.available_qty === "number"
-					? newItem.available_qty
-					: typeof newItem.actual_qty === "number"
-						? newItem.actual_qty
-						: null;
+                                const requestedQtyRaw =
+                                        qtyFromBarcode !== null && !isNaN(qtyFromBarcode) ? qtyFromBarcode : (newItem.qty ?? 1);
+                                const requestedQty = Math.abs(requestedQtyRaw || 1);
+                                const availableQty =
+                                        typeof newItem.available_qty === "number"
+                                                ? newItem.available_qty
+                                                : typeof newItem.actual_qty === "number"
+                                                        ? newItem.actual_qty
+                                                        : null;
 
-			if (availableQty !== null && availableQty < requestedQty) {
-				const formattedAvailable = this.format_number
-					? this.format_number(availableQty, this.hide_qty_decimals ? 0 : this.float_precision)
-					: availableQty;
-				const formattedRequested = this.format_number
-					? this.format_number(requestedQty, this.hide_qty_decimals ? 0 : this.float_precision)
-					: requestedQty;
-				const negativeStockEnabled = this.isNegativeStockEnabled();
-				const shouldBlock =
-					!negativeStockEnabled &&
-					(this.pos_profile?.posa_block_sale_beyond_available_qty || availableQty <= 0);
+                                if (availableQty !== null && availableQty < requestedQty) {
+                                        const formattedAvailable = this.format_number
+                                                ? this.format_number(
+                                                          availableQty,
+                                                          this.hide_qty_decimals ? 0 : this.float_precision,
+                                                  )
+                                                : availableQty;
+                                        const formattedRequested = this.format_number
+                                                ? this.format_number(
+                                                          requestedQty,
+                                                          this.hide_qty_decimals ? 0 : this.float_precision,
+                                                  )
+                                                : requestedQty;
+                                        const negativeStockEnabled = this.isNegativeStockEnabled();
+                                        const shouldBlock =
+                                                !negativeStockEnabled &&
+                                                (this.pos_profile?.posa_block_sale_beyond_available_qty || availableQty <= 0);
 
-				if (shouldBlock) {
-					this.showScanError({
-						message: this.__("Quantity not available for {0}", [
-							newItem.item_name || scannedCode,
-						]),
-						code: scannedCode,
-						details: this.__("Available: {0}. Requested: {1}.", [
-							formattedAvailable,
-							formattedRequested,
-						]),
-					});
-					return;
-				}
+                                        if (shouldBlock) {
+                                                this.showScanError({
+                                                        message: this.__("Quantity not available for {0}", [
+                                                                newItem.item_name || scannedCode,
+                                                        ]),
+                                                        code: scannedCode,
+                                                        details: this.__("Available: {0}. Requested: {1}.", [
+                                                                formattedAvailable,
+                                                                formattedRequested,
+                                                        ]),
+                                                });
+                                                return;
+                                        }
 
-				if (negativeStockEnabled) {
-					this.eventBus.emit("show_message", {
-						title: this.__(
-							"Available stock {0} is less than requested {1}. Negative stock setting allows continuing.",
-							[formattedAvailable, formattedRequested],
-						),
-						color: "warning",
-					});
-				}
-			}
+                                        if (negativeStockEnabled) {
+                                                this.eventBus.emit("show_message", {
+                                                        title: this.__(
+                                                                "Available stock {0} is less than requested {1}. Negative stock setting allows continuing.",
+                                                                [formattedAvailable, formattedRequested],
+                                                        ),
+                                                        color: "warning",
+                                                });
+                                        }
+                                }
 
-			this.awaitingScanResult = true;
+                                this.awaitingScanResult = true;
 
-			try {
-				// Use existing add_item method with enhanced feedback
-				await this.add_item(newItem);
-				this.playScanTone("success");
-				this.scannerLocked = false;
-				this.search_from_scanner = false;
-				this.pendingScanCode = "";
+                                try {
+                                        // Use existing add_item method with enhanced feedback
+                                        await this.add_item(newItem);
+                                        this.playScanTone("success");
+                                        this.scannerLocked = false;
+                                        this.search_from_scanner = false;
+                                        this.pendingScanCode = "";
 
-				// Show success message
-				frappe.show_alert(
-					{
-						message: `Added: ${item.item_name}`,
-						indicator: "green",
-					},
-					3,
-				);
+                                        // Show success message
+                                        frappe.show_alert(
+                                                {
+                                                        message: `Added: ${item.item_name}`,
+                                                        indicator: "green",
+                                                },
+                                                3,
+                                        );
 
-				// Clear search after successful addition and refocus input
-				this.clearSearch();
-				this.$refs.debounce_search && this.$refs.debounce_search.focus();
-			} finally {
-				this.awaitingScanResult = false;
-			}
-		},
+                                        // Clear search after successful addition and refocus input
+                                        this.clearSearch();
+                                        this.$refs.debounce_search && this.$refs.debounce_search.focus();
+                                } finally {
+                                        this.awaitingScanResult = false;
+                                }
+                        } finally {
+                                this.lastScanCompletedAt = Date.now();
+                        }
+                },
 		isNegativeStockEnabled() {
 			const setting = this.stock_settings?.allow_negative_stock;
 			if (setting === undefined || setting === null) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -574,18 +574,19 @@ export default {
 		isOverflowing: false,
 		// Track background loading state and pending searches
 		isBackgroundLoading: false,
-		pendingItemSearch: null,
-		loadProgress: 0,
-		totalItemCount: 0,
-		scanErrorDialog: false,
-		scanErrorMessage: "",
-		scanErrorDetails: "",
-		scanErrorCode: "",
-		scannerLocked: false,
-		scanAudioContext: null,
-		pendingScanCode: "",
-		awaitingScanResult: false,
-	}),
+                pendingItemSearch: null,
+                loadProgress: 0,
+                totalItemCount: 0,
+                scanErrorDialog: false,
+                scanErrorMessage: "",
+                scanErrorDetails: "",
+                scanErrorCode: "",
+                scannerLocked: false,
+                scanAudioContext: null,
+                pendingScanCode: "",
+                awaitingScanResult: false,
+                lastItemDetailsSignature: null,
+        }),
 
 	watch: {
 		customer: _.debounce(function () {
@@ -671,28 +672,29 @@ export default {
 			// Apply cached rates if available for immediate update
 			if (this.items_loaded && this.items && this.items.length > 0) {
 				const cached = await getCachedPriceListItems(this.customer_price_list);
-				if (cached && cached.length) {
-					const map = {};
-					cached.forEach((ci) => {
-						map[ci.item_code] = ci;
-					});
-					this.items.forEach((it) => {
-						const ci = map[it.item_code];
-						if (ci) {
-							const force =
-								this.pos_profile?.posa_force_price_from_customer_price_list !== false;
-							const price = ci.price_list_rate ?? ci.rate ?? 0;
-							if (force || price) {
-								it.rate = price;
-								it.price_list_rate = price;
-							}
-						}
-					});
-					this.eventBus.emit("set_all_items", this.items);
-					this.update_items_details(this.items);
-					return;
-				}
-			}
+                                        if (cached && cached.length) {
+                                                const map = {};
+                                                cached.forEach((ci) => {
+                                                        map[ci.item_code] = ci;
+                                                });
+                                                this.items.forEach((it) => {
+                                                        const ci = map[it.item_code];
+                                                        if (ci) {
+                                                                const force =
+                                                                        this.pos_profile?.posa_force_price_from_customer_price_list !== false;
+                                                                const price = ci.price_list_rate ?? ci.rate ?? 0;
+                                                                if (force || price) {
+                                                                        it.rate = price;
+                                                                        it.price_list_rate = price;
+                                                                }
+                                                        }
+                                                });
+                                                this.eventBus.emit("set_all_items", this.items);
+                                                this.lastItemDetailsSignature = null;
+                                                this.update_items_details(this.items);
+                                                return;
+                                        }
+                                }
 			// No cache found - force a reload so prices are updated
 			this.items_loaded = false;
 			if (!isOffline()) {
@@ -948,16 +950,17 @@ export default {
 			}
 			return dbHealthy;
 		},
-		async loadVisibleItems(reset = false) {
-			this.loadProgress = 0;
-			this.eventBus.emit("data-load-progress", { name: "items", progress: 0 });
-			await initPromise;
-			await this.ensureStorageHealth();
-			if (reset) {
-				this.currentPage = 0;
-				this.items = [];
-			}
-			const search = this.get_search(this.first_search);
+                async loadVisibleItems(reset = false) {
+                        this.loadProgress = 0;
+                        this.eventBus.emit("data-load-progress", { name: "items", progress: 0 });
+                        await initPromise;
+                        await this.ensureStorageHealth();
+                        if (reset) {
+                                this.currentPage = 0;
+                                this.items = [];
+                                this.lastItemDetailsSignature = null;
+                        }
+                        const search = this.get_search(this.first_search);
 			const itemGroup = this.item_group !== "ALL" ? this.item_group.toLowerCase() : "";
 			const pageItems = await searchStoredItems({
 				search,
@@ -1121,11 +1124,16 @@ export default {
 			});
 
 			if (cacheResult.missing.length === 0) {
-				vm.$nextTick(() => {
-					updates.forEach(({ item, upd }) => Object.assign(item, upd));
-					updateLocalStockCache(cacheResult.cached);
-					vm.loading = false;
-				});
+                                vm.$nextTick(() => {
+                                        updates.forEach(({ item, upd }) => {
+                                                Object.assign(item, upd);
+                                                if (upd.batch_no_data || upd.serial_no_data) {
+                                                        vm.invalidateItemSearchMeta(item);
+                                                }
+                                        });
+                                        updateLocalStockCache(cacheResult.cached);
+                                        vm.loading = false;
+                                });
 				return;
 			}
 
@@ -1162,10 +1170,15 @@ export default {
 					}
 				});
 
-				vm.$nextTick(async () => {
-					updates.forEach(({ item, upd }) => Object.assign(item, upd));
-					updateLocalStockCache(details);
-					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
+                                vm.$nextTick(async () => {
+                                        updates.forEach(({ item, upd }) => {
+                                                Object.assign(item, upd);
+                                                if (upd.batch_no_data || upd.serial_no_data) {
+                                                        vm.invalidateItemSearchMeta(item);
+                                                }
+                                        });
+                                        updateLocalStockCache(details);
+                                        saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
 					if (
 						vm.pos_profile &&
 						vm.pos_profile.posa_local_storage &&
@@ -1208,20 +1221,21 @@ export default {
 			}
 			await this.get_items(true);
 		},
-		async forceReloadItems() {
-			console.log("[ItemsSelector] forceReloadItems called");
-			// Clear cached price list items so the reload always
-			// fetches the latest data from the server
-			await clearPriceListCache();
-			console.log("[ItemsSelector] price list cache cleared");
-			await this.ensureStorageHealth();
-			console.log("[ItemsSelector] storage health ensured");
-			this.items_loaded = false;
+                async forceReloadItems() {
+                        console.log("[ItemsSelector] forceReloadItems called");
+                        // Clear cached price list items so the reload always
+                        // fetches the latest data from the server
+                        await clearPriceListCache();
+                        console.log("[ItemsSelector] price list cache cleared");
+                        await this.ensureStorageHealth();
+                        console.log("[ItemsSelector] storage health ensured");
+                        this.items_loaded = false;
+                        this.lastItemDetailsSignature = null;
 
-			// When no search term is entered, reset the search so
-			// we fetch the entire item list from the server.
-			if (!this.first_search || !this.first_search.trim()) {
-				console.log("[ItemsSelector] resetting empty search before reload");
+                        // When no search term is entered, reset the search so
+                        // we fetch the entire item list from the server.
+                        if (!this.first_search || !this.first_search.trim()) {
+                                console.log("[ItemsSelector] resetting empty search before reload");
 				this.first_search = "";
 				this.search = "";
 			}
@@ -1373,11 +1387,12 @@ export default {
 					if (item.actual_qty === undefined) {
 						item.actual_qty = 0;
 					}
-				});
+                                });
 
-				vm.items = items;
-				vm.items_loaded = true;
-				vm.eventBus.emit("set_all_items", vm.items);
+                                vm.items = items;
+                                vm.lastItemDetailsSignature = null;
+                                vm.items_loaded = true;
+                                vm.eventBus.emit("set_all_items", vm.items);
 				console.log("[ItemsSelector] set_all_items emitted", { itemsLength: vm.items.length });
 
 				const hasMore = !vm.pos_profile.pose_use_limit_search && items.length === vm.itemsPageLimit;
@@ -2079,73 +2094,163 @@ export default {
 			}
 			return scal_qty;
 		},
-		get_search(first_search) {
-			if (!first_search) return "";
-			const prefix_len = this.pos_profile.posa_scale_barcode_start?.length || 0;
-			if (!first_search.startsWith(this.pos_profile.posa_scale_barcode_start)) {
-				return first_search;
-			}
-			// Calculate item code length from total barcode length
-			const item_code_len = first_search.length - prefix_len - 6;
-			return first_search.substr(0, prefix_len + item_code_len);
-		},
-		esc_event() {
-			this.search = null;
-			this.first_search = null;
-			this.search_backup = null;
-			this.qty = 1;
+                get_search(first_search) {
+                        if (!first_search) return "";
+                        const prefix_len = this.pos_profile.posa_scale_barcode_start?.length || 0;
+                        if (!first_search.startsWith(this.pos_profile.posa_scale_barcode_start)) {
+                                return first_search;
+                        }
+                        // Calculate item code length from total barcode length
+                        const item_code_len = first_search.length - prefix_len - 6;
+                        return first_search.substr(0, prefix_len + item_code_len);
+                },
+                computeItemsSignature(items) {
+                        if (!Array.isArray(items) || items.length === 0) {
+                                return null;
+                        }
+
+                        const codes = items
+                                .map((it) => it && it.item_code)
+                                .filter((code) => typeof code === "string" && code.length > 0);
+
+                        if (!codes.length) {
+                                return `len:${items.length}`;
+                        }
+
+                        const uniqueCodes = Array.from(new Set(codes)).sort();
+                        return `${items.length}:${uniqueCodes.join("|")}`;
+                },
+                getItemSearchMeta(item) {
+                        if (!item) {
+                                return { fields: [], item_group: "" };
+                        }
+
+                        if (item.__searchMeta && !item.__searchMeta.dirty) {
+                                return item.__searchMeta;
+                        }
+
+                        const barcodeList = [];
+                        if (Array.isArray(item.item_barcode)) {
+                                barcodeList.push(
+                                        ...item.item_barcode
+                                                .map((b) => (b && b.barcode != null ? String(b.barcode) : ""))
+                                                .filter(Boolean),
+                                );
+                        } else if (item.item_barcode) {
+                                barcodeList.push(String(item.item_barcode));
+                        }
+                        if (Array.isArray(item.barcodes)) {
+                                barcodeList.push(
+                                        ...item.barcodes.map((b) => (b != null ? String(b) : "")).filter(Boolean),
+                                );
+                        }
+
+                        const serials =
+                                this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)
+                                        ? item.serial_no_data
+                                                .map((s) => (s && s.serial_no != null ? String(s.serial_no) : ""))
+                                                .filter(Boolean)
+                                        : [];
+                        const batches =
+                                this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
+                                        ? item.batch_no_data
+                                                .map((b) => (b && b.batch_no != null ? String(b.batch_no) : ""))
+                                                .filter(Boolean)
+                                        : [];
+
+                        const fields = [
+                                item.item_code,
+                                item.item_name,
+                                item.barcode,
+                                item.description,
+                                ...barcodeList,
+                                ...serials,
+                                ...batches,
+                        ]
+                                .filter((field) => field != null)
+                                .map((field) => String(field).toLowerCase());
+
+                        const meta = {
+                                fields,
+                                item_group: typeof item.item_group === "string" ? item.item_group.toLowerCase() : "",
+                        };
+
+                        item.__searchMeta = meta;
+                        return meta;
+                },
+                invalidateItemSearchMeta(item) {
+                        if (item && item.__searchMeta) {
+                                item.__searchMeta = { fields: [], item_group: "", dirty: true };
+                        }
+                },
+                esc_event() {
+                        this.search = null;
+                        this.first_search = null;
+                        this.search_backup = null;
+                        this.qty = 1;
 			this.$refs.debounce_search.focus();
 		},
-		async update_items_details(items) {
-			const vm = this;
-			if (!items || !items.length) return;
+                async update_items_details(items) {
+                        const vm = this;
+                        if (!items || !items.length) return;
 
-			// reset any pending retry timer
-			if (vm.itemDetailsRetryTimeout) {
-				clearTimeout(vm.itemDetailsRetryTimeout);
-				vm.itemDetailsRetryTimeout = null;
-			}
+                        const signature = vm.computeItemsSignature(items);
+                        if (
+                                items.length > 1 &&
+                                signature &&
+                                vm.lastItemDetailsSignature === signature &&
+                                vm.itemDetailsRetryCount === 0
+                        ) {
+                                return;
+                        }
 
-			const itemCodes = items.map((it) => it.item_code);
-			const cacheResult = await getCachedItemDetails(
-				vm.pos_profile.name,
-				vm.active_price_list,
-				itemCodes,
-			);
-			cacheResult.cached.forEach((det) => {
-				const item = items.find((it) => it.item_code === det.item_code);
-				if (item) {
-					Object.assign(item, {
-						actual_qty: det.actual_qty,
-						has_batch_no: det.has_batch_no,
-						has_serial_no: det.has_serial_no,
-					});
-					if (det.item_uoms && det.item_uoms.length > 0) {
-						item.item_uoms = det.item_uoms;
-						saveItemUOMs(item.item_code, det.item_uoms);
-					}
-					if (det.rate !== undefined) {
-						const force = vm.pos_profile?.posa_force_price_from_customer_price_list !== false;
-						const price = det.price_list_rate ?? det.rate ?? 0;
-						if (force || price) {
-							item.rate = price;
-							item.price_list_rate = price;
-						}
-					}
-					if (det.currency) {
-						item.currency = det.currency;
-					}
+                        // reset any pending retry timer
+                        if (vm.itemDetailsRetryTimeout) {
+                                clearTimeout(vm.itemDetailsRetryTimeout);
+                                vm.itemDetailsRetryTimeout = null;
+                        }
 
-					if (!item.original_rate) {
-						item.original_rate = item.rate;
-						item.original_currency = item.currency || vm.pos_profile.currency;
-					}
+                        const itemCodes = items.map((it) => it.item_code);
+                        const cacheResult = await getCachedItemDetails(
+                                vm.pos_profile.name,
+                                vm.active_price_list,
+                                itemCodes,
+                        );
+                        cacheResult.cached.forEach((det) => {
+                                const item = items.find((it) => it.item_code === det.item_code);
+                                if (item) {
+                                        Object.assign(item, {
+                                                actual_qty: det.actual_qty,
+                                                has_batch_no: det.has_batch_no,
+                                                has_serial_no: det.has_serial_no,
+                                        });
+                                        if (det.item_uoms && det.item_uoms.length > 0) {
+                                                item.item_uoms = det.item_uoms;
+                                                saveItemUOMs(item.item_code, det.item_uoms);
+                                        }
+                                        if (det.rate !== undefined) {
+                                                const force = vm.pos_profile?.posa_force_price_from_customer_price_list !== false;
+                                                const price = det.price_list_rate ?? det.rate ?? 0;
+                                                if (force || price) {
+                                                        item.rate = price;
+                                                        item.price_list_rate = price;
+                                                }
+                                        }
+                                        if (det.currency) {
+                                                item.currency = det.currency;
+                                        }
 
-					vm.applyCurrencyConversionToItem(item);
-				}
-			});
+                                        if (!item.original_rate) {
+                                                item.original_rate = item.rate;
+                                                item.original_currency = item.currency || vm.pos_profile.currency;
+                                        }
 
-			let allCached = cacheResult.missing.length === 0;
+                                        vm.invalidateItemSearchMeta(item);
+                                        vm.applyCurrencyConversionToItem(item);
+                                }
+                        });
+
+                        let allCached = cacheResult.missing.length === 0;
 			items.forEach((item) => {
 				const localQty = getLocalStock(item.item_code);
 				if (localQty !== null) {
@@ -2154,89 +2259,101 @@ export default {
 					allCached = false;
 				}
 
-				if (!item.item_uoms || item.item_uoms.length === 0) {
-					const cachedUoms = getItemUOMs(item.item_code);
-					if (cachedUoms.length > 0) {
-						item.item_uoms = cachedUoms;
-					} else if (isOffline()) {
-						item.item_uoms = [{ uom: item.stock_uom, conversion_factor: 1.0 }];
-					} else {
-						allCached = false;
-					}
-				}
-			});
+                                if (!item.item_uoms || item.item_uoms.length === 0) {
+                                        const cachedUoms = getItemUOMs(item.item_code);
+                                        if (cachedUoms.length > 0) {
+                                                item.item_uoms = cachedUoms;
+                                        } else if (isOffline()) {
+                                                item.item_uoms = [{ uom: item.stock_uom, conversion_factor: 1.0 }];
+                                        } else {
+                                                allCached = false;
+                                        }
+                                }
+                        });
 
-			// When offline or everything is cached, skip server call
-			if (isOffline() || allCached) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                        // When offline or everything is cached, skip server call
+                        if (isOffline() && cacheResult.missing.length > 0) {
+                                vm.itemDetailsRetryCount = 0;
+                                return;
+                        }
 
-			const itemsToFetch = items.filter(
-				(it) => cacheResult.missing.includes(it.item_code) && !it.has_variants,
-			);
+                        if (allCached) {
+                                vm.itemDetailsRetryCount = 0;
+                                if (signature) {
+                                        vm.lastItemDetailsSignature = signature;
+                                }
+                                return;
+                        }
 
-			if (itemsToFetch.length === 0) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                        const itemsToFetch = items.filter(
+                                (it) => cacheResult.missing.includes(it.item_code) && !it.has_variants,
+                        );
 
-			try {
-				const details = await vm.fetchItemDetails(itemsToFetch);
-				if (details && details.length) {
-					vm.itemDetailsRetryCount = 0;
-					let qtyChanged = false;
-					let updatedItems = [];
+                        if (itemsToFetch.length === 0) {
+                                vm.itemDetailsRetryCount = 0;
+                                if (signature) {
+                                        vm.lastItemDetailsSignature = signature;
+                                }
+                                return;
+                        }
 
-					items.forEach((item) => {
-						const updated_item = details.find((element) => element.item_code == item.item_code);
-						if (updated_item) {
-							const prev_qty = item.actual_qty;
+                        try {
+                                const details = await vm.fetchItemDetails(itemsToFetch);
+                                if (details && details.length) {
+                                        vm.itemDetailsRetryCount = 0;
+                                        let qtyChanged = false;
+                                        let updatedItems = [];
 
-							updatedItems.push({
-								item: item,
-								updates: {
-									actual_qty: updated_item.actual_qty,
-									has_batch_no: updated_item.has_batch_no,
-									has_serial_no: updated_item.has_serial_no,
-									batch_no_data:
-										updated_item.batch_no_data && updated_item.batch_no_data.length > 0
-											? updated_item.batch_no_data
-											: item.batch_no_data,
-									serial_no_data:
-										updated_item.serial_no_data && updated_item.serial_no_data.length > 0
-											? updated_item.serial_no_data
-											: item.serial_no_data,
-									item_uoms:
-										updated_item.item_uoms && updated_item.item_uoms.length > 0
-											? updated_item.item_uoms
-											: item.item_uoms,
-									rate: updated_item.rate !== undefined ? updated_item.rate : item.rate,
-									price_list_rate:
-										updated_item.price_list_rate !== undefined
-											? updated_item.price_list_rate
-											: item.price_list_rate,
-									currency: updated_item.currency || item.currency,
-								},
-							});
+                                        items.forEach((item) => {
+                                                const updated_item = details.find((element) => element.item_code == item.item_code);
+                                                if (updated_item) {
+                                                        const prev_qty = item.actual_qty;
 
-							if (prev_qty > 0 && updated_item.actual_qty === 0) {
-								qtyChanged = true;
-							}
+                                                        updatedItems.push({
+                                                                item: item,
+                                                                updates: {
+                                                                        actual_qty: updated_item.actual_qty,
+                                                                        has_batch_no: updated_item.has_batch_no,
+                                                                        has_serial_no: updated_item.has_serial_no,
+                                                                        batch_no_data:
+                                                                                updated_item.batch_no_data && updated_item.batch_no_data.length > 0
+                                                                                        ? updated_item.batch_no_data
+                                                                                        : item.batch_no_data,
+                                                                        serial_no_data:
+                                                                                updated_item.serial_no_data && updated_item.serial_no_data.length > 0
+                                                                                        ? updated_item.serial_no_data
+                                                                                        : item.serial_no_data,
+                                                                        item_uoms:
+                                                                                updated_item.item_uoms && updated_item.item_uoms.length > 0
+                                                                                        ? updated_item.item_uoms
+                                                                                        : item.item_uoms,
+                                                                        rate: updated_item.rate !== undefined ? updated_item.rate : item.rate,
+                                                                        price_list_rate:
+                                                                                updated_item.price_list_rate !== undefined
+                                                                                        ? updated_item.price_list_rate
+                                                                                        : item.price_list_rate,
+                                                                        currency: updated_item.currency || item.currency,
+                                                                },
+                                                        });
 
-							if (updated_item.item_uoms && updated_item.item_uoms.length > 0) {
-								saveItemUOMs(item.item_code, updated_item.item_uoms);
-							}
-						}
-					});
+                                                        if (prev_qty > 0 && updated_item.actual_qty === 0) {
+                                                                qtyChanged = true;
+                                                        }
 
-					updatedItems.forEach(({ item, updates }) => {
-						Object.assign(item, updates);
-						vm.applyCurrencyConversionToItem(item);
-					});
+                                                        if (updated_item.item_uoms && updated_item.item_uoms.length > 0) {
+                                                                saveItemUOMs(item.item_code, updated_item.item_uoms);
+                                                        }
+                                                }
+                                        });
 
-					updateLocalStockCache(details);
-					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
+                                        updatedItems.forEach(({ item, updates }) => {
+                                                Object.assign(item, updates);
+                                                vm.invalidateItemSearchMeta(item);
+                                                vm.applyCurrencyConversionToItem(item);
+                                        });
+
+                                        updateLocalStockCache(details);
+                                        saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
 
 					if (
 						vm.pos_profile &&
@@ -2252,15 +2369,19 @@ export default {
 						}
 					}
 
-					if (qtyChanged) {
-						vm.$forceUpdate();
-					}
-				}
-			} catch (err) {
-				if (err.name !== "AbortError") {
-					console.error("Error fetching item details:", err);
-					items.forEach((item) => {
-						const localQty = getLocalStock(item.item_code);
+                                        if (qtyChanged) {
+                                                vm.$forceUpdate();
+                                        }
+                                }
+
+                                if (signature) {
+                                        vm.lastItemDetailsSignature = signature;
+                                }
+                        } catch (err) {
+                                if (err.name !== "AbortError") {
+                                        console.error("Error fetching item details:", err);
+                                        items.forEach((item) => {
+                                                const localQty = getLocalStock(item.item_code);
 						if (localQty !== null) {
 							item.actual_qty = localQty;
 						}
@@ -2272,15 +2393,15 @@ export default {
 						}
 					});
 
-					if (!isOffline()) {
-						vm.itemDetailsRetryCount += 1;
-						const delay = Math.min(32000, 1000 * Math.pow(2, vm.itemDetailsRetryCount - 1));
-						vm.itemDetailsRetryTimeout = setTimeout(() => {
-							vm.update_items_details(items);
-						}, delay);
-					}
-				}
-			}
+                                        if (!isOffline()) {
+                                                vm.itemDetailsRetryCount += 1;
+                                                const delay = Math.min(32000, 1000 * Math.pow(2, vm.itemDetailsRetryCount - 1));
+                                                vm.itemDetailsRetryTimeout = setTimeout(() => {
+                                                        vm.update_items_details(items);
+                                                }, delay);
+                                        }
+                                }
+                        }
 
 			// Cleanup on component destroy
 			this.cleanupBeforeDestroy = () => {
@@ -2289,11 +2410,12 @@ export default {
 				}
 			};
 		},
-		update_cur_items_details() {
-			if (this.filtered_items && this.filtered_items.length > 0) {
-				this.update_items_details(this.filtered_items);
-			}
-		},
+                update_cur_items_details() {
+                        if (this.filtered_items && this.filtered_items.length > 0) {
+                                this.lastItemDetailsSignature = null;
+                                this.update_items_details(this.filtered_items);
+                        }
+                },
 		async prePopulateStockCache(items) {
 			if (this.prePopulateInProgress) {
 				return;
@@ -3067,78 +3189,65 @@ export default {
 		headers() {
 			return this.getItemsHeaders();
 		},
-		filtered_items() {
-			if (!this.items || this.items.length === 0) {
-				return [];
-			}
+                filtered_items() {
+                        if (!this.items || this.items.length === 0) {
+                                return [];
+                        }
 
-			const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
-			let filteredItems = [...this.items];
+                        const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
+                        const shouldSearch = searchTerm.length >= 3;
+                        const groupFilter = this.item_group !== "ALL" ? this.item_group.toLowerCase() : null;
+                        const hideVariants = this.pos_profile?.posa_hide_variants_items;
 
-			// Apply search filter only for queries with at least three characters
-			if (searchTerm.length >= 3) {
-				filteredItems = filteredItems.filter((item) => {
-					const barcodeList = [];
-					if (Array.isArray(item.item_barcode)) {
-						barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
-					} else if (item.item_barcode) {
-						barcodeList.push(String(item.item_barcode));
-					}
-					if (Array.isArray(item.barcodes)) {
-						barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
-					}
+                        const limitConfig = this.enable_custom_items_per_page ? this.items_per_page : this.itemsPerPage;
+                        const numericLimit = Number(limitConfig);
+                        const hasPositiveLimit = Number.isFinite(numericLimit) && numericLimit > 0;
+                        const limit = hasPositiveLimit ? Math.floor(numericLimit) : 0;
 
-					const searchFields = [
-						item.item_code,
-						item.item_name,
-						item.barcode,
-						item.description,
-						...barcodeList,
-						...(this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)
-							? item.serial_no_data.map((s) => s.serial_no)
-							: []),
-						...(this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
-							? item.batch_no_data.map((b) => b.batch_no)
-							: []),
-					]
-						.filter(Boolean)
-						.map((field) => field.toLowerCase());
+                        if (!hasPositiveLimit) {
+                                return [];
+                        }
 
-					return searchFields.some((field) => field.includes(searchTerm));
-				});
-			}
+                        const maxResults = Math.max(limit * 2, limit);
+                        const filteredItems = [];
 
-			// Apply item group filter
-			if (this.item_group !== "ALL") {
-				filteredItems = filteredItems.filter(
-					(item) =>
-						item.item_group && item.item_group.toLowerCase() === this.item_group.toLowerCase(),
-				);
-			}
+                        for (let index = 0; index < this.items.length && filteredItems.length < maxResults; index += 1) {
+                                const item = this.items[index];
+                                const needsMeta = shouldSearch || !!groupFilter;
+                                const meta = needsMeta ? this.getItemSearchMeta(item) : null;
 
-			// Apply zero rate filter
-			if (this.hide_zero_rate_items) {
-				filteredItems = filteredItems.filter((item) => parseFloat(item.rate || 0) > 0);
-			}
+                                if (shouldSearch) {
+                                        const fields = meta?.fields || [];
+                                        if (!fields.some((field) => field.includes(searchTerm))) {
+                                                continue;
+                                        }
+                                }
 
-			// Apply template/variant filter
-			if (this.pos_profile?.posa_hide_variants_items) {
-				filteredItems = filteredItems.filter((item) => !item.variant_of);
-			}
+                                if (groupFilter) {
+                                        const groupValue = meta?.item_group ??
+                                                (typeof item.item_group === "string" ? item.item_group.toLowerCase() : "");
+                                        if (groupValue !== groupFilter) {
+                                                continue;
+                                        }
+                                }
 
-			// Apply pagination
-			const limit = this.enable_custom_items_per_page ? this.items_per_page : this.itemsPerPage;
-			filteredItems = filteredItems.slice(0, limit);
+                                if (this.hide_zero_rate_items && !(parseFloat(item.rate || 0) > 0)) {
+                                        continue;
+                                }
 
-			// Ensure quantities are defined
-			filteredItems.forEach((item) => {
-				if (item.actual_qty === undefined || item.actual_qty === null) {
-					item.actual_qty = 0;
-				}
-			});
+                                if (hideVariants && item.variant_of) {
+                                        continue;
+                                }
 
-			return filteredItems;
-		},
+                                if (item.actual_qty === undefined || item.actual_qty === null) {
+                                        item.actual_qty = 0;
+                                }
+
+                                filteredItems.push(item);
+                        }
+
+                        return filteredItems.slice(0, limit);
+                },
 		debounce_search: {
 			get() {
 				return this.first_search;
@@ -3234,12 +3343,14 @@ export default {
 			this.couponsCount = data.couponsCount;
 			this.appliedCouponsCount = data.appliedCouponsCount;
 		});
-		this.eventBus.on("update_customer_price_list", (data) => {
-			this.customer_price_list = data;
-		});
-		this.eventBus.on("update_customer", (data) => {
-			this.customer = data;
-		});
+                this.eventBus.on("update_customer_price_list", (data) => {
+                        this.customer_price_list = data;
+                        this.lastItemDetailsSignature = null;
+                });
+                this.eventBus.on("update_customer", (data) => {
+                        this.customer = data;
+                        this.lastItemDetailsSignature = null;
+                });
 
 		this.eventBus.on("focus_item_search", () => {
 			this.focusItemSearch();
@@ -3265,11 +3376,12 @@ export default {
 		});
 
 		// Refresh item quantities when connection to server is restored
-		this.eventBus.on("server-online", async () => {
-			if (this.items && this.items.length > 0) {
-				await this.update_items_details(this.items);
-			}
-		});
+                this.eventBus.on("server-online", async () => {
+                        if (this.items && this.items.length > 0) {
+                                this.lastItemDetailsSignature = null;
+                                await this.update_items_details(this.items);
+                        }
+                });
 
 		if (typeof Worker !== "undefined") {
 			try {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2754,6 +2754,20 @@ export default {
                                 });
                         });
 
+                        if (codes.length === 1 && codes[0] === trimmed) {
+                                const knownSplit = this.splitSegmentByKnownCodes(trimmed);
+                                if (knownSplit && knownSplit.length > 1) {
+                                        return knownSplit;
+                                }
+                        }
+
+                        if (!codes.length) {
+                                const knownSplit = this.splitSegmentByKnownCodes(trimmed);
+                                if (knownSplit && knownSplit.length) {
+                                        return knownSplit;
+                                }
+                        }
+
                         return codes;
                 },
                 splitRepeatedScanSegment(segment) {
@@ -2910,6 +2924,108 @@ export default {
                         }
 
                         return parts;
+                },
+                splitSegmentByKnownCodes(segment) {
+                        if (typeof segment !== "string" || !segment.length) {
+                                return null;
+                        }
+
+                        const knownCodes = this.getKnownScannableCodes();
+                        if (!knownCodes.size) {
+                                return null;
+                        }
+
+                        const lengths = Array.from(
+                                new Set(Array.from(knownCodes, (code) => code.length).filter((len) => len > 0)),
+                        ).sort((a, b) => a - b);
+
+                        const segmentLength = segment.length;
+                        const path = [];
+                        const memo = new Map();
+
+                        const dfs = (index) => {
+                                if (index === segmentLength) {
+                                        return true;
+                                }
+
+                                if (memo.has(index)) {
+                                        return memo.get(index);
+                                }
+
+                                for (let i = 0; i < lengths.length; i += 1) {
+                                        const length = lengths[i];
+                                        const nextIndex = index + length;
+                                        if (nextIndex > segmentLength) {
+                                                break;
+                                        }
+
+                                        const candidate = segment.slice(index, nextIndex);
+                                        if (!knownCodes.has(candidate)) {
+                                                continue;
+                                        }
+
+                                        path.push(candidate);
+                                        if (dfs(nextIndex)) {
+                                                memo.set(index, true);
+                                                return true;
+                                        }
+                                        path.pop();
+                                }
+
+                                memo.set(index, false);
+                                return false;
+                        };
+
+                        if (dfs(0) && path.length) {
+                                return path.slice();
+                        }
+
+                        return null;
+                },
+                getKnownScannableCodes(limit = 500) {
+                        if (!Array.isArray(this.items) || !this.items.length) {
+                                return new Set();
+                        }
+
+                        const codes = new Set();
+
+                        const addCode = (value) => {
+                                if (!value || codes.size >= limit) {
+                                        return;
+                                }
+                                const normalized = typeof value === "string" ? value.trim() : String(value).trim();
+                                if (normalized) {
+                                        codes.add(normalized);
+                                }
+                        };
+
+                        for (let index = 0; index < this.items.length && codes.size < limit; index += 1) {
+                                const item = this.items[index];
+                                if (!item) {
+                                        continue;
+                                }
+
+                                addCode(item.item_code);
+                                addCode(item.barcode);
+
+                                if (Array.isArray(item.item_barcode)) {
+                                        item.item_barcode.forEach((entry) => addCode(entry?.barcode));
+                                }
+
+                                if (Array.isArray(item.barcodes)) {
+                                        item.barcodes.forEach((barcode) => addCode(barcode));
+                                }
+
+                                if (Array.isArray(item.serial_no_data)) {
+                                        item.serial_no_data.forEach((serial) => addCode(serial));
+                                }
+
+                                if (Array.isArray(item.batch_no_data)) {
+                                        item.batch_no_data.forEach((batch) => addCode(batch));
+                                }
+                        }
+
+                        return codes;
                 },
                 async handleHardwareScan({ code, fromScanner = true }) {
                         const scannedCode = code;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2763,7 +2763,9 @@ export default {
 
                         const hints = this.collectScanLengthHints();
                         for (const length of hints) {
-                                const attempt = this.splitSegmentByLength(segment, length);
+                                const attempt = this.splitSegmentByLength(segment, length, {
+                                        requireUniformChunks: false,
+                                });
                                 if (attempt) {
                                         return attempt;
                                 }
@@ -2771,7 +2773,9 @@ export default {
 
                         const startLength = Math.floor(segment.length / 2);
                         for (let length = startLength; length >= 2; length -= 1) {
-                                const attempt = this.splitSegmentByLength(segment, length);
+                                const attempt = this.splitSegmentByLength(segment, length, {
+                                        requireUniformChunks: true,
+                                });
                                 if (attempt) {
                                         return attempt;
                                 }
@@ -2799,11 +2803,79 @@ export default {
                                 });
                         }
 
+                        if (!lengths.size) {
+                                this.getKnownBarcodeLengths(40).forEach((len) => lengths.add(len));
+                        }
+
                         const ordered = Array.from(lengths).filter((len) => Number.isFinite(len) && len > 0);
                         ordered.sort((a, b) => b - a);
                         return ordered;
                 },
-                splitSegmentByLength(segment, length) {
+                getKnownBarcodeLengths(limit = 50) {
+                        if (!Array.isArray(this.items) || !this.items.length) {
+                                return [];
+                        }
+
+                        const lengths = new Set();
+                        const maxItems = Math.min(this.items.length, 200);
+
+                        for (let index = 0; index < maxItems && lengths.size < limit; index += 1) {
+                                this.collectBarcodeLengthsForItem(this.items[index], lengths, limit);
+                        }
+
+                        return Array.from(lengths).filter((len) => Number.isFinite(len) && len > 0);
+                },
+                collectBarcodeLengthsForItem(item, targetSet, limit) {
+                        if (!item || !targetSet || targetSet.size >= limit) {
+                                return;
+                        }
+
+                        const addLength = (value) => {
+                                if (targetSet.size >= limit) {
+                                        return;
+                                }
+                                if (value === null || value === undefined) {
+                                        return;
+                                }
+                                const stringValue = typeof value === "string" ? value : String(value);
+                                const normalized = stringValue.trim();
+                                if (!normalized) {
+                                        return;
+                                }
+                                const length = normalized.length;
+                                if (length >= 4 && length <= 64) {
+                                        targetSet.add(length);
+                                }
+                        };
+
+                        addLength(item.item_code);
+                        addLength(item.barcode);
+
+                        if (Array.isArray(item.item_barcode)) {
+                                item.item_barcode.forEach((entry) => {
+                                        addLength(entry?.barcode);
+                                });
+                        }
+
+                        if (Array.isArray(item.barcodes)) {
+                                item.barcodes.forEach((barcode) => {
+                                        addLength(barcode);
+                                });
+                        }
+
+                        if (Array.isArray(item.serial_no_data)) {
+                                item.serial_no_data.forEach((serial) => {
+                                        addLength(serial);
+                                });
+                        }
+
+                        if (Array.isArray(item.batch_no_data)) {
+                                item.batch_no_data.forEach((batch) => {
+                                        addLength(batch);
+                                });
+                        }
+                },
+                splitSegmentByLength(segment, length, { requireUniformChunks = true } = {}) {
                         if (!length || length <= 0) {
                                 return null;
                         }
@@ -2821,17 +2893,23 @@ export default {
                         if (!chunk) {
                                 return null;
                         }
-
                         const repeats = segment.length / length;
+                        const parts = [chunk];
+
                         for (let index = 1; index < repeats; index += 1) {
                                 const start = index * length;
                                 const end = start + length;
-                                if (segment.slice(start, end) !== chunk) {
+                                const nextChunk = segment.slice(start, end);
+                                if (!nextChunk) {
                                         return null;
                                 }
+                                if (requireUniformChunks && nextChunk !== chunk) {
+                                        return null;
+                                }
+                                parts.push(nextChunk);
                         }
 
-                        return Array.from({ length: repeats }, () => chunk);
+                        return parts;
                 },
                 async handleHardwareScan({ code, fromScanner = true }) {
                         const scannedCode = code;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -596,6 +596,7 @@ export default {
                 hardwareScanQueue: [],
                 processingHardwareScan: false,
                 currentHardwareScan: null,
+                lastProcessedScanLength: 0,
                 isClearingSearch: false,
                 suppressSearchWatcher: false,
                 suppressSearchWatcherTimeout: null,
@@ -2588,13 +2589,43 @@ export default {
                                 return;
                         }
 
-                        const code = typeof sCode === "string" ? sCode.trim() : "";
-                        if (!code) {
+                        const raw = typeof sCode === "string" ? sCode : "";
+                        const trimmed = raw.trim();
+                        if (!trimmed) {
                                 return;
                         }
 
-                        this.hardwareScanQueue.push({ code });
-                        this.processHardwareScanQueue();
+                        const hasActiveScan =
+                                this.processingHardwareScan &&
+                                this.currentHardwareScan &&
+                                typeof this.currentHardwareScan.code === "string";
+                        const shouldStripActivePrefix =
+                                hasActiveScan &&
+                                trimmed.startsWith(this.currentHardwareScan.code) &&
+                                trimmed.length > this.currentHardwareScan.code.length;
+
+                        let normalizedCodes = this.normalizeHardwareScanPayload(trimmed);
+
+                        if (shouldStripActivePrefix && normalizedCodes.length) {
+                                const activeCode = this.currentHardwareScan.code;
+                                if (normalizedCodes[0] === activeCode) {
+                                        normalizedCodes = normalizedCodes.slice(1);
+                                }
+                        }
+
+                        if (!normalizedCodes.length) {
+                                return;
+                        }
+
+                        normalizedCodes.forEach((code) => {
+                                if (code) {
+                                        this.hardwareScanQueue.push({ code });
+                                }
+                        });
+
+                        if (this.hardwareScanQueue.length) {
+                                this.processHardwareScanQueue();
+                        }
                 },
                 async processHardwareScanQueue() {
                         if (this.processingHardwareScan || this.scanErrorDialog) {
@@ -2610,6 +2641,7 @@ export default {
                                                 continue;
                                         }
 
+                                        const activeCode = nextScan.code;
                                         this.currentHardwareScan = { ...nextScan };
                                         this.scannerLocked = true;
 
@@ -2628,6 +2660,9 @@ export default {
                                                 this.pendingScanCode = "";
                                                 this.scannerLocked = false;
                                                 this.lastScanCompletedAt = Date.now();
+                                                if (activeCode) {
+                                                        this.lastProcessedScanLength = activeCode.length;
+                                                }
 
                                                 if (!this.scanErrorDialog) {
                                                         this.clearSearch();
@@ -2641,6 +2676,113 @@ export default {
                                         this.processHardwareScanQueue();
                                 }
                         }
+                },
+                normalizeHardwareScanPayload(rawCode) {
+                        const codes = [];
+                        if (typeof rawCode !== "string") {
+                                return codes;
+                        }
+
+                        const trimmed = rawCode.trim();
+                        if (!trimmed) {
+                                return codes;
+                        }
+
+                        const segments = trimmed.split(/\s+/).filter(Boolean);
+                        const queue = segments.length ? segments : [trimmed];
+
+                        queue.forEach((segment) => {
+                                const candidate = segment.trim();
+                                if (!candidate) {
+                                        return;
+                                }
+
+                                const parts = this.splitRepeatedScanSegment(candidate);
+                                parts.forEach((part) => {
+                                        if (part) {
+                                                codes.push(part);
+                                        }
+                                });
+                        });
+
+                        return codes;
+                },
+                splitRepeatedScanSegment(segment) {
+                        if (!segment) {
+                                return [];
+                        }
+
+                        const hints = this.collectScanLengthHints();
+                        for (const length of hints) {
+                                const attempt = this.splitSegmentByLength(segment, length);
+                                if (attempt) {
+                                        return attempt;
+                                }
+                        }
+
+                        const startLength = Math.floor(segment.length / 2);
+                        for (let length = startLength; length >= 2; length -= 1) {
+                                const attempt = this.splitSegmentByLength(segment, length);
+                                if (attempt) {
+                                        return attempt;
+                                }
+                        }
+
+                        return [segment];
+                },
+                collectScanLengthHints() {
+                        const lengths = new Set();
+
+                        if (this.currentHardwareScan?.code) {
+                                lengths.add(this.currentHardwareScan.code.length);
+                        }
+                        if (this.lastProcessedScanLength) {
+                                lengths.add(this.lastProcessedScanLength);
+                        }
+                        if (this.pendingScanCode) {
+                                lengths.add(this.pendingScanCode.length);
+                        }
+                        if (Array.isArray(this.hardwareScanQueue)) {
+                                this.hardwareScanQueue.forEach((entry) => {
+                                        if (entry?.code) {
+                                                lengths.add(entry.code.length);
+                                        }
+                                });
+                        }
+
+                        const ordered = Array.from(lengths).filter((len) => Number.isFinite(len) && len > 0);
+                        ordered.sort((a, b) => b - a);
+                        return ordered;
+                },
+                splitSegmentByLength(segment, length) {
+                        if (!length || length <= 0) {
+                                return null;
+                        }
+                        if (length >= segment.length) {
+                                return null;
+                        }
+                        if (segment.length % length !== 0) {
+                                return null;
+                        }
+                        if (length < 2) {
+                                return null;
+                        }
+
+                        const chunk = segment.slice(0, length);
+                        if (!chunk) {
+                                return null;
+                        }
+
+                        const repeats = segment.length / length;
+                        for (let index = 1; index < repeats; index += 1) {
+                                const start = index * length;
+                                const end = start + length;
+                                if (segment.slice(start, end) !== chunk) {
+                                        return null;
+                                }
+                        }
+
+                        return Array.from({ length: repeats }, () => chunk);
                 },
                 async handleHardwareScan({ code }) {
                         const scannedCode = code;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3070,9 +3070,16 @@ export default {
 
                         await this.$nextTick();
 
-                        const filteredItems = this.filtered_items.slice();
-
+                        let filteredItems = this.filtered_items.slice();
                         if (!filteredItems.length) {
+                                filteredItems = await this.fetchItemsForScan({
+                                        scannedCode,
+                                        searchCode: search,
+                                        rawSearchInput,
+                                });
+                        }
+
+                        if (!Array.isArray(filteredItems) || !filteredItems.length) {
                                 this.notifyHardwareScanFailure(scannedCode, {
                                         message: `${this.__("Item not found")}: ${scannedCode}`,
                                         details: this.__("Please verify the barcode or search manually."),
@@ -3086,6 +3093,230 @@ export default {
                                 filteredItems,
                                 fromScanner: isScanner,
                         });
+                },
+                async fetchItemsForScan({ scannedCode, searchCode, rawSearchInput }) {
+                        const candidates = new Set();
+                        if (typeof searchCode === "string" && searchCode.trim()) {
+                                candidates.add(searchCode.trim());
+                        }
+                        if (typeof scannedCode === "string" && scannedCode.trim()) {
+                                candidates.add(scannedCode.trim());
+                        }
+                        if (typeof rawSearchInput === "string" && rawSearchInput.trim()) {
+                                candidates.add(rawSearchInput.trim());
+                        }
+
+                        if (!candidates.size) {
+                                return [];
+                        }
+
+                        const candidateList = Array.from(candidates);
+
+                        const directMatches = [];
+                        candidateList.some((code) => {
+                                const matches = this.items.filter((item) => this.itemMatchesScannedCode(item, code));
+                                if (matches.length) {
+                                        directMatches.push(...matches);
+                                        return true;
+                                }
+                                return false;
+                        });
+
+                        if (directMatches.length) {
+                                return directMatches;
+                        }
+
+                        if (this.pos_profile?.posa_local_storage && this.storageAvailable) {
+                                for (let index = 0; index < candidateList.length; index += 1) {
+                                        const code = candidateList[index];
+                                        try {
+                                                const storedResults = await searchStoredItems({
+                                                        search: code,
+                                                        itemGroup:
+                                                                this.item_group !== "ALL"
+                                                                        ? this.item_group.toLowerCase()
+                                                                        : "",
+                                                        limit: Math.max(this.itemsPerPage, 50),
+                                                        offset: 0,
+                                                });
+
+                                                const matchingStored = Array.isArray(storedResults)
+                                                        ? storedResults.filter((item) =>
+                                                                  this.itemMatchesScannedCode(item, code),
+                                                          )
+                                                        : [];
+
+                                                if (matchingStored.length) {
+                                                        return this.mergeScannedItems(matchingStored);
+                                                }
+                                        } catch (error) {
+                                                console.warn("Failed to search stored items for scan", error);
+                                        }
+                                }
+                        }
+
+                        for (let index = 0; index < candidateList.length; index += 1) {
+                                const code = candidateList[index];
+                                const remoteItem = await this.fetchRemoteItemForScan(code);
+                                if (remoteItem) {
+                                        return [remoteItem];
+                                }
+                        }
+
+                        return [];
+                },
+                itemMatchesScannedCode(item, code) {
+                        if (!item || !code) {
+                                return false;
+                        }
+
+                        const normalized = String(code).trim();
+                        if (!normalized) {
+                                return false;
+                        }
+
+                        const lower = normalized.toLowerCase();
+                        const compare = (value) => {
+                                if (value === null || value === undefined) {
+                                        return false;
+                                }
+                                const stringValue = String(value).trim();
+                                if (!stringValue) {
+                                        return false;
+                                }
+                                const lowerValue = stringValue.toLowerCase();
+                                return stringValue === normalized || lowerValue === lower;
+                        };
+
+                        if (compare(item.item_code) || compare(item.barcode)) {
+                                return true;
+                        }
+
+                        if (Array.isArray(item.item_barcode)) {
+                                if (item.item_barcode.some((entry) => compare(entry?.barcode))) {
+                                        return true;
+                                }
+                        }
+
+                        if (Array.isArray(item.barcodes)) {
+                                if (item.barcodes.some((barcode) => compare(barcode))) {
+                                        return true;
+                                }
+                        }
+
+                        if (Array.isArray(item.serial_no_data)) {
+                                if (
+                                        item.serial_no_data.some((serial) =>
+                                                compare(serial?.serial_no ?? serial),
+                                        )
+                                ) {
+                                        return true;
+                                }
+                        }
+
+                        if (Array.isArray(item.batch_no_data)) {
+                                if (
+                                        item.batch_no_data.some((batch) =>
+                                                compare(batch?.batch_no ?? batch),
+                                        )
+                                ) {
+                                        return true;
+                                }
+                        }
+
+                        return false;
+                },
+                mergeScannedItems(items) {
+                        if (!Array.isArray(items) || !items.length) {
+                                return [];
+                        }
+
+                        const merged = [];
+
+                        items.forEach((incoming) => {
+                                if (!incoming || !incoming.item_code) {
+                                        return;
+                                }
+
+                                const itemCode = incoming.item_code;
+                                const incomingUom = incoming.uom || "";
+
+                                const existingIndex = this.items.findIndex((existing) => {
+                                        if (!existing || existing.item_code !== itemCode) {
+                                                return false;
+                                        }
+                                        if (!incomingUom) {
+                                                return true;
+                                        }
+                                        return (existing.uom || "") === incomingUom;
+                                });
+
+                                if (existingIndex >= 0) {
+                                        const updated = { ...this.items[existingIndex], ...incoming };
+                                        this.items.splice(existingIndex, 1, updated);
+                                        this.invalidateItemSearchMeta(updated);
+                                        merged.push(updated);
+                                } else {
+                                        const cloned = { ...incoming };
+                                        this.items.unshift(cloned);
+                                        this.invalidateItemSearchMeta(cloned);
+                                        merged.push(cloned);
+                                }
+                        });
+
+                        if (merged.length) {
+                                this.eventBus.emit("set_all_items", this.items);
+                        }
+
+                        return merged;
+                },
+                async fetchRemoteItemForScan(code) {
+                        const normalized = typeof code === "string" ? code.trim() : "";
+                        if (!normalized) {
+                                return null;
+                        }
+
+                        try {
+                                const response = await frappe.call({
+                                        method: "posawesome.posawesome.api.items.get_items_from_barcode",
+                                        args: {
+                                                selling_price_list: this.active_price_list,
+                                                currency: this.pos_profile?.currency,
+                                                barcode: normalized,
+                                        },
+                                });
+
+                                const item = response?.message;
+                                if (!item) {
+                                        return null;
+                                }
+
+                                const [merged] = this.mergeScannedItems([item]);
+
+                                if (this.searchCache) {
+                                        this.searchCache.clear();
+                                }
+
+                                try {
+                                        await saveItems(this.items);
+                                        await savePriceListItems(this.customer_price_list, this.items);
+                                } catch (error) {
+                                        console.warn("Failed to persist scanned item cache", error);
+                                }
+
+                                if (merged) {
+                                        try {
+                                                await this.update_items_details([merged]);
+                                        } catch (error) {
+                                                console.warn("Failed to hydrate scanned item details", error);
+                                        }
+                                }
+
+                                return merged || item;
+                        } catch (error) {
+                                console.error("Failed to fetch item for scanned code", error);
+                                return null;
+                        }
                 },
                 notifyHardwareScanFailure(scannedCode, { message, details } = {}) {
                         const code = scannedCode || this.currentHardwareScan?.code || this.pendingScanCode;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -593,6 +593,9 @@ export default {
                 awaitingScanResult: false,
                 lastScanCompletedAt: 0,
                 scanCooldownMs: 600,
+                isClearingSearch: false,
+                suppressSearchWatcher: false,
+                suppressSearchWatcherTimeout: null,
                 lastItemDetailsSignature: null,
         }),
 
@@ -747,17 +750,19 @@ export default {
 			this.$nextTick(this.checkItemContainerOverflow);
 		},
 		// Automatically search when the query has at least 3 characters
-		first_search: _.debounce(function (val, oldVal) {
-			const newLen = (val || "").trim().length;
-			const oldLen = (oldVal || "").trim().length;
-			if (newLen >= 3) {
-				// Call without arguments so search_onchange treats it like an Enter key
-				this.search_onchange();
-			} else if (oldLen >= 3 && newLen === 0) {
-				// Reset items only when search is fully cleared
-				this.clearSearch();
-			}
-		}, 300),
+                first_search: _.debounce(function (val, oldVal) {
+                        const newLen = (val || "").trim().length;
+                        const oldLen = (oldVal || "").trim().length;
+                        if (newLen >= 3) {
+                                // Call without arguments so search_onchange treats it like an Enter key
+                                this.search_onchange();
+                        } else if (oldLen >= 3 && newLen === 0) {
+                                // Reset items only when search is fully cleared
+                                if (!this.suppressSearchWatcher) {
+                                        this.clearSearch();
+                                }
+                        }
+                }, 300),
 
 		// Refresh item prices whenever the user changes currency
 		selected_currency() {
@@ -2607,34 +2612,54 @@ export default {
 
 			return combinations;
 		},
-		clearSearch() {
-			this.search_backup = this.first_search;
-			this.first_search = "";
-			this.search = "";
+                clearSearch() {
+                        if (this.isClearingSearch) {
+                                return;
+                        }
+                        this.isClearingSearch = true;
 
-			if (this.pos_profile?.posa_local_storage && this.storageAvailable) {
-				this.loadVisibleItems(true);
-				if (!this.isBackgroundLoading) {
-					this.verifyServerItemCount();
-				}
-				return;
-			}
+                        if (this.suppressSearchWatcherTimeout) {
+                                clearTimeout(this.suppressSearchWatcherTimeout);
+                                this.suppressSearchWatcherTimeout = null;
+                        }
+                        this.suppressSearchWatcher = true;
+                        this.suppressSearchWatcherTimeout = setTimeout(() => {
+                                this.suppressSearchWatcher = false;
+                                this.suppressSearchWatcherTimeout = null;
+                        }, 500);
 
-			if (this.isBackgroundLoading) {
-				if (this.pendingGetItems) {
-					this.pendingGetItems.force_server = this.pendingGetItems.force_server || false;
-				} else {
-					this.pendingGetItems = { force_server: false };
-				}
-				return;
-			}
+                        this.search_backup = this.first_search;
+                        this.first_search = "";
+                        this.search = "";
 
-			if (!this.items_loaded || !this.items.length) {
-				this.get_items(true);
-			} else {
-				this.eventBus.emit("set_all_items", this.items);
-			}
-		},
+                        try {
+                                if (this.pos_profile?.posa_local_storage && this.storageAvailable) {
+                                        this.loadVisibleItems(true);
+                                        if (!this.isBackgroundLoading) {
+                                                this.verifyServerItemCount();
+                                        }
+                                        return;
+                                }
+
+                                if (this.isBackgroundLoading) {
+                                        if (this.pendingGetItems) {
+                                                this.pendingGetItems.force_server =
+                                                        this.pendingGetItems.force_server || false;
+                                        } else {
+                                                this.pendingGetItems = { force_server: false };
+                                        }
+                                        return;
+                                }
+
+                                if (!this.items_loaded || !this.items.length) {
+                                        this.get_items(true);
+                                } else {
+                                        this.eventBus.emit("set_all_items", this.items);
+                                }
+                        } finally {
+                                this.isClearingSearch = false;
+                        }
+                },
 
 		restoreSearch() {
 			if (this.first_search === "") {
@@ -3539,21 +3564,26 @@ export default {
 		this.$nextTick(this.checkItemContainerOverflow);
 	},
 
-	beforeUnmount() {
-		// Clear interval when component is destroyed
-		if (this.refresh_interval) {
-			clearInterval(this.refresh_interval);
-		}
+        beforeUnmount() {
+                // Clear interval when component is destroyed
+                if (this.refresh_interval) {
+                        clearInterval(this.refresh_interval);
+                }
 
-		if (this.itemDetailsRetryTimeout) {
-			clearTimeout(this.itemDetailsRetryTimeout);
-		}
-		this.itemDetailsRetryCount = 0;
+                if (this.itemDetailsRetryTimeout) {
+                        clearTimeout(this.itemDetailsRetryTimeout);
+                }
+                this.itemDetailsRetryCount = 0;
 
-		// Call cleanup function for abort controller
-		if (this.cleanupBeforeDestroy) {
-			this.cleanupBeforeDestroy();
-		}
+                if (this.suppressSearchWatcherTimeout) {
+                        clearTimeout(this.suppressSearchWatcherTimeout);
+                        this.suppressSearchWatcherTimeout = null;
+                }
+
+                // Call cleanup function for abort controller
+                if (this.cleanupBeforeDestroy) {
+                        this.cleanupBeforeDestroy();
+                }
 
 		// Detach scanner if it was attached
 		if (document._scannerAttached) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -593,6 +593,9 @@ export default {
                 awaitingScanResult: false,
                 lastScanCompletedAt: 0,
                 scanCooldownMs: 600,
+                hardwareScanQueue: [],
+                processingHardwareScan: false,
+                currentHardwareScan: null,
                 isClearingSearch: false,
                 suppressSearchWatcher: false,
                 suppressSearchWatcherTimeout: null,
@@ -1924,30 +1927,47 @@ export default {
 				this.qty = 1;
 			}
 		},
-		async enter_event() {
-			if (!this.filtered_items.length || !this.first_search) {
-				return;
-			}
+                async enter_event(scanContext = null) {
+                        const context = scanContext || {};
+                        const filteredItems = Array.isArray(context.filteredItems)
+                                ? context.filteredItems
+                                : this.filtered_items;
+                        const rawSearchInput =
+                                typeof context.firstSearch === "string" && context.firstSearch.length
+                                        ? context.firstSearch
+                                        : this.first_search;
 
-			// Derive the searchable code and detect scale barcode
-			const search = this.get_search(this.first_search);
-			const isScaleBarcode =
-				this.pos_profile?.posa_scale_barcode_start &&
-				this.first_search.startsWith(this.pos_profile.posa_scale_barcode_start);
-			this.search = search;
+                        if (!filteredItems.length || !rawSearchInput) {
+                                return;
+                        }
 
-			const qty = parseFloat(this.get_item_qty(this.first_search));
-			const new_item = { ...this.filtered_items[0] };
-			new_item.qty = flt(qty);
-			if (isScaleBarcode) {
-				new_item._barcode_qty = true;
-			}
+                        // Derive the searchable code and detect scale barcode
+                        const search = this.get_search(rawSearchInput);
+                        const isScaleBarcode =
+                                this.pos_profile?.posa_scale_barcode_start &&
+                                rawSearchInput.startsWith(this.pos_profile.posa_scale_barcode_start);
+                        this.search = search;
 
-			let match = false;
-			if (Array.isArray(new_item.item_barcode)) {
-				new_item.item_barcode.forEach((element) => {
-					if (search === element.barcode) {
-						new_item.uom = element.posa_uom;
+                        const qty = parseFloat(this.get_item_qty(rawSearchInput));
+                        const sourceItem = context.item || filteredItems[0];
+                        if (!sourceItem) {
+                                return;
+                        }
+                        const new_item = { ...sourceItem };
+                        new_item.qty = flt(qty);
+                        if (isScaleBarcode) {
+                                new_item._barcode_qty = true;
+                        }
+
+                        const fromScanner = context.fromScanner ?? this.search_from_scanner;
+                        const scannedCodeForDisplay =
+                                context.scannedCode ?? this.pendingScanCode || rawSearchInput || search;
+
+                        let match = false;
+                        if (Array.isArray(new_item.item_barcode)) {
+                                new_item.item_barcode.forEach((element) => {
+                                        if (search === element.barcode) {
+                                                new_item.uom = element.posa_uom;
 						match = true;
 					}
 				});
@@ -1966,14 +1986,12 @@ export default {
 				new_item.to_set_batch_no = this.flags.batch_no;
 			}
 
-			if (match) {
-				const fromScanner = this.search_from_scanner;
-				const scannedCodeForDisplay = this.pendingScanCode || this.first_search || search;
-				const availableQty =
-					typeof new_item.available_qty === "number"
-						? new_item.available_qty
-						: typeof new_item.actual_qty === "number"
-							? new_item.actual_qty
+                        if (match) {
+                                const availableQty =
+                                        typeof new_item.available_qty === "number"
+                                                ? new_item.available_qty
+                                                : typeof new_item.actual_qty === "number"
+                                                        ? new_item.actual_qty
 							: null;
 				const requestedQty = Math.abs(new_item.qty || 1);
 
@@ -2021,38 +2039,38 @@ export default {
 					}
 				}
 
-				if (fromScanner) {
-					this.awaitingScanResult = true;
-				}
+                                if (fromScanner) {
+                                        this.awaitingScanResult = true;
+                                }
 
-				try {
-					await this.add_item(new_item);
-					if (fromScanner) {
-						this.playScanTone("success");
-						this.scannerLocked = false;
-						this.pendingScanCode = "";
-					}
-				} finally {
-					if (fromScanner) {
-						this.awaitingScanResult = false;
-					}
-				}
+                                try {
+                                        await this.add_item(new_item);
+                                        if (fromScanner) {
+                                                this.playScanTone("success");
+                                                this.scannerLocked = false;
+                                                this.pendingScanCode = "";
+                                        }
+                                } finally {
+                                        if (fromScanner) {
+                                                this.awaitingScanResult = false;
+                                        }
+                                }
 
-				this.flags.serial_no = null;
-				this.flags.batch_no = null;
-				this.qty = 1;
+                                this.flags.serial_no = null;
+                                this.flags.batch_no = null;
+                                this.qty = 1;
 
-				if (fromScanner) {
-					this.search_from_scanner = false;
-				}
+                                if (fromScanner) {
+                                        this.search_from_scanner = false;
+                                }
 
-				if (!this.scanErrorDialog) {
-					// Clear search field after successfully adding an item
-					this.clearSearch();
-					this.$refs.debounce_search.focus();
-				}
-			}
-		},
+                                if (!this.scanErrorDialog) {
+                                        // Clear search field after successfully adding an item
+                                        this.clearSearch();
+                                        this.$refs.debounce_search.focus();
+                                }
+                        }
+                },
 		search_onchange: _.debounce(async function (newSearchTerm) {
 			const vm = this;
 
@@ -2541,13 +2559,21 @@ export default {
 						oEvent.preventDefault();
 						return onScan.decodeKeyEvent(oEvent);
 					},
-					onScan: function (sCode) {
-						if (vm.scannerLocked) {
-							vm.playScanTone("error");
-							return;
-						}
-						vm.trigger_onscan(sCode);
-					},
+                                        onScan: function (sCode) {
+                                                if (vm.scanErrorDialog) {
+                                                        vm.playScanTone("error");
+                                                        return;
+                                                }
+                                                if (vm.processingHardwareScan) {
+                                                        vm.trigger_onscan(sCode);
+                                                        return;
+                                                }
+                                                if (vm.scannerLocked) {
+                                                        vm.playScanTone("error");
+                                                        return;
+                                                }
+                                                vm.trigger_onscan(sCode);
+                                        },
 				});
 
 				// Mark document as having scanner attached
@@ -2556,44 +2582,126 @@ export default {
 				console.warn("Scanner initialization error:", error.message);
 			}
 		},
-		trigger_onscan(sCode) {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
-				return;
-			}
-			// indicate this search came from a scanner
-			this.search_from_scanner = true;
-			// apply scanned code as search term
-			this.first_search = sCode;
-			this.search = sCode;
-			this.pendingScanCode = sCode;
+                trigger_onscan(sCode) {
+                        if (this.scanErrorDialog) {
+                                this.playScanTone("error");
+                                return;
+                        }
 
-			this.$nextTick(() => {
-				if (this.filtered_items.length == 0) {
-					this.eventBus.emit("show_message", {
-						title: `No Item has this barcode "${sCode}"`,
-						color: "error",
-					});
-					this.showScanError({
-						message: `${this.__("Item not found")}: ${sCode}`,
-						code: sCode,
-						details: this.__("Please verify the barcode or search manually."),
-					});
-				} else {
-					this.enter_event();
-				}
+                        const code = typeof sCode === "string" ? sCode.trim() : "";
+                        if (!code) {
+                                return;
+                        }
 
-				// clear search field for next scan and refocus input
-				if (!this.scanErrorDialog) {
-					this.clearSearch();
-					this.$refs.debounce_search && this.$refs.debounce_search.focus();
-				}
-			});
-		},
-		generateWordCombinations(inputString) {
-			const words = inputString.split(" ");
-			const wordCount = words.length;
-			const combinations = [];
+                        this.hardwareScanQueue.push({ code });
+                        this.processHardwareScanQueue();
+                },
+                async processHardwareScanQueue() {
+                        if (this.processingHardwareScan || this.scanErrorDialog) {
+                                return;
+                        }
+
+                        this.processingHardwareScan = true;
+
+                        try {
+                                while (this.hardwareScanQueue.length) {
+                                        const nextScan = this.hardwareScanQueue.shift();
+                                        if (!nextScan || !nextScan.code) {
+                                                continue;
+                                        }
+
+                                        this.currentHardwareScan = { ...nextScan };
+                                        this.scannerLocked = true;
+
+                                        try {
+                                                await this.handleHardwareScan(nextScan);
+                                        } catch (error) {
+                                                console.error("Hardware scan processing failed", error);
+                                                this.notifyHardwareScanFailure(nextScan.code, {
+                                                        message: this.__("Unable to add scanned item."),
+                                                        details: error?.message,
+                                                });
+                                        } finally {
+                                                this.currentHardwareScan = null;
+                                                this.awaitingScanResult = false;
+                                                this.search_from_scanner = false;
+                                                this.pendingScanCode = "";
+                                                this.scannerLocked = false;
+                                                this.lastScanCompletedAt = Date.now();
+
+                                                if (!this.scanErrorDialog) {
+                                                        this.clearSearch();
+                                                }
+                                        }
+                                }
+                        } finally {
+                                this.processingHardwareScan = false;
+                                this.scannerLocked = false;
+                                if (this.hardwareScanQueue.length && !this.scanErrorDialog) {
+                                        this.processHardwareScanQueue();
+                                }
+                        }
+                },
+                async handleHardwareScan({ code }) {
+                        const scannedCode = code;
+                        this.search_from_scanner = true;
+                        this.pendingScanCode = scannedCode;
+                        this.first_search = scannedCode;
+                        this.search = scannedCode;
+
+                        await this.$nextTick();
+
+                        const filteredItems = this.filtered_items.slice();
+
+                        if (!filteredItems.length) {
+                                this.notifyHardwareScanFailure(scannedCode, {
+                                        message: `${this.__("Item not found")}: ${scannedCode}`,
+                                        details: this.__("Please verify the barcode or search manually."),
+                                });
+                                return;
+                        }
+
+                        await this.enter_event({
+                                firstSearch: scannedCode,
+                                scannedCode,
+                                filteredItems,
+                                fromScanner: true,
+                        });
+                },
+                notifyHardwareScanFailure(scannedCode, { message, details } = {}) {
+                        const code = scannedCode || this.currentHardwareScan?.code || this.pendingScanCode;
+                        if (code) {
+                                this.pendingScanCode = code;
+                        }
+
+                        const fallbackMessage = message || this.__("Unable to add scanned item.");
+                        const detailsMessage = details || "";
+
+                        this.eventBus.emit("show_message", {
+                                title: `No Item has this barcode "${code}"`,
+                                color: "error",
+                        });
+
+                        if (frappe?.show_alert) {
+                                frappe.show_alert(
+                                        {
+                                                message: fallbackMessage,
+                                                indicator: "red",
+                                        },
+                                        5,
+                                );
+                        }
+
+                        this.scanErrorMessage = fallbackMessage;
+                        this.scanErrorCode = code;
+                        this.scanErrorDetails = detailsMessage;
+                        this.scanErrorDialog = false;
+                        this.playScanTone("error");
+                },
+                generateWordCombinations(inputString) {
+                        const words = inputString.split(" ");
+                        const wordCount = words.length;
+                        const combinations = [];
 
 			// Helper function to generate all permutations
 			function permute(arr, m = []) {
@@ -2757,20 +2865,23 @@ export default {
 				);
 			}
 		},
-		acknowledgeScanError() {
-			this.scanErrorDialog = false;
-			this.scannerLocked = false;
-			this.scanErrorMessage = "";
-			this.scanErrorCode = "";
-			this.scanErrorDetails = "";
-			this.pendingScanCode = "";
-			this.awaitingScanResult = false;
-			this.$nextTick(() => {
-				if (this.$refs.debounce_search) {
-					this.$refs.debounce_search.focus();
-				}
-			});
-		},
+                acknowledgeScanError() {
+                        this.scanErrorDialog = false;
+                        this.scannerLocked = false;
+                        this.scanErrorMessage = "";
+                        this.scanErrorCode = "";
+                        this.scanErrorDetails = "";
+                        this.pendingScanCode = "";
+                        this.awaitingScanResult = false;
+                        this.$nextTick(() => {
+                                if (this.$refs.debounce_search) {
+                                        this.$refs.debounce_search.focus();
+                                }
+                        });
+                        if (this.hardwareScanQueue.length) {
+                                this.processHardwareScanQueue();
+                        }
+                },
 
 		startCameraScanning() {
 			if (this.scannerLocked) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1937,6 +1937,22 @@ export default {
                                 typeof context.firstSearch === "string" && context.firstSearch.length
                                         ? context.firstSearch
                                         : this.first_search;
+                        const fromScanner = context.fromScanner ?? this.search_from_scanner;
+
+                        if (!fromScanner && typeof rawSearchInput === "string") {
+                                const trimmedInput = rawSearchInput.trim();
+                                if (trimmedInput) {
+                                        const normalizedBatch = this.normalizeHardwareScanPayload(trimmedInput);
+                                        const isCompositeInput =
+                                                normalizedBatch.length > 1 ||
+                                                (normalizedBatch.length === 1 &&
+                                                        normalizedBatch[0] !== trimmedInput);
+
+                                        if (isCompositeInput && this.queueManualScanBatch(normalizedBatch)) {
+                                                return;
+                                        }
+                                }
+                        }
 
                         if (!filteredItems.length || !rawSearchInput) {
                                 return;
@@ -1960,7 +1976,7 @@ export default {
                                 new_item._barcode_qty = true;
                         }
 
-                        const fromScanner = context.fromScanner ?? this.search_from_scanner;
+                        
                         const scannedCodeForDisplay =
                                 (context.scannedCode ?? this.pendingScanCode) || rawSearchInput || search;
 
@@ -2619,13 +2635,45 @@ export default {
 
                         normalizedCodes.forEach((code) => {
                                 if (code) {
-                                        this.hardwareScanQueue.push({ code });
+                                        this.hardwareScanQueue.push({ code, fromScanner: true });
                                 }
                         });
 
                         if (this.hardwareScanQueue.length) {
                                 this.processHardwareScanQueue();
                         }
+                },
+                queueManualScanBatch(codes) {
+                        if (!Array.isArray(codes) || !codes.length) {
+                                return false;
+                        }
+
+                        const entries = codes
+                                .map((code) => (typeof code === "string" ? code.trim() : ""))
+                                .filter(Boolean);
+
+                        if (!entries.length) {
+                                return false;
+                        }
+
+                        entries.forEach((code) => {
+                                this.hardwareScanQueue.push({ code, fromScanner: false, source: "manual-batch" });
+                        });
+
+                        this.pendingScanCode = "";
+                        this.awaitingScanResult = false;
+                        this.search_from_scanner = false;
+                        this.first_search = "";
+                        this.search = "";
+
+                        this.$nextTick(() => {
+                                if (this.$refs.debounce_search) {
+                                        this.$refs.debounce_search.focus();
+                                }
+                        });
+
+                        this.processHardwareScanQueue();
+                        return true;
                 },
                 async processHardwareScanQueue() {
                         if (this.processingHardwareScan || this.scanErrorDialog) {
@@ -2642,8 +2690,9 @@ export default {
                                         }
 
                                         const activeCode = nextScan.code;
+                                        const shouldLockScanner = nextScan.fromScanner !== false;
                                         this.currentHardwareScan = { ...nextScan };
-                                        this.scannerLocked = true;
+                                        this.scannerLocked = shouldLockScanner;
 
                                         try {
                                                 await this.handleHardwareScan(nextScan);
@@ -2784,9 +2833,10 @@ export default {
 
                         return Array.from({ length: repeats }, () => chunk);
                 },
-                async handleHardwareScan({ code }) {
+                async handleHardwareScan({ code, fromScanner = true }) {
                         const scannedCode = code;
-                        this.search_from_scanner = true;
+                        const isScanner = fromScanner !== false;
+                        this.search_from_scanner = isScanner;
                         this.pendingScanCode = scannedCode;
                         this.first_search = scannedCode;
                         this.search = scannedCode;
@@ -2807,7 +2857,7 @@ export default {
                                 firstSearch: scannedCode,
                                 scannedCode,
                                 filteredItems,
-                                fromScanner: true,
+                                fromScanner: isScanner,
                         });
                 },
                 notifyHardwareScanFailure(scannedCode, { message, details } = {}) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1961,7 +1961,7 @@ export default {
 
                         const fromScanner = context.fromScanner ?? this.search_from_scanner;
                         const scannedCodeForDisplay =
-                                context.scannedCode ?? this.pendingScanCode || rawSearchInput || search;
+                                (context.scannedCode ?? this.pendingScanCode) || rawSearchInput || search;
 
                         let match = false;
                         if (Array.isArray(new_item.item_barcode)) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2689,6 +2689,39 @@ export default {
                                                 continue;
                                         }
 
+                                        const normalizedBatch = this.normalizeHardwareScanPayload(nextScan.code);
+                                        if (
+                                                !nextScan.__normalized &&
+                                                Array.isArray(normalizedBatch) &&
+                                                normalizedBatch.length
+                                        ) {
+                                                const sanitizedBatch = normalizedBatch
+                                                        .map((part) => (typeof part === "string" ? part.trim() : ""))
+                                                        .filter(Boolean);
+                                                const originalTrimmed = typeof nextScan.code === "string" ? nextScan.code.trim() : "";
+                                                const isComposite =
+                                                        sanitizedBatch.length > 1 ||
+                                                        (sanitizedBatch.length === 1 && sanitizedBatch[0] !== originalTrimmed);
+
+                                                if (isComposite) {
+                                                        for (let index = sanitizedBatch.length - 1; index >= 0; index -= 1) {
+                                                                const part = sanitizedBatch[index];
+                                                                this.hardwareScanQueue.unshift({
+                                                                        ...nextScan,
+                                                                        code: part,
+                                                                        __normalized: true,
+                                                                });
+                                                        }
+                                                        continue;
+                                                }
+
+                                                if (sanitizedBatch.length === 1 && sanitizedBatch[0] !== originalTrimmed) {
+                                                        nextScan.code = sanitizedBatch[0];
+                                                }
+                                        }
+
+                                        nextScan.__normalized = true;
+
                                         const activeCode = nextScan.code;
                                         const shouldLockScanner = nextScan.fromScanner !== false;
                                         this.currentHardwareScan = { ...nextScan };

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -3,32 +3,107 @@ import { formatUtils } from "../../format.js";
 /* global __, frappe, flt */
 
 export default {
-	normalizeBrand(brand) {
-		return (brand || "").trim().toLowerCase();
-	},
-	getItemBrand(item) {
-		let brand = this.normalizeBrand(item.brand);
-		if (brand) {
-			item.brand = brand;
-			return brand;
-		}
-		if (this.brand_cache && this.brand_cache[item.item_code]) {
-			brand = this.brand_cache[item.item_code];
-		} else {
-			frappe.call({
-				method: "posawesome.posawesome.api.items.get_item_brand",
-				args: { item_code: item.item_code },
-				async: false,
-				callback: (r) => {
-					brand = this.normalizeBrand(r.message);
-				},
-			});
-			this.brand_cache = this.brand_cache || {};
-			this.brand_cache[item.item_code] = brand;
-		}
-		item.brand = brand;
-		return brand;
-	},
+        scheduleOffersRefresh() {
+                if (this.isApplyingOffer) {
+                        return;
+                }
+
+                if (!this._offerRefreshState) {
+                        this._offerRefreshState = {
+                                pending: false,
+                                rafId: null,
+                                timeoutId: null,
+                        };
+                }
+
+                const state = this._offerRefreshState;
+                if (state.pending) {
+                        return;
+                }
+
+                state.pending = true;
+
+                const run = () => {
+                        state.pending = false;
+                        state.rafId = null;
+                        state.timeoutId = null;
+
+                        if (this.isApplyingOffer) {
+                                return;
+                        }
+
+                        this.handelOffers();
+                };
+
+                if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+                        state.rafId = window.requestAnimationFrame(run);
+                } else {
+                        state.timeoutId = setTimeout(run, 16);
+                }
+        },
+        normalizeBrand(brand) {
+                return (brand || "").trim().toLowerCase();
+        },
+        getItemBrand(item) {
+                const directBrand = this.normalizeBrand(item.brand);
+                if (directBrand) {
+                        if (item.brand !== directBrand) {
+                                item.brand = directBrand;
+                        }
+                        return directBrand;
+                }
+
+                this.brand_cache = this.brand_cache || {};
+                const cachedBrand = this.brand_cache[item.item_code];
+                if (typeof cachedBrand === "string") {
+                        item.brand = cachedBrand;
+                        return cachedBrand;
+                }
+
+                if (!this._brandFetchCache) {
+                        this._brandFetchCache = {};
+                }
+
+                if (!this._brandFetchCache[item.item_code]) {
+                        this._brandFetchCache[item.item_code] = this.fetchAndCacheItemBrand(item);
+                }
+
+                return "";
+        },
+        fetchAndCacheItemBrand(item) {
+                return new Promise((resolve) => {
+                        frappe.call({
+                                method: "posawesome.posawesome.api.items.get_item_brand",
+                                args: { item_code: item.item_code },
+                                callback: (r) => {
+                                        const message = r && r.message;
+                                        resolve(this.normalizeBrand(message));
+                                },
+                                error: () => {
+                                        resolve("");
+                                },
+                        });
+                })
+                        .then((brand) => {
+                                this.brand_cache = this.brand_cache || {};
+                                this.brand_cache[item.item_code] = brand;
+
+                                if (!this.normalizeBrand(item.brand)) {
+                                        item.brand = brand;
+                                }
+
+                                if (typeof this.scheduleOffersRefresh === "function") {
+                                        this.scheduleOffersRefresh();
+                                }
+
+                                return brand;
+                        })
+                        .finally(() => {
+                                if (this._brandFetchCache) {
+                                        delete this._brandFetchCache[item.item_code];
+                                }
+                        });
+        },
 	checkOfferIsAppley(item, offer) {
 		let applied = false;
 		const item_offers = JSON.parse(item.posa_offers);

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -31,22 +31,20 @@ export default {
 		});
 	},
 	// Watch for items array changes (deep) and re-handle offers
-	items: {
-		deep: true,
-		handler() {
-			if (this.isApplyingOffer) return;
-			this.handelOffers();
-			this.$forceUpdate();
-		},
-	},
-	packed_items: {
-		deep: true,
-		handler() {
-			if (this.isApplyingOffer) return;
-			this.handelOffers();
-			this.$forceUpdate();
-		},
-	},
+        items: {
+                deep: true,
+                handler() {
+                        if (this.isApplyingOffer) return;
+                        this.scheduleOffersRefresh();
+                },
+        },
+        packed_items: {
+                deep: true,
+                handler() {
+                        if (this.isApplyingOffer) return;
+                        this.scheduleOffersRefresh();
+                },
+        },
 	// Watch for invoice type change and emit
 	invoiceType() {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);

--- a/frontend/src/posapp/posapp.js
+++ b/frontend/src/posapp/posapp.js
@@ -10,7 +10,6 @@ import eventBus from "./bus";
 import themePlugin from "./plugins/theme.js";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
-import Home from "./Home.vue";
 
 // Expose Dexie globally for libraries that expect a global Dexie instance
 if (typeof window !== "undefined" && !window.Dexie) {
@@ -30,81 +29,88 @@ frappe.PosApp.posapp = class {
 		this.page = parent?.page || parent;
 		this.make_body();
 	}
-	make_body() {
-		this.$el = this.$parent.find(".main-section");
-		const vuetify = createVuetify({
-			components,
-			directives,
-			locale: {
-				rtl: frappe.utils.is_rtl(),
-			},
-			theme: {
-				defaultTheme: "light",
-				themes: {
-					light: {
-						colors: {
-							background: "#FFFFFF",
-							primary: "#0097A7",
-							secondary: "#00BCD4",
-							accent: "#FF6B35",
-							success: "#66BB6A",
-							info: "#2196F3",
-							warning: "#FF9800",
-							error: "#E86674",
-							orange: "#E65100",
-							golden: "#A68C59",
-							badge: "#F5528C",
-							customPrimary: "#085294",
-						},
-					},
-					dark: {
-						dark: true,
-						colors: {
-							background: "#121212",
-							surface: "#1E1E1E",
-							primary: "#00D4FF",
-							primaryVariant: "#00A0CC",
-							secondary: "#03DAC6",
-							accent: "#FF6B35",
-							success: "#66BB6A",
-							info: "#2196F3",
-							warning: "#FF9800",
-							error: "#CF6679",
-							orange: "#FF6F00",
-							golden: "#A68C59",
-							badge: "#F5528C",
-							customPrimary: "#4FC3F7",
-							onBackground: "#FFFFFF",
-							onSurface: "#FFFFFF",
-							divider: "#373737",
-						},
-					},
-				},
-			},
-		});
-		const app = createApp(Home);
-		app.component("VueDatePicker", VueDatePicker);
-		app.use(eventBus);
-		app.use(vuetify);
-		app.use(themePlugin, { vuetify });
-		app.mount(this.$el[0]);
+        async make_body() {
+                this.$el = this.$parent.find(".main-section");
+                try {
+                        const { default: Home } = await import(
+                                /* webpackChunkName: "posapp-home" */ "./Home.vue"
+                        );
+                        const vuetify = createVuetify({
+                                components,
+                                directives,
+                                locale: {
+                                        rtl: frappe.utils.is_rtl(),
+                                },
+                                theme: {
+                                        defaultTheme: "light",
+                                        themes: {
+                                                light: {
+                                                        colors: {
+                                                                background: "#FFFFFF",
+                                                                primary: "#0097A7",
+                                                                secondary: "#00BCD4",
+                                                                accent: "#FF6B35",
+                                                                success: "#66BB6A",
+                                                                info: "#2196F3",
+                                                                warning: "#FF9800",
+                                                                error: "#E86674",
+                                                                orange: "#E65100",
+                                                                golden: "#A68C59",
+                                                                badge: "#F5528C",
+                                                                customPrimary: "#085294",
+                                                        },
+                                                },
+                                                dark: {
+                                                        dark: true,
+                                                        colors: {
+                                                                background: "#121212",
+                                                                surface: "#1E1E1E",
+                                                                primary: "#00D4FF",
+                                                                primaryVariant: "#00A0CC",
+                                                                secondary: "#03DAC6",
+                                                                accent: "#FF6B35",
+                                                                success: "#66BB6A",
+                                                                info: "#2196F3",
+                                                                warning: "#FF9800",
+                                                                error: "#CF6679",
+                                                                orange: "#FF6F00",
+                                                                golden: "#A68C59",
+                                                                badge: "#F5528C",
+                                                                customPrimary: "#4FC3F7",
+                                                                onBackground: "#FFFFFF",
+                                                                onSurface: "#FFFFFF",
+                                                                divider: "#373737",
+                                                        },
+                                                },
+                                        },
+                                },
+                        });
+                        const app = createApp(Home);
+                        app.component("VueDatePicker", VueDatePicker);
+                        app.use(eventBus);
+                        app.use(vuetify);
+                        app.use(themePlugin, { vuetify });
+                        app.mount(this.$el[0]);
 
-		if (!document.querySelector('link[rel="manifest"]')) {
-			const link = document.createElement("link");
-			link.rel = "manifest";
-			link.href = "/manifest.json";
-			document.head.appendChild(link);
-		}
+                        if (!document.querySelector('link[rel="manifest"]')) {
+                                const link = document.createElement("link");
+                                link.rel = "manifest";
+                                link.href = "/manifest.json";
+                                document.head.appendChild(link);
+                        }
 
-		if (
-			("serviceWorker" in navigator && window.location.protocol === "https:") ||
-			window.location.hostname === "localhost" ||
-			window.location.hostname === "127.0.0.1"
-		) {
-			navigator.serviceWorker
-				.register("/sw.js")
-				.catch((err) => console.error("SW registration failed", err));
-		}
-	}
+                        if (
+                                ("serviceWorker" in navigator && window.location.protocol === "https:") ||
+                                window.location.hostname === "localhost" ||
+                                window.location.hostname === "127.0.0.1"
+                        ) {
+                                navigator.serviceWorker
+                                        .register("/sw.js")
+                                        .catch((err) => console.error("SW registration failed", err));
+                        }
+                } catch (error) {
+                        console.error("Failed to initialize POS app", error);
+                }
+        }
 	setup_header() {}
 };

--- a/frontend/src/posapp/workers/itemWorker.js
+++ b/frontend/src/posapp/workers/itemWorker.js
@@ -2,46 +2,110 @@
 /* global importScripts, Dexie */
 
 let db;
+
+function prepareItemForStorage(item) {
+        if (!item || typeof item !== "object") {
+                return item;
+        }
+
+        const normalized = item;
+        const lower = (value) => (value != null ? String(value).toLowerCase() : "");
+        const toCleanArray = (collection, extractor) => {
+                if (!Array.isArray(collection)) {
+                        return [];
+                }
+                return collection
+                        .map((entry) => {
+                                let value;
+                                try {
+                                        value = extractor(entry);
+                                } catch (e) {
+                                        value = null;
+                                }
+                                return value != null ? String(value).trim() : "";
+                        })
+                        .filter(Boolean);
+        };
+
+        normalized.item_code_lower = lower(normalized.item_code);
+        normalized.item_name_lower = lower(normalized.item_name);
+        normalized.item_group_lower = lower(normalized.item_group);
+
+        if (Array.isArray(normalized.item_barcode)) {
+                normalized.barcodes = toCleanArray(normalized.item_barcode, (b) =>
+                        b && typeof b === "object" ? b.barcode : b,
+                );
+        } else if (normalized.item_barcode) {
+                normalized.barcodes = [String(normalized.item_barcode)];
+        } else if (Array.isArray(normalized.barcodes)) {
+                normalized.barcodes = toCleanArray(normalized.barcodes, (b) => b);
+        } else {
+                normalized.barcodes = [];
+        }
+
+        if (normalized.item_name_lower) {
+                normalized.name_keywords = normalized.item_name_lower.split(/\s+/).map((kw) => kw.trim()).filter(Boolean);
+        } else if (Array.isArray(normalized.name_keywords)) {
+                normalized.name_keywords = toCleanArray(normalized.name_keywords, (kw) =>
+                        typeof kw === "string" ? kw.toLowerCase() : kw,
+                );
+        } else {
+                normalized.name_keywords = [];
+        }
+
+        if (Array.isArray(normalized.serial_no_data)) {
+                normalized.serials = toCleanArray(normalized.serial_no_data, (s) => s && s.serial_no);
+        } else if (Array.isArray(normalized.serials)) {
+                normalized.serials = toCleanArray(normalized.serials, (s) => s);
+        } else {
+                normalized.serials = [];
+        }
+
+        if (Array.isArray(normalized.batch_no_data)) {
+                normalized.batches = toCleanArray(normalized.batch_no_data, (b) => b && b.batch_no);
+        } else if (Array.isArray(normalized.batches)) {
+                normalized.batches = toCleanArray(normalized.batches, (b) => b);
+        } else {
+                normalized.batches = [];
+        }
+
+        return normalized;
+}
+
+function prepareItemsForStorage(items) {
+        if (!Array.isArray(items)) {
+                return [];
+        }
+        return items.map((item) => prepareItemForStorage(item));
+}
+
 (async () => {
-	let DexieLib;
-	try {
-		importScripts("/assets/posawesome/dist/js/libs/dexie.min.js?v=1");
-		DexieLib = { default: Dexie };
-	} catch {
+        let DexieLib;
+        try {
+                importScripts("/assets/posawesome/dist/js/libs/dexie.min.js?v=1");
+                DexieLib = { default: Dexie };
+        } catch {
 		// Fallback to dynamic import when importScripts fails
 		DexieLib = await import("/assets/posawesome/dist/js/libs/dexie.min.js?v=1");
 	}
-	db = new DexieLib.default("posawesome_offline");
-	db.version(7)
-		.stores({
-			keyval: "&key",
-			queue: "&key",
-			cache: "&key",
-			items: "&item_code,item_name,item_group,*barcodes,*name_keywords,*serials,*batches",
-			item_prices: "&[price_list+item_code],price_list,item_code",
-			customers: "&name,customer_name,mobile_no,email_id,tax_id",
-		})
-		.upgrade((tx) =>
-			tx
-				.table("items")
-				.toCollection()
-				.modify((item) => {
-					item.barcodes = Array.isArray(item.item_barcode)
-						? item.item_barcode.map((b) => b.barcode).filter(Boolean)
-						: item.item_barcode
-							? [String(item.item_barcode)]
-							: [];
-					item.name_keywords = item.item_name
-						? item.item_name.toLowerCase().split(/\s+/).filter(Boolean)
-						: [];
-					item.serials = Array.isArray(item.serial_no_data)
-						? item.serial_no_data.map((s) => s.serial_no).filter(Boolean)
-						: [];
-					item.batches = Array.isArray(item.batch_no_data)
-						? item.batch_no_data.map((b) => b.batch_no).filter(Boolean)
-						: [];
-				}),
-		);
+        db = new DexieLib.default("posawesome_offline");
+        db.version(8)
+                .stores({
+                        keyval: "&key",
+                        queue: "&key",
+                        cache: "&key",
+                        items: "&item_code,item_name,item_group,item_code_lower,item_name_lower,item_group_lower,*barcodes,*name_keywords,*serials,*batches",
+                        item_prices: "&[price_list+item_code],price_list,item_code",
+                        customers: "&name,customer_name,mobile_no,email_id,tax_id",
+                })
+                .upgrade((tx) =>
+                        tx
+                                .table("items")
+                                .toCollection()
+                                .modify((item) => {
+                                        prepareItemForStorage(item);
+                                }),
+                );
 	try {
 		await db.open();
 	} catch (err) {
@@ -84,20 +148,21 @@ async function persist(key, value) {
 }
 
 async function bulkPutItems(items) {
-	try {
-		if (!db.isOpen()) {
-			await db.open();
-		}
-		const CHUNK_SIZE = 1000;
-		await db.transaction("rw", db.table("items"), async () => {
-			for (let i = 0; i < items.length; i += CHUNK_SIZE) {
-				const chunk = items.slice(i, i + CHUNK_SIZE);
-				await db.table("items").bulkPut(chunk);
-			}
-		});
-	} catch (e) {
-		console.error("Worker bulkPut items failed", e);
-	}
+        try {
+                if (!db.isOpen()) {
+                        await db.open();
+                }
+                const normalized = prepareItemsForStorage(items);
+                const CHUNK_SIZE = 1000;
+                await db.transaction("rw", db.table("items"), async () => {
+                        for (let i = 0; i < normalized.length; i += CHUNK_SIZE) {
+                                const chunk = normalized.slice(i, i + CHUNK_SIZE);
+                                await db.table("items").bulkPut(chunk);
+                        }
+                });
+        } catch (e) {
+                console.error("Worker bulkPut items failed", e);
+        }
 }
 
 async function bulkPutPrices(priceList, items) {
@@ -146,35 +211,40 @@ self.onmessage = async (event) => {
 				self.postMessage({ type: "error", error: e.message });
 				return;
 			}
-			let trimmed = items.map((it) => ({
-				item_code: it.item_code,
-				item_name: it.item_name,
-				description: it.description,
-				stock_uom: it.stock_uom,
-				image: it.image,
-				item_group: it.item_group,
-				rate: it.rate,
-				price_list_rate: it.price_list_rate,
-				currency: it.currency,
-				item_barcode: it.item_barcode,
-				item_uoms: it.item_uoms,
-				actual_qty: it.actual_qty,
-				has_batch_no: it.has_batch_no,
-				has_serial_no: it.has_serial_no,
-				has_variants: !!it.has_variants,
-				barcodes: Array.isArray(it.item_barcode)
-					? it.item_barcode.map((b) => b.barcode).filter(Boolean)
-					: it.item_barcode
-						? [String(it.item_barcode)]
-						: [],
-				name_keywords: it.item_name ? it.item_name.toLowerCase().split(/\s+/).filter(Boolean) : [],
-				serials: Array.isArray(it.serial_no_data)
-					? it.serial_no_data.map((s) => s.serial_no).filter(Boolean)
-					: [],
-				batches: Array.isArray(it.batch_no_data)
-					? it.batch_no_data.map((b) => b.batch_no).filter(Boolean)
-					: [],
-			}));
+                        let trimmed = items.map((it) => {
+                                const base = {
+                                        item_code: it.item_code,
+                                        item_name: it.item_name,
+                                        description: it.description,
+                                        stock_uom: it.stock_uom,
+                                        image: it.image,
+                                        item_group: it.item_group,
+                                        rate: it.rate,
+                                        price_list_rate: it.price_list_rate,
+                                        currency: it.currency,
+                                        item_barcode: it.item_barcode,
+                                        item_uoms: it.item_uoms,
+                                        actual_qty: it.actual_qty,
+                                        has_batch_no: it.has_batch_no,
+                                        has_serial_no: it.has_serial_no,
+                                        has_variants: !!it.has_variants,
+                                        barcodes: Array.isArray(it.item_barcode)
+                                                ? it.item_barcode.map((b) => b.barcode).filter(Boolean)
+                                                : it.item_barcode
+                                                        ? [String(it.item_barcode)]
+                                                        : [],
+                                        name_keywords: it.item_name
+                                                ? it.item_name.toLowerCase().split(/\s+/).filter(Boolean)
+                                                : [],
+                                        serials: Array.isArray(it.serial_no_data)
+                                                ? it.serial_no_data.map((s) => s.serial_no).filter(Boolean)
+                                                : [],
+                                        batches: Array.isArray(it.batch_no_data)
+                                                ? it.batch_no_data.map((b) => b.batch_no).filter(Boolean)
+                                                : [],
+                                };
+                                return prepareItemForStorage(base);
+                        });
 			await bulkPutItems(trimmed);
 			await bulkPutPrices(data.priceList, trimmed);
 			// Clear references to release memory before posting back

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -192,6 +192,7 @@ def get_items(
             search_limit = pos_profile.get("posa_search_limit") or 500
 
         result = []
+        details_cache = {}
 
         # Build ORM filters
         filters = {"disabled": 0, "is_sales_item": 1, "is_fixed_asset": 0}
@@ -314,12 +315,33 @@ def get_items(
             if not items_data:
                 break
 
-            details = get_items_details(
-                json.dumps(pos_profile),
-                json.dumps(items_data),
-                price_list=price_list,
-                customer=customer,
+            signature = tuple(
+                sorted(
+                    (
+                        item.get("item_code"),
+                        item.get("uom") or "",
+                    )
+                    for item in items_data
+                    if item.get("item_code")
+                )
             )
+            cache_key = (
+                pos_profile.get("name") or "",
+                price_list or "",
+                customer or "",
+                pos_profile.get("warehouse") or "",
+                signature,
+            )
+
+            details = details_cache.get(cache_key)
+            if details is None:
+                details = get_items_details(
+                    json.dumps(pos_profile),
+                    json.dumps(items_data),
+                    price_list=price_list,
+                    customer=customer,
+                )
+                details_cache[cache_key] = details
             detail_map = {d["item_code"]: d for d in details}
 
             for item in items_data:


### PR DESCRIPTION
## Summary
- cache lowercase search metadata per item and restrict filtering work to at most two pages of results for faster lookups
- gate item detail refreshes on the current item-code signature and clear the signature when data context changes to avoid redundant fetches

## Testing
- `yarn lint` *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfda9c31c832693f056fd30dde42b