### PR TITLE
Adjust hinted barcode scoring penalties

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3462,6 +3462,7 @@ export default {
                         });
 
                         const numericPattern = /^\d+$/;
+                        const gtinSpecLengths = new Set([8, 12, 13, 14]);
                         const evaluateChunk = (chunk, length) => {
                                 const trimmed = chunk.trim();
                                 if (!trimmed) {
@@ -3492,6 +3493,12 @@ export default {
                                                 validMatches += 1;
                                         } else if (gtinValidity === false) {
                                                 score -= 4;
+                                                invalidMatches += 1;
+                                        } else if (
+                                                !hintLengthSet.has(length) &&
+                                                !gtinSpecLengths.has(length)
+                                        ) {
+                                                score -= 3;
                                                 invalidMatches += 1;
                                         }
                                 }


### PR DESCRIPTION
## Summary
- penalize numeric fallback chunks without hints or GTIN-spec length when GTIN validation is unavailable
- ensure hint/spec-backed splits outrank ad-hoc lengths by increasing invalid match tracking

## Testing
- node - <<'NODE' ... (see run in analysis)

------
https://chatgpt.com/codex/tasks/task_e_68ce5749e140832693391ab6b4e06153