### PR TITLE
fix: improve cache usage estimation and API access

### DIFF
--- a/posawesome/posawesome/api/utilities.py
+++ b/posawesome/posawesome/api/utilities.py
@@ -137,6 +137,7 @@ def get_selling_price_lists():
     )
 
 
+@frappe.whitelist()
 def get_app_info() -> Dict[str, List[Dict[str, str]]]:
     """
     Return a list of installed apps and their versions.


### PR DESCRIPTION
## Summary
- avoid duplicate cache usage calculations by caching in-flight promises
- rely on the browser StorageManager API for cache usage metrics with a lightweight IndexedDB fallback
- whitelist `get_app_info` so the navbar about dialog can load without access errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2512df3e4832694c61105fedd1139