### PR TITLE
Fix ERPNext breadcrumb layout

### DIFF
--- a/frontend/src/posapp/styles/theme.css
+++ b/frontend/src/posapp/styles/theme.css
@@ -298,8 +298,19 @@
 .navbar-right,
 .awesome-bar,
 .navbar-user-image {
-	visibility: visible !important;
-	display: block !important;
+        visibility: visible !important;
+}
+
+/* Restore horizontal layout for Frappe breadcrumbs */
+#navbar-breadcrumbs {
+        display: flex !important;
+        align-items: center;
+        flex-wrap: nowrap;
+}
+
+#navbar-breadcrumbs .breadcrumb {
+        margin-bottom: 0;
+        flex-wrap: nowrap;
 }
 
 .posapp .pos-themed-button {


### PR DESCRIPTION
## Summary
- ensure ERPNext navbar elements remain visible without forcing block layout
- restore breadcrumb container to flex layout to keep items on a single line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d229c49c2883268799d45465c23ece