### PR TITLE
Fix barcode matching when multiple items share code

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3074,6 +3074,7 @@ export default {
 
                         return null;
                 },
+
                 splitSegmentByHintedLengths(segment) {
                         if (typeof segment !== "string") {
                                 return null;
@@ -3085,18 +3086,21 @@ export default {
                         }
 
                         const hintedLengths = this.collectScanLengthHints();
-                        const combinedLengths = new Set();
-
+                        const hintLengthSet = new Set();
                         if (hintedLengths && hintedLengths.size) {
                                 hintedLengths.forEach((length) => {
                                         if (typeof length === "number") {
-                                                combinedLengths.add(length);
+                                                hintLengthSet.add(length);
                                         }
                                 });
                         }
 
-                        const commonBarcodeLengths = [14, 13, 12, 11, 10, 9, 8];
-                        commonBarcodeLengths.forEach((length) => combinedLengths.add(length));
+                        const fallbackLengths = [14, 13, 12, 11, 10, 9, 8];
+                        const fallbackLengthSet = new Set(fallbackLengths);
+                        const combinedLengths = new Set();
+
+                        hintLengthSet.forEach((length) => combinedLengths.add(length));
+                        fallbackLengths.forEach((length) => combinedLengths.add(length));
 
                         const lengths = Array.from(combinedLengths)
                                 .map((length) => Number(length))
@@ -3112,16 +3116,106 @@ export default {
                                 return null;
                         }
 
-                        const memo = new Map();
-                        const path = [];
+                        const knownCodes = this.getKnownScannableCodes();
+                        const knownNormalizedCodes = new Set();
+                        knownCodes.forEach((code) => {
+                                if (code === null || code === undefined) {
+                                        return;
+                                }
+                                const stringValue = typeof code === "string" ? code : String(code);
+                                const trimmed = stringValue.trim();
+                                if (!trimmed) {
+                                        return;
+                                }
+                                knownNormalizedCodes.add(this.normalizeScanCode(trimmed));
+                        });
 
-                        const dfs = (index) => {
-                                if (index === normalized.length) {
-                                        return true;
+                        const numericPattern = /^\d+$/;
+                        const evaluateChunk = (chunk, length) => {
+                                const trimmed = chunk.trim();
+                                if (!trimmed) {
+                                        return { allowed: false };
                                 }
 
-                                if (memo.has(index)) {
-                                        return memo.get(index);
+                                const normalizedChunk = this.normalizeScanCode(trimmed);
+                                let score = 0;
+                                let knownMatches = 0;
+                                let validMatches = 0;
+                                let invalidMatches = 0;
+
+                                if (knownNormalizedCodes.has(normalizedChunk)) {
+                                        score += 15;
+                                        knownMatches += 1;
+                                }
+
+                                if (hintLengthSet.has(length)) {
+                                        score += 3;
+                                } else if (fallbackLengthSet.has(length)) {
+                                        score += 1;
+                                }
+
+                                if (numericPattern.test(trimmed)) {
+                                        const gtinValidity = this.validateGtinCode(trimmed);
+                                        if (gtinValidity === true) {
+                                                score += 5;
+                                                validMatches += 1;
+                                        } else if (gtinValidity === false) {
+                                                score -= 4;
+                                                invalidMatches += 1;
+                                        }
+                                }
+
+                                return {
+                                        allowed: true,
+                                        chunk: trimmed,
+                                        normalizedChunk,
+                                        score,
+                                        knownMatches,
+                                        validMatches,
+                                        invalidMatches,
+                                };
+                        };
+
+                        const results = [];
+                        const bestStatsAtIndex = new Map();
+
+                        const shouldPrune = (index, stats) => {
+                                const existing = bestStatsAtIndex.get(index);
+                                if (!existing) {
+                                        bestStatsAtIndex.set(index, { ...stats });
+                                        return false;
+                                }
+
+                                const betterScore = stats.score > existing.score;
+                                const equalScore = stats.score === existing.score;
+                                const betterKnown = stats.knownMatches > existing.knownMatches;
+                                const equalKnown = stats.knownMatches === existing.knownMatches;
+                                const fewerInvalid = stats.invalidMatches < existing.invalidMatches;
+
+                                if (betterScore || (equalScore && betterKnown) || (equalScore && equalKnown && fewerInvalid)) {
+                                        bestStatsAtIndex.set(index, { ...stats });
+                                        return false;
+                                }
+
+                                return true;
+                        };
+
+                        const dfs = (index, path, stats) => {
+                                if (index === normalized.length) {
+                                        if (path.length > 1) {
+                                                results.push({
+                                                        chunks: path.slice(),
+                                                        score: stats.score,
+                                                        knownMatches: stats.knownMatches,
+                                                        validMatches: stats.validMatches,
+                                                        invalidMatches: stats.invalidMatches,
+                                                });
+                                        }
+                                        return;
+                                }
+
+                                if (shouldPrune(index, stats)) {
+                                        return;
                                 }
 
                                 for (const length of lengths) {
@@ -3135,24 +3229,99 @@ export default {
                                                 continue;
                                         }
 
-                                        path.push(chunk);
-                                        if (dfs(nextIndex)) {
-                                                memo.set(index, true);
-                                                return true;
+                                        const evaluation = evaluateChunk(chunk, length);
+                                        if (!evaluation.allowed) {
+                                                continue;
                                         }
+
+                                        path.push(evaluation.chunk);
+                                        dfs(nextIndex, path, {
+                                                score: stats.score + evaluation.score,
+                                                knownMatches: stats.knownMatches + evaluation.knownMatches,
+                                                validMatches: stats.validMatches + evaluation.validMatches,
+                                                invalidMatches: stats.invalidMatches + evaluation.invalidMatches,
+                                        });
                                         path.pop();
                                 }
-
-                                memo.set(index, false);
-                                return false;
                         };
 
-                        if (dfs(0) && path.length > 1) {
-                                return path.slice();
+                        dfs(0, [], { score: 0, knownMatches: 0, validMatches: 0, invalidMatches: 0 });
+
+                        if (!results.length) {
+                                return null;
+                        }
+
+                        results.sort((a, b) => {
+                                if (b.knownMatches !== a.knownMatches) {
+                                        return b.knownMatches - a.knownMatches;
+                                }
+                                if (b.validMatches !== a.validMatches) {
+                                        return b.validMatches - a.validMatches;
+                                }
+                                if (a.invalidMatches !== b.invalidMatches) {
+                                        return a.invalidMatches - b.invalidMatches;
+                                }
+                                if (b.score !== a.score) {
+                                        return b.score - a.score;
+                                }
+                                return a.chunks.length - b.chunks.length;
+                        });
+
+                        const best = results[0];
+                        if (best && Array.isArray(best.chunks) && best.chunks.length > 1) {
+                                return best.chunks;
                         }
 
                         return null;
                 },
+
+                computeGtinCheckDigit(payload) {
+                        if (typeof payload !== "string" || !payload || /\D/.test(payload)) {
+                                return null;
+                        }
+
+                        let sum = 0;
+                        const reversed = payload.split("").reverse();
+                        reversed.forEach((digit, index) => {
+                                const numeric = Number(digit);
+                                if (!Number.isFinite(numeric)) {
+                                        return;
+                                }
+                                sum += index % 2 === 0 ? numeric * 3 : numeric;
+                        });
+
+                        const mod = sum % 10;
+                        return mod === 0 ? 0 : 10 - mod;
+                },
+                validateGtinCode(value) {
+                        if (typeof value !== "string") {
+                                return null;
+                        }
+
+                        const trimmed = value.trim();
+                        if (!trimmed || /\D/.test(trimmed)) {
+                                return null;
+                        }
+
+                        const length = trimmed.length;
+                        if (![8, 12, 13, 14].includes(length)) {
+                                return null;
+                        }
+
+                        const body = trimmed.slice(0, -1);
+                        const checkDigit = Number(trimmed.slice(-1));
+                        if (!Number.isFinite(checkDigit)) {
+                                return null;
+                        }
+
+                        const expected = this.computeGtinCheckDigit(body);
+                        if (expected === null) {
+                                return null;
+                        }
+
+                        return expected === checkDigit;
+                },
+
                 getKnownScannableCodes(limit = 500) {
                         if (!Array.isArray(this.items) || !this.items.length) {
                                 return new Set();

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -587,6 +587,11 @@ export default {
                 scanErrorMessage: "",
                 scanErrorDetails: "",
                 scanErrorCode: "",
+                lastCompositeNormalization: {
+                        attempted: false,
+                        success: false,
+                        reason: "",
+                },
                 scannerLocked: false,
                 scanAudioContext: null,
                 pendingScanCode: "",
@@ -1943,6 +1948,25 @@ export default {
                                 const trimmedInput = rawSearchInput.trim();
                                 if (trimmedInput) {
                                         const normalizedBatch = this.normalizeHardwareScanPayload(trimmedInput);
+                                        const normalizationMeta = this.lastCompositeNormalization || {};
+
+                                        if (
+                                                normalizationMeta.attempted &&
+                                                normalizationMeta.reason === "progressive-lengths"
+                                        ) {
+                                                if (normalizationMeta.success) {
+                                                        if (this.queueManualScanBatch(normalizedBatch)) {
+                                                                return;
+                                                        }
+                                                } else {
+                                                        this.notifyHardwareScanFailure(trimmedInput, {
+                                                                message: this.__("Item not found"),
+                                                                details: this.getCompositeBarcodeLengthFailureDetails(),
+                                                        });
+                                                        return;
+                                                }
+                                        }
+
                                         const isCompositeInput =
                                                 normalizedBatch.length > 1 ||
                                                 (normalizedBatch.length === 1 &&
@@ -2672,6 +2696,7 @@ export default {
                                 trimmed.length > this.currentHardwareScan.code.length;
 
                         let normalizedCodes = this.normalizeHardwareScanPayload(trimmed);
+                        const normalizationMeta = this.lastCompositeNormalization || {};
 
                         if (shouldStripActivePrefix && normalizedCodes.length) {
                                 const activeCode = this.currentHardwareScan.code;
@@ -2681,6 +2706,16 @@ export default {
                         }
 
                         if (!normalizedCodes.length) {
+                                if (
+                                        normalizationMeta.attempted &&
+                                        !normalizationMeta.success &&
+                                        normalizationMeta.reason === "progressive-lengths"
+                                ) {
+                                        this.notifyHardwareScanFailure(trimmed, {
+                                                message: this.__("Item not found"),
+                                                details: this.getCompositeBarcodeLengthFailureDetails(),
+                                        });
+                                }
                                 return;
                         }
 
@@ -2812,6 +2847,28 @@ export default {
                 },
                 normalizeHardwareScanPayload(rawCode) {
                         const codes = [];
+                        if (!this.lastCompositeNormalization) {
+                                this.lastCompositeNormalization = {
+                                        attempted: false,
+                                        success: false,
+                                        reason: "",
+                                };
+                        } else {
+                                this.lastCompositeNormalization.attempted = false;
+                                this.lastCompositeNormalization.success = false;
+                                this.lastCompositeNormalization.reason = "";
+                        }
+
+                        const markCompositeNormalization = (attempted, success, reason = "") => {
+                                if (!this.lastCompositeNormalization) {
+                                        this.lastCompositeNormalization = { attempted, success, reason };
+                                        return;
+                                }
+                                this.lastCompositeNormalization.attempted = attempted;
+                                this.lastCompositeNormalization.success = success;
+                                this.lastCompositeNormalization.reason = reason;
+                        };
+
                         if (typeof rawCode !== "string") {
                                 return codes;
                         }
@@ -2823,6 +2880,21 @@ export default {
 
                         const segments = trimmed.split(/\s+/).filter(Boolean);
                         const queue = segments.length ? segments : [trimmed];
+
+                        const applyProgressiveSplit = () => {
+                                const progressive = this.splitSegmentByProgressiveBarcodeTypes(trimmed);
+                                if (!progressive.attempted) {
+                                        return null;
+                                }
+
+                                if (progressive.success && progressive.codes.length) {
+                                        markCompositeNormalization(true, true, "progressive-lengths");
+                                        return progressive.codes.slice();
+                                }
+
+                                markCompositeNormalization(true, false, "progressive-lengths");
+                                return [];
+                        };
 
                         queue.forEach((segment) => {
                                 const candidate = segment.trim();
@@ -2847,6 +2919,10 @@ export default {
                                 if (hintedSplit && hintedSplit.length > 1) {
                                         return hintedSplit;
                                 }
+                                const progressiveResult = applyProgressiveSplit();
+                                if (progressiveResult !== null) {
+                                        return progressiveResult;
+                                }
                         }
 
                         if (!codes.length) {
@@ -2857,6 +2933,10 @@ export default {
                                 const hintedSplit = this.splitSegmentByHintedLengths(trimmed);
                                 if (hintedSplit && hintedSplit.length) {
                                         return hintedSplit;
+                                }
+                                const progressiveResult = applyProgressiveSplit();
+                                if (progressiveResult !== null) {
+                                        return progressiveResult;
                                 }
                         }
 
@@ -3073,6 +3153,112 @@ export default {
                         }
 
                         return null;
+                },
+
+                splitSegmentByProgressiveBarcodeTypes(segment) {
+                        const response = {
+                                attempted: false,
+                                success: false,
+                                codes: [],
+                        };
+
+                        if (typeof segment !== "string") {
+                                return response;
+                        }
+
+                        const normalized = segment.trim();
+                        if (!normalized) {
+                                return response;
+                        }
+
+                        if (!/^\d+$/.test(normalized)) {
+                                return response;
+                        }
+
+                        if (normalized.length <= 13) {
+                                return response;
+                        }
+
+                        const allowedLengths = [8, 12, 13];
+                        const maxLength = normalized.length;
+                        const dp = new Array(maxLength + 1).fill(false);
+                        dp[0] = true;
+
+                        for (let index = 1; index <= maxLength; index += 1) {
+                                for (const length of allowedLengths) {
+                                        if (index >= length && dp[index - length]) {
+                                                dp[index] = true;
+                                                break;
+                                        }
+                                }
+                        }
+
+                        if (!dp[maxLength]) {
+                                return response;
+                        }
+
+                        response.attempted = true;
+
+                        const knownCodes = this.getKnownScannableCodes();
+                        const normalizedKnownCodes = new Set();
+                        knownCodes.forEach((code) => {
+                                if (code === null || code === undefined) {
+                                        return;
+                                }
+                                const value = typeof code === "string" ? code : String(code);
+                                const trimmed = value.trim();
+                                if (!trimmed) {
+                                        return;
+                                }
+                                normalizedKnownCodes.add(this.normalizeScanCode(trimmed));
+                        });
+
+                        let index = 0;
+                        while (index < normalized.length) {
+                                let matched = false;
+                                for (const length of allowedLengths) {
+                                        const end = index + length;
+                                        if (end > normalized.length) {
+                                                continue;
+                                        }
+
+                                        const chunk = normalized.slice(index, end);
+                                        if (!chunk) {
+                                                continue;
+                                        }
+
+                                        const normalizedChunk = this.normalizeScanCode(chunk);
+                                        const knownMatch = normalizedKnownCodes.has(normalizedChunk);
+                                        const gtinCheck = this.validateGtinCode(chunk);
+
+                                        if (knownMatch || gtinCheck === true) {
+                                                response.codes.push(chunk);
+                                                index = end;
+                                                matched = true;
+                                                break;
+                                        }
+                                }
+
+                                if (!matched) {
+                                        response.codes = [];
+                                        return response;
+                                }
+                        }
+
+                        const meaningfulSplit = response.codes.length > 1;
+                        response.success = meaningfulSplit && index === normalized.length;
+
+                        if (!response.success) {
+                                response.codes = [];
+                        }
+
+                        return response;
+                },
+
+                getCompositeBarcodeLengthFailureDetails() {
+                        return this.__(
+                                "Tried matching the combined barcode using EAN-8, UPC-A, and EAN-13 lengths.",
+                        );
                 },
 
                 splitSegmentByHintedLengths(segment) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2843,12 +2843,20 @@ export default {
                                 if (knownSplit && knownSplit.length > 1) {
                                         return knownSplit;
                                 }
+                                const hintedSplit = this.splitSegmentByHintedLengths(trimmed);
+                                if (hintedSplit && hintedSplit.length > 1) {
+                                        return hintedSplit;
+                                }
                         }
 
                         if (!codes.length) {
                                 const knownSplit = this.splitSegmentByKnownCodes(trimmed);
                                 if (knownSplit && knownSplit.length) {
                                         return knownSplit;
+                                }
+                                const hintedSplit = this.splitSegmentByHintedLengths(trimmed);
+                                if (hintedSplit && hintedSplit.length) {
+                                        return hintedSplit;
                                 }
                         }
 
@@ -3061,6 +3069,85 @@ export default {
                         };
 
                         if (dfs(0) && path.length) {
+                                return path.slice();
+                        }
+
+                        return null;
+                },
+                splitSegmentByHintedLengths(segment) {
+                        if (typeof segment !== "string") {
+                                return null;
+                        }
+
+                        const normalized = segment.trim();
+                        if (!normalized) {
+                                return null;
+                        }
+
+                        const hintedLengths = this.collectScanLengthHints();
+                        const combinedLengths = new Set();
+
+                        if (hintedLengths && hintedLengths.size) {
+                                hintedLengths.forEach((length) => {
+                                        if (typeof length === "number") {
+                                                combinedLengths.add(length);
+                                        }
+                                });
+                        }
+
+                        const commonBarcodeLengths = [14, 13, 12, 11, 10, 9, 8];
+                        commonBarcodeLengths.forEach((length) => combinedLengths.add(length));
+
+                        const lengths = Array.from(combinedLengths)
+                                .map((length) => Number(length))
+                                .filter(
+                                        (length) =>
+                                                Number.isFinite(length) &&
+                                                length >= 4 &&
+                                                length < normalized.length,
+                                )
+                                .sort((a, b) => b - a);
+
+                        if (!lengths.length) {
+                                return null;
+                        }
+
+                        const memo = new Map();
+                        const path = [];
+
+                        const dfs = (index) => {
+                                if (index === normalized.length) {
+                                        return true;
+                                }
+
+                                if (memo.has(index)) {
+                                        return memo.get(index);
+                                }
+
+                                for (const length of lengths) {
+                                        const nextIndex = index + length;
+                                        if (nextIndex > normalized.length) {
+                                                continue;
+                                        }
+
+                                        const chunk = normalized.slice(index, nextIndex);
+                                        if (!chunk) {
+                                                continue;
+                                        }
+
+                                        path.push(chunk);
+                                        if (dfs(nextIndex)) {
+                                                memo.set(index, true);
+                                                return true;
+                                        }
+                                        path.pop();
+                                }
+
+                                memo.set(index, false);
+                                return false;
+                        };
+
+                        if (dfs(0) && path.length > 1) {
                                 return path.slice();
                         }
 

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1959,7 +1959,7 @@ export default {
                         }
 
                         // Derive the searchable code and detect scale barcode
-                        const search = this.get_search(rawSearchInput);
+                        let search = this.get_search(rawSearchInput);
                         const isScaleBarcode =
                                 this.pos_profile?.posa_scale_barcode_start &&
                                 rawSearchInput.startsWith(this.pos_profile.posa_scale_barcode_start);
@@ -1970,31 +1970,82 @@ export default {
                         if (!sourceItem) {
                                 return;
                         }
-                        const new_item = { ...sourceItem };
+
+                        const trimmedSearchInput =
+                                typeof rawSearchInput === "string" ? rawSearchInput.trim() : "";
+                        const scannedCodeCandidate =
+                                typeof context.scannedCode === "string"
+                                        ? context.scannedCode
+                                        : this.pendingScanCode;
+                        const trimmedScannedCode =
+                                typeof scannedCodeCandidate === "string" ? scannedCodeCandidate.trim() : "";
+
+                        let new_item = { ...sourceItem };
                         new_item.qty = flt(qty);
                         if (isScaleBarcode) {
                                 new_item._barcode_qty = true;
                         }
 
-                        
                         const scannedCodeForDisplay =
                                 (context.scannedCode ?? this.pendingScanCode) || rawSearchInput || search;
 
-                        let match = false;
-                        if (Array.isArray(new_item.item_barcode)) {
-                                new_item.item_barcode.forEach((element) => {
-                                        if (search === element.barcode) {
-                                                new_item.uom = element.posa_uom || element.uom || new_item.uom;
+                        let match = this.applyBarcodeMatchToItem(new_item, search).matched;
+
+                        if (!match && trimmedSearchInput) {
+                                const normalizedInput = this.normalizeScanCode(trimmedSearchInput);
+                                if (normalizedInput && normalizedInput !== this.normalizeScanCode(search)) {
+                                        const alternativeMatch = this.applyBarcodeMatchToItem(
+                                                new_item,
+                                                trimmedSearchInput,
+                                        );
+                                        if (alternativeMatch.matched) {
                                                 match = true;
+                                                search = trimmedSearchInput;
+                                                this.search = search;
                                         }
-                                });
-			}
-			if (!match && new_item.barcode === search) {
-				match = true;
-			}
-			if (!match && Array.isArray(new_item.barcodes)) {
-				match = new_item.barcodes.some((bc) => String(bc) === search);
-			}
+                                }
+                        }
+
+                        if (!match && trimmedScannedCode) {
+                                const normalizedScan = this.normalizeScanCode(trimmedScannedCode);
+                                if (normalizedScan && normalizedScan !== this.normalizeScanCode(search)) {
+                                        const alternativeMatch = this.applyBarcodeMatchToItem(
+                                                new_item,
+                                                trimmedScannedCode,
+                                        );
+                                        if (alternativeMatch.matched) {
+                                                match = true;
+                                                search = trimmedScannedCode;
+                                                this.search = search;
+                                        }
+                                }
+                        }
+
+                        if (!match) {
+                                const candidateCodes = [search, trimmedSearchInput, trimmedScannedCode];
+                                const fallbackMatch = this.findMatchingItemForCodes(
+                                        filteredItems,
+                                        candidateCodes,
+                                );
+                                if (fallbackMatch && fallbackMatch.item) {
+                                        new_item = { ...fallbackMatch.item };
+                                        new_item.qty = flt(qty);
+                                        if (isScaleBarcode) {
+                                                new_item._barcode_qty = true;
+                                        }
+                                        const fallbackMatchInfo = this.applyBarcodeMatchToItem(
+                                                new_item,
+                                                fallbackMatch.code,
+                                        );
+                                        if (fallbackMatchInfo.matched) {
+                                                match = true;
+                                                search = fallbackMatch.code;
+                                                if (search) {
+                                                        this.search = search;
+                                                }
+                                        }
+                                }
+                        }
 
 			if (this.flags.serial_no) {
 				new_item.to_set_serial_no = this.flags.serial_no;
@@ -3182,6 +3233,96 @@ export default {
                         }
 
                         return { items: [], searchCode };
+                },
+                normalizeScanCode(value) {
+                        if (value === null || value === undefined) {
+                                return "";
+                        }
+                        const str = typeof value === "string" ? value.trim() : String(value).trim();
+                        return str ? str.toLowerCase() : "";
+                },
+                getItemBarcodeMatch(item, code) {
+                        const normalizedCode = this.normalizeScanCode(code);
+                        if (!item || !normalizedCode) {
+                                return { matched: false, normalizedCode };
+                        }
+
+                        const compare = (value) => this.normalizeScanCode(value) === normalizedCode;
+
+                        if (Array.isArray(item.item_barcode)) {
+                                for (const entry of item.item_barcode) {
+                                        if (entry && compare(entry.barcode)) {
+                                                return {
+                                                        matched: true,
+                                                        normalizedCode,
+                                                        entry,
+                                                        source: "item_barcode",
+                                                };
+                                        }
+                                }
+                        }
+
+                        if (compare(item.barcode)) {
+                                return { matched: true, normalizedCode, source: "barcode" };
+                        }
+
+                        if (Array.isArray(item.barcodes)) {
+                                for (const barcode of item.barcodes) {
+                                        if (compare(barcode)) {
+                                                return { matched: true, normalizedCode, source: "barcodes" };
+                                        }
+                                }
+                        }
+
+                        if (compare(item.item_code)) {
+                                return { matched: true, normalizedCode, source: "item_code" };
+                        }
+
+                        return { matched: false, normalizedCode };
+                },
+                applyBarcodeMatchToItem(item, code) {
+                        const matchInfo = this.getItemBarcodeMatch(item, code);
+                        if (matchInfo.matched && matchInfo.entry) {
+                                const barcodeUom = matchInfo.entry.posa_uom || matchInfo.entry.uom;
+                                if (barcodeUom) {
+                                        item.uom = barcodeUom;
+                                }
+                        }
+                        return matchInfo;
+                },
+                findMatchingItemForCodes(items, candidateCodes = []) {
+                        if (!Array.isArray(items) || !items.length || !Array.isArray(candidateCodes)) {
+                                return null;
+                        }
+
+                        const seenCodes = new Set();
+                        for (const rawCode of candidateCodes) {
+                                const normalizedCode = this.normalizeScanCode(rawCode);
+                                if (!normalizedCode || seenCodes.has(normalizedCode)) {
+                                        continue;
+                                }
+                                seenCodes.add(normalizedCode);
+
+                                for (const item of items) {
+                                        if (!item) {
+                                                continue;
+                                        }
+
+                                        const matchInfo = this.getItemBarcodeMatch(item, rawCode);
+                                        if (matchInfo.matched) {
+                                                const trimmedCode =
+                                                        typeof rawCode === "string"
+                                                                ? rawCode.trim()
+                                                                : rawCode != null
+                                                                        ? String(rawCode).trim()
+                                                                        : "";
+                                                const effectiveCode = trimmedCode || normalizedCode;
+                                                return { item, code: effectiveCode };
+                                        }
+                                }
+                        }
+
+                        return null;
                 },
                 findItemsMatchingScanCodes(collection, codesToCheck) {
                         if (!Array.isArray(collection) || !collection.length || !codesToCheck || !codesToCheck.size) {


### PR DESCRIPTION
## Summary
- improve barcode matching in the POS item selector by normalizing scanned codes
- prioritize exact barcode matches from all filtered results before failing
- add reusable helpers to evaluate and apply barcode matches for scanner and manual searches

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cd9df2884c832683b52c9c821f8ac8