### PR TITLE
Fix manual keyboard entry being intercepted by scanner hook

### DIFF
--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -18,8 +18,8 @@
 				></v-btn>
 			</v-card-title>
 
-			<v-card-text class="pa-0">
-				<div v-if="!cameraPermissionDenied">
+                        <v-card-text class="pa-0">
+                                <div v-if="!cameraPermissionDenied">
 					<!-- Scanner container -->
 					<div class="scanner-container" v-if="isScanning && scannerDialog">
 						<qrcode-stream
@@ -50,11 +50,11 @@
 					</div>
 
 					<!-- Status messages -->
-					<div class="status-messages pa-3">
-						<v-alert v-if="errorMessage" type="error" variant="tonal" class="mb-2">
-							<v-icon>mdi-alert-circle</v-icon>
-							{{ errorMessage }}
-						</v-alert>
+                                        <div class="status-messages pa-3">
+                                                <v-alert v-if="errorMessage" type="error" variant="tonal" class="mb-2">
+                                                        <v-icon>mdi-alert-circle</v-icon>
+                                                        {{ errorMessage }}
+                                                </v-alert>
 
 						<v-alert v-if="scanResult" type="success" variant="tonal" class="mb-2">
 							{{ __("Successfully scanned:") }} <strong>{{ scanResult }}</strong> <br /><small
@@ -62,25 +62,69 @@
 							>
 						</v-alert>
 
-						<v-alert
-							v-if="!scanResult && !errorMessage && isScanning && scannerDialog"
-							type="info"
-							variant="tonal"
-						>
-							{{ __("Position the QR code or barcode within the scanning area") }}
-							<br /><small>{{ __("Detecting formats:") }} {{ readerFormats.join(", ") }}</small>
-						</v-alert>
-					</div>
-				</div>
+                                                <v-alert
+                                                        v-if="!scanResult && !errorMessage && isScanning && scannerDialog"
+                                                        type="info"
+                                                        variant="tonal"
+                                                >
+                                                        {{ __("Position the QR code or barcode within the scanning area") }}
+                                                        <br /><small>{{ __("Detecting formats:") }} {{ readerFormats.join(", ") }}</small>
+                                                </v-alert>
+                                        </div>
+                                </div>
 
-				<!-- Camera permission denied message -->
-				<div v-else class="pa-4 text-center">
-					<v-icon size="64" color="error">mdi-camera-off</v-icon>
-					<h3 class="mt-2">{{ __("Camera Access Required") }}</h3>
-					<p class="mt-2">{{ __("Please allow camera access to scan codes") }}</p>
-					<!-- Requesting permission is handled by the browser when QrcodeStream tries to access camera -->
-				</div>
-			</v-card-text>
+                                <!-- Camera permission denied message -->
+                                <div v-else class="pa-4 text-center">
+                                        <v-icon size="64" color="error">mdi-camera-off</v-icon>
+                                        <h3 class="mt-2">{{ __("Camera Access Required") }}</h3>
+                                        <p class="mt-2">{{ __("Please allow camera access to scan codes") }}</p>
+                                        <!-- Requesting permission is handled by the browser when QrcodeStream tries to access camera -->
+                                </div>
+                                <div
+                                        v-if="shouldShowManualEntry"
+                                        class="manual-entry pa-4 pt-0"
+                                        data-allow-scanner-input="true"
+                                >
+                                        <v-divider class="my-3"></v-divider>
+                                        <div class="text-subtitle-1 font-weight-medium mb-2">
+                                                {{ __("Manual Entry") }}
+                                        </div>
+                                        <v-alert
+                                                v-if="manualError"
+                                                type="warning"
+                                                variant="tonal"
+                                                density="comfortable"
+                                                class="mb-3"
+                                        >
+                                                <v-icon class="mr-2">mdi-alert</v-icon>
+                                                {{ manualError }}
+                                        </v-alert>
+                                        <v-text-field
+                                                ref="manualInput"
+                                                v-model="manualCode"
+                                                density="comfortable"
+                                                variant="outlined"
+                                                color="primary"
+                                                :label="__('Enter item code or barcode')"
+                                                :hint="__('Use your hardware scanner or keyboard to add items manually')"
+                                                persistent-hint
+                                                hide-details="auto"
+                                                clearable
+                                                @keydown.enter.prevent="submitManualCode"
+                                                @update:model-value="manualError = ''"
+                                                data-allow-scanner-input="true"
+                                        ></v-text-field>
+                                        <v-btn
+                                                class="mt-3"
+                                                color="primary"
+                                                block
+                                                :disabled="!manualCode"
+                                                @click="submitManualCode"
+                                        >
+                                                {{ __("Add Item") }}
+                                        </v-btn>
+                                </div>
+                        </v-card-text>
 
 			<!-- Action buttons -->
 			<v-card-actions class="justify-space-between pa-3">
@@ -209,6 +253,7 @@
 </style>
 
 <script>
+/* global frappe */
 import { QrcodeStream } from "vue-qrcode-reader";
 
 export default {
@@ -224,16 +269,18 @@ export default {
 	},
 
 	data() {
-		return {
-			scannerDialog: false,
-			scanResult: "",
-			scanFormat: "", // We might get this from the 'detect' event payload
-			errorMessage: "",
-			cameraPermissionDenied: false,
-			isScanning: false,
-			torchActive: false,
-			selectedDeviceId: null, // For camera switching
-			cameras: [], // To store available cameras
+                return {
+                        scannerDialog: false,
+                        scanResult: "",
+                        scanFormat: "", // We might get this from the 'detect' event payload
+                        errorMessage: "",
+                        cameraPermissionDenied: false,
+                        isScanning: false,
+                        torchActive: false,
+                        selectedDeviceId: null, // For camera switching
+                        cameras: [], // To store available cameras
+                        manualCode: "",
+                        manualError: "",
 			// Old properties to be removed or re-evaluated:
 			// qrScanner: null,
 			// flashlightSupported: false, // vue-qrcode-reader handles this via QrcodeStream's torch prop
@@ -247,11 +294,11 @@ export default {
 		};
 	},
 
-	computed: {
-		readerFormats() {
-			// Define the formats based on scanType prop or default to all common ones
-			// Ensure these format names are valid as per vue-qrcode-reader documentation
-			const availableFormats = [
+        computed: {
+                readerFormats() {
+                        // Define the formats based on scanType prop or default to all common ones
+                        // Ensure these format names are valid as per vue-qrcode-reader documentation
+                        const availableFormats = [
 				"qr_code",
 				"ean_13",
 				"ean_8",
@@ -265,31 +312,42 @@ export default {
 				// Add other formats if needed and supported by zxing-wasm
 			];
 
-			if (this.scanType === "QR Code") {
-				return ["qr_code"];
-			}
-			if (this.scanType === "Barcode") {
-				return availableFormats.filter((f) => f !== "qr_code");
-			}
-			return availableFormats; // 'Both'
-		},
-	},
+                        if (this.scanType === "QR Code") {
+                                return ["qr_code"];
+                        }
+                        if (this.scanType === "Barcode") {
+                                return availableFormats.filter((f) => f !== "qr_code");
+                        }
+                        return availableFormats; // 'Both'
+                },
+                isCameraAvailable() {
+                        return Array.isArray(this.cameras) && this.cameras.length > 0;
+                },
+                shouldShowManualEntry() {
+                        return this.cameraPermissionDenied || !this.isCameraAvailable;
+                },
+        },
 
 	methods: {
-		async startScanning() {
-			this.scannerDialog = true;
-			this.errorMessage = "";
-			this.scanResult = "";
-			this.scanFormat = "";
-			this.cameraPermissionDenied = false;
-			this.isScanning = true; // QrcodeStream will attempt to start camera automatically
-			// We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
-			await this.$nextTick();
-			// Camera listing can be done here or in a dedicated method
-			// vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
-			// but we can use navigator.mediaDevices.enumerateDevices()
-			await this.listCameras();
-		},
+                async startScanning() {
+                        this.scannerDialog = true;
+                        this.errorMessage = "";
+                        this.scanResult = "";
+                        this.scanFormat = "";
+                        this.cameraPermissionDenied = false;
+                        this.isScanning = true; // QrcodeStream will attempt to start camera automatically
+                        this.manualCode = "";
+                        this.manualError = "";
+                        // We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
+                        await this.$nextTick();
+                        // Camera listing can be done here or in a dedicated method
+                        // vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
+                        // but we can use navigator.mediaDevices.enumerateDevices()
+                        await this.listCameras();
+                        if (this.shouldShowManualEntry) {
+                                this.$nextTick(() => this.focusManualInput());
+                        }
+                },
 
 		async listCameras() {
 			try {
@@ -345,41 +403,68 @@ export default {
 			}
 		},
 
-		onError(error) {
-			this.errorMessage = error.name || "Unknown error";
-			if (error.name === "NotAllowedError") {
-				this.cameraPermissionDenied = true;
-				this.errorMessage = this.__(
-					"Camera permission denied. Please allow camera access in your browser settings.",
-				);
-			} else if (error.name === "NotFoundError" || error.name === "DevicesNotFoundError") {
-				this.errorMessage = this.__("No camera found on this device.");
-			} else if (error.name === "NotSupportedError") {
-				this.errorMessage = this.__("Secure context (HTTPS) required for camera access.");
-			} else if (error.name === "AbortError") {
-				this.errorMessage = this.__("Camera access aborted.");
-			} else {
-				this.errorMessage = this.__("Error accessing camera:") + ` ${error.message}`;
-			}
-			console.error("Camera error:", error);
-			this.isScanning = false;
-		},
+                onError(error) {
+                        this.errorMessage = error.name || "Unknown error";
+                        if (error.name === "NotAllowedError") {
+                                this.cameraPermissionDenied = true;
+                                this.errorMessage = this.__(
+                                        "Camera permission denied. Please allow camera access in your browser settings.",
+                                );
+                        } else if (error.name === "NotFoundError" || error.name === "DevicesNotFoundError") {
+                                this.errorMessage = this.__("No camera found on this device.");
+                        } else if (error.name === "NotSupportedError") {
+                                this.errorMessage = this.__("Secure context (HTTPS) required for camera access.");
+                        } else if (error.name === "AbortError") {
+                                this.errorMessage = this.__("Camera access aborted.");
+                        } else {
+                                this.errorMessage = this.__("Error accessing camera:") + ` ${error.message}`;
+                        }
+                        console.error("Camera error:", error);
+                        this.isScanning = false;
+                        if (this.shouldShowManualEntry) {
+                                this.$nextTick(() => this.focusManualInput());
+                        }
+                },
 
-		stopScanning() {
-			this.isScanning = false; // This should make QrcodeStream stop/hide
-			this.scannerDialog = false;
-			this.scanResult = "";
-			this.scanFormat = "";
-			this.errorMessage = "";
-			this.torchActive = false;
-			// selectedDeviceId and cameras can remain as they are for next scan
-			this.$emit("scanner-closed");
-		},
+                stopScanning() {
+                        this.isScanning = false; // This should make QrcodeStream stop/hide
+                        this.scannerDialog = false;
+                        this.scanResult = "";
+                        this.scanFormat = "";
+                        this.errorMessage = "";
+                        this.torchActive = false;
+                        this.manualCode = "";
+                        this.manualError = "";
+                        // selectedDeviceId and cameras can remain as they are for next scan
+                        this.$emit("scanner-closed");
+                },
 
-		async toggleTorch() {
-			this.torchActive = !this.torchActive;
-			// The QrcodeStream component has a :torch prop, binding this.torchActive to it should work.
-		},
+                submitManualCode() {
+                        const code = (this.manualCode || "").trim();
+
+                        if (!code) {
+                                this.manualError = this.__("Please enter a code before adding an item.");
+                                this.$nextTick(() => this.focusManualInput());
+                                return;
+                        }
+
+                        this.manualError = "";
+                        this.$emit("barcode-scanned", code);
+                        this.manualCode = "";
+                        this.$nextTick(() => this.focusManualInput());
+                },
+
+                focusManualInput() {
+                        const input = this.$refs.manualInput;
+                        if (input && typeof input.focus === "function") {
+                                input.focus();
+                        }
+                },
+
+                async toggleTorch() {
+                        this.torchActive = !this.torchActive;
+                        // The QrcodeStream component has a :torch prop, binding this.torchActive to it should work.
+                },
 
 		async switchCamera() {
 			if (this.cameras.length > 1) {
@@ -419,20 +504,28 @@ export default {
 		},
 	},
 
-	watch: {
-		scannerDialog(newVal) {
-			if (newVal) {
-				// When dialog opens, if no camera is selected, list them.
-				if (!this.selectedDeviceId && this.cameras.length === 0) {
-					this.listCameras();
-				}
-			} else {
-				// When dialog closes, ensure scanning is stopped.
-				this.isScanning = false;
-				this.torchActive = false;
-			}
-		},
-	},
+        watch: {
+                scannerDialog(newVal) {
+                        if (newVal) {
+                                // When dialog opens, if no camera is selected, list them.
+                                if (!this.selectedDeviceId && this.cameras.length === 0) {
+                                        this.listCameras();
+                                }
+                                if (this.shouldShowManualEntry) {
+                                        this.$nextTick(() => this.focusManualInput());
+                                }
+                        } else {
+                                // When dialog closes, ensure scanning is stopped.
+                                this.isScanning = false;
+                                this.torchActive = false;
+                        }
+                },
+                shouldShowManualEntry(value) {
+                        if (value) {
+                                this.$nextTick(() => this.focusManualInput());
+                        }
+                },
+        },
 
 	mounted() {
 		if (typeof document !== "undefined") {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -584,8 +584,10 @@ export default {
 		scannerLocked: false,
 		scanAudioContext: null,
 		pendingScanCode: "",
-		awaitingScanResult: false,
-	}),
+                awaitingScanResult: false,
+                suppressSearchWatchers: false,
+                searchWatcherRestoreHandle: null,
+        }),
 
 	watch: {
 		customer: _.debounce(function () {
@@ -736,7 +738,7 @@ export default {
 		},
 		// Automatically search when the query has at least 3 characters
                first_search: _.debounce(function (val, oldVal) {
-                       if (this.search_from_scanner) {
+                       if (this.search_from_scanner || this.suppressSearchWatchers) {
                                return;
                        }
                        const newLen = (val || "").trim().length;
@@ -1997,7 +1999,7 @@ export default {
                search_onchange: _.debounce(async function (newSearchTerm) {
                        const vm = this;
 
-                       if (vm.search_from_scanner) {
+                       if (vm.search_from_scanner || vm.suppressSearchWatchers) {
                                return;
                        }
 
@@ -2434,6 +2436,8 @@ export default {
                                return;
                        }
 
+                       this.suspendSearchWatchers();
+
                        // Mark the upcoming search as originating from a scanner
                        this.search_from_scanner = true;
                        this.pendingScanCode = sCode;
@@ -2629,16 +2633,18 @@ export default {
 				this.$refs.cameraScanner.startScanning();
 			}
 		},
-		onBarcodeScanned(scannedCode) {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
-				return;
-			}
-			console.log("Barcode scanned:", scannedCode);
-			this.pendingScanCode = scannedCode;
+                onBarcodeScanned(scannedCode) {
+                        if (this.scannerLocked) {
+                                this.playScanTone("error");
+                                return;
+                        }
+                        console.log("Barcode scanned:", scannedCode);
+                        this.pendingScanCode = scannedCode;
 
-			// mark this search as coming from a scanner
-			this.search_from_scanner = true;
+                        this.suspendSearchWatchers();
+
+                        // mark this search as coming from a scanner
+                        this.search_from_scanner = true;
 
 			// Clear any previous search
 			this.search = "";
@@ -2660,82 +2666,106 @@ export default {
 			// Enhanced item search and submission logic
 			this.processScannedItem(scannedCode);
 		},
-		async processScannedItem(scannedCode) {
-			this.pendingScanCode = scannedCode;
-			// Handle scale barcodes by extracting the item code and quantity
-			let searchCode = scannedCode;
-			let qtyFromBarcode = null;
-			if (
-				this.pos_profile?.posa_scale_barcode_start &&
-				scannedCode.startsWith(this.pos_profile.posa_scale_barcode_start)
-			) {
-				searchCode = this.get_search(scannedCode);
-				qtyFromBarcode = parseFloat(this.get_item_qty(scannedCode));
-			}
+               async processScannedItem(scannedCode) {
+                        this.pendingScanCode = scannedCode;
+                        this.suspendSearchWatchers();
+                        const releaseDelay = 400;
 
-			// First try to find exact match by processed code
-			let foundItem = this.items.find((item) => {
-				const barcodeMatch =
-					item.barcode === searchCode ||
-					(Array.isArray(item.item_barcode) &&
-						item.item_barcode.some((b) => b.barcode === searchCode)) ||
-					(Array.isArray(item.barcodes) && item.barcodes.some((bc) => String(bc) === searchCode));
-				return barcodeMatch || item.item_code === searchCode;
-			});
+                        try {
+                                // Handle scale barcodes by extracting the item code and quantity
+                                let searchCode = scannedCode;
+                                let qtyFromBarcode = null;
+                                if (
+                                        this.pos_profile?.posa_scale_barcode_start &&
+                                        scannedCode.startsWith(this.pos_profile.posa_scale_barcode_start)
+                                ) {
+                                        searchCode = this.get_search(scannedCode);
+                                        qtyFromBarcode = parseFloat(this.get_item_qty(scannedCode));
+                                }
 
-			if (foundItem) {
-				console.log("Found item by processed code:", foundItem);
-				await this.addScannedItemToInvoice(foundItem, searchCode, qtyFromBarcode);
-				return;
-			}
+                                // First try to find exact match by processed code
+                                const foundItem = this.items.find((item) => {
+                                        const barcodeMatch =
+                                                item.barcode === searchCode ||
+                                                (Array.isArray(item.item_barcode) &&
+                                                        item.item_barcode.some((b) => b.barcode === searchCode)) ||
+                                                (Array.isArray(item.barcodes) &&
+                                                        item.barcodes.some((bc) => String(bc) === searchCode));
+                                        return barcodeMatch || item.item_code === searchCode;
+                                });
 
-			// If not found locally, attempt to fetch from server using processed code
-			try {
-				const res = await frappe.call({
-					method: "posawesome.posawesome.api.items.get_items_from_barcode",
-					args: {
-						selling_price_list: this.active_price_list,
-						currency: this.pos_profile.currency,
-						barcode: searchCode,
-					},
-				});
+                                if (foundItem) {
+                                        console.log("Found item by processed code:", foundItem);
+                                        await this.addScannedItemToInvoice(foundItem, searchCode, qtyFromBarcode);
+                                        return;
+                                }
 
-				if (res && res.message) {
-					const newItem = res.message;
-					this.items.push(newItem);
+                                // If not found locally, attempt to fetch from server using processed code
+                                try {
+                                        const res = await frappe.call({
+                                                method: "posawesome.posawesome.api.items.get_items_from_barcode",
+                                                args: {
+                                                        selling_price_list: this.active_price_list,
+                                                        currency: this.pos_profile.currency,
+                                                        barcode: searchCode,
+                                                },
+                                        });
 
-					if (this.searchCache) {
-						this.searchCache.clear();
-					}
+                                        if (res && res.message) {
+                                                const newItem = res.message;
+                                                this.items.push(newItem);
 
-					await saveItems(this.items);
-					await savePriceListItems(this.customer_price_list, this.items);
-					this.eventBus.emit("set_all_items", this.items);
-					await this.update_items_details([newItem]);
-					await this.addScannedItemToInvoice(newItem, searchCode, qtyFromBarcode);
-					return;
-				}
+                                                if (this.searchCache) {
+                                                        this.searchCache.clear();
+                                                }
 
-				this.first_search = scannedCode;
-				this.search = scannedCode;
-				this.showScanError({
-					message: `${this.__("Item not found")}: ${scannedCode}`,
-					code: scannedCode,
-					details: this.__("Please verify the barcode or check the item's availability."),
-				});
-				return;
-			} catch (e) {
-				console.error("Error fetching item from barcode:", e);
-				this.first_search = scannedCode;
-				this.search = scannedCode;
-				this.showScanError({
-					message: `${this.__("Item not found")}: ${scannedCode}`,
-					code: scannedCode,
-					details: this.__("The system could not retrieve the item details. Please try again."),
-				});
-				return;
-			}
-		},
+                                                await saveItems(this.items);
+                                                await savePriceListItems(this.customer_price_list, this.items);
+                                                this.eventBus.emit("set_all_items", this.items);
+                                                await this.update_items_details([newItem]);
+                                                await this.addScannedItemToInvoice(newItem, searchCode, qtyFromBarcode);
+                                                return;
+                                        }
+
+                                        this.first_search = scannedCode;
+                                        this.search = scannedCode;
+                                        this.showScanError({
+                                                message: `${this.__("Item not found")}: ${scannedCode}`,
+                                                code: scannedCode,
+                                                details: this.__("Please verify the barcode or check the item's availability."),
+                                        });
+                                        return;
+                                } catch (e) {
+                                        console.error("Error fetching item from barcode:", e);
+                                        this.first_search = scannedCode;
+                                        this.search = scannedCode;
+                                        this.showScanError({
+                                                message: `${this.__("Item not found")}: ${scannedCode}`,
+                                                code: scannedCode,
+                                                details: this.__("The system could not retrieve the item details. Please try again."),
+                                        });
+                                        return;
+                                }
+                        } finally {
+                                this.releaseSearchWatcherSuppression(releaseDelay);
+                        }
+                },
+                suspendSearchWatchers() {
+                        if (this.searchWatcherRestoreHandle) {
+                                clearTimeout(this.searchWatcherRestoreHandle);
+                                this.searchWatcherRestoreHandle = null;
+                        }
+                        this.suppressSearchWatchers = true;
+                },
+                releaseSearchWatcherSuppression(delay = 0) {
+                        if (this.searchWatcherRestoreHandle) {
+                                clearTimeout(this.searchWatcherRestoreHandle);
+                        }
+                        this.searchWatcherRestoreHandle = setTimeout(() => {
+                                this.suppressSearchWatchers = false;
+                                this.searchWatcherRestoreHandle = null;
+                        }, Math.max(0, delay));
+                },
 		searchItemsByCode(code) {
 			return this.items.filter((item) => {
 				const searchTerm = code.toLowerCase();
@@ -3400,15 +3430,20 @@ export default {
 		this.$nextTick(this.checkItemContainerOverflow);
 	},
 
-	beforeUnmount() {
-		// Clear interval when component is destroyed
-		if (this.refresh_interval) {
-			clearInterval(this.refresh_interval);
-		}
+        beforeUnmount() {
+                // Clear interval when component is destroyed
+                if (this.refresh_interval) {
+                        clearInterval(this.refresh_interval);
+                }
 
-		if (this.itemDetailsRetryTimeout) {
-			clearTimeout(this.itemDetailsRetryTimeout);
-		}
+                if (this.searchWatcherRestoreHandle) {
+                        clearTimeout(this.searchWatcherRestoreHandle);
+                        this.searchWatcherRestoreHandle = null;
+                }
+
+                if (this.itemDetailsRetryTimeout) {
+                        clearTimeout(this.itemDetailsRetryTimeout);
+                }
 		this.itemDetailsRetryCount = 0;
 
 		// Call cleanup function for abort controller

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -735,12 +735,15 @@ export default {
 			this.$nextTick(this.checkItemContainerOverflow);
 		},
 		// Automatically search when the query has at least 3 characters
-		first_search: _.debounce(function (val, oldVal) {
-			const newLen = (val || "").trim().length;
-			const oldLen = (oldVal || "").trim().length;
-			if (newLen >= 3) {
-				// Call without arguments so search_onchange treats it like an Enter key
-				this.search_onchange();
+               first_search: _.debounce(function (val, oldVal) {
+                       if (this.search_from_scanner) {
+                               return;
+                       }
+                       const newLen = (val || "").trim().length;
+                       const oldLen = (oldVal || "").trim().length;
+                       if (newLen >= 3) {
+                               // Call without arguments so search_onchange treats it like an Enter key
+                               this.search_onchange();
 			} else if (oldLen >= 3 && newLen === 0) {
 				// Reset items only when search is fully cleared
 				this.clearSearch();
@@ -1991,20 +1994,24 @@ export default {
 				}
 			}
 		},
-		search_onchange: _.debounce(async function (newSearchTerm) {
-			const vm = this;
+               search_onchange: _.debounce(async function (newSearchTerm) {
+                       const vm = this;
 
-			vm.cancelItemDetailsRequest();
+                       if (vm.search_from_scanner) {
+                               return;
+                       }
 
-			// Determine the actual query string and trim whitespace
-			const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
-			const trimmedQuery = (query || "").trim();
+                       vm.cancelItemDetailsRequest();
 
-			// Require a minimum of three characters before running a search
-			if (!trimmedQuery || trimmedQuery.length < 3) {
-				vm.search_from_scanner = false;
-				return;
-			}
+                       // Determine the actual query string and trim whitespace
+                       const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
+                       const trimmedQuery = (query || "").trim();
+
+                       // Require a minimum of three characters before running a search
+                       if (!trimmedQuery || trimmedQuery.length < 3) {
+                               vm.search_from_scanner = false;
+                               return;
+                       }
 
 			// If background loading is in progress, defer the search without changing the active query
 			if (vm.isBackgroundLoading) {
@@ -2367,18 +2374,50 @@ export default {
 					return;
 				}
 
-				onScan.attachTo(document, {
-					suffixKeyCodes: [],
-					keyCodeMapper: function (oEvent) {
-						oEvent.stopImmediatePropagation();
-						oEvent.preventDefault();
-						return onScan.decodeKeyEvent(oEvent);
-					},
-					onScan: function (sCode) {
-						if (vm.scannerLocked) {
-							vm.playScanTone("error");
-							return;
-						}
+                                onScan.attachTo(document, {
+                                        suffixKeyCodes: [],
+                                        keyCodeMapper: function (oEvent) {
+                                                const allowManualInput = (node) => {
+                                                        if (!node) {
+                                                                return false;
+                                                        }
+                                                        if (
+                                                                node.isContentEditable ||
+                                                                ["INPUT", "TEXTAREA"].includes(node.tagName)
+                                                        ) {
+                                                                return true;
+                                                        }
+                                                        if (node.dataset?.allowScannerInput === "true") {
+                                                                return true;
+                                                        }
+                                                        if (typeof node.closest === "function") {
+                                                                return !!node.closest("[data-allow-scanner-input='true']");
+                                                        }
+                                                        return false;
+                                                };
+
+                                                const manualTarget =
+                                                        allowManualInput(oEvent.target) ||
+                                                        allowManualInput(document.activeElement);
+
+                                                if (manualTarget) {
+                                                        return null;
+                                                }
+
+                                                const decoded = onScan.decodeKeyEvent(oEvent);
+
+                                                if (decoded != null) {
+                                                        oEvent.stopImmediatePropagation();
+                                                        oEvent.preventDefault();
+                                                }
+
+                                                return decoded;
+                                        },
+                                        onScan: function (sCode) {
+                                                if (vm.scannerLocked) {
+                                                        vm.playScanTone("error");
+                                                        return;
+                                                }
 						vm.trigger_onscan(sCode);
 					},
 				});
@@ -2389,40 +2428,36 @@ export default {
 				console.warn("Scanner initialization error:", error.message);
 			}
 		},
-		trigger_onscan(sCode) {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
-				return;
-			}
-			// indicate this search came from a scanner
-			this.search_from_scanner = true;
-			// apply scanned code as search term
-			this.first_search = sCode;
-			this.search = sCode;
-			this.pendingScanCode = sCode;
+               async trigger_onscan(sCode) {
+                       if (this.scannerLocked) {
+                               this.playScanTone("error");
+                               return;
+                       }
 
-			this.$nextTick(() => {
-				if (this.filtered_items.length == 0) {
-					this.eventBus.emit("show_message", {
-						title: `No Item has this barcode "${sCode}"`,
-						color: "error",
-					});
-					this.showScanError({
-						message: `${this.__("Item not found")}: ${sCode}`,
-						code: sCode,
-						details: this.__("Please verify the barcode or search manually."),
-					});
-				} else {
-					this.enter_event();
-				}
+                       // Mark the upcoming search as originating from a scanner
+                       this.search_from_scanner = true;
+                       this.pendingScanCode = sCode;
+                       this.first_search = sCode;
+                       this.search = sCode;
 
-				// clear search field for next scan and refocus input
-				if (!this.scanErrorDialog) {
-					this.clearSearch();
-					this.$refs.debounce_search && this.$refs.debounce_search.focus();
-				}
-			});
-		},
+                       try {
+                               await this.$nextTick();
+                               await this.processScannedItem(sCode);
+                       } catch (error) {
+                               console.error("Failed to process scanned item:", error);
+                               this.showScanError({
+                                       message: this.__("Unable to add scanned item."),
+                                       code: sCode,
+                                       details: error?.message || "",
+                               });
+                       } finally {
+                               this.$nextTick(() => {
+                                       if (!this.scanErrorDialog && this.$refs.debounce_search) {
+                                               this.$refs.debounce_search.focus();
+                                       }
+                               });
+                       }
+               },
 		generateWordCombinations(inputString) {
 			const words = inputString.split(" ");
 			const wordCount = words.length;


### PR DESCRIPTION
## Summary
- allow text inputs, textareas, and editable fields to bypass the document-level scanner interception so regular typing is no longer blocked
- only suppress key events after the onScan decoder actually produces scanner data, ensuring manual keystrokes can flow through untouched while scans still trigger the processing pipeline

## Testing
- npx eslint frontend/src/posapp/components/pos/CameraScanner.vue frontend/src/posapp/components/pos/ItemsSelector.vue

------
https://chatgpt.com/codex/tasks/task_e_68d169c1db148326aab07f56d9203df6