### PR TITLE
fix: improve hinted barcode splitting priority

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3482,7 +3482,7 @@ export default {
                                 if (hintLengthSet.has(length)) {
                                         score += 3;
                                 } else if (fallbackLengthSet.has(length)) {
-                                        score += 1;
+                                        score -= 1;
                                 }
 
                                 if (numericPattern.test(trimmed)) {
@@ -3592,10 +3592,14 @@ export default {
                                 if (a.invalidMatches !== b.invalidMatches) {
                                         return a.invalidMatches - b.invalidMatches;
                                 }
+                                const lengthDiff = a.chunks.length - b.chunks.length;
+                                if (lengthDiff !== 0) {
+                                        return lengthDiff;
+                                }
                                 if (b.score !== a.score) {
                                         return b.score - a.score;
                                 }
-                                return a.chunks.length - b.chunks.length;
+                                return 0;
                         });
 
                         const best = results[0];


### PR DESCRIPTION
## Summary
- penalize fallback-only barcode chunk lengths so hinted segments carry higher scores
- prioritize solutions with fewer segments before relying on raw score comparisons

## Testing
- yarn --cwd frontend build

------
https://chatgpt.com/codex/tasks/task_e_68ce435e59308326b1610704b7aaaa1c