### PR TITLE
Fix merged hardware scan normalization fallback

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2747,38 +2747,86 @@ export default {
                                 trimmed.startsWith(this.currentHardwareScan.code) &&
                                 trimmed.length > this.currentHardwareScan.code.length;
 
-                        let normalizedCodes = this.normalizeHardwareScanPayload(trimmed);
-                        const normalizationMeta = this.lastCompositeNormalization || {};
+                       let normalizedCodes = this.normalizeHardwareScanPayload(trimmed);
+                       const normalizationMeta = this.lastCompositeNormalization || {};
 
-                        if (shouldStripActivePrefix) {
-                                const activeCode = this.currentHardwareScan.code;
-                                if (normalizedCodes.length) {
-                                        if (normalizedCodes[0] === activeCode) {
-                                                normalizedCodes = normalizedCodes.slice(1);
-                                        } else if (
-                                                normalizedCodes.length === 1 &&
-                                                normalizedCodes[0] === trimmed &&
-                                                trimmed.startsWith(activeCode)
-                                        ) {
-                                                const remainder = trimmed.slice(activeCode.length).trim();
-                                                if (remainder) {
-                                                        let fallbackCodes = this.normalizeHardwareScanPayload(remainder);
-                                                        if (!Array.isArray(fallbackCodes)) {
-                                                                fallbackCodes = [];
-                                                        }
-                                                        fallbackCodes = fallbackCodes
-                                                                .map((code) => (typeof code === "string" ? code.trim() : ""))
-                                                                .filter(Boolean);
-                                                        if (!fallbackCodes.length) {
-                                                                fallbackCodes = [remainder];
-                                                        }
-                                                        normalizedCodes = fallbackCodes;
-                                                } else {
-                                                        normalizedCodes = [];
-                                                }
-                                        }
-                                }
-                        }
+                       if (shouldStripActivePrefix) {
+                               const activeCode = this.currentHardwareScan.code;
+                               const coerceCode = (value) => (typeof value === "string" ? value.trim() : "");
+                               let workingCodes = Array.isArray(normalizedCodes)
+                                       ? normalizedCodes.map(coerceCode).filter(Boolean)
+                                       : [];
+
+                               while (workingCodes.length && workingCodes[0] === activeCode) {
+                                       workingCodes.shift();
+                               }
+
+                               const remainderFromTrimmed = trimmed.slice(activeCode.length).trim();
+                               const fallbackSources = [];
+
+                               if (workingCodes.length) {
+                                       const firstCandidate = workingCodes[0];
+                                       if (
+                                               typeof firstCandidate === "string" &&
+                                               firstCandidate.startsWith(activeCode) &&
+                                               firstCandidate.length > activeCode.length
+                                       ) {
+                                               const extractedRemainder = firstCandidate.slice(activeCode.length).trim();
+                                               if (extractedRemainder) {
+                                                       fallbackSources.push(extractedRemainder);
+                                               }
+                                               workingCodes.shift();
+                                       }
+                               } else if (remainderFromTrimmed) {
+                                       fallbackSources.push(remainderFromTrimmed);
+                               }
+
+                               if (workingCodes.length === 1 && workingCodes[0] === trimmed) {
+                                       workingCodes = [];
+                                       if (remainderFromTrimmed) {
+                                               fallbackSources.push(remainderFromTrimmed);
+                                       }
+                               }
+
+                               const sanitizedCodes = [];
+                               const seenFallbacks = new Set();
+
+                               fallbackSources.forEach((source) => {
+                                       const key = typeof source === "string" ? source : "";
+                                       if (!key || seenFallbacks.has(key)) {
+                                               return;
+                                       }
+                                       seenFallbacks.add(key);
+
+                                       let fallbackCodes = this.normalizeHardwareScanPayload(key);
+                                       if (!Array.isArray(fallbackCodes) || !fallbackCodes.length) {
+                                               fallbackCodes = [key];
+                                       }
+
+                                       const prepared = fallbackCodes
+                                               .map(coerceCode)
+                                               .filter(
+                                                       (code) =>
+                                                               code && code !== trimmed && code !== activeCode,
+                                               );
+
+                                       if (prepared.length) {
+                                               sanitizedCodes.push(...prepared);
+                                       }
+                               });
+
+                               const remaining = workingCodes.filter(
+                                       (code) => code !== trimmed && code !== activeCode,
+                               );
+
+                               normalizedCodes = [...sanitizedCodes, ...remaining];
+                       }
+
+                       normalizedCodes = Array.isArray(normalizedCodes)
+                               ? normalizedCodes
+                                        .map((code) => (typeof code === "string" ? code.trim() : ""))
+                                        .filter(Boolean)
+                               : [];
 
                         if (!normalizedCodes.length) {
                                 if (

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2750,10 +2750,33 @@ export default {
                         let normalizedCodes = this.normalizeHardwareScanPayload(trimmed);
                         const normalizationMeta = this.lastCompositeNormalization || {};
 
-                        if (shouldStripActivePrefix && normalizedCodes.length) {
+                        if (shouldStripActivePrefix) {
                                 const activeCode = this.currentHardwareScan.code;
-                                if (normalizedCodes[0] === activeCode) {
-                                        normalizedCodes = normalizedCodes.slice(1);
+                                if (normalizedCodes.length) {
+                                        if (normalizedCodes[0] === activeCode) {
+                                                normalizedCodes = normalizedCodes.slice(1);
+                                        } else if (
+                                                normalizedCodes.length === 1 &&
+                                                normalizedCodes[0] === trimmed &&
+                                                trimmed.startsWith(activeCode)
+                                        ) {
+                                                const remainder = trimmed.slice(activeCode.length).trim();
+                                                if (remainder) {
+                                                        let fallbackCodes = this.normalizeHardwareScanPayload(remainder);
+                                                        if (!Array.isArray(fallbackCodes)) {
+                                                                fallbackCodes = [];
+                                                        }
+                                                        fallbackCodes = fallbackCodes
+                                                                .map((code) => (typeof code === "string" ? code.trim() : ""))
+                                                                .filter(Boolean);
+                                                        if (!fallbackCodes.length) {
+                                                                fallbackCodes = [remainder];
+                                                        }
+                                                        normalizedCodes = fallbackCodes;
+                                                } else {
+                                                        normalizedCodes = [];
+                                                }
+                                        }
                                 }
                         }
 

--- a/scripts/testMergedScan.js
+++ b/scripts/testMergedScan.js
@@ -1,0 +1,174 @@
+const path = require('path');
+const fs = require('fs');
+const vm = require('vm');
+const { parse } = require('@vue/compiler-sfc');
+
+const filePath = path.join(__dirname, '..', 'frontend/src/posapp/components/pos/ItemsSelector.vue');
+const source = fs.readFileSync(filePath, 'utf8');
+const { descriptor } = parse(source, { filename: filePath });
+
+if (!descriptor || !descriptor.script || !descriptor.script.content) {
+  throw new Error('Unable to extract script content from ItemsSelector.vue');
+}
+
+const scriptContent = descriptor.script.content;
+const cleaned = scriptContent
+  .replace(/^import[^;]+;\n/gm, '')
+  .replace(/export default/, 'module.exports =');
+
+const stubbedPreamble = `
+const format = {};
+const _ = require('lodash');
+const ensurePosProfile = async () => ({});
+const CameraScanner = {};
+const useResponsive = () => ({ responsiveStyles: {}, rtlClasses: '' });
+const useRtl = () => ({ rtlClasses: '' });
+const useFlyAnimation = () => ({ fly: () => {} });
+const placeholderImage = '';
+const Skeleton = {};
+const saveItemUOMs = () => {};
+const getItemUOMs = () => Promise.resolve([]);
+const getLocalStock = () => Promise.resolve([]);
+const isOffline = () => false;
+const getStoredItemsCount = () => Promise.resolve(0);
+const initializeStockCache = () => Promise.resolve();
+const searchStoredItems = () => Promise.resolve([]);
+const saveItemsBulk = () => Promise.resolve();
+const saveItems = () => Promise.resolve();
+const clearStoredItems = () => Promise.resolve();
+const getLocalStockCache = () => Promise.resolve([]);
+const setLocalStockCache = () => Promise.resolve();
+const initPromise = Promise.resolve();
+const memoryInitPromise = Promise.resolve();
+const checkDbHealth = () => Promise.resolve(true);
+const getCachedPriceListItems = () => Promise.resolve([]);
+const savePriceListItems = () => Promise.resolve();
+const clearPriceListCache = () => Promise.resolve();
+const updateLocalStockCache = () => Promise.resolve();
+const isStockCacheReady = () => Promise.resolve(true);
+const getCachedItemDetails = () => Promise.resolve(null);
+const saveItemDetailsCache = () => Promise.resolve();
+const saveItemGroups = () => Promise.resolve();
+const getCachedItemGroups = () => Promise.resolve([]);
+const getItemsLastSync = () => Promise.resolve(null);
+const setItemsLastSync = () => Promise.resolve();
+const forceClearAllCache = () => Promise.resolve();
+`;
+
+const moduleCode = `${stubbedPreamble}\n${cleaned}`;
+
+const sandbox = {
+  module: { exports: {} },
+  exports: {},
+  require,
+  console,
+  setTimeout,
+  clearTimeout,
+  Intl,
+  __: (value) => value,
+  frappe: {
+    __: (value) => value,
+    call: () => Promise.resolve(),
+    msgprint: () => {},
+  },
+};
+
+sandbox.global = sandbox;
+sandbox.window = {};
+sandbox.document = {};
+sandbox.navigator = {};
+
+vm.createContext(sandbox);
+
+try {
+  const script = new vm.Script(moduleCode, { filename: 'ItemsSelector.js' });
+  script.runInContext(sandbox);
+} catch (error) {
+  console.error('Failed to evaluate component script:', error);
+  process.exit(1);
+}
+
+const component = sandbox.module.exports;
+if (!component) {
+  throw new Error('Component export not found');
+}
+
+const data = typeof component.data === 'function' ? component.data() : {};
+const instance = { ...data };
+instance.__ = sandbox.__;
+instance.frappe = sandbox.frappe;
+
+const handledCodes = [];
+const enqueuedCodes = [];
+const failures = [];
+
+const bindMethod = (name, fn) => {
+  if (typeof fn === 'function') {
+    instance[name] = function boundMethod(...args) {
+      return fn.apply(instance, args);
+    };
+  }
+};
+
+if (component.methods && typeof component.methods === 'object') {
+  Object.entries(component.methods).forEach(([name, fn]) => {
+    bindMethod(name, fn);
+  });
+}
+
+instance.notifyHardwareScanFailure = function (code, payload) {
+  failures.push({ code, payload });
+};
+
+instance.playScanTone = () => {};
+
+instance.processHardwareScanQueue = function () {
+  while (this.hardwareScanQueue.length) {
+    const next = this.hardwareScanQueue.shift();
+    if (next && next.code) {
+      enqueuedCodes.push(next.code);
+    }
+    this.handleHardwareScan(next);
+  }
+};
+
+instance.handleHardwareScan = async function ({ code }) {
+  handledCodes.push(code);
+  return true;
+};
+
+instance.getCompositeBarcodeLengthFailureDetails = () => 'stub';
+
+instance.splitRepeatedScanSegment = function (segment) {
+  return segment ? [segment] : [];
+};
+instance.splitSegmentBySequentialStandardLengths = () => null;
+instance.splitSegmentByKnownCodes = () => null;
+instance.splitSegmentByHintedLengths = () => null;
+instance.splitSegmentByProgressiveBarcodeTypes = () => null;
+
+instance.scanErrorDialog = false;
+instance.processingHardwareScan = true;
+instance.currentHardwareScan = { code: 'ABC123' };
+instance.lastCompositeNormalization = { attempted: false, success: false, reason: '' };
+
+instance.trigger_onscan('ABC123XYZ456');
+
+if (!enqueuedCodes.length) {
+  throw new Error('No codes were enqueued by trigger_onscan');
+}
+
+console.log('Enqueued codes:', enqueuedCodes);
+console.log('Handled codes:', handledCodes);
+console.log('Failures:', failures);
+
+if (handledCodes.includes('ABC123XYZ456')) {
+  throw new Error('Combined payload was processed by handleHardwareScan');
+}
+
+if (!enqueuedCodes.includes('XYZ456')) {
+  throw new Error('Expected remainder barcode to be enqueued');
+}
+
+console.log('Merged scan fallback behaved as expected.');
+

--- a/scripts/testMergedScan.js
+++ b/scripts/testMergedScan.js
@@ -152,23 +152,57 @@ instance.processingHardwareScan = true;
 instance.currentHardwareScan = { code: 'ABC123' };
 instance.lastCompositeNormalization = { attempted: false, success: false, reason: '' };
 
+const resetTracking = () => {
+  handledCodes.length = 0;
+  enqueuedCodes.length = 0;
+  failures.length = 0;
+};
+
+const logScenario = (label) => {
+  console.log(`\nScenario: ${label}`);
+  console.log('Enqueued codes:', [...enqueuedCodes]);
+  console.log('Handled codes:', [...handledCodes]);
+  console.log('Failures:', [...failures]);
+};
+
+resetTracking();
 instance.trigger_onscan('ABC123XYZ456');
 
 if (!enqueuedCodes.length) {
-  throw new Error('No codes were enqueued by trigger_onscan');
+  throw new Error('No codes were enqueued by trigger_onscan (single remainder)');
 }
 
-console.log('Enqueued codes:', enqueuedCodes);
-console.log('Handled codes:', handledCodes);
-console.log('Failures:', failures);
+logScenario('single remainder barcode');
 
 if (handledCodes.includes('ABC123XYZ456')) {
-  throw new Error('Combined payload was processed by handleHardwareScan');
+  throw new Error('Combined payload was processed by handleHardwareScan for single remainder');
 }
 
 if (!enqueuedCodes.includes('XYZ456')) {
-  throw new Error('Expected remainder barcode to be enqueued');
+  throw new Error('Expected remainder barcode to be enqueued for single remainder');
 }
 
-console.log('Merged scan fallback behaved as expected.');
+if (failures.length) {
+  throw new Error('Unexpected failure reported for single remainder');
+}
+
+resetTracking();
+
+instance.trigger_onscan('ABC123XYZ456 LMN789');
+
+if (handledCodes.includes('ABC123XYZ456 LMN789') || handledCodes.includes('ABC123XYZ456')) {
+  throw new Error('Merged payload should not reach handleHardwareScan for multi remainder');
+}
+
+logScenario('multiple remainder barcodes');
+
+if (!enqueuedCodes.includes('XYZ456') || !enqueuedCodes.includes('LMN789')) {
+  throw new Error('Expected both remainder barcodes to be enqueued for multi remainder');
+}
+
+if (failures.length) {
+  throw new Error('Unexpected failure reported for multi remainder');
+}
+
+console.log('\nMerged scan fallback behaved as expected for both scenarios.');
 


### PR DESCRIPTION
## Summary
- add a manual fallback in `trigger_onscan` so merged payloads are re-normalized after stripping the active prefix
- avoid re-enqueuing the merged payload and push each remainder barcode individually
- add a node script that simulates the merged scan scenario to confirm the queue contents and handler behavior

## Testing
- node scripts/testMergedScan.js

------
https://chatgpt.com/codex/tasks/task_e_68d0cf4667548326ae57f269b3db1b53