### PR TITLE
feat: relocate manual barcode entry

### DIFF
--- a/frontend/src/posapp/components/pos/CameraScanner.vue
+++ b/frontend/src/posapp/components/pos/CameraScanner.vue
@@ -89,41 +89,6 @@
                                         <!-- Requesting permission is handled by the browser when QrcodeStream tries to access camera -->
                                 </div>
 
-                                <div class="manual-entry pa-4 pt-0">
-                                        <v-divider class="mb-4"></v-divider>
-                                        <h3 class="text-subtitle-1 font-weight-medium mb-2">
-                                                {{ __("Manual or Hardware Scanner Input") }}
-                                        </h3>
-                                        <p class="text-body-2 mb-3">
-                                                {{ __("Scan with a hardware scanner or type the code, then press Enter.") }}
-                                        </p>
-                                        <v-text-field
-                                                density="comfortable"
-                                                variant="outlined"
-                                                color="primary"
-                                                clearable
-                                                hide-details
-                                                :label="__('Enter Code Manually')"
-                                                v-model="manualScanValue"
-                                                @keydown.enter.prevent="submitManualScan"
-                                                @click:clear="manualScanValue = ''"
-                                                autocomplete="off"
-                                                ref="manualScanInput"
-                                                :autofocus="scannerDialog"
-                                                prepend-inner-icon="mdi-barcode-scan"
-                                        >
-                                                <template #append-inner>
-                                                        <v-btn
-                                                                icon="mdi-check"
-                                                                variant="tonal"
-                                                                color="primary"
-                                                                size="small"
-                                                                @click="submitManualScan"
-                                                                :title="__('Submit Code')"
-                                                        ></v-btn>
-                                                </template>
-                                        </v-text-field>
-                                </div>
                         </v-card-text>
 
 			<!-- Action buttons -->
@@ -251,11 +216,6 @@
         background: rgba(255, 255, 255, 0.95);
 }
 
-.manual-entry {
-        background: rgba(255, 255, 255, 0.95);
-        border-top: 1px solid rgba(0, 0, 0, 0.08);
-}
-
 .camera-scanner-dialog {
         align-self: flex-start;
         justify-self: flex-end;
@@ -264,6 +224,7 @@
 </style>
 
 <script>
+/* global frappe */
 import { QrcodeStream } from "vue-qrcode-reader";
 
 export default {
@@ -293,7 +254,6 @@ export default {
                         torchActive: false,
                         selectedDeviceId: null, // For camera switching
                         cameras: [], // To store available cameras
-                        manualScanValue: "",
                         scanResetTimeoutId: null,
                         dialogCloseTimeoutId: null,
                         scannerLockedExternally: false,
@@ -347,10 +307,8 @@ export default {
                         this.scanFormat = "";
                         this.cameraPermissionDenied = false;
                         this.isScanning = true; // QrcodeStream will attempt to start camera automatically
-                        this.manualScanValue = "";
                         // We might need to await this.$nextTick() if QrcodeStream is inside v-if controlled by scannerDialog
                         await this.$nextTick();
-                        this.queueManualInputFocus();
                         // Camera listing can be done here or in a dedicated method
                         // vue-qrcode-reader doesn't directly list cameras in QrcodeStream,
                         // but we can use navigator.mediaDevices.enumerateDevices()
@@ -453,27 +411,10 @@ export default {
                                         this.isScanning = true;
                                 }
                                 this.scanResetTimeoutId = null;
-                                this.queueManualInputFocus();
                         }, Math.max(0, resetDelay));
-                        this.queueManualInputFocus();
                 },
 
-                submitManualScan() {
-                        const code = (this.manualScanValue ?? "").toString().trim();
-                        if (!code) {
-                                return;
-                        }
-
-                        this.handleScannedCode(code, this.__("Manual Entry"), {
-                                pauseCamera: false,
-                                closeDialog: false,
-                                closeDelay: 0,
-                        });
-                        this.manualScanValue = "";
-                        this.queueManualInputFocus();
-                },
-
-		onError(error) {
+                onError(error) {
 			this.errorMessage = error.name || "Unknown error";
 			if (error.name === "NotAllowedError") {
 				this.cameraPermissionDenied = true;
@@ -509,7 +450,6 @@ export default {
                         this.scanFormat = "";
                         this.errorMessage = "";
                         this.torchActive = false;
-                        this.manualScanValue = "";
                         // selectedDeviceId and cameras can remain as they are for next scan
                 },
 
@@ -555,28 +495,6 @@ export default {
                         }
                 },
 
-                focusManualInput() {
-                        const input = this.$refs.manualScanInput;
-                        if (input && typeof input.focus === "function") {
-                                input.focus();
-                        }
-                },
-
-                queueManualInputFocus() {
-                        if (!this.scannerDialog) {
-                                return;
-                        }
-                        this.$nextTick(() => {
-                                const scheduler =
-                                        typeof requestAnimationFrame === "function"
-                                                ? requestAnimationFrame
-                                                : (cb) => setTimeout(cb, 16);
-                                scheduler(() => {
-                                        this.focusManualInput();
-                                });
-                        });
-                },
-
                 pauseForExternalLock() {
                         this.scannerLockedExternally = true;
                         if (this.scanResetTimeoutId) {
@@ -602,11 +520,8 @@ export default {
                                 this.$nextTick(() => {
                                         if (this.scannerDialog && !this.isScanning) {
                                                 this.isScanning = true;
-                                                this.queueManualInputFocus();
                                         }
                                 });
-                        } else {
-                                this.queueManualInputFocus();
                         }
                 },
         },
@@ -618,13 +533,11 @@ export default {
                                 if (!this.selectedDeviceId && this.cameras.length === 0) {
                                         this.listCameras();
                                 }
-                                this.queueManualInputFocus();
                                 this.$emit("scanner-opened");
                         } else {
                                 // When dialog closes, ensure scanning is stopped.
                                 this.isScanning = false;
                                 this.torchActive = false;
-                                this.manualScanValue = "";
                                 this.$emit("scanner-closed");
                         }
                 },

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2569,6 +2569,10 @@ export default {
                                 if (this.cameraScannerActive) {
                                         return;
                                 }
+                                if (this.showManualScanInput) {
+                                        this.queueManualScanFocus();
+                                        return;
+                                }
                                 const input = this.$refs.debounce_search;
                                 if (input && typeof input.focus === "function") {
                                         input.focus();

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -66,26 +66,84 @@
 								prepend-inner-icon="mdi-magnify"
 								@focus="handleItemSearchFocus"
 								ref="debounce_search"
-							>
-								<!-- Add camera scan button if enabled -->
-								<template v-slot:append-inner v-if="pos_profile.posa_enable_camera_scanning">
-									<v-btn
-										icon="mdi-camera"
-										size="small"
-										color="primary"
-										variant="text"
-										:disabled="scannerLocked"
-										@click="startCameraScanning"
-										:title="
-											scannerLocked
-												? __('Acknowledge the error to resume scanning')
-												: __('Scan with Camera')
-										"
-									>
-									</v-btn>
-								</template>
-							</v-text-field>
-						</v-col>
+                                                        >
+                                                                <template v-slot:append-inner>
+                                                                        <v-btn
+                                                                                :icon="
+                                                                                        showManualScanInput
+                                                                                                ? 'mdi-barcode-off'
+                                                                                                : 'mdi-barcode-scan'
+                                                                                "
+                                                                                size="small"
+                                                                                color="primary"
+                                                                                :variant="showManualScanInput ? 'tonal' : 'text'"
+                                                                                class="mr-1"
+                                                                                @click.stop="toggleManualScanInput"
+                                                                                :title="
+                                                                                        showManualScanInput
+                                                                                                ? __('Hide Manual Entry')
+                                                                                                : __('Show Manual Entry')
+                                                                                "
+                                                                        >
+                                                                        </v-btn>
+                                                                        <v-btn
+                                                                                v-if="pos_profile.posa_enable_camera_scanning"
+                                                                                icon="mdi-camera"
+                                                                                size="small"
+                                                                                color="primary"
+                                                                                variant="text"
+                                                                                :disabled="scannerLocked"
+                                                                                @click="startCameraScanning"
+                                                                                :title="
+                                                                                        scannerLocked
+                                                                                                ? __('Acknowledge the error to resume scanning')
+                                                                                                : __('Scan with Camera')
+                                                                                "
+                                                                        >
+                                                                        </v-btn>
+                                                                </template>
+                                                        </v-text-field>
+                                                        <v-expand-transition>
+                                                                <div
+                                                                        v-if="showManualScanInput"
+                                                                        class="manual-scan-container mt-2"
+                                                                >
+                                                                        <div class="manual-scan-text mb-3">
+                                                                                <div class="text-subtitle-2 font-weight-medium">
+                                                                                        {{ __("Manual or Hardware Scanner Input") }}
+                                                                                </div>
+                                                                                <div class="text-body-2 text-medium-emphasis">
+                                                                                        {{ __("Scan with a hardware scanner or type the code, then press Enter.") }}
+                                                                                </div>
+                                                                        </div>
+                                                                        <v-text-field
+                                                                                density="comfortable"
+                                                                                variant="outlined"
+                                                                                color="primary"
+                                                                                clearable
+                                                                                hide-details
+                                                                                :label="__('Enter Code Manually')"
+                                                                                v-model="manualScanValue"
+                                                                                @keydown.enter.prevent="submitManualScan"
+                                                                                @click:clear="manualScanValue = ''"
+                                                                                autocomplete="off"
+                                                                                ref="manualScanInput"
+                                                                                prepend-inner-icon="mdi-barcode-scan"
+                                                                        >
+                                                                                <template #append-inner>
+                                                                                        <v-btn
+                                                                                                icon="mdi-check"
+                                                                                                variant="tonal"
+                                                                                                color="primary"
+                                                                                                size="small"
+                                                                                                @click="submitManualScan"
+                                                                                                :title="__('Submit Code')"
+                                                                                        ></v-btn>
+                                                                                </template>
+                                                                        </v-text-field>
+                                                                </div>
+                                                        </v-expand-transition>
+                                                </v-col>
 						<v-col cols="3" class="pb-0" v-if="pos_profile.posa_input_qty">
 							<v-text-field
 								density="compact"
@@ -585,13 +643,25 @@ export default {
                 scanErrorCode: "",
                 scannerLocked: false,
                 cameraScannerActive: false,
+                showManualScanInput: false,
+                manualScanValue: "",
                 scanAudioContext: null,
-		pendingScanCode: "",
-		awaitingScanResult: false,
+                pendingScanCode: "",
+                awaitingScanResult: false,
 	}),
 
-	watch: {
-		customer: _.debounce(function () {
+        watch: {
+                showManualScanInput(newVal) {
+                        if (newVal) {
+                                this.queueManualScanFocus();
+                        } else {
+                                this.manualScanValue = "";
+                                if (!this.cameraScannerActive) {
+                                        this.$nextTick(() => this.focusItemSearch());
+                                }
+                        }
+                },
+                customer: _.debounce(function () {
 			if (this.pos_profile.posa_force_reload_items) {
 				if (this.pos_profile.posa_smart_reload_mode) {
 					// When limit search is enabled there may be no items yet.
@@ -2603,8 +2673,53 @@ export default {
                         this.focusItemSearch();
                 },
 
+                toggleManualScanInput() {
+                        this.showManualScanInput = !this.showManualScanInput;
+                        if (this.showManualScanInput) {
+                                this.queueManualScanFocus();
+                        } else {
+                                this.focusItemSearch();
+                        }
+                },
+
+                submitManualScan() {
+                        const code = (this.manualScanValue ?? "").toString().trim();
+                        if (!code) {
+                                return;
+                        }
+                        if (this.scannerLocked) {
+                                this.onBarcodeScanned(code);
+                                this.queueManualScanFocus();
+                                return;
+                        }
+                        this.manualScanValue = "";
+                        this.onBarcodeScanned(code);
+                        this.queueManualScanFocus();
+                },
+
+                focusManualScanInput() {
+                        const input = this.$refs.manualScanInput;
+                        if (input && typeof input.focus === "function") {
+                                input.focus();
+                        }
+                },
+
+                queueManualScanFocus() {
+                        this.$nextTick(() => {
+                                const scheduler =
+                                        typeof requestAnimationFrame === "function"
+                                                ? requestAnimationFrame
+                                                : (cb) => setTimeout(cb, 16);
+                                scheduler(() => {
+                                        this.focusManualScanInput();
+                                });
+                        });
+                },
+
                 onScannerOpened() {
                         this.cameraScannerActive = true;
+                        this.showManualScanInput = false;
+                        this.manualScanValue = "";
                         this.blurItemSearch();
                 },
 
@@ -2616,17 +2731,26 @@ export default {
                 startCameraScanning() {
                         if (this.scannerLocked) {
                                 this.playScanTone("error");
-				return;
-			}
+                                return;
+                        }
 			if (this.$refs.cameraScanner) {
 				this.$refs.cameraScanner.startScanning();
 			}
-		},
-		onBarcodeScanned(scannedCode) {
-			if (this.scannerLocked) {
-				this.playScanTone("error");
-				return;
-			}
+                },
+                onBarcodeScanned(scannedCode) {
+                        if (this.scannerLocked) {
+                                this.playScanTone("error");
+                                if (frappe?.show_alert) {
+                                        frappe.show_alert(
+                                                {
+                                                        message: this.__("Acknowledge the error to resume scanning."),
+                                                        indicator: "red",
+                                                },
+                                                3,
+                                        );
+                                }
+                                return;
+                        }
 			console.log("Barcode scanned:", scannedCode);
 			this.pendingScanCode = scannedCode;
 
@@ -3450,12 +3574,35 @@ export default {
 <style scoped>
 /* "dynamic-card" no longer composes from pos-card; the pos-card class is added directly in the template */
 .dynamic-padding {
-	/* Equal spacing on all sides for consistent alignment */
-	padding: var(--dynamic-sm);
+        /* Equal spacing on all sides for consistent alignment */
+        padding: var(--dynamic-sm);
+}
+
+.manual-scan-container {
+        padding: 16px;
+        border-radius: 12px;
+        border: 1px solid var(--pos-border, rgba(0, 0, 0, 0.08));
+        background-color: var(--pos-card-bg, rgba(255, 255, 255, 0.96));
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+        transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.manual-scan-text .text-body-2 {
+        color: rgba(0, 0, 0, 0.6);
+}
+
+:deep(.v-theme--dark) .manual-scan-container {
+        background-color: rgba(30, 30, 30, 0.92);
+        border-color: rgba(255, 255, 255, 0.12);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+:deep(.v-theme--dark) .manual-scan-text .text-body-2 {
+        color: rgba(255, 255, 255, 0.7);
 }
 
 .scan-error-dialog {
-	border-radius: 16px;
+        border-radius: 16px;
 }
 
 .scan-error-dialog .scan-error-message {


### PR DESCRIPTION
## Summary
- add a toggleable manual barcode entry section beneath the item search input so users can key or hardware-scan codes without opening the camera dialog
- manage manual entry focus, scanner lock handling, and automatic hiding when the camera scanner opens for a smoother workflow
- simplify the camera scanner dialog by removing the embedded manual entry UI so it only handles camera-related controls

## Testing
- `npx eslint frontend/src/posapp/components/pos/CameraScanner.vue frontend/src/posapp/components/pos/ItemsSelector.vue`


------
https://chatgpt.com/codex/tasks/task_e_68d3962dc4ec8326a2c0683e52677929