### PR TITLE
Refactor scanner search handling in ItemsSelector

### DIFF
--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -18,8 +18,8 @@
 				></v-btn>
 			</v-card-title>
 
-			<v-card-text class="pa-0">
-				<div v-if="!cameraPermissionDenied">
+                        <v-card-text class="pa-0">
+                                <div v-if="!cameraPermissionDenied">
 					<!-- Scanner container -->
 					<div class="scanner-container" v-if="isScanning && scannerDialog">
 						<qrcode-stream
@@ -50,11 +50,11 @@
 					</div>
 
 					<!-- Status messages -->
-					<div class="status-messages pa-3">
-						<v-alert v-if="errorMessage" type="error" variant="tonal" class="mb-2">
-							<v-icon>mdi-alert-circle</v-icon>
-							{{ errorMessage }}
-						</v-alert>
+                                        <div class="status-messages pa-3">
+                                                <v-alert v-if="errorMessage" type="error" variant="tonal" class="mb-2">
+                                                        <v-icon>mdi-alert-circle</v-icon>
+                                                        {{ errorMessage }}
+                                                </v-alert>
 
 						<v-alert v-if="scanResult" type="success" variant="tonal" class="mb-2">
 							{{ __("Successfully scanned:") }} <strong>{{ scanResult }}</strong> <br /><small
@@ -62,25 +62,69 @@
 							>
 						</v-alert>
 
-						<v-alert
-							v-if="!scanResult && !errorMessage && isScanning && scannerDialog"
-							type="info"
-							variant="tonal"
-						>
-							{{ __("Position the QR code or barcode within the scanning area") }}
-							<br /><small>{{ __("Detecting formats:") }} {{ readerFormats.join(", ") }}</small>
-						</v-alert>
-					</div>
-				</div>
+                                                <v-alert
+                                                        v-if="!scanResult && !errorMessage && isScanning && scannerDialog"
+                                                        type="info"
+                                                        variant="tonal"
+                                                >
+                                                        {{ __("Position the QR code or barcode within the scanning area") }}
+                                                        <br /><small>{{ __("Detecting formats:") }} {{ readerFormats.join(", ") }}</small>
+                                                </v-alert>
+                                        </div>
+                                </div>
 
-				<!-- Camera permission denied message -->
-				<div v-else class="pa-4 text-center">
-					<v-icon size="64" color="error">mdi-camera-off</v-icon>
-					<h3 class="mt-2">{{ __("Camera Access Required") }}</h3>
-					<p class="mt-2">{{ __("Please allow camera access to scan codes") }}</p>
-					<!-- Requesting permission is handled by the browser when QrcodeStream tries to access camera -->
-				</div>
-			</v-card-text>
+                                <!-- Camera permission denied message -->
+                                <div v-else class="pa-4 text-center">
+                                        <v-icon size="64" color="error">mdi-camera-off</v-icon>
+                                        <h3 class="mt-2">{{ __("Camera Access Required") }}</h3>
+                                        <p class="mt-2">{{ __("Please allow camera access to scan codes") }}</p>
+                                        <!-- Requesting permission is handled by the browser when QrcodeStream tries to access camera -->
+                                </div>
+                                <div
+                                        v-if="shouldShowManualEntry"
+                                        class="manual-entry pa-4 pt-0"
+                                        data-allow-scanner-input="true"
+                                >
+                                        <v-divider class="my-3"></v-divider>
+                                        <div class="text-subtitle-1 font-weight-medium mb-2">
+                                                {{ __("Manual Entry") }}
+                                        </div>
+                                        <v-alert
+                                                v-if="manualError"
+                                                type="warning"
+                                                variant="tonal"
+                                                density="comfortable"
+                                                class="mb-3"
+                                        >
+                                                <v-icon class="mr-2">mdi-alert</v-icon>
+                                                {{ manualError }}
+                                        </v-alert>
+                                        <v-text-field
+                                                ref="manualInput"
+                                                v-model="manualCode"
+                                                density="comfortable"
+                                                variant="outlined"
+                                                color="primary"
+                                                :label="__('Enter item code or barcode')"
+                                                :hint="__('Use your hardware scanner or keyboard to add items manually')"
+                                                persistent-hint
+                                                hide-details="auto"
+                                                clearable
+                                                @keydown.enter.prevent="submitManualCode"
+                                                @update:model-value="manualError = ''"
+                                                data-allow-scanner-input="true"
+                                        ></v-text-field>
+                                        <v-btn
+                                                class="mt-3"
+                                                color="primary"
+                                                block
+                                                :disabled="!manualCode"
+                                                @click="submitManualCode"
+                                        >
+                                                {{ __("Add Item") }}
+                                        </v-btn>
+                                </div>
+                        </v-card-text>
 
 			<!-- Action buttons -->
 			<v-card-actions class="justify-space-between pa-3">
@@ -209,6 +253,7 @@
 </style>
 
 <script>
+/* global frappe */
 import { QrcodeStream } from "vue-qrcode-reader";
 
 export default {
@@ -224,16 +269,18 @@ export default {
 	},
 
 	data() {
-		return {
-			scannerDialog: false,
-			scanResult: "",
-			scanFormat: "", // We might get this from the 'detect' event payload
-			errorMessage: "",
-			cameraPermissionDenied: false,
-			isScanning: false,
-			torchActive: false,
-			selectedDeviceId: null, // For camera switching
-			cameras: [], // To store available cameras
+                return {
+                        scannerDialog: false,
+                        scanResult: "",
+                        scanFormat: "", // We might get this from the 'detect' event payload
+                        errorMessage: "",
+                        cameraPermissionDenied: false,
+                        isScanning: false,
+                        torchActive: false,
+                        selectedDeviceId: null, // For camera switching
+                        cameras: [], // To store available cameras
+                        manualCode: "",
+                        manualError: "",
 			// Old properties to be removed or re-evaluated:
 			// qrScanner: null,
 			// flashlightSupported: false, // vue-qrcode-reader handles this via QrcodeStream's torch prop
@@ -247,11 +294,11 @@ export default {
 		};
 	},
 
-	computed: {
-		readerFormats() {
-			// Define the formats based on scanType prop or default to all common ones
-			// Ensure these format names are valid as per vue-qrcode-reader documentation
-			const availableFormats = [
+        computed: {
+                readerFormats() {
+                        // Define the formats based on scanType prop or default to all common ones
+                        // Ensure these format names are valid as per vue-qrcode-reader documentation
+                        const availableFormats = [
 				"qr_code",
 				"ean_13",
 				"ean_8",
@@ -265,31 +312,42 @@ export default {
 				// Add other formats if needed and supported by zxing-wasm
 			];
 
-			if (this.scanType === "QR Code") {
-				return ["qr_code"];
-			}
-			if (this.scanType === "Barcode") {
-				return availableFormats.filter((f) => f !== "qr_code");
-			}
-			return availableFormats; // 'Both'
-		},
-	},
+                        if (this.scanType === "QR Code") {
+                                return ["qr_code"];
+                        }
+                        if (this.scanType === "Barcode") {
+                                return availableFormats.filter((f) => f !== "qr_code");
+                        }
+                        return availableFormats; // 'Both'
+                },
+                isCameraAvailable() {
+                        return Array.isArray(this.cameras) && this.cameras.length > 0;
+                },
+                shouldShowManualEntry() {
+                        return this.cameraPermissionDenied || !this.isCameraAvailable;
+                },
+        },
 
 	methods: {
-		async startScanning() {
-			this.scannerDialog = true;
-			this.errorMessage = "";
-			this.scanResult = "";
-			this.scanFormat = "";
-			this.cameraPermissionDenied = false;
-			this.isScanning = true; // QrcodeStream will attempt to start camera automatically
-			// We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
-			await this.$nextTick();
-			// Camera listing can be done here or in a dedicated method
-			// vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
-			// but we can use navigator.mediaDevices.enumerateDevices()
-			await this.listCameras();
-		},
+                async startScanning() {
+                        this.scannerDialog = true;
+                        this.errorMessage = "";
+                        this.scanResult = "";
+                        this.scanFormat = "";
+                        this.cameraPermissionDenied = false;
+                        this.isScanning = true; // QrcodeStream will attempt to start camera automatically
+                        this.manualCode = "";
+                        this.manualError = "";
+                        // We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
+                        await this.$nextTick();
+                        // Camera listing can be done here or in a dedicated method
+                        // vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
+                        // but we can use navigator.mediaDevices.enumerateDevices()
+                        await this.listCameras();
+                        if (this.shouldShowManualEntry) {
+                                this.$nextTick(() => this.focusManualInput());
+                        }
+                },
 
 		async listCameras() {
 			try {
@@ -345,41 +403,68 @@ export default {
 			}
 		},
 
-		onError(error) {
-			this.errorMessage = error.name || "Unknown error";
-			if (error.name === "NotAllowedError") {
-				this.cameraPermissionDenied = true;
-				this.errorMessage = this.__(
-					"Camera permission denied. Please allow camera access in your browser settings.",
-				);
-			} else if (error.name === "NotFoundError" || error.name === "DevicesNotFoundError") {
-				this.errorMessage = this.__("No camera found on this device.");
-			} else if (error.name === "NotSupportedError") {
-				this.errorMessage = this.__("Secure context (HTTPS) required for camera access.");
-			} else if (error.name === "AbortError") {
-				this.errorMessage = this.__("Camera access aborted.");
-			} else {
-				this.errorMessage = this.__("Error accessing camera:") + ` ${error.message}`;
-			}
-			console.error("Camera error:", error);
-			this.isScanning = false;
-		},
+                onError(error) {
+                        this.errorMessage = error.name || "Unknown error";
+                        if (error.name === "NotAllowedError") {
+                                this.cameraPermissionDenied = true;
+                                this.errorMessage = this.__(
+                                        "Camera permission denied. Please allow camera access in your browser settings.",
+                                );
+                        } else if (error.name === "NotFoundError" || error.name === "DevicesNotFoundError") {
+                                this.errorMessage = this.__("No camera found on this device.");
+                        } else if (error.name === "NotSupportedError") {
+                                this.errorMessage = this.__("Secure context (HTTPS) required for camera access.");
+                        } else if (error.name === "AbortError") {
+                                this.errorMessage = this.__("Camera access aborted.");
+                        } else {
+                                this.errorMessage = this.__("Error accessing camera:") + ` ${error.message}`;
+                        }
+                        console.error("Camera error:", error);
+                        this.isScanning = false;
+                        if (this.shouldShowManualEntry) {
+                                this.$nextTick(() => this.focusManualInput());
+                        }
+                },
 
-		stopScanning() {
-			this.isScanning = false; // This should make QrcodeStream stop/hide
-			this.scannerDialog = false;
-			this.scanResult = "";
-			this.scanFormat = "";
-			this.errorMessage = "";
-			this.torchActive = false;
-			// selectedDeviceId and cameras can remain as they are for next scan
-			this.$emit("scanner-closed");
-		},
+                stopScanning() {
+                        this.isScanning = false; // This should make QrcodeStream stop/hide
+                        this.scannerDialog = false;
+                        this.scanResult = "";
+                        this.scanFormat = "";
+                        this.errorMessage = "";
+                        this.torchActive = false;
+                        this.manualCode = "";
+                        this.manualError = "";
+                        // selectedDeviceId and cameras can remain as they are for next scan
+                        this.$emit("scanner-closed");
+                },
 
-		async toggleTorch() {
-			this.torchActive = !this.torchActive;
-			// The QrcodeStream component has a :torch prop, binding this.torchActive to it should work.
-		},
+                submitManualCode() {
+                        const code = (this.manualCode || "").trim();
+
+                        if (!code) {
+                                this.manualError = this.__("Please enter a code before adding an item.");
+                                this.$nextTick(() => this.focusManualInput());
+                                return;
+                        }
+
+                        this.manualError = "";
+                        this.$emit("barcode-scanned", code);
+                        this.manualCode = "";
+                        this.$nextTick(() => this.focusManualInput());
+                },
+
+                focusManualInput() {
+                        const input = this.$refs.manualInput;
+                        if (input && typeof input.focus === "function") {
+                                input.focus();
+                        }
+                },
+
+                async toggleTorch() {
+                        this.torchActive = !this.torchActive;
+                        // The QrcodeStream component has a :torch prop, binding this.torchActive to it should work.
+                },
 
 		async switchCamera() {
 			if (this.cameras.length > 1) {
@@ -419,20 +504,28 @@ export default {
 		},
 	},
 
-	watch: {
-		scannerDialog(newVal) {
-			if (newVal) {
-				// When dialog opens, if no camera is selected, list them.
-				if (!this.selectedDeviceId && this.cameras.length === 0) {
-					this.listCameras();
-				}
-			} else {
-				// When dialog closes, ensure scanning is stopped.
-				this.isScanning = false;
-				this.torchActive = false;
-			}
-		},
-	},
+        watch: {
+                scannerDialog(newVal) {
+                        if (newVal) {
+                                // When dialog opens, if no camera is selected, list them.
+                                if (!this.selectedDeviceId && this.cameras.length === 0) {
+                                        this.listCameras();
+                                }
+                                if (this.shouldShowManualEntry) {
+                                        this.$nextTick(() => this.focusManualInput());
+                                }
+                        } else {
+                                // When dialog closes, ensure scanning is stopped.
+                                this.isScanning = false;
+                                this.torchActive = false;
+                        }
+                },
+                shouldShowManualEntry(value) {
+                        if (value) {
+                                this.$nextTick(() => this.focusManualInput());
+                        }
+                },
+        },
 
 	mounted() {
 		if (typeof document !== "undefined") {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2374,13 +2374,34 @@ export default {
 					return;
 				}
 
-				onScan.attachTo(document, {
-					suffixKeyCodes: [],
-					keyCodeMapper: function (oEvent) {
-						oEvent.stopImmediatePropagation();
-						oEvent.preventDefault();
-						return onScan.decodeKeyEvent(oEvent);
-					},
+                                onScan.attachTo(document, {
+                                        suffixKeyCodes: [],
+                                        keyCodeMapper: function (oEvent) {
+                                                const allowManualInput = (node) => {
+                                                        if (!node) {
+                                                                return false;
+                                                        }
+                                                        if (node.dataset?.allowScannerInput === "true") {
+                                                                return true;
+                                                        }
+                                                        if (typeof node.closest === "function") {
+                                                                return !!node.closest("[data-allow-scanner-input='true']");
+                                                        }
+                                                        return false;
+                                                };
+
+                                                const manualTarget =
+                                                        allowManualInput(oEvent.target) ||
+                                                        allowManualInput(document.activeElement);
+
+                                                if (manualTarget) {
+                                                        return null;
+                                                }
+
+                                                oEvent.stopImmediatePropagation();
+                                                oEvent.preventDefault();
+                                                return onScan.decodeKeyEvent(oEvent);
+                                        },
 					onScan: function (sCode) {
 						if (vm.scannerLocked) {
 							vm.playScanTone("error");

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2417,17 +2417,29 @@ export default {
 				console.warn("Scanner initialization error:", error.message);
 			}
 		},
-               async trigger_onscan(sCode) {
+              async trigger_onscan(sCode, options = {}) {
                        if (this.scannerLocked) {
                                this.playScanTone("error");
                                return;
                        }
+
+                       const { showFeedback = false } = options;
 
                        // Mark the upcoming search as originating from a scanner
                        this.search_from_scanner = true;
                        this.pendingScanCode = sCode;
                        this.first_search = sCode;
                        this.search = sCode;
+
+                       if (showFeedback && frappe?.show_alert) {
+                               frappe.show_alert(
+                                       {
+                                               message: `Scanning for: ${sCode}`,
+                                               indicator: "blue",
+                                       },
+                                       2,
+                               );
+                       }
 
                        try {
                                await this.$nextTick();
@@ -2618,37 +2630,25 @@ export default {
 				this.$refs.cameraScanner.startScanning();
 			}
 		},
-		onBarcodeScanned(scannedCode) {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
-				return;
-			}
-			console.log("Barcode scanned:", scannedCode);
-			this.pendingScanCode = scannedCode;
+               async onBarcodeScanned(scannedCode) {
+                       if (this.scannerLocked) {
+                               this.playScanTone("error");
+                               return;
+                       }
 
-			// mark this search as coming from a scanner
-			this.search_from_scanner = true;
+                       console.log("Barcode scanned:", scannedCode);
 
-			// Clear any previous search
-			this.search = "";
-			this.first_search = "";
-
-			// Set the scanned code as search term
-			this.first_search = scannedCode;
-			this.search = scannedCode;
-
-			// Show scanning feedback
-			frappe.show_alert(
-				{
-					message: `Scanning for: ${scannedCode}`,
-					indicator: "blue",
-				},
-				2,
-			);
-
-			// Enhanced item search and submission logic
-			this.processScannedItem(scannedCode);
-		},
+                       try {
+                               await this.trigger_onscan(scannedCode, { showFeedback: true });
+                       } catch (error) {
+                               console.error("Barcode processing failed:", error);
+                               this.showScanError({
+                                       message: this.__("Unable to add scanned item."),
+                                       code: scannedCode,
+                                       details: error?.message || "",
+                               });
+                       }
+               },
 		async processScannedItem(scannedCode) {
 			this.pendingScanCode = scannedCode;
 			// Handle scale barcodes by extracting the item code and quantity

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -735,12 +735,15 @@ export default {
 			this.$nextTick(this.checkItemContainerOverflow);
 		},
 		// Automatically search when the query has at least 3 characters
-		first_search: _.debounce(function (val, oldVal) {
-			const newLen = (val || "").trim().length;
-			const oldLen = (oldVal || "").trim().length;
-			if (newLen >= 3) {
-				// Call without arguments so search_onchange treats it like an Enter key
-				this.search_onchange();
+               first_search: _.debounce(function (val, oldVal) {
+                       if (this.search_from_scanner) {
+                               return;
+                       }
+                       const newLen = (val || "").trim().length;
+                       const oldLen = (oldVal || "").trim().length;
+                       if (newLen >= 3) {
+                               // Call without arguments so search_onchange treats it like an Enter key
+                               this.search_onchange();
 			} else if (oldLen >= 3 && newLen === 0) {
 				// Reset items only when search is fully cleared
 				this.clearSearch();
@@ -1991,20 +1994,24 @@ export default {
 				}
 			}
 		},
-		search_onchange: _.debounce(async function (newSearchTerm) {
-			const vm = this;
+               search_onchange: _.debounce(async function (newSearchTerm) {
+                       const vm = this;
 
-			vm.cancelItemDetailsRequest();
+                       if (vm.search_from_scanner) {
+                               return;
+                       }
 
-			// Determine the actual query string and trim whitespace
-			const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
-			const trimmedQuery = (query || "").trim();
+                       vm.cancelItemDetailsRequest();
 
-			// Require a minimum of three characters before running a search
-			if (!trimmedQuery || trimmedQuery.length < 3) {
-				vm.search_from_scanner = false;
-				return;
-			}
+                       // Determine the actual query string and trim whitespace
+                       const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
+                       const trimmedQuery = (query || "").trim();
+
+                       // Require a minimum of three characters before running a search
+                       if (!trimmedQuery || trimmedQuery.length < 3) {
+                               vm.search_from_scanner = false;
+                               return;
+                       }
 
 			// If background loading is in progress, defer the search without changing the active query
 			if (vm.isBackgroundLoading) {
@@ -2389,40 +2396,36 @@ export default {
 				console.warn("Scanner initialization error:", error.message);
 			}
 		},
-		trigger_onscan(sCode) {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
-				return;
-			}
-			// indicate this search came from a scanner
-			this.search_from_scanner = true;
-			// apply scanned code as search term
-			this.first_search = sCode;
-			this.search = sCode;
-			this.pendingScanCode = sCode;
+               async trigger_onscan(sCode) {
+                       if (this.scannerLocked) {
+                               this.playScanTone("error");
+                               return;
+                       }
 
-			this.$nextTick(() => {
-				if (this.filtered_items.length == 0) {
-					this.eventBus.emit("show_message", {
-						title: `No Item has this barcode "${sCode}"`,
-						color: "error",
-					});
-					this.showScanError({
-						message: `${this.__("Item not found")}: ${sCode}`,
-						code: sCode,
-						details: this.__("Please verify the barcode or search manually."),
-					});
-				} else {
-					this.enter_event();
-				}
+                       // Mark the upcoming search as originating from a scanner
+                       this.search_from_scanner = true;
+                       this.pendingScanCode = sCode;
+                       this.first_search = sCode;
+                       this.search = sCode;
 
-				// clear search field for next scan and refocus input
-				if (!this.scanErrorDialog) {
-					this.clearSearch();
-					this.$refs.debounce_search && this.$refs.debounce_search.focus();
-				}
-			});
-		},
+                       try {
+                               await this.$nextTick();
+                               await this.processScannedItem(sCode);
+                       } catch (error) {
+                               console.error("Failed to process scanned item:", error);
+                               this.showScanError({
+                                       message: this.__("Unable to add scanned item."),
+                                       code: sCode,
+                                       details: error?.message || "",
+                               });
+                       } finally {
+                               this.$nextTick(() => {
+                                       if (!this.scanErrorDialog && this.$refs.debounce_search) {
+                                               this.$refs.debounce_search.focus();
+                                       }
+                               });
+                       }
+               },
 		generateWordCombinations(inputString) {
 			const words = inputString.split(" ");
 			const wordCount = words.length;


### PR DESCRIPTION
## Summary
- route hardware-triggered scans through processScannedItem while preserving scanner UX
- guard the first_search watcher and search_onchange handler so scanner-originated queries bypass item filtering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d169c1db148326aab07f56d9203df6