### PR TITLE
refactor: close payments on item mutations

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -3,13 +3,12 @@
 export default {
         // Calculate total quantity of all items
         total_qty() {
-                this.close_payments();
                 let qty = 0;
-		this.items.forEach((item) => {
-			qty += flt(item.qty);
-		});
-		return this.flt(qty, this.float_precision);
-	},
+                this.items.forEach((item) => {
+                        qty += flt(item.qty);
+                });
+                return this.flt(qty, this.float_precision);
+        },
 	// Calculate total amount for all items (handles returns)
 	Total() {
 		let sum = 0;
@@ -21,14 +20,13 @@ export default {
 		});
 		return this.flt(sum, this.currency_precision);
 	},
-	// Calculate subtotal after discounts and delivery charges
-	subtotal() {
-		this.close_payments();
-		let sum = 0;
-		this.items.forEach((item) => {
-			// For returns, use absolute value for correct calculation
-			const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
-			const rate = flt(item.rate);
+        // Calculate subtotal after discounts and delivery charges
+        subtotal() {
+                let sum = 0;
+                this.items.forEach((item) => {
+                        // For returns, use absolute value for correct calculation
+                        const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
+                        const rate = flt(item.rate);
 			sum += qty * rate;
 		});
 

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -24,6 +24,9 @@ const { calcUom, calcStockQty } = useStockUtils();
 export default {
         remove_item(item) {
                 const result = removeItem(item, this);
+                if (typeof this.close_payments === "function") {
+                        this.close_payments();
+                }
                 if (typeof this.refreshOfferSignatures === "function") {
                         this.refreshOfferSignatures();
                 }
@@ -32,6 +35,9 @@ export default {
 
         async add_item(item) {
                 const res = await addItem(item, this);
+                if (typeof this.close_payments === "function") {
+                        this.close_payments();
+                }
                 const target = this.items.find(
                         (it) =>
                                 it.item_code === item.item_code &&
@@ -55,6 +61,9 @@ export default {
 	// Reset all invoice fields to default/empty values
         clear_invoice() {
                 const result = clearInvoice(this);
+                if (typeof this.close_payments === "function") {
+                        this.close_payments();
+                }
                 if (typeof this.refreshOfferSignatures === "function") {
                         this.refreshOfferSignatures();
                 }

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -54,10 +54,13 @@ export default {
 
                 this.scheduleOffersRefresh();
         },
-	// Watch for invoice type change and emit
-	invoiceType() {
-		this.eventBus.emit("update_invoice_type", this.invoiceType);
-	},
+        // Watch for invoice type change and emit
+        invoiceType() {
+                if (typeof this.close_payments === "function") {
+                        this.close_payments();
+                }
+                this.eventBus.emit("update_invoice_type", this.invoiceType);
+        },
 	// Watch for additional discount and update percentage accordingly
 	additional_discount() {
 		if (!this.additional_discount || this.additional_discount == 0) {


### PR DESCRIPTION
## Summary
- keep invoice total quantity and subtotal computed properties pure by removing payment dialog side effects
- close the payment dialog only after item additions/removals and full invoice clears where structural changes occur
- ensure invoice type switches also close the dialog without relying on computed re-evaluation

## Testing
- yarn lint *(fails: Command "lint" not found.)*

------
https://chatgpt.com/codex/tasks/task_e_68ce73d193ec83269cd8b83d11c06ece