### PR TITLE
feat: add scan queue composable

### DIFF
--- a/frontend/src/posapp/composables/__tests__/useScanQueue.spec.ts
+++ b/frontend/src/posapp/composables/__tests__/useScanQueue.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { nextTick } from "vue";
+import { useScanQueue } from "../useScanQueue";
+
+describe("useScanQueue", () => {
+        it("processes enqueued scans sequentially without dropping any", async () => {
+                const queue = useScanQueue();
+                const processed: string[] = [];
+
+                queue.onDequeue((scan) => {
+                        processed.push(scan);
+                });
+
+                queue.start();
+
+                const enqueued = Array.from({ length: 100 }, (_, index) => `scan-${index}`);
+                enqueued.forEach((scan) => queue.enqueue(scan));
+
+                let attempts = 0;
+                while (processed.length < enqueued.length && attempts < 200) {
+                        attempts += 1;
+                        await nextTick();
+                        await new Promise((resolve) => setTimeout(resolve, 0));
+                }
+
+                expect(processed).toEqual(enqueued);
+                expect(queue.size()).toBe(0);
+        });
+});

--- a/frontend/src/posapp/composables/useScanQueue.ts
+++ b/frontend/src/posapp/composables/useScanQueue.ts
@@ -1,0 +1,84 @@
+import { nextTick, ref } from "vue";
+
+type ScanCallback = (scan: string) => void;
+
+export function useScanQueue() {
+        const queue: string[] = [];
+        const callbacks = new Set<ScanCallback>();
+        const sizeRef = ref(0);
+        let active = false;
+        let processing = false;
+
+        async function processQueue() {
+                if (processing) {
+                        return;
+                }
+                processing = true;
+                try {
+                        while (active && queue.length > 0) {
+                                const scan = queue.shift();
+                                sizeRef.value = queue.length;
+                                if (typeof scan === "undefined") {
+                                        continue;
+                                }
+
+                                callbacks.forEach((callback) => {
+                                        try {
+                                                callback(scan);
+                                        } catch (error) {
+                                                console.error("useScanQueue callback failed", error);
+                                        }
+                                });
+
+                                if (queue.length > 0) {
+                                        await nextTick();
+                                }
+                        }
+                } finally {
+                        processing = false;
+                        if (active && queue.length > 0) {
+                                void processQueue();
+                        }
+                }
+        }
+
+        function enqueue(scan: string) {
+                queue.push(scan);
+                sizeRef.value = queue.length;
+                if (active) {
+                        void processQueue();
+                }
+        }
+
+        function onDequeue(callback: ScanCallback) {
+                callbacks.add(callback);
+                return () => {
+                        callbacks.delete(callback);
+                };
+        }
+
+        function start() {
+                if (!active) {
+                        active = true;
+                        if (queue.length > 0) {
+                                void processQueue();
+                        }
+                }
+        }
+
+        function stop() {
+                active = false;
+        }
+
+        function size() {
+                return sizeRef.value;
+        }
+
+        return {
+                enqueue,
+                onDequeue,
+                start,
+                stop,
+                size,
+        };
+}


### PR DESCRIPTION
## Summary
- add a `useScanQueue` composable that serializes scan handling with start/stop controls and next-tick yielding
- cover the queue with a Vitest ensuring 100 FIFO enqueues are delivered without drops

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d10634a014832696b077f84f7d80d3