### PR TITLE
Limit auto item addition to numeric codes of eight or more digits

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -760,9 +760,15 @@ export default {
 		},
 		// Automatically search when the query has at least 3 characters
                 first_search: _.debounce(function (val, oldVal) {
-                        const newLen = (val || "").trim().length;
-                        const oldLen = (oldVal || "").trim().length;
-                        if (newLen >= 3) {
+                        const trimmedNew = (val || "").trim();
+                        const trimmedOld = (oldVal || "").trim();
+                        const newLen = trimmedNew.length;
+                        const oldLen = trimmedOld.length;
+                        const isNumericSearch = newLen > 0 && /^\d+$/.test(trimmedNew);
+                        const meetsAutoSearchThreshold =
+                                newLen >= 3 && (!isNumericSearch || newLen >= 8);
+
+                        if (meetsAutoSearchThreshold) {
                                 // Call without arguments so search_onchange treats it like an Enter key
                                 this.search_onchange();
                         } else if (oldLen >= 3 && newLen === 0) {


### PR DESCRIPTION
## Summary
- prevent the item selector's auto-search watcher from running for purely numeric queries shorter than eight digits
- keep existing behaviour for alphanumeric searches while still auto adding long barcode scans

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce7e947e80832697ddd4ec6def995f