### PR TITLE
Optimize offer watchers with targeted signatures

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -414,10 +414,14 @@ export default {
 			selected_columns: [], // Selected columns for items table
 			temp_selected_columns: [], // Temporary array for column selection
 			available_columns: [], // All available columns
-			show_column_selector: false, // Column selector dialog visibility
-			invoiceHeight: null,
-		};
-	},
+                        show_column_selector: false, // Column selector dialog visibility
+                        invoiceHeight: null,
+                        offerSignatureSnapshot: {
+                                items: "[]",
+                                packed: "[]",
+                        },
+                };
+        },
 
 	components: {
 		Customer,
@@ -432,13 +436,33 @@ export default {
 		...invoiceComputed,
 	},
 
-	methods: {
-		...shortcutMethods,
-		...offerMethods,
-		...invoiceItemMethods,
-		initializeItemsHeaders() {
-			// Define all available columns
-			this.available_columns = [
+        methods: {
+                ...shortcutMethods,
+                ...offerMethods,
+                ...invoiceItemMethods,
+                buildOfferSignature(collection) {
+                        if (!Array.isArray(collection) || collection.length === 0) {
+                                return "[]";
+                        }
+
+                        return JSON.stringify(
+                                collection.map((item) => [
+                                        item?.posa_row_id ?? item?.name ?? "",
+                                        Number(item?.qty) || 0,
+                                        Number(item?.rate) || 0,
+                                        Number(item?.discount_amount) || 0,
+                                ]),
+                        );
+                },
+                refreshOfferSignatures() {
+                        this.offerSignatureSnapshot = {
+                                items: this.itemsOfferSignature,
+                                packed: this.packedItemsOfferSignature,
+                        };
+                },
+                initializeItemsHeaders() {
+                        // Define all available columns
+                        this.available_columns = [
 				{ title: __("Name"), align: "start", sortable: true, key: "item_name", required: true },
 				{ title: __("QTY"), key: "qty", align: "center", required: true },
 				{ title: __("UOM"), key: "uom", align: "center", required: false },
@@ -720,16 +744,17 @@ export default {
 
 			// Recalculate stock quantity with the adjusted value
 			this.calc_stock_qty(item, item[field_name]);
-			if (field_name === "qty" && item.is_bundle) {
-				this.packed_items
-					.filter((it) => it.bundle_id === item.bundle_id)
-					.forEach((ch) => {
-						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
-						this.calc_stock_qty(ch, ch.qty);
-					});
-			}
-			return parsedValue;
-		},
+                        if (field_name === "qty" && item.is_bundle) {
+                                this.packed_items
+                                        .filter((it) => it.bundle_id === item.bundle_id)
+                                        .forEach((ch) => {
+                                                ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
+                                                this.calc_stock_qty(ch, ch.qty);
+                                        });
+                        }
+                        this.refreshOfferSignatures();
+                        return parsedValue;
+                },
 		async fetch_available_currencies() {
 			try {
 				console.log("Fetching available currencies...");
@@ -1142,16 +1167,17 @@ export default {
 				this.remove_item(item);
 			}
 			this.calc_stock_qty(item, item.qty);
-			if (item.is_bundle) {
-				this.packed_items
-					.filter((it) => it.bundle_id === item.bundle_id)
-					.forEach((ch) => {
-						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
-						this.calc_stock_qty(ch, ch.qty);
-					});
-			}
-			this.$forceUpdate();
-		},
+                        if (item.is_bundle) {
+                                this.packed_items
+                                        .filter((it) => it.bundle_id === item.bundle_id)
+                                        .forEach((ch) => {
+                                                ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
+                                                this.calc_stock_qty(ch, ch.qty);
+                                        });
+                        }
+                        this.$forceUpdate();
+                        this.refreshOfferSignatures();
+                },
 
 		// Decrease quantity of an item (handles return logic)
 		subtract_one(item) {
@@ -1165,16 +1191,17 @@ export default {
 				this.remove_item(item);
 			}
 			this.calc_stock_qty(item, item.qty);
-			if (item.is_bundle) {
-				this.packed_items
-					.filter((it) => it.bundle_id === item.bundle_id)
-					.forEach((ch) => {
-						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
-						this.calc_stock_qty(ch, ch.qty);
-					});
-			}
-			this.$forceUpdate();
-		},
+                        if (item.is_bundle) {
+                                this.packed_items
+                                        .filter((it) => it.bundle_id === item.bundle_id)
+                                        .forEach((ch) => {
+                                                ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
+                                                this.calc_stock_qty(ch, ch.qty);
+                                        });
+                        }
+                        this.$forceUpdate();
+                        this.refreshOfferSignatures();
+                },
 
 		// Handle item reordering from drag and drop
 		handleItemReorder(reorderData) {
@@ -1191,10 +1218,14 @@ export default {
 			// Insert the item at its new position
 			newItems.splice(toIndex, 0, movedItem);
 
-			// Update the items array
-			this.items = newItems;
+                        // Update the items array
+                        this.items = newItems;
 
-			// Show success feedback
+                        if (typeof this.refreshOfferSignatures === "function") {
+                                this.refreshOfferSignatures();
+                        }
+
+                        // Show success feedback
 			this.eventBus.emit("show_message", {
 				title: __("Item order updated"),
 				color: "success",
@@ -1342,10 +1373,14 @@ export default {
 		this.eventBus.on("item-drag-start", () => {
 			this.showDropFeedback(true);
 		});
-		this.eventBus.on("item-drag-end", () => {
-			this.showDropFeedback(false);
-		});
-	},
+                this.eventBus.on("item-drag-end", () => {
+                        this.showDropFeedback(false);
+                });
+
+                if (typeof this.refreshOfferSignatures === "function") {
+                        this.refreshOfferSignatures();
+                }
+        },
 	// Cleanup event listeners before component is destroyed
 	beforeUnmount() {
 		// Existing cleanup

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -1,10 +1,10 @@
 /* global flt, __, get_currency_symbol */
 
 export default {
-	// Calculate total quantity of all items
-	total_qty() {
-		this.close_payments();
-		let qty = 0;
+        // Calculate total quantity of all items
+        total_qty() {
+                this.close_payments();
+                let qty = 0;
 		this.items.forEach((item) => {
 			qty += flt(item.qty);
 		});
@@ -95,13 +95,13 @@ export default {
 		);
 	},
 	// Table headers for item table (for another table if needed)
-	itemTableHeaders() {
-		return [
-			{
-				text: __("Item"),
-				value: "item_name",
-				width: "35%",
-			},
+        itemTableHeaders() {
+                return [
+                        {
+                                text: __("Item"),
+                                value: "item_name",
+                                width: "35%",
+                        },
 			{
 				text: __("Qty"),
 				value: "qty",
@@ -122,7 +122,15 @@ export default {
 				value: "actions",
 				sortable: false,
 				width: "10%",
-			},
-		];
-	},
+                        },
+                ];
+        },
+
+        itemsOfferSignature() {
+                return this.buildOfferSignature(this.items);
+        },
+
+        packedItemsOfferSignature() {
+                return this.buildOfferSignature(this.packed_items);
+        },
 };

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -22,23 +22,30 @@ const { removeItem, addItem, getNewItem, clearInvoice } = useItemAddition();
 const { calcUom, calcStockQty } = useStockUtils();
 
 export default {
-	remove_item(item) {
-		return removeItem(item, this);
-	},
+        remove_item(item) {
+                const result = removeItem(item, this);
+                if (typeof this.refreshOfferSignatures === "function") {
+                        this.refreshOfferSignatures();
+                }
+                return result;
+        },
 
-	async add_item(item) {
-		const res = await addItem(item, this);
-		const target = this.items.find(
-			(it) =>
-				it.item_code === item.item_code &&
-				it.uom === (item.uom || it.uom) &&
-				(!it.batch_no || it.batch_no === item.batch_no),
-		);
-		if (target && this.fetch_available_qty) {
-			this.fetch_available_qty(target);
-		}
-		return res;
-	},
+        async add_item(item) {
+                const res = await addItem(item, this);
+                const target = this.items.find(
+                        (it) =>
+                                it.item_code === item.item_code &&
+                                it.uom === (item.uom || it.uom) &&
+                                (!it.batch_no || it.batch_no === item.batch_no),
+                );
+                if (target && this.fetch_available_qty) {
+                        this.fetch_available_qty(target);
+                }
+                if (typeof this.refreshOfferSignatures === "function") {
+                        this.refreshOfferSignatures();
+                }
+                return res;
+        },
 
 	// Create a new item object with default and calculated fields
 	get_new_item(item) {
@@ -46,9 +53,13 @@ export default {
 	},
 
 	// Reset all invoice fields to default/empty values
-	clear_invoice() {
-		return clearInvoice(this);
-	},
+        clear_invoice() {
+                const result = clearInvoice(this);
+                if (typeof this.refreshOfferSignatures === "function") {
+                        this.refreshOfferSignatures();
+                }
+                return result;
+        },
 
 	// Fetch customer balance from backend or cache
 	async fetch_customer_balance() {
@@ -194,16 +205,20 @@ export default {
 			console.log("Warning: No items in return invoice");
 		}
 
-		if (this.packed_items.length > 0) {
-			this.update_items_details(this.packed_items);
-			this.packed_items.forEach((pi) => {
-				if (!pi.posa_row_id) {
-					pi.posa_row_id = this.makeid(20);
-				}
-			});
-		}
+                if (this.packed_items.length > 0) {
+                        this.update_items_details(this.packed_items);
+                        this.packed_items.forEach((pi) => {
+                                if (!pi.posa_row_id) {
+                                        pi.posa_row_id = this.makeid(20);
+                                }
+                        });
+                }
 
-		this.customer = data.customer;
+                if (typeof this.refreshOfferSignatures === "function") {
+                        this.refreshOfferSignatures();
+                }
+
+                this.customer = data.customer;
 		this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
 		this.discount_amount = data.discount_amount;
 		this.additional_discount_percentage = data.additional_discount_percentage;
@@ -312,21 +327,24 @@ export default {
 			this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
 			this.discount_amount = data.discount_amount;
 			this.additional_discount_percentage = data.additional_discount_percentage;
-			this.items.forEach((item) => {
-				if (item.serial_no) {
-					item.serial_no_selected = [];
-					const serial_list = item.serial_no.split("\n");
-					serial_list.forEach((element) => {
-						if (element.length) {
-							item.serial_no_selected.push(element);
-						}
-					});
-					item.serial_no_selected_count = item.serial_no_selected.length;
-				}
-			});
-		}
-		return old_invoice;
-	},
+                        this.items.forEach((item) => {
+                                if (item.serial_no) {
+                                        item.serial_no_selected = [];
+                                        const serial_list = item.serial_no.split("\n");
+                                        serial_list.forEach((element) => {
+                                                if (element.length) {
+                                                        item.serial_no_selected.push(element);
+                                                }
+                                        });
+                                        item.serial_no_selected_count = item.serial_no_selected.length;
+                                }
+                        });
+                }
+                if (typeof this.refreshOfferSignatures === "function") {
+                        this.refreshOfferSignatures();
+                }
+                return old_invoice;
+        },
 
 	// Build the invoice document object for backend submission
 	get_invoice_doc() {
@@ -1892,19 +1910,22 @@ export default {
 						uom: item.uom,
 					},
 					callback(r) {
-						if (!r.exc) {
-							item.price_list_rate = rate;
-							item.base_price_list_rate = rate;
-							if (!item._manual_rate_set) {
-								item.rate = rate;
-								item.base_rate = rate;
-							}
-							vm.calc_item_price(item);
-							vm.eventBus.emit("show_message", {
-								title: r.message || __("Item price updated"),
-								color: "success",
-							});
-						}
+                                                if (!r.exc) {
+                                                        item.price_list_rate = rate;
+                                                        item.base_price_list_rate = rate;
+                                                        if (!item._manual_rate_set) {
+                                                                item.rate = rate;
+                                                                item.base_rate = rate;
+                                                        }
+                                                        vm.calc_item_price(item);
+                                                        if (typeof vm.refreshOfferSignatures === "function") {
+                                                                vm.refreshOfferSignatures();
+                                                        }
+                                                        vm.eventBus.emit("show_message", {
+                                                                title: r.message || __("Item price updated"),
+                                                                color: "success",
+                                                        });
+                                                }
 					},
 				});
 				d.hide();

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -30,20 +30,29 @@ export default {
 			value: this.discount_percentage_offer_name,
 		});
 	},
-	// Watch for items array changes (deep) and re-handle offers
-        items: {
-                deep: true,
-                handler() {
-                        if (this.isApplyingOffer) return;
-                        this.scheduleOffersRefresh();
-                },
+        // Watch offer-relevant signature for main items
+        itemsOfferSignature(newSignature, oldSignature) {
+                if (newSignature === oldSignature) {
+                        return;
+                }
+
+                if (this.isApplyingOffer) {
+                        return;
+                }
+
+                this.scheduleOffersRefresh();
         },
-        packed_items: {
-                deep: true,
-                handler() {
-                        if (this.isApplyingOffer) return;
-                        this.scheduleOffersRefresh();
-                },
+        // Watch offer-relevant signature for packed items
+        packedItemsOfferSignature(newSignature, oldSignature) {
+                if (newSignature === oldSignature) {
+                        return;
+                }
+
+                if (this.isApplyingOffer) {
+                        return;
+                }
+
+                this.scheduleOffersRefresh();
         },
 	// Watch for invoice type change and emit
 	invoiceType() {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -145,14 +145,17 @@ export function useDiscounts() {
 				item.discount_percentage = 100;
 			}
 
-			// Update stock calculations and force UI update
-			if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);
-			if (context.forceUpdate) context.forceUpdate();
-		} catch (error) {
-			console.error("Error calculating prices:", error);
-			context.eventBus.emit("show_message", {
-				title: __("Error calculating prices"),
-				color: "error",
+                        // Update stock calculations and force UI update
+                        if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);
+                        if (context.forceUpdate) context.forceUpdate();
+                        if (typeof context.refreshOfferSignatures === "function") {
+                                context.refreshOfferSignatures();
+                        }
+                } catch (error) {
+                        console.error("Error calculating prices:", error);
+                        context.eventBus.emit("show_message", {
+                                title: __("Error calculating prices"),
+                                color: "error",
 			});
 		}
 	};
@@ -249,8 +252,11 @@ export function useDiscounts() {
 			item.base_amount = item.amount;
 		}
 
-		if (context.forceUpdate) context.forceUpdate();
-	};
+                if (context.forceUpdate) context.forceUpdate();
+                if (typeof context.refreshOfferSignatures === "function") {
+                        context.refreshOfferSignatures();
+                }
+        };
 
 	return {
 		updateDiscountAmount,

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -6,17 +6,21 @@ import { useBundles } from "./useBundles.js";
 
 export function useItemAddition() {
 	// Remove item from invoice
-	const removeItem = (item, context) => {
-		const index = context.items.findIndex((el) => el.posa_row_id == item.posa_row_id);
-		if (index >= 0) {
-			context.items.splice(index, 1);
-		}
-		if (item.is_bundle) {
-			context.packed_items = context.packed_items.filter((it) => it.bundle_id !== item.bundle_id);
-		}
-		// Remove from expanded if present
-		context.expanded = context.expanded.filter((id) => id !== item.posa_row_id);
-	};
+        const removeItem = (item, context) => {
+                const index = context.items.findIndex((el) => el.posa_row_id == item.posa_row_id);
+                if (index >= 0) {
+                        context.items.splice(index, 1);
+                }
+                if (item.is_bundle) {
+                        context.packed_items = context.packed_items.filter((it) => it.bundle_id !== item.bundle_id);
+                }
+                // Remove from expanded if present
+                context.expanded = context.expanded.filter((id) => id !== item.posa_row_id);
+
+                if (typeof context.refreshOfferSignatures === "function") {
+                        context.refreshOfferSignatures();
+                }
+        };
 
 	const { getBundleComponents } = useBundles();
 
@@ -33,8 +37,8 @@ export function useItemAddition() {
 		parent.bundle_id = context.makeid ? context.makeid(10) : Math.random().toString(36).substr(2, 10);
 		// Force reactivity so the bundle badge appears immediately
 		context.items = [...context.items];
-		for (const comp of components) {
-			const child = {
+                for (const comp of components) {
+                        const child = {
 				parent_item: parent.item_code,
 				bundle_id: parent.bundle_id,
 				item_code: comp.item_code,
@@ -58,11 +62,15 @@ export function useItemAddition() {
 				context.update_item_detail(child, false);
 				context.calc_stock_qty && context.calc_stock_qty(child, child.qty);
 			}
-			if (context.fetch_available_qty) {
-				context.fetch_available_qty(child);
-			}
-		}
-	};
+                        if (context.fetch_available_qty) {
+                                context.fetch_available_qty(child);
+                        }
+                }
+
+                if (typeof context.refreshOfferSignatures === "function") {
+                        context.refreshOfferSignatures();
+                }
+        };
 
 	const moveItemToTop = (context, target) => {
 		if (!target) return;
@@ -327,16 +335,20 @@ export function useItemAddition() {
 				moveItemToTop(context, cur_item);
 			}
 		}
-		if (context.forceUpdate) context.forceUpdate();
+                if (context.forceUpdate) context.forceUpdate();
 
-		// Only try to expand if new_item exists and should be expanded
-		if (
-			new_item &&
+                // Only try to expand if new_item exists and should be expanded
+                if (
+                        new_item &&
 			((!context.pos_profile.posa_auto_set_batch && new_item.has_batch_no) || new_item.has_serial_no)
-		) {
-			context.expanded = [new_item.posa_row_id];
-		}
-	};
+                ) {
+                        context.expanded = [new_item.posa_row_id];
+                }
+
+                if (typeof context.refreshOfferSignatures === "function") {
+                        context.refreshOfferSignatures();
+                }
+        };
 
 	// Create a new item object with default and calculated fields
 	const getNewItem = (item, context) => {
@@ -423,9 +435,9 @@ export function useItemAddition() {
 	};
 
 	// Reset all invoice fields to default/empty values
-	const clearInvoice = (context) => {
-		context.items = [];
-		context.packed_items = [];
+        const clearInvoice = (context) => {
+                context.items = [];
+                context.packed_items = [];
 		context.posa_offers = [];
 		context.expanded = [];
 		context.eventBus.emit("set_pos_coupons", []);
@@ -450,10 +462,14 @@ export function useItemAddition() {
 		context.invoiceType = context.pos_profile.posa_default_sales_order ? "Order" : "Invoice";
 		context.invoiceTypes = ["Invoice", "Order", "Quotation"];
 
-		if (Object.prototype.hasOwnProperty.call(context, "itemSearch")) {
-			context.itemSearch = "";
-		}
-	};
+                if (Object.prototype.hasOwnProperty.call(context, "itemSearch")) {
+                        context.itemSearch = "";
+                }
+
+                if (typeof context.refreshOfferSignatures === "function") {
+                        context.refreshOfferSignatures();
+                }
+        };
 
 	// Add this utility for grouping logic, matching ItemsTable.vue
 	function groupAndAddItem(items, newItem) {

--- a/frontend/src/posapp/composables/useStockUtils.js
+++ b/frontend/src/posapp/composables/useStockUtils.js
@@ -283,10 +283,13 @@ export function useStockUtils() {
 			}
 		}
 
-		// Update item details
-		if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);
-		if (context.forceUpdate) context.forceUpdate();
-	};
+                // Update item details
+                if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);
+                if (context.forceUpdate) context.forceUpdate();
+                if (typeof context.refreshOfferSignatures === "function") {
+                        context.refreshOfferSignatures();
+                }
+        };
 
 	// Calculate stock quantity for an item
 	const calcStockQty = (item, value) => {


### PR DESCRIPTION
## Summary
- replace deep invoice item watchers with a compact signature-driven watcher so only offer-relevant changes trigger recalculation
- add reusable helpers that build and refresh offer signatures and wire them into add/remove/qty/discount/UOM flows to keep offers accurate without excess churn

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce644ad63883269fdf3d85e5a9e9c5