### PR TITLE
Ensure item search refocuses after invoice actions

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -5042,12 +5042,12 @@ export default {
 		});
 	},
 
-	async mounted() {
-		// Ensure POS profile is available
-		if (!this.pos_profile || !this.pos_profile.name) {
-			try {
-				// Try to get from global frappe context
-				if (frappe.boot && frappe.boot.pos_profile) {
+        async mounted() {
+                // Ensure POS profile is available
+                if (!this.pos_profile || !this.pos_profile.name) {
+                        try {
+                                // Try to get from global frappe context
+                                if (frappe.boot && frappe.boot.pos_profile) {
 					this.pos_profile = frappe.boot.pos_profile;
 				} else if (window.cur_pos && window.cur_pos.pos_profile) {
 					this.pos_profile = window.cur_pos.pos_profile;
@@ -5063,16 +5063,19 @@ export default {
 			await this.get_items();
 		}
 
-		// Setup barcode scanner if enabled
-		if (this.pos_profile?.posa_enable_barcode_scanning) {
-			this.scan_barcoud();
-		}
+                // Setup barcode scanner if enabled
+                if (this.pos_profile?.posa_enable_barcode_scanning) {
+                        this.scan_barcoud();
+                }
 
-		// Apply the configured items per page on mount
-		this.itemsPerPage = this.items_per_page;
-		window.addEventListener("resize", this.checkItemContainerOverflow);
-		this.$nextTick(this.checkItemContainerOverflow);
-	},
+                // Apply the configured items per page on mount
+                this.itemsPerPage = this.items_per_page;
+                window.addEventListener("resize", this.checkItemContainerOverflow);
+                this.$nextTick(this.checkItemContainerOverflow);
+
+                // Ensure the item search is ready for immediate input
+                this.focusItemSearch();
+        },
 
         beforeUnmount() {
                 // Clear interval when component is destroyed

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -254,13 +254,16 @@ export default {
 			this.eventBus.emit("set_pos_coupons", data.posa_coupons);
 		}
 
-		console.log("load_invoice completed, invoice state:", {
-			invoiceType: this.invoiceType,
-			is_return: this.invoice_doc.is_return,
-			items: this.items.length,
-			customer: this.customer,
-		});
-	},
+                console.log("load_invoice completed, invoice state:", {
+                        invoiceType: this.invoiceType,
+                        is_return: this.invoice_doc.is_return,
+                        items: this.items.length,
+                        customer: this.customer,
+                });
+
+                await this.$nextTick();
+                this.eventBus.emit("focus_item_search");
+        },
 
 	// Save and clear the current invoice (draft logic)
 	save_and_clear_invoice() {


### PR DESCRIPTION
## Summary
- focus the item selector search box when the component mounts to speed up item entry
- refocus the item search after invoices are loaded from drafts so users can immediately scan or type items

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce7713152c832687099a0bf17847f4