### PR TITLE
feat: support manual barcode entry alongside camera scanning

### DIFF
--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -18,8 +18,8 @@
 				></v-btn>
 			</v-card-title>
 
-			<v-card-text class="pa-0">
-				<div v-if="!cameraPermissionDenied">
+                        <v-card-text class="pa-0">
+                                <div v-if="!cameraPermissionDenied">
 					<!-- Scanner container -->
 					<div class="scanner-container" v-if="isScanning && scannerDialog">
 						<qrcode-stream
@@ -73,14 +73,50 @@
 					</div>
 				</div>
 
-				<!-- Camera permission denied message -->
-				<div v-else class="pa-4 text-center">
-					<v-icon size="64" color="error">mdi-camera-off</v-icon>
-					<h3 class="mt-2">{{ __("Camera Access Required") }}</h3>
-					<p class="mt-2">{{ __("Please allow camera access to scan codes") }}</p>
-					<!-- Requesting permission is handled by the browser when QrcodeStream tries to access camera -->
-				</div>
-			</v-card-text>
+                                <!-- Camera permission denied message -->
+                                <div v-else class="pa-4 text-center">
+                                        <v-icon size="64" color="error">mdi-camera-off</v-icon>
+                                        <h3 class="mt-2">{{ __("Camera Access Required") }}</h3>
+                                        <p class="mt-2">{{ __("Please allow camera access to scan codes") }}</p>
+                                        <!-- Requesting permission is handled by the browser when QrcodeStream tries to access camera -->
+                                </div>
+
+                                <!-- Manual / hardware scanner entry -->
+                                <div class="manual-entry pa-4 pt-0">
+                                        <v-divider class="mb-4"></v-divider>
+                                        <h3 class="text-subtitle-1 font-weight-medium mb-2">
+                                                {{ __("Manual or Hardware Scanner Input") }}
+                                        </h3>
+                                        <p class="text-body-2 mb-3">
+                                                {{ __("Scan with a hardware scanner or type the code, then press Enter.") }}
+                                        </p>
+                                        <v-text-field
+                                                density="comfortable"
+                                                variant="outlined"
+                                                color="primary"
+                                                clearable
+                                                hide-details
+                                                :label="__('Enter Code Manually')"
+                                                v-model="manualScanValue"
+                                                @keydown.enter.prevent="submitManualScan"
+                                                @click:clear="manualScanValue = ''"
+                                                autocomplete="off"
+                                                ref="manualScanInput"
+                                                prepend-inner-icon="mdi-barcode-scan"
+                                        >
+                                                <template #append-inner>
+                                                        <v-btn
+                                                                icon="mdi-check"
+                                                                variant="tonal"
+                                                                color="primary"
+                                                                size="small"
+                                                                @click="submitManualScan"
+                                                                :title="__('Submit Code')"
+                                                        ></v-btn>
+                                                </template>
+                                        </v-text-field>
+                                </div>
+                        </v-card-text>
 
 			<!-- Action buttons -->
 			<v-card-actions class="justify-space-between pa-3">
@@ -204,7 +240,12 @@
 }
 
 .status-messages {
-	background: rgba(255, 255, 255, 0.95);
+        background: rgba(255, 255, 255, 0.95);
+}
+
+.manual-entry {
+        background: rgba(255, 255, 255, 0.95);
+        border-top: 1px solid rgba(0, 0, 0, 0.08);
 }
 </style>
 
@@ -224,17 +265,18 @@ export default {
 	},
 
 	data() {
-		return {
-			scannerDialog: false,
-			scanResult: "",
-			scanFormat: "", // We might get this from the 'detect' event payload
-			errorMessage: "",
-			cameraPermissionDenied: false,
-			isScanning: false,
-			torchActive: false,
-			selectedDeviceId: null, // For camera switching
-			cameras: [], // To store available cameras
-			// Old properties to be removed or re-evaluated:
+                return {
+                        scannerDialog: false,
+                        scanResult: "",
+                        scanFormat: "", // We might get this from the 'detect' event payload
+                        errorMessage: "",
+                        cameraPermissionDenied: false,
+                        isScanning: false,
+                        torchActive: false,
+                        selectedDeviceId: null, // For camera switching
+                        cameras: [], // To store available cameras
+                        manualScanValue: "",
+                        // Old properties to be removed or re-evaluated:
 			// qrScanner: null,
 			// flashlightSupported: false, // vue-qrcode-reader handles this via QrcodeStream's torch prop
 			// flashlightOn: false, // replaced by torchActive
@@ -276,16 +318,17 @@ export default {
 	},
 
 	methods: {
-		async startScanning() {
-			this.scannerDialog = true;
-			this.errorMessage = "";
-			this.scanResult = "";
-			this.scanFormat = "";
-			this.cameraPermissionDenied = false;
-			this.isScanning = true; // QrcodeStream will attempt to start camera automatically
-			// We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
-			await this.$nextTick();
-			// Camera listing can be done here or in a dedicated method
+                async startScanning() {
+                        this.scannerDialog = true;
+                        this.errorMessage = "";
+                        this.scanResult = "";
+                        this.scanFormat = "";
+                        this.cameraPermissionDenied = false;
+                        this.isScanning = true; // QrcodeStream will attempt to start camera automatically
+                        // We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
+                        await this.$nextTick();
+                        this.focusManualInput();
+                        // Camera listing can be done here or in a dedicated method
 			// vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
 			// but we can use navigator.mediaDevices.enumerateDevices()
 			await this.listCameras();
@@ -313,39 +356,71 @@ export default {
 			}
 		},
 
-		onDetect(detectedCodes) {
-			// detectedCodes is an array of objects, each with rawValue, format, etc.
-			if (detectedCodes && detectedCodes.length > 0) {
-				const firstResult = detectedCodes[0];
-				this.scanResult = firstResult.rawValue;
-				this.scanFormat = firstResult.format;
-				this.errorMessage = "";
+                onDetect(detectedCodes) {
+                        // detectedCodes is an array of objects, each with rawValue, format, etc.
+                        if (detectedCodes && detectedCodes.length > 0) {
+                                const firstResult = detectedCodes[0];
+                                this.processDetectedValue(firstResult.rawValue, firstResult.format);
+                        }
+                },
 
-				this.$emit("barcode-scanned", this.scanResult);
+                processDetectedValue(rawValue, formatLabel = "", options = {}) {
+                        const code = (rawValue ?? "").toString().trim();
+                        if (!code) {
+                                return;
+                        }
 
-				if (typeof frappe !== "undefined" && frappe.show_alert) {
-					frappe.show_alert(
-						{
-							message: this.__("Code scanned successfully") + ` (${this.scanFormat})`,
-							indicator: "green",
-						},
-						3,
-					);
-				}
+                        this.scanResult = code;
+                        this.scanFormat = formatLabel || "";
+                        this.errorMessage = "";
 
-				// Reset scan result and temporarily pause scanning
-				this.isScanning = false;
+                        this.$emit("barcode-scanned", code);
 
-				// Resume scanning after a short delay
-				setTimeout(() => {
-					this.scanResult = "";
-					this.scanFormat = "";
-					this.isScanning = true;
-				}, 1000);
-			}
-		},
+                        if (typeof frappe !== "undefined" && frappe.show_alert) {
+                                const formatSuffix = this.scanFormat ? ` (${this.scanFormat})` : "";
+                                frappe.show_alert(
+                                        {
+                                                message: this.__("Code scanned successfully") + formatSuffix,
+                                                indicator: "green",
+                                        },
+                                        3,
+                                );
+                        }
 
-		onError(error) {
+                        const resumeCamera = options.resumeCamera !== undefined ? options.resumeCamera : true;
+                        const wasScanning = this.isScanning;
+                        const shouldResumeCamera = resumeCamera && wasScanning;
+
+                        if (shouldResumeCamera) {
+                                this.isScanning = false;
+                        }
+
+                        setTimeout(() => {
+                                if (!this.scannerDialog) {
+                                        return;
+                                }
+                                this.scanResult = "";
+                                this.scanFormat = "";
+                                if (shouldResumeCamera) {
+                                        this.isScanning = true;
+                                }
+                        }, 1000);
+                },
+
+                submitManualScan() {
+                        const code = (this.manualScanValue ?? "").toString().trim();
+                        if (!code) {
+                                return;
+                        }
+
+                        this.processDetectedValue(code, this.__("Manual Entry"));
+                        this.manualScanValue = "";
+                        this.$nextTick(() => {
+                                this.focusManualInput();
+                        });
+                },
+
+                onError(error) {
 			this.errorMessage = error.name || "Unknown error";
 			if (error.name === "NotAllowedError") {
 				this.cameraPermissionDenied = true;
@@ -365,16 +440,17 @@ export default {
 			this.isScanning = false;
 		},
 
-		stopScanning() {
-			this.isScanning = false; // This should make QrcodeStream stop/hide
-			this.scannerDialog = false;
-			this.scanResult = "";
-			this.scanFormat = "";
-			this.errorMessage = "";
-			this.torchActive = false;
-			// selectedDeviceId and cameras can remain as they are for next scan
-			this.$emit("scanner-closed");
-		},
+                stopScanning() {
+                        this.isScanning = false; // This should make QrcodeStream stop/hide
+                        this.scannerDialog = false;
+                        this.scanResult = "";
+                        this.scanFormat = "";
+                        this.errorMessage = "";
+                        this.torchActive = false;
+                        this.manualScanValue = "";
+                        // selectedDeviceId and cameras can remain as they are for next scan
+                        this.$emit("scanner-closed");
+                },
 
 		async toggleTorch() {
 			this.torchActive = !this.torchActive;
@@ -411,28 +487,38 @@ export default {
 		// onScanSuccess (replaced by onDetect), stopCurrentScanner, toggleFlashlight (replaced by toggleTorch)
 		// handleScannerError (replaced by onError)
 
-		handleEscKey(event) {
-			if (event.key === "Escape" && this.scannerDialog) {
-				event.preventDefault();
-				this.stopScanning();
-			}
-		},
-	},
+                handleEscKey(event) {
+                        if (event.key === "Escape" && this.scannerDialog) {
+                                event.preventDefault();
+                                this.stopScanning();
+                        }
+                },
 
-	watch: {
-		scannerDialog(newVal) {
-			if (newVal) {
-				// When dialog opens, if no camera is selected, list them.
-				if (!this.selectedDeviceId && this.cameras.length === 0) {
-					this.listCameras();
-				}
-			} else {
-				// When dialog closes, ensure scanning is stopped.
-				this.isScanning = false;
-				this.torchActive = false;
-			}
-		},
-	},
+                focusManualInput() {
+                        if (this.$refs.manualScanInput && this.$refs.manualScanInput.focus) {
+                                this.$refs.manualScanInput.focus();
+                        }
+                },
+        },
+
+        watch: {
+                scannerDialog(newVal) {
+                        if (newVal) {
+                                // When dialog opens, if no camera is selected, list them.
+                                if (!this.selectedDeviceId && this.cameras.length === 0) {
+                                        this.listCameras();
+                                }
+                                this.$nextTick(() => {
+                                        this.focusManualInput();
+                                });
+                        } else {
+                                // When dialog closes, ensure scanning is stopped.
+                                this.isScanning = false;
+                                this.torchActive = false;
+                                this.manualScanValue = "";
+                        }
+                },
+        },
 
 	mounted() {
 		if (typeof document !== "undefined") {

--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -296,6 +296,7 @@ export default {
                         manualScanValue: "",
                         scanResetTimeoutId: null,
                         dialogCloseTimeoutId: null,
+                        scannerLockedExternally: false,
 			// Old properties to be removed or re-evaluated:
 			// qrScanner: null,
 			// flashlightSupported: false, // vue-qrcode-reader handles this via QrcodeStream's torch prop
@@ -339,6 +340,7 @@ export default {
 
 	methods: {
                 async startScanning() {
+                        this.scannerLockedExternally = false;
                         this.scannerDialog = true;
                         this.errorMessage = "";
                         this.scanResult = "";
@@ -447,7 +449,7 @@ export default {
                         this.scanResetTimeoutId = setTimeout(() => {
                                 this.scanResult = "";
                                 this.scanFormat = "";
-                                if (shouldPauseCamera && this.scannerDialog) {
+                                if (shouldPauseCamera && this.scannerDialog && !this.scannerLockedExternally) {
                                         this.isScanning = true;
                                 }
                                 this.scanResetTimeoutId = null;
@@ -492,6 +494,7 @@ export default {
 		},
 
                 stopScanning() {
+                        this.scannerLockedExternally = false;
                         if (this.scanResetTimeoutId) {
                                 clearTimeout(this.scanResetTimeoutId);
                                 this.scanResetTimeoutId = null;
@@ -572,6 +575,39 @@ export default {
                                         this.focusManualInput();
                                 });
                         });
+                },
+
+                pauseForExternalLock() {
+                        this.scannerLockedExternally = true;
+                        if (this.scanResetTimeoutId) {
+                                clearTimeout(this.scanResetTimeoutId);
+                                this.scanResetTimeoutId = null;
+                        }
+                        if (this.dialogCloseTimeoutId) {
+                                clearTimeout(this.dialogCloseTimeoutId);
+                                this.dialogCloseTimeoutId = null;
+                        }
+                        if (this.isScanning) {
+                                this.isScanning = false;
+                        }
+                },
+
+                resumeFromExternalLock() {
+                        if (!this.scannerDialog) {
+                                this.scannerLockedExternally = false;
+                                return;
+                        }
+                        this.scannerLockedExternally = false;
+                        if (!this.isScanning) {
+                                this.$nextTick(() => {
+                                        if (this.scannerDialog && !this.isScanning) {
+                                                this.isScanning = true;
+                                                this.queueManualInputFocus();
+                                        }
+                                });
+                        } else {
+                                this.queueManualInputFocus();
+                        }
                 },
         },
 

--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -256,14 +256,18 @@ export default {
 	components: {
 		QrcodeStream,
 	},
-	props: {
-		scanType: {
-			type: String,
-			default: "Both", // 'QR Code', 'Barcode', 'Both'. Note: vue-qrcode-reader uses a 'formats' prop.
-		},
-	},
+        props: {
+                scanType: {
+                        type: String,
+                        default: "Both", // 'QR Code', 'Barcode', 'Both'. Note: vue-qrcode-reader uses a 'formats' prop.
+                },
+                autoCloseOnScan: {
+                        type: Boolean,
+                        default: true,
+                },
+        },
 
-	data() {
+        data() {
                 return {
                         scannerDialog: false,
                         scanResult: "",
@@ -276,6 +280,7 @@ export default {
                         cameras: [], // To store available cameras
                         manualScanValue: "",
                         scanResetTimeoutId: null,
+                        dialogCloseTimeoutId: null,
 			// Old properties to be removed or re-evaluated:
 			// qrScanner: null,
 			// flashlightSupported: false, // vue-qrcode-reader handles this via QrcodeStream's torch prop
@@ -366,7 +371,12 @@ export default {
                 },
 
                 handleScannedCode(rawValue, formatLabel = "", options = {}) {
-                        const { pauseCamera = true, resetDelay = 1000 } = options;
+                        const {
+                                pauseCamera = true,
+                                resetDelay = 1000,
+                                closeDialog = this.autoCloseOnScan,
+                                closeDelay,
+                        } = options;
                         const code = (rawValue ?? "").toString().trim();
                         if (!code) {
                                 return;
@@ -399,6 +409,26 @@ export default {
                                 this.scanResetTimeoutId = null;
                         }
 
+                        if (this.dialogCloseTimeoutId) {
+                                clearTimeout(this.dialogCloseTimeoutId);
+                                this.dialogCloseTimeoutId = null;
+                        }
+
+                        if (closeDialog) {
+                                const effectiveDelay = Math.max(
+                                        0,
+                                        typeof closeDelay === "number"
+                                                ? closeDelay
+                                                : Math.min(resetDelay, 250),
+                                );
+
+                                this.dialogCloseTimeoutId = setTimeout(() => {
+                                        this.dialogCloseTimeoutId = null;
+                                        this.stopScanning();
+                                }, effectiveDelay);
+                                return;
+                        }
+
                         this.scanResetTimeoutId = setTimeout(() => {
                                 this.scanResult = "";
                                 this.scanFormat = "";
@@ -417,6 +447,7 @@ export default {
 
                         this.handleScannedCode(code, this.__("Manual Entry"), {
                                 pauseCamera: false,
+                                closeDelay: 0,
                         });
                         this.manualScanValue = "";
                         this.$nextTick(() => {
@@ -448,6 +479,10 @@ export default {
                         if (this.scanResetTimeoutId) {
                                 clearTimeout(this.scanResetTimeoutId);
                                 this.scanResetTimeoutId = null;
+                        }
+                        if (this.dialogCloseTimeoutId) {
+                                clearTimeout(this.dialogCloseTimeoutId);
+                                this.dialogCloseTimeoutId = null;
                         }
                         this.isScanning = false; // This should make QrcodeStream stop/hide
                         this.scannerDialog = false;

--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -1,5 +1,13 @@
 <template>
-	<v-dialog v-model="scannerDialog" max-width="600px" persistent="false">
+        <v-dialog
+                v-model="scannerDialog"
+                max-width="520px"
+                persistent="false"
+                :scrim="false"
+                :retain-focus="false"
+                location="top right"
+                content-class="camera-scanner-dialog"
+        >
 		<v-card>
 			<v-card-title class="text-h5 text-primary d-flex align-center">
 				<v-icon class="mr-2" size="large">mdi-camera</v-icon>
@@ -245,6 +253,12 @@
 .manual-entry {
         background: rgba(255, 255, 255, 0.95);
         border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.camera-scanner-dialog {
+        align-self: flex-start;
+        justify-self: flex-end;
+        margin: 16px;
 }
 </style>
 

--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -109,6 +109,7 @@
                                                 @click:clear="manualScanValue = ''"
                                                 autocomplete="off"
                                                 ref="manualScanInput"
+                                                :autofocus="scannerDialog"
                                                 prepend-inner-icon="mdi-barcode-scan"
                                         >
                                                 <template #append-inner>
@@ -347,7 +348,7 @@ export default {
                         this.manualScanValue = "";
                         // We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
                         await this.$nextTick();
-                        this.focusManualInput();
+                        this.queueManualInputFocus();
                         // Camera listing can be done here or in a dedicated method
                         // vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
                         // but we can use navigator.mediaDevices.enumerateDevices()
@@ -450,7 +451,9 @@ export default {
                                         this.isScanning = true;
                                 }
                                 this.scanResetTimeoutId = null;
+                                this.queueManualInputFocus();
                         }, Math.max(0, resetDelay));
+                        this.queueManualInputFocus();
                 },
 
                 submitManualScan() {
@@ -465,9 +468,7 @@ export default {
                                 closeDelay: 0,
                         });
                         this.manualScanValue = "";
-                        this.$nextTick(() => {
-                                this.focusManualInput();
-                        });
+                        this.queueManualInputFocus();
                 },
 
 		onError(error) {
@@ -558,6 +559,21 @@ export default {
                                 input.focus();
                         }
                 },
+
+                queueManualInputFocus() {
+                        if (!this.scannerDialog) {
+                                return;
+                        }
+                        this.$nextTick(() => {
+                                const scheduler =
+                                        typeof requestAnimationFrame === "function"
+                                                ? requestAnimationFrame
+                                                : (cb) => setTimeout(cb, 16);
+                                scheduler(() => {
+                                        this.focusManualInput();
+                                });
+                        });
+                },
         },
 
 	watch: {
@@ -567,9 +583,7 @@ export default {
                                 if (!this.selectedDeviceId && this.cameras.length === 0) {
                                         this.listCameras();
                                 }
-                                this.$nextTick(() => {
-                                        this.focusManualInput();
-                                });
+                                this.queueManualInputFocus();
                         } else {
                                 // When dialog closes, ensure scanning is stopped.
                                 this.isScanning = false;

--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -264,17 +264,18 @@ export default {
 	},
 
 	data() {
-		return {
-			scannerDialog: false,
-			scanResult: "",
-			scanFormat: "", // We might get this from the 'detect' event payload
-			errorMessage: "",
-			cameraPermissionDenied: false,
-			isScanning: false,
-			torchActive: false,
-			selectedDeviceId: null, // For camera switching
+                return {
+                        scannerDialog: false,
+                        scanResult: "",
+                        scanFormat: "", // We might get this from the 'detect' event payload
+                        errorMessage: "",
+                        cameraPermissionDenied: false,
+                        isScanning: false,
+                        torchActive: false,
+                        selectedDeviceId: null, // For camera switching
                         cameras: [], // To store available cameras
                         manualScanValue: "",
+                        scanResetTimeoutId: null,
 			// Old properties to be removed or re-evaluated:
 			// qrScanner: null,
 			// flashlightSupported: false, // vue-qrcode-reader handles this via QrcodeStream's torch prop
@@ -364,7 +365,8 @@ export default {
                         }
                 },
 
-                handleScannedCode(rawValue, formatLabel = "") {
+                handleScannedCode(rawValue, formatLabel = "", options = {}) {
+                        const { pauseCamera = true, resetDelay = 1000 } = options;
                         const code = (rawValue ?? "").toString().trim();
                         if (!code) {
                                 return;
@@ -387,17 +389,24 @@ export default {
                                 );
                         }
 
-                        const wasScanning = this.isScanning;
-                        this.isScanning = false;
+                        const shouldPauseCamera = pauseCamera && this.isScanning;
+                        if (shouldPauseCamera) {
+                                this.isScanning = false;
+                        }
 
-                        // Resume scanning after a short delay if the camera was already active
-                        setTimeout(() => {
+                        if (this.scanResetTimeoutId) {
+                                clearTimeout(this.scanResetTimeoutId);
+                                this.scanResetTimeoutId = null;
+                        }
+
+                        this.scanResetTimeoutId = setTimeout(() => {
                                 this.scanResult = "";
                                 this.scanFormat = "";
-                                if (wasScanning) {
+                                if (shouldPauseCamera && this.scannerDialog) {
                                         this.isScanning = true;
                                 }
-                        }, 1000);
+                                this.scanResetTimeoutId = null;
+                        }, Math.max(0, resetDelay));
                 },
 
                 submitManualScan() {
@@ -406,7 +415,9 @@ export default {
                                 return;
                         }
 
-                        this.handleScannedCode(code, this.__("Manual Entry"));
+                        this.handleScannedCode(code, this.__("Manual Entry"), {
+                                pauseCamera: false,
+                        });
                         this.manualScanValue = "";
                         this.$nextTick(() => {
                                 this.focusManualInput();
@@ -434,6 +445,10 @@ export default {
 		},
 
                 stopScanning() {
+                        if (this.scanResetTimeoutId) {
+                                clearTimeout(this.scanResetTimeoutId);
+                                this.scanResetTimeoutId = null;
+                        }
                         this.isScanning = false; // This should make QrcodeStream stop/hide
                         this.scannerDialog = false;
                         this.scanResult = "";
@@ -520,11 +535,11 @@ export default {
 		}
 	},
 
-	beforeUnmount() {
-		if (typeof document !== "undefined") {
-			document.removeEventListener("keydown", this.handleEscKey);
-		}
-		this.stopScanning(); // Ensure scanner stops when component is unmounted
-	},
+        beforeUnmount() {
+                if (typeof document !== "undefined") {
+                        document.removeEventListener("keydown", this.handleEscKey);
+                }
+                this.stopScanning(); // Ensure scanner stops when component is unmounted
+        },
 };
 </script>

--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -20,11 +20,11 @@
 
                         <v-card-text class="pa-0">
                                 <div v-if="!cameraPermissionDenied">
-					<!-- Scanner container -->
-					<div class="scanner-container" v-if="isScanning && scannerDialog">
-						<qrcode-stream
-							:formats="readerFormats"
-							:torch="torchActive"
+                                        <!-- Scanner container -->
+                                        <div class="scanner-container" v-if="isScanning && scannerDialog">
+                                                <qrcode-stream
+                                                        :formats="readerFormats"
+                                                        :torch="torchActive"
 							:camera="
 								selectedDeviceId
 									? { deviceId: selectedDeviceId, exact: selectedDeviceId }
@@ -69,9 +69,9 @@
 						>
 							{{ __("Position the QR code or barcode within the scanning area") }}
 							<br /><small>{{ __("Detecting formats:") }} {{ readerFormats.join(", ") }}</small>
-						</v-alert>
-					</div>
-				</div>
+                                                </v-alert>
+                                        </div>
+                                </div>
 
                                 <!-- Camera permission denied message -->
                                 <div v-else class="pa-4 text-center">
@@ -81,7 +81,6 @@
                                         <!-- Requesting permission is handled by the browser when QrcodeStream tries to access camera -->
                                 </div>
 
-                                <!-- Manual / hardware scanner entry -->
                                 <div class="manual-entry pa-4 pt-0">
                                         <v-divider class="mb-4"></v-divider>
                                         <h3 class="text-subtitle-1 font-weight-medium mb-2">
@@ -265,18 +264,18 @@ export default {
 	},
 
 	data() {
-                return {
-                        scannerDialog: false,
-                        scanResult: "",
-                        scanFormat: "", // We might get this from the 'detect' event payload
-                        errorMessage: "",
-                        cameraPermissionDenied: false,
-                        isScanning: false,
-                        torchActive: false,
-                        selectedDeviceId: null, // For camera switching
+		return {
+			scannerDialog: false,
+			scanResult: "",
+			scanFormat: "", // We might get this from the 'detect' event payload
+			errorMessage: "",
+			cameraPermissionDenied: false,
+			isScanning: false,
+			torchActive: false,
+			selectedDeviceId: null, // For camera switching
                         cameras: [], // To store available cameras
                         manualScanValue: "",
-                        // Old properties to be removed or re-evaluated:
+			// Old properties to be removed or re-evaluated:
 			// qrScanner: null,
 			// flashlightSupported: false, // vue-qrcode-reader handles this via QrcodeStream's torch prop
 			// flashlightOn: false, // replaced by torchActive
@@ -325,14 +324,15 @@ export default {
                         this.scanFormat = "";
                         this.cameraPermissionDenied = false;
                         this.isScanning = true; // QrcodeStream will attempt to start camera automatically
+                        this.manualScanValue = "";
                         // We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
                         await this.$nextTick();
                         this.focusManualInput();
                         // Camera listing can be done here or in a dedicated method
-			// vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
-			// but we can use navigator.mediaDevices.enumerateDevices()
-			await this.listCameras();
-		},
+                        // vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
+                        // but we can use navigator.mediaDevices.enumerateDevices()
+                        await this.listCameras();
+                },
 
 		async listCameras() {
 			try {
@@ -360,11 +360,11 @@ export default {
                         // detectedCodes is an array of objects, each with rawValue, format, etc.
                         if (detectedCodes && detectedCodes.length > 0) {
                                 const firstResult = detectedCodes[0];
-                                this.processDetectedValue(firstResult.rawValue, firstResult.format);
+                                this.handleScannedCode(firstResult.rawValue, firstResult.format);
                         }
                 },
 
-                processDetectedValue(rawValue, formatLabel = "", options = {}) {
+                handleScannedCode(rawValue, formatLabel = "") {
                         const code = (rawValue ?? "").toString().trim();
                         if (!code) {
                                 return;
@@ -387,21 +387,14 @@ export default {
                                 );
                         }
 
-                        const resumeCamera = options.resumeCamera !== undefined ? options.resumeCamera : true;
                         const wasScanning = this.isScanning;
-                        const shouldResumeCamera = resumeCamera && wasScanning;
+                        this.isScanning = false;
 
-                        if (shouldResumeCamera) {
-                                this.isScanning = false;
-                        }
-
+                        // Resume scanning after a short delay if the camera was already active
                         setTimeout(() => {
-                                if (!this.scannerDialog) {
-                                        return;
-                                }
                                 this.scanResult = "";
                                 this.scanFormat = "";
-                                if (shouldResumeCamera) {
+                                if (wasScanning) {
                                         this.isScanning = true;
                                 }
                         }, 1000);
@@ -413,14 +406,14 @@ export default {
                                 return;
                         }
 
-                        this.processDetectedValue(code, this.__("Manual Entry"));
+                        this.handleScannedCode(code, this.__("Manual Entry"));
                         this.manualScanValue = "";
                         this.$nextTick(() => {
                                 this.focusManualInput();
                         });
                 },
 
-                onError(error) {
+		onError(error) {
 			this.errorMessage = error.name || "Unknown error";
 			if (error.name === "NotAllowedError") {
 				this.cameraPermissionDenied = true;
@@ -495,13 +488,14 @@ export default {
                 },
 
                 focusManualInput() {
-                        if (this.$refs.manualScanInput && this.$refs.manualScanInput.focus) {
-                                this.$refs.manualScanInput.focus();
+                        const input = this.$refs.manualScanInput;
+                        if (input && typeof input.focus === "function") {
+                                input.focus();
                         }
                 },
         },
 
-        watch: {
+	watch: {
                 scannerDialog(newVal) {
                         if (newVal) {
                                 // When dialog opens, if no camera is selected, list them.

--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -508,7 +508,6 @@ export default {
                         this.torchActive = false;
                         this.manualScanValue = "";
                         // selectedDeviceId and cameras can remain as they are for next scan
-                        this.$emit("scanner-closed");
                 },
 
 		async toggleTorch() {
@@ -576,7 +575,7 @@ export default {
                 },
         },
 
-	watch: {
+        watch: {
                 scannerDialog(newVal) {
                         if (newVal) {
                                 // When dialog opens, if no camera is selected, list them.
@@ -584,11 +583,13 @@ export default {
                                         this.listCameras();
                                 }
                                 this.queueManualInputFocus();
+                                this.$emit("scanner-opened");
                         } else {
                                 // When dialog closes, ensure scanning is stopped.
                                 this.isScanning = false;
                                 this.torchActive = false;
                                 this.manualScanValue = "";
+                                this.$emit("scanner-closed");
                         }
                 },
         },

--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -263,7 +263,7 @@ export default {
                 },
                 autoCloseOnScan: {
                         type: Boolean,
-                        default: true,
+                        default: false,
                 },
         },
 
@@ -447,6 +447,7 @@ export default {
 
                         this.handleScannedCode(code, this.__("Manual Entry"), {
                                 pauseCamera: false,
+                                closeDialog: false,
                                 closeDelay: 0,
                         });
                         this.manualScanValue = "";

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2564,22 +2564,25 @@ export default {
 				}
 			}
 		},
-		showScanError({ message, code = "", details = "" } = {}) {
-			this.scanErrorMessage = message || this.__("Unable to add scanned item.");
-			this.scanErrorCode = code;
-			this.scanErrorDetails = details;
-			if (code) {
-				this.pendingScanCode = code;
-			}
-			this.awaitingScanResult = false;
-			this.search_from_scanner = false;
-			this.scanErrorDialog = true;
-			this.scannerLocked = true;
-			this.playScanTone("error");
-			if (frappe?.show_alert) {
-				frappe.show_alert(
-					{
-						message: this.scanErrorMessage,
+                showScanError({ message, code = "", details = "" } = {}) {
+                        this.scanErrorMessage = message || this.__("Unable to add scanned item.");
+                        this.scanErrorCode = code;
+                        this.scanErrorDetails = details;
+                        if (code) {
+                                this.pendingScanCode = code;
+                        }
+                        this.awaitingScanResult = false;
+                        this.search_from_scanner = false;
+                        this.scanErrorDialog = true;
+                        this.scannerLocked = true;
+                        if (this.$refs.cameraScanner?.pauseForExternalLock) {
+                                this.$refs.cameraScanner.pauseForExternalLock();
+                        }
+                        this.playScanTone("error");
+                        if (frappe?.show_alert) {
+                                frappe.show_alert(
+                                        {
+                                                message: this.scanErrorMessage,
 						indicator: "red",
 					},
 					5,
@@ -2594,6 +2597,9 @@ export default {
                         this.scanErrorDetails = "";
                         this.pendingScanCode = "";
                         this.awaitingScanResult = false;
+                        if (this.$refs.cameraScanner?.resumeFromExternalLock) {
+                                this.$refs.cameraScanner.resumeFromExternalLock();
+                        }
                         this.focusItemSearch();
                 },
 

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -442,12 +442,14 @@
 		</v-card>
 
 		<!-- Camera Scanner Component -->
-		<CameraScanner
-			v-if="pos_profile.posa_enable_camera_scanning"
-			ref="cameraScanner"
-			:scan-type="pos_profile.posa_camera_scan_type || 'Both'"
-			@barcode-scanned="onBarcodeScanned"
-		/>
+                <CameraScanner
+                        v-if="pos_profile.posa_enable_camera_scanning"
+                        ref="cameraScanner"
+                        :scan-type="pos_profile.posa_camera_scan_type || 'Both'"
+                        @barcode-scanned="onBarcodeScanned"
+                        @scanner-opened="onScannerOpened"
+                        @scanner-closed="onScannerClosed"
+                />
 	</div>
 </template>
 
@@ -579,10 +581,11 @@ export default {
 		totalItemCount: 0,
 		scanErrorDialog: false,
 		scanErrorMessage: "",
-		scanErrorDetails: "",
-		scanErrorCode: "",
-		scannerLocked: false,
-		scanAudioContext: null,
+                scanErrorDetails: "",
+                scanErrorCode: "",
+                scannerLocked: false,
+                cameraScannerActive: false,
+                scanAudioContext: null,
 		pendingScanCode: "",
 		awaitingScanResult: false,
 	}),
@@ -1984,11 +1987,11 @@ export default {
 					this.search_from_scanner = false;
 				}
 
-				if (!this.scanErrorDialog) {
-					// Clear search field after successfully adding an item
-					this.clearSearch();
-					this.$refs.debounce_search.focus();
-				}
+                                if (!this.scanErrorDialog) {
+                                        // Clear search field after successfully adding an item
+                                        this.clearSearch();
+                                        this.focusItemSearch();
+                                }
 			}
 		},
 		search_onchange: _.debounce(async function (newSearchTerm) {
@@ -2044,11 +2047,11 @@ export default {
 			}
 
 			// Clear the input only when triggered via scanner
-			if (fromScanner) {
-				vm.clearSearch();
-				vm.$refs.debounce_search && vm.$refs.debounce_search.focus();
-				vm.search_from_scanner = false;
-			}
+                        if (fromScanner) {
+                                vm.clearSearch();
+                                vm.focusItemSearch();
+                                vm.search_from_scanner = false;
+                        }
 		}, 300),
 		get_item_qty(first_search) {
 			const qtyVal = this.qty != null ? this.qty : 1;
@@ -2089,13 +2092,13 @@ export default {
 			const item_code_len = first_search.length - prefix_len - 6;
 			return first_search.substr(0, prefix_len + item_code_len);
 		},
-		esc_event() {
-			this.search = null;
-			this.first_search = null;
-			this.search_backup = null;
-			this.qty = 1;
-			this.$refs.debounce_search.focus();
-		},
+                esc_event() {
+                        this.search = null;
+                        this.first_search = null;
+                        this.search_backup = null;
+                        this.qty = 1;
+                        this.focusItemSearch();
+                },
 		async update_items_details(items) {
 			const vm = this;
 			if (!items || !items.length) return;
@@ -2416,13 +2419,13 @@ export default {
 					this.enter_event();
 				}
 
-				// clear search field for next scan and refocus input
-				if (!this.scanErrorDialog) {
-					this.clearSearch();
-					this.$refs.debounce_search && this.$refs.debounce_search.focus();
-				}
-			});
-		},
+                                // clear search field for next scan and refocus input
+                                if (!this.scanErrorDialog) {
+                                        this.clearSearch();
+                                        this.focusItemSearch();
+                                }
+                        });
+                },
 		generateWordCombinations(inputString) {
 			const words = inputString.split(" ");
 			const wordCount = words.length;
@@ -2488,14 +2491,27 @@ export default {
 			// this.search_backup = "";
 		},
 
-		focusItemSearch() {
-			this.$nextTick(() => {
-				const input = this.$refs.debounce_search;
-				if (input && typeof input.focus === "function") {
-					input.focus();
-				}
-			});
-		},
+                focusItemSearch() {
+                        if (this.cameraScannerActive) {
+                                return;
+                        }
+                        this.$nextTick(() => {
+                                if (this.cameraScannerActive) {
+                                        return;
+                                }
+                                const input = this.$refs.debounce_search;
+                                if (input && typeof input.focus === "function") {
+                                        input.focus();
+                                }
+                        });
+                },
+
+                blurItemSearch() {
+                        const input = this.$refs.debounce_search;
+                        if (input && typeof input.blur === "function") {
+                                input.blur();
+                        }
+                },
 
 		clearQty() {
 			this.qty = null;
@@ -2570,24 +2586,30 @@ export default {
 				);
 			}
 		},
-		acknowledgeScanError() {
-			this.scanErrorDialog = false;
-			this.scannerLocked = false;
-			this.scanErrorMessage = "";
-			this.scanErrorCode = "";
-			this.scanErrorDetails = "";
-			this.pendingScanCode = "";
-			this.awaitingScanResult = false;
-			this.$nextTick(() => {
-				if (this.$refs.debounce_search) {
-					this.$refs.debounce_search.focus();
-				}
-			});
-		},
+                acknowledgeScanError() {
+                        this.scanErrorDialog = false;
+                        this.scannerLocked = false;
+                        this.scanErrorMessage = "";
+                        this.scanErrorCode = "";
+                        this.scanErrorDetails = "";
+                        this.pendingScanCode = "";
+                        this.awaitingScanResult = false;
+                        this.focusItemSearch();
+                },
 
-		startCameraScanning() {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
+                onScannerOpened() {
+                        this.cameraScannerActive = true;
+                        this.blurItemSearch();
+                },
+
+                onScannerClosed() {
+                        this.cameraScannerActive = false;
+                        this.focusItemSearch();
+                },
+
+                startCameraScanning() {
+                        if (this.scannerLocked) {
+                                this.playScanTone("error");
 				return;
 			}
 			if (this.$refs.cameraScanner) {
@@ -2828,13 +2850,13 @@ export default {
 					3,
 				);
 
-				// Clear search after successful addition and refocus input
-				this.clearSearch();
-				this.$refs.debounce_search && this.$refs.debounce_search.focus();
-			} finally {
-				this.awaitingScanResult = false;
-			}
-		},
+                                // Clear search after successful addition and refocus input
+                                this.clearSearch();
+                                this.focusItemSearch();
+                        } finally {
+                                this.awaitingScanResult = false;
+                        }
+                },
 		isNegativeStockEnabled() {
 			const setting = this.stock_settings?.allow_negative_stock;
 			if (setting === undefined || setting === null) {


### PR DESCRIPTION
## Summary
- add a manual input area to the camera scanner so hardware scanners can submit codes without camera access
- reuse shared processing logic for camera and manual entries and keep focus on the manual input for consecutive scans

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d18ab4151083269f722ae49e9ac72f