### PR TITLE
Ensure item search refocus after POS actions

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -5064,15 +5064,16 @@ export default {
 		}
 
 		// Setup barcode scanner if enabled
-		if (this.pos_profile?.posa_enable_barcode_scanning) {
-			this.scan_barcoud();
-		}
+                if (this.pos_profile?.posa_enable_barcode_scanning) {
+                        this.scan_barcoud();
+                }
 
-		// Apply the configured items per page on mount
-		this.itemsPerPage = this.items_per_page;
-		window.addEventListener("resize", this.checkItemContainerOverflow);
-		this.$nextTick(this.checkItemContainerOverflow);
-	},
+                // Apply the configured items per page on mount
+                this.itemsPerPage = this.items_per_page;
+                window.addEventListener("resize", this.checkItemContainerOverflow);
+                this.$nextTick(this.checkItemContainerOverflow);
+                this.focusItemSearch();
+        },
 
         beforeUnmount() {
                 // Clear interval when component is destroyed

--- a/frontend/src/posapp/components/pos/Pos.vue
+++ b/frontend/src/posapp/components/pos/Pos.vue
@@ -150,11 +150,16 @@ export default {
 					this.get_offers(data.pos_profile.name, data.pos_profile);
 				}
 			});
-			this.eventBus.on("show_payment", (data) => {
-				this.payment = data === "true";
-				this.showOffers = false;
-				this.coupons = false;
-			});
+                        this.eventBus.on("show_payment", (data) => {
+                                this.payment = data === "true";
+                                this.showOffers = false;
+                                this.coupons = false;
+                                if (data !== "true") {
+                                        this.$nextTick(() => {
+                                                this.eventBus.emit("focus_item_search");
+                                        });
+                                }
+                        });
 			this.eventBus.on("show_offers", (data) => {
 				this.showOffers = data === "true";
 				this.payment = false;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -254,13 +254,17 @@ export default {
 			this.eventBus.emit("set_pos_coupons", data.posa_coupons);
 		}
 
-		console.log("load_invoice completed, invoice state:", {
-			invoiceType: this.invoiceType,
-			is_return: this.invoice_doc.is_return,
-			items: this.items.length,
-			customer: this.customer,
-		});
-	},
+                console.log("load_invoice completed, invoice state:", {
+                        invoiceType: this.invoiceType,
+                        is_return: this.invoice_doc.is_return,
+                        items: this.items.length,
+                        customer: this.customer,
+                });
+
+                this.$nextTick(() => {
+                        this.eventBus.emit("focus_item_search");
+                });
+        },
 
 	// Save and clear the current invoice (draft logic)
 	save_and_clear_invoice() {
@@ -1317,9 +1321,12 @@ export default {
 	},
 
 	// Close payment dialog
-	close_payments() {
-		this.eventBus.emit("show_payment", "false");
-	},
+        close_payments() {
+                this.eventBus.emit("show_payment", "false");
+                this.$nextTick(() => {
+                        this.eventBus.emit("focus_item_search");
+                });
+        },
 
 	// Update details for all items (fetch from backend)
 	async update_items_details(items) {


### PR DESCRIPTION
## Summary
- focus the item selector search box whenever the POS screen mounts so users can start scanning immediately
- automatically return focus to the search field after closing payments or loading invoices/drafts
- trigger search focus when payments view is dismissed to streamline cancel, save & clear, and escape flows

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7713152c832687099a0bf17847f4