### PR TITLE
feat(frontend): add in-memory barcode resolver

### DIFF
--- a/frontend/src/utils/__tests__/memoryResolver.spec.ts
+++ b/frontend/src/utils/__tests__/memoryResolver.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { parseCandidate } from "@/utils/barcode";
+import { createMemoryResolver, type MemoryResolverEntry } from "@/utils/memoryResolver";
+
+describe("memoryResolver", () => {
+        const baseMap: Record<string, MemoryResolverEntry> = {
+                "4006381333931": { item_id: "ITEM-001", price: 5.75 },
+                "55123457": { item_id: "ITEM-002", uom: "Box", pack_size: 10 },
+        };
+
+        let resolver = createMemoryResolver({ normalizeUpcToEan13: false });
+
+        beforeEach(() => {
+                resolver = createMemoryResolver({ normalizeUpcToEan13: false });
+                resolver.load(baseMap);
+        });
+
+        it("resolves known barcodes from the loaded map", () => {
+                const parsed = parseCandidate("4006381333931");
+                const result = resolver.resolve(parsed);
+                expect(result).toEqual({
+                        found: true,
+                        item: {
+                                item_id: "ITEM-001",
+                                price: 5.75,
+                                barcode: "4006381333931",
+                                resolvedBarcode: "4006381333931",
+                                symbology: "EAN13",
+                        },
+                });
+        });
+
+        it("keeps optional UOM metadata in the result", () => {
+                const parsed = parseCandidate("55123457");
+                const result = resolver.resolve(parsed);
+                expect(result).toEqual({
+                        found: true,
+                        item: {
+                                item_id: "ITEM-002",
+                                uom: "Box",
+                                pack_size: 10,
+                                barcode: "55123457",
+                                resolvedBarcode: "55123457",
+                                symbology: "EAN8",
+                        },
+                });
+        });
+
+        it("returns NOT_FOUND when lookup fails", () => {
+                const parsed = parseCandidate("9780201379624");
+                const result = resolver.resolve(parsed);
+                expect(result).toEqual({ found: false, reason: "NOT_FOUND" });
+        });
+
+        it("returns NOT_NUMERIC for raw non-digit input", () => {
+                const parsed = parseCandidate("HELLO");
+                const result = resolver.resolve(parsed);
+                expect(result).toEqual({ found: false, reason: "NOT_NUMERIC" });
+        });
+
+        it("returns INVALID_CHECKSUM when checksum fails", () => {
+                const parsed = parseCandidate("036000291453");
+                const result = resolver.resolve(parsed);
+                expect(result).toEqual({ found: false, reason: "INVALID_CHECKSUM" });
+        });
+
+        it("normalizes UPC-A to EAN-13 when configured", () => {
+                const withNormalization = createMemoryResolver({ normalizeUpcToEan13: true });
+                withNormalization.load({
+                        "0036000291452": { item_id: "UPC-TO-EAN", price: 2.99 },
+                });
+                const parsed = parseCandidate("036000291452");
+                const result = withNormalization.resolve(parsed);
+                expect(result).toEqual({
+                        found: true,
+                        item: {
+                                item_id: "UPC-TO-EAN",
+                                price: 2.99,
+                                barcode: "036000291452",
+                                resolvedBarcode: "0036000291452",
+                                symbology: "UPCA",
+                        },
+                });
+        });
+
+        it("allows updating config from POS settings shape", () => {
+                const parsed = parseCandidate("036000291452");
+                const resultBefore = resolver.resolve(parsed);
+                expect(resultBefore).toEqual({ found: false, reason: "NOT_FOUND" });
+
+                resolver.load({
+                        "0036000291452": { item_id: "CONFIG-UPC" },
+                });
+
+                resolver.configureFromSettings({ posa_normalize_upc_to_ean13: 1 });
+                const resultAfter = resolver.resolve(parsed);
+                expect(resultAfter).toEqual({
+                        found: true,
+                        item: {
+                                item_id: "CONFIG-UPC",
+                                barcode: "036000291452",
+                                resolvedBarcode: "0036000291452",
+                                symbology: "UPCA",
+                        },
+                });
+        });
+});

--- a/frontend/src/utils/memoryResolver.ts
+++ b/frontend/src/utils/memoryResolver.ts
@@ -1,0 +1,181 @@
+import type { BarcodeParseResult } from "@/utils/barcode";
+
+const DIGIT_PATTERN = /^\d+$/;
+
+export type MemoryResolverEntry = {
+        item_id: string;
+        uom?: string;
+        pack_size?: number;
+        price?: number;
+};
+
+export type MemoryResolvedItem = MemoryResolverEntry & {
+        /**
+         * Raw code that was provided by the scanner/user.
+         */
+        barcode: string;
+        /**
+         * Code that matched the in-memory map (may differ when normalization is applied).
+         */
+        resolvedBarcode: string;
+        /**
+         * Symbology that parseCandidate detected for the scan attempt.
+         */
+        symbology: BarcodeParseResult["type"];
+};
+
+export type MemoryResolverResult =
+        | { found: true; item: MemoryResolvedItem }
+        | { found: false; reason: "NOT_NUMERIC" | "NOT_FOUND" | "INVALID_CHECKSUM" };
+
+export type MemoryResolverConfig = {
+        normalizeUpcToEan13: boolean;
+};
+
+const DEFAULT_CONFIG: MemoryResolverConfig = {
+        normalizeUpcToEan13: false,
+};
+
+type ConfigSource = {
+        posa_normalize_upc_to_ean13?: unknown;
+        normalize_upc_to_ean13?: unknown;
+        normalizeUpcToEan13?: unknown;
+};
+
+function extractBoolean(value: unknown): boolean | undefined {
+        if (typeof value === "boolean") {
+                return value;
+        }
+        if (typeof value === "number") {
+                return value !== 0;
+        }
+        if (typeof value === "string") {
+                const normalized = value.trim().toLowerCase();
+                if (!normalized) return undefined;
+                if (["1", "true", "yes", "y"].includes(normalized)) {
+                        return true;
+                }
+                if (["0", "false", "no", "n"].includes(normalized)) {
+                        return false;
+                }
+        }
+        return undefined;
+}
+
+function extractFromSource(source: unknown): boolean | undefined {
+        if (!source || typeof source !== "object") {
+                return undefined;
+        }
+        const candidate = source as ConfigSource;
+        const value =
+                candidate.posa_normalize_upc_to_ean13 ??
+                candidate.normalize_upc_to_ean13 ??
+                candidate.normalizeUpcToEan13;
+        return extractBoolean(value);
+}
+
+function deriveInitialConfig(): MemoryResolverConfig {
+        const globalContext = globalThis as { frappe?: { boot?: Record<string, unknown> } };
+        const boot = globalContext.frappe?.boot;
+        const sources = [boot?.pos_profile, boot?.pos_settings, boot?.posa_settings];
+        for (const source of sources) {
+                const derived = extractFromSource(source);
+                if (typeof derived === "boolean") {
+                        return { normalizeUpcToEan13: derived };
+                }
+        }
+        return { ...DEFAULT_CONFIG };
+}
+
+function applySettings(
+        config: MemoryResolverConfig,
+        source: unknown,
+): MemoryResolverConfig {
+        const value = extractFromSource(source);
+        if (typeof value === "boolean") {
+                return { ...config, normalizeUpcToEan13: value };
+        }
+        return config;
+}
+
+export function createMemoryResolver(initial?: Partial<MemoryResolverConfig>) {
+        const state = {
+                config: { ...DEFAULT_CONFIG, ...deriveInitialConfig(), ...initial },
+                table: new Map<string, MemoryResolverEntry>(),
+        };
+
+        function load(barcodeMap: Record<string, MemoryResolverEntry>) {
+                state.table.clear();
+                if (!barcodeMap || typeof barcodeMap !== "object") {
+                        return;
+                }
+                for (const [rawKey, entry] of Object.entries(barcodeMap)) {
+                        const key = String(rawKey ?? "").trim();
+                        if (!key) {
+                                continue;
+                        }
+                        if (!entry || typeof entry !== "object") {
+                                continue;
+                        }
+                        state.table.set(key, { ...entry });
+                }
+        }
+
+        function resolve(parsed: BarcodeParseResult): MemoryResolverResult {
+                const rawValue = parsed.value.trim();
+
+                if (parsed.type === "RAW" && !DIGIT_PATTERN.test(rawValue)) {
+                        return { found: false, reason: "NOT_NUMERIC" };
+                }
+
+                if (parsed.type !== "RAW" && !parsed.valid) {
+                        return { found: false, reason: "INVALID_CHECKSUM" };
+                }
+
+                const candidates: string[] = [rawValue];
+                if (state.config.normalizeUpcToEan13 && parsed.type === "UPCA" && parsed.valid) {
+                        candidates.unshift(`0${rawValue}`);
+                }
+
+                for (const candidate of candidates) {
+                        const hit = state.table.get(candidate);
+                        if (hit) {
+                                return {
+                                        found: true,
+                                        item: {
+                                                ...hit,
+                                                barcode: rawValue,
+                                                resolvedBarcode: candidate,
+                                                symbology: parsed.type,
+                                        },
+                                };
+                        }
+                }
+
+                return { found: false, reason: "NOT_FOUND" };
+        }
+
+        function configure(next: Partial<MemoryResolverConfig>) {
+                if (next && typeof next.normalizeUpcToEan13 === "boolean") {
+                        state.config.normalizeUpcToEan13 = next.normalizeUpcToEan13;
+                }
+        }
+
+        function configureFromSettings(source: unknown) {
+                state.config = applySettings(state.config, source);
+        }
+
+        function getConfig(): MemoryResolverConfig {
+                return { ...state.config };
+        }
+
+        return {
+                load,
+                resolve,
+                configure,
+                configureFromSettings,
+                getConfig,
+        };
+}
+
+export const memoryResolver = createMemoryResolver();


### PR DESCRIPTION
## Summary
- add a reusable memoryResolver utility that stores barcode to item mappings in-memory
- support optional UPC-A to EAN-13 normalization driven by POS settings and expose helper configuration APIs
- cover resolver behavior with Vitest tests for lookups, metadata preservation, and normalization scenarios

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d10816079483268a2874f3c5828aba