### PR TITLE
feat: add barcode candidate parser

### DIFF
--- a/frontend/src/utils/__tests__/barcode.spec.ts
+++ b/frontend/src/utils/__tests__/barcode.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isValidEAN13, isValidEAN8, isValidUPCA } from "@/utils/barcode";
+import { isValidEAN13, isValidEAN8, isValidUPCA, parseCandidate } from "@/utils/barcode";
 
 describe("barcode checksum validators", () => {
         describe("isValidEAN13", () => {
@@ -50,6 +50,42 @@ describe("barcode checksum validators", () => {
                         expect(isValidUPCA("03600029145")).toBe(false);
                         expect(isValidUPCA("0360002914520")).toBe(false);
                         expect(isValidUPCA("03600029145A")).toBe(false);
+                });
+        });
+});
+
+describe("parseCandidate", () => {
+        it("classifies known barcode types", () => {
+                expect(parseCandidate("4006381333931")).toEqual({
+                        type: "EAN13",
+                        value: "4006381333931",
+                        valid: true,
+                });
+                expect(parseCandidate("036000291452")).toEqual({
+                        type: "UPCA",
+                        value: "036000291452",
+                        valid: true,
+                });
+                expect(parseCandidate("55123457")).toEqual({
+                        type: "EAN8",
+                        value: "55123457",
+                        valid: true,
+                });
+        });
+
+        it("flags invalid checksum for matched symbology", () => {
+                expect(parseCandidate("036000291453")).toEqual({
+                        type: "UPCA",
+                        value: "036000291453",
+                        valid: false,
+                });
+        });
+
+        it("falls back to RAW for non-numeric input", () => {
+                expect(parseCandidate("ABC123")).toEqual({
+                        type: "RAW",
+                        value: "ABC123",
+                        valid: false,
                 });
         });
 });

--- a/frontend/src/utils/barcode.ts
+++ b/frontend/src/utils/barcode.ts
@@ -31,6 +31,32 @@ function extractCheckDigit(value: string): number {
         return charCodeToDigit(value.charCodeAt(value.length - 1));
 }
 
+export type BarcodeSymbology = "EAN13" | "UPCA" | "EAN8";
+
+export type BarcodeParseResult = {
+        type: BarcodeSymbology | "RAW";
+        value: string;
+        valid: boolean;
+};
+
+type ParseCandidateOptions = {
+        tryOrder?: BarcodeSymbology[];
+};
+
+const DEFAULT_TRY_ORDER: BarcodeSymbology[] = ["EAN13", "UPCA", "EAN8"];
+
+const EXPECTED_LENGTH: Record<BarcodeSymbology, number> = {
+        EAN13: 13,
+        UPCA: 12,
+        EAN8: 8,
+};
+
+const VALIDATORS: Record<BarcodeSymbology, (value: string) => boolean> = {
+        EAN13: isValidEAN13,
+        UPCA: isValidUPCA,
+        EAN8: isValidEAN8,
+};
+
 export function isValidEAN13(value: string): boolean {
         if (!isDigits(value, 13)) {
                 return false;
@@ -53,4 +79,30 @@ export function isValidUPCA(value: string): boolean {
         }
         const expected = computeModulo10(value.slice(0, 11), (index) => (index % 2 === 0 ? 3 : 1));
         return expected === extractCheckDigit(value);
+}
+
+export function parseCandidate(
+        raw: string,
+        options: ParseCandidateOptions = {}
+): BarcodeParseResult {
+        const normalized = raw.trim();
+        const { tryOrder = DEFAULT_TRY_ORDER } = options;
+
+        if (!DIGIT_PATTERN.test(normalized)) {
+                return { type: "RAW", value: normalized, valid: false };
+        }
+
+        for (const type of tryOrder) {
+                const expectedLength = EXPECTED_LENGTH[type];
+                if (expectedLength === normalized.length) {
+                        const validator = VALIDATORS[type];
+                        return {
+                                type,
+                                value: normalized,
+                                valid: validator(normalized),
+                        };
+                }
+        }
+
+        return { type: "RAW", value: normalized, valid: false };
 }


### PR DESCRIPTION
## Summary
- add a parseCandidate helper that classifies numeric barcodes using checksum validators with RAW fallback
- expose parser typing for EAN-13, UPC-A and EAN-8 symbologies
- extend barcode unit tests to cover parser behaviour and checksum validation scenarios

## Testing
- yarn test barcode

------
https://chatgpt.com/codex/tasks/task_e_68d1041b66a08326a0f047cfeda149a9