### PR TITLE
Keep offers and coupons panels open until explicitly closed

### DIFF
--- a/frontend/src/posapp/components/pos/Pos.vue
+++ b/frontend/src/posapp/components/pos/Pos.vue
@@ -161,15 +161,33 @@ export default {
                                 }
                         });
 			this.eventBus.on("show_offers", (data) => {
-				this.showOffers = data === "true";
-				this.payment = false;
-				this.coupons = false;
-			});
-			this.eventBus.on("show_coupons", (data) => {
-				this.coupons = data === "true";
-				this.showOffers = false;
-				this.payment = false;
-			});
+                                const isTrue = data === true || data === "true";
+                                const isFalse = data === false || data === "false";
+
+                                if (isTrue) {
+                                        this.showOffers = true;
+                                        this.payment = false;
+                                        this.coupons = false;
+                                } else if (isFalse) {
+                                        this.showOffers = false;
+                                        this.payment = false;
+                                        this.coupons = false;
+                                }
+                        });
+                        this.eventBus.on("show_coupons", (data) => {
+                                const isTrue = data === true || data === "true";
+                                const isFalse = data === false || data === "false";
+
+                                if (isTrue) {
+                                        this.coupons = true;
+                                        this.showOffers = false;
+                                        this.payment = false;
+                                } else if (isFalse) {
+                                        this.coupons = false;
+                                        this.showOffers = false;
+                                        this.payment = false;
+                                }
+                        });
 			this.eventBus.on("open_closing_dialog", () => {
 				this.get_closing_data();
 			});


### PR DESCRIPTION
## Summary
- update the POS view event handlers to only toggle offer and coupon panels when an explicit true/false signal is received
- prevent automatic closing of the offer and coupon pages while applying or removing entries so they stay open until the back button is pressed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce96fbcae083268b6d0ec2c661c02a