### PR TITLE
Ensure repeated scan hints include known barcode lengths

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3007,34 +3007,52 @@ export default {
 
                         return [segment];
                 },
-                collectScanLengthHints() {
-                        const lengths = new Set();
+               collectScanLengthHints() {
+                       const MIN_LENGTH = 4;
+                       const MAX_LENGTH = 64;
+                       const lengths = new Set();
 
-                        if (this.currentHardwareScan?.code) {
-                                lengths.add(this.currentHardwareScan.code.length);
-                        }
-                        if (this.lastProcessedScanLength) {
-                                lengths.add(this.lastProcessedScanLength);
-                        }
-                        if (this.pendingScanCode) {
-                                lengths.add(this.pendingScanCode.length);
-                        }
-                        if (Array.isArray(this.hardwareScanQueue)) {
-                                this.hardwareScanQueue.forEach((entry) => {
-                                        if (entry?.code) {
-                                                lengths.add(entry.code.length);
-                                        }
-                                });
-                        }
+                       const addLength = (value) => {
+                               if (value === null || value === undefined) {
+                                       return;
+                               }
 
-                        if (!lengths.size) {
-                                this.getKnownBarcodeLengths(40).forEach((len) => lengths.add(len));
-                        }
+                               const numeric = Number(value);
+                               if (!Number.isFinite(numeric)) {
+                                       return;
+                               }
 
-                        const ordered = Array.from(lengths).filter((len) => Number.isFinite(len) && len > 0);
-                        ordered.sort((a, b) => b - a);
-                        return ordered;
-                },
+                               const rounded = Math.floor(numeric);
+                               if (rounded < MIN_LENGTH || rounded > MAX_LENGTH) {
+                                       return;
+                               }
+
+                               lengths.add(rounded);
+                       };
+
+                       if (this.currentHardwareScan?.code) {
+                               addLength(this.currentHardwareScan.code.length);
+                       }
+                       if (this.lastProcessedScanLength) {
+                               addLength(this.lastProcessedScanLength);
+                       }
+                       if (this.pendingScanCode) {
+                               addLength(this.pendingScanCode.length);
+                       }
+                       if (Array.isArray(this.hardwareScanQueue)) {
+                               this.hardwareScanQueue.forEach((entry) => {
+                                       if (entry?.code) {
+                                               addLength(entry.code.length);
+                                       }
+                               });
+                       }
+
+                       this.getKnownBarcodeLengths(40).forEach((length) => addLength(length));
+
+                       const ordered = Array.from(lengths);
+                       ordered.sort((a, b) => b - a);
+                       return ordered;
+               },
                 getKnownBarcodeLengths(limit = 50) {
                         if (!Array.isArray(this.items) || !this.items.length) {
                                 return [];


### PR DESCRIPTION
## Summary
- ensure collectScanLengthHints always merges known barcode lengths and enforces numeric bounds
- confirmed splitRepeatedScanSegment receives the expanded hints so 13-digit EAN segments are split out even after other barcode types

## Testing
- yarn --cwd frontend build
- node <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68ce4059b19c83269e995b8bff9e3fb9