### PR TITLE
Add POS performance instrumentation and guardrails

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1285,12 +1285,14 @@ export default {
 			this.posa_coupons = data;
 			this.handelOffers();
 		});
-		this.eventBus.on("set_all_items", (data) => {
-			this.allItems = data;
-			this.items.forEach((item) => {
-				this.update_item_detail(item);
-			});
-		});
+                this.eventBus.on("set_all_items", (data) => {
+                        this.allItems = data;
+                        this.items.forEach((item) => {
+                                if (item._detailSynced !== true) {
+                                        this.update_item_detail(item);
+                                }
+                        });
+                });
 		this.eventBus.on("load_return_invoice", (data) => {
 			// Handle loading of return invoice and set all related fields
 			console.log("Invoice component received load_return_invoice event with data:", data);

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -550,6 +550,7 @@ import {
 import { useResponsive } from "../../composables/useResponsive.js";
 import { useRtl } from "../../composables/useRtl.js";
 import { useFlyAnimation } from "../../composables/useFlyAnimation.js";
+import { withPerf, perfMarkStart, perfMarkEnd, scheduleFrame } from "../../utils/perf.js";
 import placeholderImage from "./placeholder-image.png";
 import Skeleton from "../ui/Skeleton.vue";
 
@@ -648,7 +649,9 @@ export default {
                 scanAudioContext: null,
                 pendingScanCode: "",
                 awaitingScanResult: false,
-	}),
+                scanDebounceId: null,
+                scanQueuedCode: "",
+        }),
 
         watch: {
                 showManualScanInput(newVal) {
@@ -856,8 +859,8 @@ export default {
 
 	methods: {
 		// Performance optimization: Memoized search function
-		memoizedSearch(searchTerm, itemGroup) {
-			const cacheKey = `${searchTerm || ""}_${itemGroup || "ALL"}`;
+                memoizedSearch(searchTerm, itemGroup) {
+                        const cacheKey = `${searchTerm || ""}_${itemGroup || "ALL"}`;
 
 			// Check if we have a cached result
 			if (this.searchCache && this.searchCache.has(cacheKey)) {
@@ -866,7 +869,7 @@ export default {
 			}
 
 			// Perform the search
-			const result = this.performSearch(searchTerm, itemGroup);
+                        const result = this.performSearch(searchTerm, itemGroup);
 
 			// Cache the result
 			if (this.searchCache) {
@@ -876,10 +879,12 @@ export default {
 			return result;
 		},
 
-		performSearch(searchTerm, itemGroup) {
-			if (!this.items || !this.items.length) {
-				return [];
-			}
+                performSearch(searchTerm, itemGroup) {
+                        const mark = perfMarkStart("pos:search-filter");
+                        if (!this.items || !this.items.length) {
+                                perfMarkEnd("pos:search-filter", mark);
+                                return [];
+                        }
 
 			let filtered = this.items;
 
@@ -892,8 +897,8 @@ export default {
 			}
 
 			// Filter by search term only if it exists and is long enough
-			if (searchTerm && searchTerm.trim() && searchTerm.trim().length >= 3) {
-				const term = searchTerm.toLowerCase();
+                        if (searchTerm && searchTerm.trim() && searchTerm.trim().length >= 3) {
+                                const term = searchTerm.toLowerCase();
 				filtered = filtered.filter((item) => {
 					const barcodeMatch =
 						(Array.isArray(item.item_barcode) &&
@@ -912,8 +917,9 @@ export default {
 				});
 			}
 
-			return filtered;
-		},
+                        perfMarkEnd("pos:search-filter", mark);
+                        return filtered;
+                },
 
 		async fetchServerItemsTimestamp() {
 			try {
@@ -2064,10 +2070,11 @@ export default {
                                 }
 			}
 		},
-		search_onchange: _.debounce(async function (newSearchTerm) {
-			const vm = this;
+                search_onchange: _.debounce(
+                        withPerf("pos:search-trigger", async function (newSearchTerm) {
+                                const vm = this;
 
-			vm.cancelItemDetailsRequest();
+                                vm.cancelItemDetailsRequest();
 
 			// Determine the actual query string and trim whitespace
 			const query = typeof newSearchTerm === "string" ? newSearchTerm : vm.first_search;
@@ -2116,13 +2123,15 @@ export default {
 				}
 			}
 
-			// Clear the input only when triggered via scanner
+                        // Clear the input only when triggered via scanner
                         if (fromScanner) {
                                 vm.clearSearch();
                                 vm.focusItemSearch();
                                 vm.search_from_scanner = false;
                         }
-		}, 300),
+                        }),
+                        300,
+                ),
 		get_item_qty(first_search) {
 			const qtyVal = this.qty != null ? this.qty : 1;
 			let scal_qty = Math.abs(qtyVal);
@@ -2755,34 +2764,56 @@ export default {
                                 }
                                 return;
                         }
-			console.log("Barcode scanned:", scannedCode);
-			this.pendingScanCode = scannedCode;
 
-			// mark this search as coming from a scanner
-			this.search_from_scanner = true;
+                        const scheduleScan = (code) => {
+                                const mark = perfMarkStart("pos:scan-handler");
+                                scheduleFrame(() => {
+                                        try {
+                                                console.log("Barcode scanned:", code);
+                                                this.pendingScanCode = code;
 
-			// Clear any previous search
-			this.search = "";
-			this.first_search = "";
+                                                // mark this search as coming from a scanner
+                                                this.search_from_scanner = true;
 
-			// Set the scanned code as search term
-			this.first_search = scannedCode;
-			this.search = scannedCode;
+                                                // Clear any previous search
+                                                this.search = "";
+                                                this.first_search = "";
 
-			// Show scanning feedback
-			frappe.show_alert(
-				{
-					message: `Scanning for: ${scannedCode}`,
-					indicator: "blue",
-				},
-				2,
-			);
+                                                // Set the scanned code as search term
+                                                this.first_search = code;
+                                                this.search = code;
 
-			// Enhanced item search and submission logic
-			this.processScannedItem(scannedCode);
-		},
-		async processScannedItem(scannedCode) {
-			this.pendingScanCode = scannedCode;
+                                                // Show scanning feedback
+                                                frappe.show_alert(
+                                                        {
+                                                                message: `Scanning for: ${code}`,
+                                                                indicator: "blue",
+                                                        },
+                                                        2,
+                                                );
+
+                                                // Enhanced item search and submission logic
+                                                this.processScannedItem(code);
+                                        } finally {
+                                                perfMarkEnd("pos:scan-handler", mark);
+                                        }
+                                });
+                        };
+
+                        if (this.scanDebounceId) {
+                                clearTimeout(this.scanDebounceId);
+                        }
+                        this.scanQueuedCode = scannedCode;
+                        this.scanDebounceId = setTimeout(() => {
+                                this.scanDebounceId = null;
+                                const code = this.scanQueuedCode || scannedCode;
+                                this.scanQueuedCode = "";
+                                scheduleScan(code);
+                        }, 12);
+                },
+                async processScannedItem(scannedCode) {
+                        const mark = perfMarkStart("pos:scan-process");
+                        this.pendingScanCode = scannedCode;
 			// Handle scale barcodes by extracting the item code and quantity
 			let searchCode = scannedCode;
 			let qtyFromBarcode = null;
@@ -2811,8 +2842,8 @@ export default {
 			}
 
 			// If not found locally, attempt to fetch from server using processed code
-			try {
-				const res = await frappe.call({
+                        try {
+                                const res = await frappe.call({
 					method: "posawesome.posawesome.api.items.get_items_from_barcode",
 					args: {
 						selling_price_list: this.active_price_list,
@@ -2845,18 +2876,20 @@ export default {
 					details: this.__("Please verify the barcode or check the item's availability."),
 				});
 				return;
-			} catch (e) {
-				console.error("Error fetching item from barcode:", e);
-				this.first_search = scannedCode;
-				this.search = scannedCode;
-				this.showScanError({
-					message: `${this.__("Item not found")}: ${scannedCode}`,
-					code: scannedCode,
-					details: this.__("The system could not retrieve the item details. Please try again."),
-				});
-				return;
-			}
-		},
+                        } catch (e) {
+                                console.error("Error fetching item from barcode:", e);
+                                this.first_search = scannedCode;
+                                this.search = scannedCode;
+                                this.showScanError({
+                                        message: `${this.__("Item not found")}: ${scannedCode}`,
+                                        code: scannedCode,
+                                        details: this.__("The system could not retrieve the item details. Please try again."),
+                                });
+                                return;
+                        } finally {
+                                perfMarkEnd("pos:scan-process", mark);
+                        }
+                },
 		searchItemsByCode(code) {
 			return this.items.filter((item) => {
 				const searchTerm = code.toLowerCase();

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -651,6 +651,7 @@ export default {
                 awaitingScanResult: false,
                 scanDebounceId: null,
                 scanQueuedCode: "",
+                refreshInFlight: false,
         }),
 
         watch: {
@@ -1162,59 +1163,76 @@ export default {
 				this.itemDetailsRequestCache.result = null;
 			}
 		},
-		async refreshPricesForVisibleItems() {
-			const vm = this;
-			if (!vm.filtered_items || vm.filtered_items.length === 0) return;
+                async refreshPricesForVisibleItems() {
+                        const vm = this;
+                        if (!vm.filtered_items || vm.filtered_items.length === 0) return;
 
-			vm.loading = true;
+                        if (vm.refreshInFlight) {
+                                return;
+                        }
 
-			const itemCodes = vm.filtered_items.map((it) => it.item_code);
-			const cacheResult = await getCachedItemDetails(
-				vm.pos_profile.name,
-				vm.active_price_list,
-				itemCodes,
-			);
-			const updates = [];
+                        vm.refreshInFlight = true;
+                        const wasLoading = vm.loading;
+                        if (!wasLoading) {
+                                vm.loading = true;
+                        }
+                        const releaseLoading = () => {
+                                if (!wasLoading) {
+                                        vm.loading = false;
+                                }
+                        };
 
-			cacheResult.cached.forEach((det) => {
-				const item = vm.filtered_items.find((it) => it.item_code === det.item_code);
-				if (item) {
-					const upd = { actual_qty: det.actual_qty };
-					if (det.item_uoms && det.item_uoms.length > 0) {
-						upd.item_uoms = det.item_uoms;
-						saveItemUOMs(item.item_code, det.item_uoms);
-					}
-					if (det.rate !== undefined) {
-						const force = vm.pos_profile?.posa_force_price_from_customer_price_list !== false;
-						const price = det.price_list_rate ?? det.rate ?? 0;
-						if (force || price) {
-							upd.rate = price;
-							upd.price_list_rate = price;
-						}
-					}
-					if (det.currency) {
-						upd.currency = det.currency;
-					}
-					updates.push({ item, upd });
-				}
-			});
+                        try {
+                                const itemCodes = vm.filtered_items.map((it) => it.item_code);
+                                const cacheResult = await getCachedItemDetails(
+                                vm.pos_profile.name,
+                                vm.active_price_list,
+                                itemCodes,
+                                );
+                                const updates = [];
 
-			if (cacheResult.missing.length === 0) {
-				vm.$nextTick(() => {
-					updates.forEach(({ item, upd }) => Object.assign(item, upd));
-					updateLocalStockCache(cacheResult.cached);
-					vm.loading = false;
-				});
-				return;
-			}
+                                cacheResult.cached.forEach((det) => {
+                                        const item = vm.filtered_items.find((it) => it.item_code === det.item_code);
+                                        if (item) {
+                                                const upd = { actual_qty: det.actual_qty };
+                                                if (det.item_uoms && det.item_uoms.length > 0) {
+                                                        upd.item_uoms = det.item_uoms;
+                                                        saveItemUOMs(item.item_code, det.item_uoms);
+                                                }
+                                                if (det.rate !== undefined) {
+                                                        const force =
+                                                                vm.pos_profile?.posa_force_price_from_customer_price_list !==
+                                                                false;
+                                                        const price = det.price_list_rate ?? det.rate ?? 0;
+                                                        if (force || price) {
+                                                                upd.rate = price;
+                                                                upd.price_list_rate = price;
+                                                        }
+                                                }
+                                                if (det.currency) {
+                                                        upd.currency = det.currency;
+                                                }
+                                                updates.push({ item, upd });
+                                        }
+                                });
 
-			const itemsToFetch = vm.filtered_items.filter((it) => cacheResult.missing.includes(it.item_code));
+                                if (cacheResult.missing.length === 0) {
+                                        vm.$nextTick(() => {
+                                                updates.forEach(({ item, upd }) => Object.assign(item, upd));
+                                                updateLocalStockCache(cacheResult.cached);
+                                                releaseLoading();
+                                        });
+                                        return;
+                                }
 
-			try {
-				const details = await vm.fetchItemDetails(itemsToFetch);
-				details.forEach((updItem) => {
-					const item = vm.filtered_items.find((it) => it.item_code === updItem.item_code);
-					if (item) {
+                                const itemsToFetch = vm.filtered_items.filter((it) =>
+                                        cacheResult.missing.includes(it.item_code),
+                                );
+
+                                const details = await vm.fetchItemDetails(itemsToFetch);
+                                details.forEach((updItem) => {
+                                        const item = vm.filtered_items.find((it) => it.item_code === updItem.item_code);
+                                        if (item) {
 						const upd = { actual_qty: updItem.actual_qty };
 						if (updItem.item_uoms && updItem.item_uoms.length > 0) {
 							upd.item_uoms = updItem.item_uoms;
@@ -1255,18 +1273,21 @@ export default {
 							await saveItemsBulk(details);
 						} catch (e) {
 							console.error("Failed to persist item details", e);
-							vm.markStorageUnavailable && vm.markStorageUnavailable();
-						}
-					}
-					vm.loading = false;
-				});
-			} catch (err) {
-				if (err.name !== "AbortError") {
-					console.error("Error fetching item details:", err);
-					vm.loading = false;
-				}
-			}
-		},
+                                                        vm.markStorageUnavailable && vm.markStorageUnavailable();
+                                                }
+                                        }
+                                        releaseLoading();
+                                });
+                        } catch (err) {
+                                if (err.name !== "AbortError") {
+                                        console.error("Error fetching item details:", err);
+                                        releaseLoading();
+                                }
+                        } finally {
+                                vm.refreshInFlight = false;
+                                releaseLoading();
+                        }
+                },
 
 		show_offers() {
 			this.eventBus.emit("show_offers", "true");

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -616,9 +616,10 @@ export default {
 		items_per_page: 50,
 		temp_items_per_page: 50,
 		temp_force_server_items: false,
-		// Performance optimizations
-		searchCache: new Map(),
-		itemCache: new Map(),
+                // Performance optimizations
+                searchCache: new Map(),
+                barcodeIndex: new Map(),
+                itemCache: new Map(),
 		virtualScrollEnabled: true,
 		renderBuffer: 10,
 		lastScrollTop: 0,
@@ -1037,10 +1038,11 @@ export default {
 			this.eventBus.emit("data-load-progress", { name: "items", progress: 0 });
 			await initPromise;
 			await this.ensureStorageHealth();
-			if (reset) {
-				this.currentPage = 0;
-				this.items = [];
-			}
+                        if (reset) {
+                                this.currentPage = 0;
+                                this.items = [];
+                                this.resetBarcodeIndex();
+                        }
 			const search = this.get_search(this.first_search);
 			const itemGroup = this.item_group !== "ALL" ? this.item_group.toLowerCase() : "";
 			const pageItems = await searchStoredItems({
@@ -1051,7 +1053,8 @@ export default {
 			});
 			const total = pageItems.length || 1;
 			pageItems.forEach((it, idx) => {
-				this.items.push(it);
+                                this.items.push(it);
+                                this.indexItem(it);
 				const progress = Math.round(((idx + 1) / total) * 100);
 				this.loadProgress = progress;
 				this.eventBus.emit("data-load-progress", {
@@ -1479,8 +1482,9 @@ export default {
 					}
 				});
 
-				vm.items = items;
-				vm.items_loaded = true;
+                                vm.items = items;
+                                vm.replaceBarcodeIndex(vm.items);
+                                vm.items_loaded = true;
 				vm.eventBus.emit("set_all_items", vm.items);
 				console.log("[ItemsSelector] set_all_items emitted", { itemsLength: vm.items.length });
 
@@ -1618,12 +1622,18 @@ export default {
 								return;
 							}
 							if (ev.data.type === "parsed") {
-								const newItems = ev.data.items || [];
-								newItems.forEach((it) => {
-									const existing = this.items.find((i) => i.item_code === it.item_code);
-									if (existing) Object.assign(existing, it);
-									else this.items.push(it);
-								});
+                                                                const newItems = ev.data.items || [];
+                                                                newItems.forEach((it) => {
+                                                                        const existing = this.items.find((i) => i.item_code === it.item_code);
+                                                                        let target = existing;
+                                                                        if (existing) {
+                                                                                Object.assign(existing, it);
+                                                                        } else {
+                                                                                target = it;
+                                                                                this.items.push(target);
+                                                                        }
+                                                                        this.indexItem(target);
+                                                                });
 								lastItemName = newItems[newItems.length - 1]?.item_name || null;
 								this.eventBus.emit("set_all_items", this.items);
 								console.log("[ItemsSelector] background load set_all_items emitted", {
@@ -1730,11 +1740,17 @@ export default {
 						}
 						const rows = r.message || [];
 						console.log("[ItemsSelector] background load callback items", { count: rows.length });
-						rows.forEach((it) => {
-							const existing = this.items.find((i) => i.item_code === it.item_code);
-							if (existing) Object.assign(existing, it);
-							else this.items.push(it);
-						});
+                                                rows.forEach((it) => {
+                                                        const existing = this.items.find((i) => i.item_code === it.item_code);
+                                                        let target = existing;
+                                                        if (existing) {
+                                                                Object.assign(existing, it);
+                                                        } else {
+                                                                target = it;
+                                                                this.items.push(target);
+                                                        }
+                                                        this.indexItem(target);
+                                                });
 						this.eventBus.emit("set_all_items", this.items);
 						console.log("[ItemsSelector] background load set_all_items emitted", {
 							length: this.items.length,
@@ -1900,11 +1916,14 @@ export default {
 								customer: this.customer,
 							},
 						});
-						if (res.message) {
-							variants = res.message.variants || res.message;
-							attrsMeta = res.message.attributes_meta || {};
-							this.items.push(...variants);
-						}
+                                                        if (res.message) {
+                                                                variants = res.message.variants || res.message;
+                                                                attrsMeta = res.message.attributes_meta || {};
+                                                                variants.forEach((variant) => {
+                                                                        this.items.push(variant);
+                                                                        this.indexItem(variant);
+                                                                });
+                                                        }
 					} catch (e) {
 						console.error("Failed to fetch variants", e);
 					}
@@ -2243,14 +2262,15 @@ export default {
 						item.currency = det.currency;
 					}
 
-					if (!item.original_rate) {
-						item.original_rate = item.rate;
-						item.original_currency = item.currency || vm.pos_profile.currency;
-					}
+                                        if (!item.original_rate) {
+                                                item.original_rate = item.rate;
+                                                item.original_currency = item.currency || vm.pos_profile.currency;
+                                        }
 
-					vm.applyCurrencyConversionToItem(item);
-				}
-			});
+                                        vm.indexItem(item);
+                                        vm.applyCurrencyConversionToItem(item);
+                                }
+                        });
 
 			let allCached = cacheResult.missing.length === 0;
 			items.forEach((item) => {
@@ -2337,10 +2357,11 @@ export default {
 						}
 					});
 
-					updatedItems.forEach(({ item, updates }) => {
-						Object.assign(item, updates);
-						vm.applyCurrencyConversionToItem(item);
-					});
+                                        updatedItems.forEach(({ item, updates }) => {
+                                                Object.assign(item, updates);
+                                                vm.indexItem(item);
+                                                vm.applyCurrencyConversionToItem(item);
+                                        });
 
 					updateLocalStockCache(details);
 					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
@@ -2899,15 +2920,23 @@ export default {
 				qtyFromBarcode = parseFloat(this.get_item_qty(scannedCode));
 			}
 
-			// First try to find exact match by processed code
-			let foundItem = this.items.find((item) => {
-				const barcodeMatch =
-					item.barcode === searchCode ||
-					(Array.isArray(item.item_barcode) &&
-						item.item_barcode.some((b) => b.barcode === searchCode)) ||
-					(Array.isArray(item.barcodes) && item.barcodes.some((bc) => String(bc) === searchCode));
-				return barcodeMatch || item.item_code === searchCode;
-			});
+                        // First try to find exact match by processed code using the pre-built index
+                        const barcodeIndex = this.ensureBarcodeIndex();
+                        let foundItem = this.lookupItemByBarcode(searchCode);
+
+                        if (!foundItem && barcodeIndex.size === 0) {
+                                // Index not populated yet, build it and fall back to a direct scan once
+                                this.replaceBarcodeIndex(this.items);
+                                foundItem = this.items.find((item) => {
+                                        const barcodeMatch =
+                                                item.barcode === searchCode ||
+                                                (Array.isArray(item.item_barcode) &&
+                                                        item.item_barcode.some((b) => b.barcode === searchCode)) ||
+                                                (Array.isArray(item.barcodes) &&
+                                                        item.barcodes.some((bc) => String(bc) === searchCode));
+                                        return barcodeMatch || item.item_code === searchCode;
+                                });
+                        }
 
 			if (foundItem) {
 				console.log("Found item by processed code:", foundItem);
@@ -2926,13 +2955,14 @@ export default {
 					},
 				});
 
-				if (res && res.message) {
-					const newItem = res.message;
-					this.items.push(newItem);
+                                if (res && res.message) {
+                                        const newItem = res.message;
+                                        this.items.push(newItem);
+                                        this.indexItem(newItem);
 
-					if (this.searchCache) {
-						this.searchCache.clear();
-					}
+                                        if (this.searchCache) {
+                                                this.searchCache.clear();
+                                        }
 
 					await saveItems(this.items);
 					await savePriceListItems(this.customer_price_list, this.items);
@@ -2964,24 +2994,86 @@ export default {
                                 perfMarkEnd("pos:scan-process", mark);
                         }
                 },
-		searchItemsByCode(code) {
-			return this.items.filter((item) => {
-				const searchTerm = code.toLowerCase();
-				const barcodeMatch =
-					(item.barcode && item.barcode.toLowerCase().includes(searchTerm)) ||
+                searchItemsByCode(code) {
+                        return this.items.filter((item) => {
+                                const searchTerm = code.toLowerCase();
+                                const barcodeMatch =
+                                        (item.barcode && item.barcode.toLowerCase().includes(searchTerm)) ||
 					(Array.isArray(item.barcodes) &&
 						item.barcodes.some((bc) => String(bc).toLowerCase().includes(searchTerm))) ||
 					(Array.isArray(item.item_barcode) &&
 						item.item_barcode.some(
 							(b) => b.barcode && b.barcode.toLowerCase().includes(searchTerm),
 						));
-				return (
-					item.item_code.toLowerCase().includes(searchTerm) ||
-					item.item_name.toLowerCase().includes(searchTerm) ||
-					barcodeMatch
-				);
-			});
-		},
+                                return (
+                                        item.item_code.toLowerCase().includes(searchTerm) ||
+                                        item.item_name.toLowerCase().includes(searchTerm) ||
+                                        barcodeMatch
+                                );
+                        });
+                },
+                // PERF: maintain a barcode index so unfound scans do not walk the full list
+                ensureBarcodeIndex() {
+                        if (!this.barcodeIndex || typeof this.barcodeIndex.set !== "function") {
+                                this.barcodeIndex = new Map();
+                        }
+                        return this.barcodeIndex;
+                },
+                resetBarcodeIndex() {
+                        const index = this.ensureBarcodeIndex();
+                        index.clear();
+                },
+                indexItem(item) {
+                        if (!item) {
+                                return;
+                        }
+                        const index = this.ensureBarcodeIndex();
+                        const register = (code) => {
+                                if (code === undefined || code === null) {
+                                        return;
+                                }
+                                const normalized = String(code).trim();
+                                if (!normalized) {
+                                        return;
+                                }
+                                if (!index.has(normalized)) {
+                                        index.set(normalized, item);
+                                }
+                                const lower = normalized.toLowerCase();
+                                if (!index.has(lower)) {
+                                        index.set(lower, item);
+                                }
+                        };
+                        register(item.item_code);
+                        register(item.barcode);
+                        if (Array.isArray(item.item_barcode)) {
+                                item.item_barcode.forEach((barcode) => register(barcode?.barcode));
+                        }
+                        if (Array.isArray(item.barcodes)) {
+                                item.barcodes.forEach((barcode) => register(barcode));
+                        }
+                        if (Array.isArray(item.serial_no_data)) {
+                                item.serial_no_data.forEach((serial) => register(serial?.serial_no));
+                        }
+                        if (Array.isArray(item.batch_no_data)) {
+                                item.batch_no_data.forEach((batch) => register(batch?.batch_no));
+                        }
+                },
+                replaceBarcodeIndex(items = this.items) {
+                        this.resetBarcodeIndex();
+                        items.forEach((item) => this.indexItem(item));
+                },
+                lookupItemByBarcode(code) {
+                        if (code === undefined || code === null) {
+                                return null;
+                        }
+                        const index = this.ensureBarcodeIndex();
+                        const normalized = String(code).trim();
+                        if (!normalized) {
+                                return null;
+                        }
+                        return index.get(normalized) || index.get(normalized.toLowerCase()) || null;
+                },
 		async addScannedItemToInvoice(item, scannedCode, qtyFromBarcode = null) {
 			console.log("Adding scanned item to invoice:", item, scannedCode);
 
@@ -3432,11 +3524,13 @@ export default {
 		},
 	},
 
-	created() {
-		console.log("ItemsSelector created - starting initialization");
+        created() {
+                console.log("ItemsSelector created - starting initialization");
 
-		// Setup search debounce
-		this.searchDebounce = _.debounce(() => {
+                this.replaceBarcodeIndex(this.items || []);
+
+                // Setup search debounce
+                this.searchDebounce = _.debounce(() => {
 			this.get_items();
 		}, 300);
 

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2718,12 +2718,25 @@ export default {
                                 frappe.show_alert(
                                         {
                                                 message: this.scanErrorMessage,
-						indicator: "red",
-					},
-					5,
-				);
-			}
-		},
+                                                indicator: "red",
+                                        },
+                                        5,
+                                );
+                        }
+                },
+                handleScanPipelineError(error, code = "") {
+                        const normalizedCode = code || this.pendingScanCode || "";
+                        console.error("Unexpected barcode processing error:", error);
+                        const details =
+                                error && typeof error.message === "string" && error.message.trim()
+                                        ? error.message
+                                        : this.__("Please try again or enter the item manually.");
+                        this.showScanError({
+                                message: this.__("Unable to add scanned item."),
+                                code: normalizedCode,
+                                details,
+                        });
+                },
                 acknowledgeScanError() {
                         this.scanErrorDialog = false;
                         this.scannerLocked = false;
@@ -2817,25 +2830,25 @@ export default {
                                 return;
                         }
 
-                        const scheduleScan = (code) => {
+                        const runScanPipeline = async (code) => {
                                 const mark = perfMarkStart("pos:scan-handler");
-                                scheduleFrame(() => {
-                                        try {
-                                                console.log("Barcode scanned:", code);
-                                                this.pendingScanCode = code;
+                                try {
+                                        console.log("Barcode scanned:", code);
+                                        this.pendingScanCode = code;
 
-                                                // mark this search as coming from a scanner
-                                                this.search_from_scanner = true;
+                                        // mark this search as coming from a scanner
+                                        this.search_from_scanner = true;
 
-                                                // Clear any previous search
-                                                this.search = "";
-                                                this.first_search = "";
+                                        // Clear any previous search
+                                        this.search = "";
+                                        this.first_search = "";
 
-                                                // Set the scanned code as search term
-                                                this.first_search = code;
-                                                this.search = code;
+                                        // Set the scanned code as search term
+                                        this.first_search = code;
+                                        this.search = code;
 
-                                                // Show scanning feedback
+                                        // Show scanning feedback
+                                        if (frappe?.show_alert) {
                                                 frappe.show_alert(
                                                         {
                                                                 message: `Scanning for: ${code}`,
@@ -2843,13 +2856,15 @@ export default {
                                                         },
                                                         2,
                                                 );
-
-                                                // Enhanced item search and submission logic
-                                                this.processScannedItem(code);
-                                        } finally {
-                                                perfMarkEnd("pos:scan-handler", mark);
                                         }
-                                });
+
+                                        // Enhanced item search and submission logic
+                                        await this.processScannedItem(code);
+                                } catch (error) {
+                                        this.handleScanPipelineError(error, code);
+                                } finally {
+                                        perfMarkEnd("pos:scan-handler", mark);
+                                }
                         };
 
                         if (this.scanDebounceId) {
@@ -2860,7 +2875,14 @@ export default {
                                 this.scanDebounceId = null;
                                 const code = this.scanQueuedCode || scannedCode;
                                 this.scanQueuedCode = "";
-                                scheduleScan(code);
+                                scheduleFrame(() => {
+                                        const maybePromise = runScanPipeline(code);
+                                        if (maybePromise && typeof maybePromise.catch === "function") {
+                                                maybePromise.catch((error) => {
+                                                        this.handleScanPipelineError(error, code);
+                                                });
+                                        }
+                                });
                         }, 12);
                 },
                 async processScannedItem(scannedCode) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -652,6 +652,7 @@ export default {
                 scanDebounceId: null,
                 scanQueuedCode: "",
                 refreshInFlight: false,
+                clearingSearch: false,
         }),
 
         watch: {
@@ -812,12 +813,15 @@ export default {
 			this.$nextTick(this.checkItemContainerOverflow);
 		},
 		// Automatically search when the query has at least 3 characters
-		first_search: _.debounce(function (val, oldVal) {
-			const newLen = (val || "").trim().length;
-			const oldLen = (oldVal || "").trim().length;
-			if (newLen >= 3) {
-				// Call without arguments so search_onchange treats it like an Enter key
-				this.search_onchange();
+                first_search: _.debounce(function (val, oldVal) {
+                        if (this.clearingSearch) {
+                                return;
+                        }
+                        const newLen = (val || "").trim().length;
+                        const oldLen = (oldVal || "").trim().length;
+                        if (newLen >= 3) {
+                                // Call without arguments so search_onchange treats it like an Enter key
+                                this.search_onchange();
 			} else if (oldLen >= 3 && newLen === 0) {
 				// Reset items only when search is fully cleared
 				this.clearSearch();
@@ -2548,34 +2552,61 @@ export default {
 
 			return combinations;
 		},
-		clearSearch() {
-			this.search_backup = this.first_search;
-			this.first_search = "";
-			this.search = "";
+                clearSearch() {
+                        if (this.clearingSearch) {
+                                return;
+                        }
 
-			if (this.pos_profile?.posa_local_storage && this.storageAvailable) {
-				this.loadVisibleItems(true);
-				if (!this.isBackgroundLoading) {
-					this.verifyServerItemCount();
-				}
-				return;
-			}
+                        const hadQuery = Boolean(
+                                (this.first_search && this.first_search.trim()) ||
+                                        (this.search && this.search.trim()),
+                        );
+                        const shouldReload =
+                                hadQuery || !this.items_loaded || !this.items.length;
 
-			if (this.isBackgroundLoading) {
-				if (this.pendingGetItems) {
-					this.pendingGetItems.force_server = this.pendingGetItems.force_server || false;
-				} else {
-					this.pendingGetItems = { force_server: false };
-				}
-				return;
-			}
+                        this.search_backup = this.first_search;
+                        this.clearingSearch = true;
+                        this.first_search = "";
+                        this.search = "";
 
-			if (!this.items_loaded || !this.items.length) {
-				this.get_items(true);
-			} else {
-				this.eventBus.emit("set_all_items", this.items);
-			}
-		},
+                        const release = () => {
+                                this.$nextTick(() => {
+                                        this.clearingSearch = false;
+                                });
+                        };
+
+                        if (!shouldReload) {
+                                release();
+                                return;
+                        }
+
+                        if (this.pos_profile?.posa_local_storage && this.storageAvailable) {
+                                this.loadVisibleItems(true);
+                                if (!this.isBackgroundLoading) {
+                                        this.verifyServerItemCount();
+                                }
+                                release();
+                                return;
+                        }
+
+                        if (this.isBackgroundLoading) {
+                                if (this.pendingGetItems) {
+                                        this.pendingGetItems.force_server = this.pendingGetItems.force_server || false;
+                                } else {
+                                        this.pendingGetItems = { force_server: false };
+                                }
+                                release();
+                                return;
+                        }
+
+                        if (!this.items_loaded || !this.items.length) {
+                                this.get_items(true);
+                        } else {
+                                this.eventBus.emit("set_all_items", this.items);
+                        }
+
+                        release();
+                },
 
 		restoreSearch() {
 			if (this.first_search === "") {

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -656,6 +656,7 @@
 <script>
 /* global process */
 import _ from "lodash";
+import { logComponentRender } from "../../utils/perf.js";
 export default {
 	name: "ItemsTable",
 	props: {
@@ -1177,12 +1178,15 @@ export default {
 		},
 	},
 
-	mounted() {
-		this.setupResizeObserver();
+        mounted() {
+                logComponentRender(this, "ItemsTable", "mounted", {
+                        rows: this.items?.length || 0,
+                });
+                this.setupResizeObserver();
 
-		// Performance optimization: defer non-critical initialization
-		this.$nextTick(() => {
-			this.updateContainerDimensions();
+                // Performance optimization: defer non-critical initialization
+                this.$nextTick(() => {
+                        this.updateContainerDimensions();
 
 			// Log performance metrics in development
 			if (process.env.NODE_ENV === "development") {
@@ -1199,8 +1203,14 @@ export default {
 					},
 				});
 			}
-		});
-	},
+                });
+        },
+
+        updated() {
+                logComponentRender(this, "ItemsTable", "updated", {
+                        rows: this.items?.length || 0,
+                });
+        },
 
 	beforeUnmount() {
 		this.cleanupResizeObserver();

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -1,34 +1,42 @@
 /* global flt, __, get_currency_symbol */
+import { perfMarkStart, perfMarkEnd } from "../../utils/perf.js";
 
 export default {
-	// Calculate total quantity of all items
-	total_qty() {
-		this.close_payments();
-		let qty = 0;
-		this.items.forEach((item) => {
-			qty += flt(item.qty);
-		});
-		return this.flt(qty, this.float_precision);
-	},
-	// Calculate total amount for all items (handles returns)
-	Total() {
-		let sum = 0;
-		this.items.forEach((item) => {
-			// For returns, use absolute value for correct calculation
-			const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
-			const rate = flt(item.rate);
-			sum += qty * rate;
-		});
-		return this.flt(sum, this.currency_precision);
-	},
-	// Calculate subtotal after discounts and delivery charges
-	subtotal() {
-		this.close_payments();
-		let sum = 0;
-		this.items.forEach((item) => {
-			// For returns, use absolute value for correct calculation
-			const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
-			const rate = flt(item.rate);
+        // Calculate total quantity of all items
+        total_qty() {
+                const mark = perfMarkStart("pos:totals-total_qty");
+                this.close_payments();
+                let qty = 0;
+                this.items.forEach((item) => {
+                        qty += flt(item.qty);
+                });
+                const result = this.flt(qty, this.float_precision);
+                perfMarkEnd("pos:totals-total_qty", mark);
+                return result;
+        },
+        // Calculate total amount for all items (handles returns)
+        Total() {
+                const mark = perfMarkStart("pos:totals-gross");
+                let sum = 0;
+                this.items.forEach((item) => {
+                        // For returns, use absolute value for correct calculation
+                        const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
+                        const rate = flt(item.rate);
+                        sum += qty * rate;
+                });
+                const result = this.flt(sum, this.currency_precision);
+                perfMarkEnd("pos:totals-gross", mark);
+                return result;
+        },
+        // Calculate subtotal after discounts and delivery charges
+        subtotal() {
+                const mark = perfMarkStart("pos:totals-subtotal");
+                this.close_payments();
+                let sum = 0;
+                this.items.forEach((item) => {
+                        // For returns, use absolute value for correct calculation
+                        const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
+                        const rate = flt(item.rate);
 			sum += qty * rate;
 		});
 
@@ -40,21 +48,26 @@ export default {
 		const delivery_charges = this.flt(this.delivery_charges_rate);
 		sum += delivery_charges;
 
-		return this.flt(sum, this.currency_precision);
-	},
-	// Calculate total discount amount for all items
-	total_items_discount_amount() {
-		let sum = 0;
-		this.items.forEach((item) => {
-			// For returns, use absolute value for correct calculation
-			if (this.isReturnInvoice) {
-				sum += Math.abs(flt(item.qty)) * flt(item.discount_amount);
+                const result = this.flt(sum, this.currency_precision);
+                perfMarkEnd("pos:totals-subtotal", mark);
+                return result;
+        },
+        // Calculate total discount amount for all items
+        total_items_discount_amount() {
+                const mark = perfMarkStart("pos:totals-discount");
+                let sum = 0;
+                this.items.forEach((item) => {
+                        // For returns, use absolute value for correct calculation
+                        if (this.isReturnInvoice) {
+                                sum += Math.abs(flt(item.qty)) * flt(item.discount_amount);
 			} else {
 				sum += flt(item.qty) * flt(item.discount_amount);
 			}
 		});
-		return this.flt(sum, this.float_precision);
-	},
+                const result = this.flt(sum, this.float_precision);
+                perfMarkEnd("pos:totals-discount", mark);
+                return result;
+        },
 	// Format posting_date for display as DD-MM-YYYY
 	formatted_posting_date: {
 		get() {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1349,231 +1349,226 @@ export default {
 		}
 	},
 
-	// Update details for a single item (fetch from backend)
-	update_item_detail(item, force_update = false) {
-		console.log("update_item_detail request", {
-			code: item.item_code,
-			force_update,
-		});
-		if (!item.item_code) {
-			return;
-		}
-		var vm = this;
+        // Update details for a single item (fetch from backend)
+        async update_item_detail(item, force_update = false) {
+                console.log("update_item_detail request", {
+                        code: item ? item.item_code : undefined,
+                        force_update,
+                });
+                if (!item || !item.item_code) {
+                        return;
+                }
 
-		// If a manual rate was set (e.g. via explicit UOM pricing), don't
-		// overwrite it on expand unless explicitly forced.
-		if (item._manual_rate_set && !force_update) {
-			return;
-		}
+                // If a manual rate was set (e.g. via explicit UOM pricing), don't
+                // overwrite it on expand unless explicitly forced.
+                if (item._manual_rate_set && !force_update) {
+                        return;
+                }
 
-		// Remove this block which was causing the issue - rates should persist regardless of currency
-		// if (item.price_list_rate && !item.posa_offer_applied) {
-		//   item.rate = item.price_list_rate;
-		//   this.$forceUpdate();
-		// }
+                if (force_update) {
+                        item._detailSynced = false;
+                }
 
-		const currentDoc = this.get_invoice_doc();
-		frappe.call({
-			method: "posawesome.posawesome.api.items.get_item_detail",
-			args: {
-				warehouse: item.warehouse || this.pos_profile.warehouse,
-				doc: currentDoc,
-				price_list: this.selected_price_list || this.pos_profile.selling_price_list,
-				item: {
-					item_code: item.item_code,
-					customer: this.customer,
-					doctype: currentDoc.doctype,
-					name: currentDoc.name || `New ${currentDoc.doctype} 1`,
-					company: this.pos_profile.company,
-					conversion_rate: 1,
-					currency: this.pos_profile.currency,
-					qty: item.qty,
-					price_list_rate: item.base_price_list_rate ?? item.price_list_rate ?? 0,
-					child_docname: `New ${currentDoc.doctype} Item 1`,
-					cost_center: this.pos_profile.cost_center,
-					pos_profile: this.pos_profile.name,
-					uom: item.uom,
-					tax_category: "",
-					transaction_type: "selling",
-					update_stock: this.pos_profile.update_stock,
-					price_list: this.get_price_list(),
-					has_batch_no: item.has_batch_no,
-					has_serial_no: item.has_serial_no,
-					serial_no: item.serial_no,
-					batch_no: item.batch_no,
-					is_stock_item: item.is_stock_item,
-				},
-			},
-			callback: function (r) {
-				if (r.message) {
-					const data = r.message;
-					if (!item.warehouse) {
-						item.warehouse = vm.pos_profile.warehouse;
-					}
-					// Ensure price list currency is synced from server response
-					if (data.price_list_currency) {
-						vm.price_list_currency = data.price_list_currency;
-					}
+                if (item._detailInFlight || (!force_update && item._detailSynced)) {
+                        return;
+                }
 
-					if (!item.original_currency) {
-						item.original_currency =
-							data.price_list_currency || vm.price_list_currency || vm.selected_currency;
-					}
-					if (!item.original_rate) {
-						item.original_rate = data.price_list_rate;
-					}
-					if (data.serial_no_data) {
-						item.serial_no_data = data.serial_no_data;
-					}
-					if (data.batch_no_data) {
-						item.batch_no_data = data.batch_no_data;
-					}
-					if (
-						item.has_batch_no &&
-						vm.pos_profile.posa_auto_set_batch &&
-						!item.batch_no &&
-						data.batch_no_data &&
-						data.batch_no_data.length > 0
-					) {
-						item.batch_no_data = data.batch_no_data;
-						// Pass null instead of undefined to avoid console warning
-						vm.set_batch_qty(item, null, false);
-					}
+                item._detailInFlight = true;
+                const vm = this;
 
-					if (!item.locked_price) {
-						// First save base rates if not exists or when force update is requested
-						// Avoid overriding existing base rates when the selected currency
-						// matches the POS Profile currency. This prevents manual or offer
-						// adjusted rates from being reset whenever an item row is expanded.
-						if (force_update || !item.base_rate) {
-							// Always store base rates from server in base currency
-							if (data.price_list_rate !== 0 || !item.base_price_list_rate) {
-								item.base_price_list_rate = data.price_list_rate;
-								if (!item.posa_offer_applied) {
-									item.base_rate = data.price_list_rate;
-								}
-							}
-						}
+                try {
+                        const currentDoc = vm.get_invoice_doc();
+                        const response = await frappe.call({
+                                method: "posawesome.posawesome.api.items.get_item_detail",
+                                args: {
+                                        warehouse: item.warehouse || vm.pos_profile.warehouse,
+                                        doc: currentDoc,
+                                        price_list: vm.selected_price_list || vm.pos_profile.selling_price_list,
+                                        item: {
+                                                item_code: item.item_code,
+                                                customer: vm.customer,
+                                                doctype: currentDoc.doctype,
+                                                name: currentDoc.name || `New ${currentDoc.doctype} 1`,
+                                                company: vm.pos_profile.company,
+                                                conversion_rate: 1,
+                                                currency: vm.pos_profile.currency,
+                                                qty: item.qty,
+                                                price_list_rate: item.base_price_list_rate ?? item.price_list_rate ?? 0,
+                                                child_docname: `New ${currentDoc.doctype} Item 1`,
+                                                cost_center: vm.pos_profile.cost_center,
+                                                pos_profile: vm.pos_profile.name,
+                                                uom: item.uom,
+                                                tax_category: "",
+                                                transaction_type: "selling",
+                                                update_stock: vm.pos_profile.update_stock,
+                                                price_list: vm.get_price_list(),
+                                                has_batch_no: item.has_batch_no,
+                                                has_serial_no: item.has_serial_no,
+                                                serial_no: item.serial_no,
+                                                batch_no: item.batch_no,
+                                                is_stock_item: item.is_stock_item,
+                                        },
+                                },
+                        });
 
-						// Only update rates if no offer is applied
-						if (!item.posa_offer_applied) {
-							const companyCurrency = vm.pos_profile.currency;
-							const baseCurrency = companyCurrency;
+                        const data = response?.message;
+                        if (!data) {
+                                return;
+                        }
 
-							if (
-								vm.selected_currency === vm.price_list_currency &&
-								vm.selected_currency !== companyCurrency
-							) {
-								const conv = vm.conversion_rate || 1;
-								item.price_list_rate = vm.flt(
-									item.base_price_list_rate / conv,
-									vm.currency_precision,
-								);
+                        if (!item.warehouse) {
+                                item.warehouse = vm.pos_profile.warehouse;
+                        }
+                        if (data.price_list_currency) {
+                                vm.price_list_currency = data.price_list_currency;
+                        }
 
-								if (!item._manual_rate_set) {
-									item.rate = vm.flt(item.base_rate / conv, vm.currency_precision);
-								}
-							} else if (vm.selected_currency !== baseCurrency) {
-								const exchange_rate = vm.exchange_rate || 1;
-								item.price_list_rate = vm.flt(
-									item.base_price_list_rate * exchange_rate,
-									vm.currency_precision,
-								);
+                        if (!item.original_currency) {
+                                item.original_currency =
+                                        data.price_list_currency || vm.price_list_currency || vm.selected_currency;
+                        }
+                        if (!item.original_rate) {
+                                item.original_rate = data.price_list_rate;
+                        }
+                        if (data.serial_no_data) {
+                                item.serial_no_data = data.serial_no_data;
+                        }
+                        if (data.batch_no_data) {
+                                item.batch_no_data = data.batch_no_data;
+                        }
+                        if (
+                                item.has_batch_no &&
+                                vm.pos_profile.posa_auto_set_batch &&
+                                !item.batch_no &&
+                                Array.isArray(data.batch_no_data) &&
+                                data.batch_no_data.length > 0
+                        ) {
+                                item.batch_no_data = data.batch_no_data;
+                                vm.set_batch_qty(item, null, false);
+                        }
 
-								item.rate = vm.flt(item.base_rate * exchange_rate, vm.currency_precision);
-							} else {
-								item.price_list_rate = item.base_price_list_rate;
+                        if (!item.locked_price) {
+                                if (force_update || !item.base_rate) {
+                                        if (data.price_list_rate !== 0 || !item.base_price_list_rate) {
+                                                item.base_price_list_rate = data.price_list_rate;
+                                                if (!item.posa_offer_applied) {
+                                                        item.base_rate = data.price_list_rate;
+                                                }
+                                        }
+                                }
 
-								if (!item._manual_rate_set) {
-									item.rate = item.base_rate;
-								}
-							}
-						} else {
-							// Preserve discounted price when an offer is applied so the
-							// rate doesn't revert to the original price list value.
-							const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
-							if (vm.selected_currency !== baseCurrency) {
-								item.price_list_rate = vm.flt(
-									item.base_rate * vm.exchange_rate,
-									vm.currency_precision,
-								);
-							} else {
-								item.price_list_rate = item.base_rate;
-							}
-						}
+                                if (!item.posa_offer_applied) {
+                                        const companyCurrency = vm.pos_profile.currency;
+                                        const baseCurrency = companyCurrency;
 
-						// Handle customer discount only if no offer is applied
-						if (
-							!item.posa_offer_applied &&
-							vm.pos_profile.posa_apply_customer_discount &&
-							vm.customer_info.posa_discount > 0 &&
-							vm.customer_info.posa_discount <= 100 &&
-							item.posa_is_offer == 0 &&
-							!item.posa_is_replace
-						) {
-							const discount_percent =
-								item.max_discount > 0
-									? Math.min(item.max_discount, vm.customer_info.posa_discount)
-									: vm.customer_info.posa_discount;
+                                        if (vm.selected_currency === vm.price_list_currency && vm.selected_currency !== companyCurrency) {
+                                                const conv = vm.conversion_rate || 1;
+                                                item.price_list_rate = vm.flt(
+                                                        item.base_price_list_rate / conv,
+                                                        vm.currency_precision,
+                                                );
 
-							item.discount_percentage = discount_percent;
+                                                if (!item._manual_rate_set) {
+                                                        item.rate = vm.flt(item.base_rate / conv, vm.currency_precision);
+                                                }
+                                        } else if (vm.selected_currency !== baseCurrency) {
+                                                const exchange_rate = vm.exchange_rate || 1;
+                                                item.price_list_rate = vm.flt(
+                                                        item.base_price_list_rate * exchange_rate,
+                                                        vm.currency_precision,
+                                                );
 
-							// Calculate discount in selected currency
-							const discount_amount = vm.flt(
-								(item.price_list_rate * discount_percent) / 100,
-								vm.currency_precision,
-							);
-							item.discount_amount = discount_amount;
+                                                item.rate = vm.flt(item.base_rate * exchange_rate, vm.currency_precision);
+                                        } else {
+                                                item.price_list_rate = item.base_price_list_rate;
 
-							// Also store base discount amount
-							item.base_discount_amount = vm.flt(
-								(item.base_price_list_rate * discount_percent) / 100,
-								vm.currency_precision,
-							);
+                                                if (!item._manual_rate_set) {
+                                                        item.rate = item.base_rate;
+                                                }
+                                        }
+                                } else {
+                                        const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
+                                        if (vm.selected_currency !== baseCurrency) {
+                                                item.price_list_rate = vm.flt(
+                                                        item.base_rate * vm.exchange_rate,
+                                                        vm.currency_precision,
+                                                );
+                                        } else {
+                                                item.price_list_rate = item.base_rate;
+                                        }
+                                }
 
-							// Update rates with discount
-							item.rate = vm.flt(item.price_list_rate - discount_amount, vm.currency_precision);
-							item.base_rate = vm.flt(
-								item.base_price_list_rate - item.base_discount_amount,
-								vm.currency_precision,
-							);
-						}
-					}
+                                if (
+                                        !item.posa_offer_applied &&
+                                        vm.pos_profile.posa_apply_customer_discount &&
+                                        vm.customer_info.posa_discount > 0 &&
+                                        vm.customer_info.posa_discount <= 100 &&
+                                        item.posa_is_offer == 0 &&
+                                        !item.posa_is_replace
+                                ) {
+                                        const discount_percent =
+                                                item.max_discount > 0
+                                                        ? Math.min(item.max_discount, vm.customer_info.posa_discount)
+                                                        : vm.customer_info.posa_discount;
 
-					// Update other item details
-					item.last_purchase_rate = data.last_purchase_rate;
-					item.projected_qty = data.projected_qty;
-					item.reserved_qty = data.reserved_qty;
-					item.conversion_factor = data.conversion_factor;
-					item.stock_qty = data.stock_qty;
-					item.actual_qty = data.actual_qty;
-					item.stock_uom = data.stock_uom;
-					item.has_serial_no = data.has_serial_no;
-					item.has_batch_no = data.has_batch_no;
+                                        item.discount_percentage = discount_percent;
 
-					// Calculate final amount
-					item.amount = vm.flt(item.qty * item.rate, vm.currency_precision);
-					item.base_amount = vm.flt(item.qty * item.base_rate, vm.currency_precision);
+                                        const discount_amount = vm.flt(
+                                                (item.price_list_rate * discount_percent) / 100,
+                                                vm.currency_precision,
+                                        );
+                                        item.discount_amount = discount_amount;
 
-					// Log updated rates for debugging
-					console.log(`Updated rates for ${item.item_code} on expand:`, {
-						base_rate: item.base_rate,
-						rate: item.rate,
-						base_price_list_rate: item.base_price_list_rate,
-						price_list_rate: item.price_list_rate,
-						exchange_rate: vm.exchange_rate,
-						selected_currency: vm.selected_currency,
-						default_currency: vm.pos_profile.currency,
-					});
+                                        item.base_discount_amount = vm.flt(
+                                                (item.base_price_list_rate * discount_percent) / 100,
+                                                vm.currency_precision,
+                                        );
 
-					// Force update UI immediately
-					vm.$forceUpdate();
-				}
-			},
-		});
-	},
+                                        item.rate = vm.flt(item.price_list_rate - discount_amount, vm.currency_precision);
+                                        item.base_rate = vm.flt(
+                                                item.base_price_list_rate - item.base_discount_amount,
+                                                vm.currency_precision,
+                                        );
+                                }
+                        }
 
-	// Fetch customer details (info, price list, etc)
+                        item.last_purchase_rate = data.last_purchase_rate;
+                        item.projected_qty = data.projected_qty;
+                        item.reserved_qty = data.reserved_qty;
+                        item.conversion_factor = data.conversion_factor;
+                        item.stock_qty = data.stock_qty;
+                        item.actual_qty = data.actual_qty;
+                        item.stock_uom = data.stock_uom;
+                        item.has_serial_no = data.has_serial_no;
+                        item.has_batch_no = data.has_batch_no;
+
+                        item.amount = vm.flt(item.qty * item.rate, vm.currency_precision);
+                        item.base_amount = vm.flt(item.qty * item.base_rate, vm.currency_precision);
+
+                        console.log(`Updated rates for ${item.item_code} on expand:`, {
+                                base_rate: item.base_rate,
+                                rate: item.rate,
+                                base_price_list_rate: item.base_price_list_rate,
+                                price_list_rate: item.price_list_rate,
+                                exchange_rate: vm.exchange_rate,
+                                selected_currency: vm.selected_currency,
+                                default_currency: vm.pos_profile.currency,
+                        });
+
+                        item._detailSynced = true;
+                        vm.$forceUpdate();
+                } catch (error) {
+                        console.error("Error updating item detail:", error);
+                        vm.eventBus.emit("show_message", {
+                                title: __("Error updating item details"),
+                                color: "error",
+                        });
+                } finally {
+                        item._detailInFlight = false;
+                }
+        },
+
+        // Fetch customer details (info, price list, etc)
 	async fetch_customer_details() {
 		var vm = this;
 		if (!this.customer) return;

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -88,21 +88,32 @@ export default {
 		this.apply_cached_price_list(applied);
 
 		// If multi-currency is enabled, sync currency with the price list currency
-		if (this.pos_profile.posa_allow_multi_currency && applied) {
-			frappe.call({
-				method: "posawesome.posawesome.api.invoices.get_price_list_currency",
-				args: { price_list: applied },
-				callback: (r) => {
-					if (r.message) {
-						// Store price list currency for later use
-						this.price_list_currency = r.message;
-						// Sync invoice currency with price list currency
-						this.update_currency(r.message);
-					}
-				},
-			});
-		}
-	},
+                if (this.pos_profile.posa_allow_multi_currency && applied) {
+                        frappe.call({
+                                method: "posawesome.posawesome.api.invoices.get_price_list_currency",
+                                args: { price_list: applied },
+                                callback: (r) => {
+                                        if (r.message) {
+                                                // Store price list currency for later use
+                                                this.price_list_currency = r.message;
+                                                // Sync invoice currency with price list currency
+                                                this.update_currency(r.message);
+                                        }
+                                },
+                        });
+                }
+
+                if (Array.isArray(this.items)) {
+                        this.items.forEach((item) => {
+                                item._detailSynced = false;
+                        });
+                }
+                if (Array.isArray(this.packed_items)) {
+                        this.packed_items.forEach((item) => {
+                                item._detailSynced = false;
+                        });
+                }
+        },
 
 	// Reactively update item prices when currency changes
 	selected_currency() {

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -341,12 +341,15 @@ export function useItemAddition() {
 
         // Create a new item object with default and calculated fields
         const getNewItem = (item, context) => {
-		const new_item = { ...item };
-		new_item.original_item_name = new_item.item_name;
-		new_item.name_overridden = 0;
-		if (!new_item.warehouse) {
-			new_item.warehouse = context.pos_profile.warehouse;
-		}
+                const new_item = { ...item };
+                new_item.original_item_name = new_item.item_name;
+                new_item.name_overridden = 0;
+                // Mark server detail state so invoice can avoid redundant refreshes
+                new_item._detailSynced = false;
+                new_item._detailInFlight = false;
+                if (!new_item.warehouse) {
+                        new_item.warehouse = context.pos_profile.warehouse;
+                }
 		if (!item.qty) {
 			item.qty = 1;
 		}

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -1,6 +1,7 @@
 import { nextTick } from "vue";
 import _ from "lodash";
 import { useBundles } from "./useBundles.js";
+import { withPerf } from "../utils/perf.js";
 
 /* global frappe, __ */
 
@@ -74,10 +75,10 @@ export function useItemAddition() {
 	};
 
 	// Add item to invoice
-	const addItem = async (item, context) => {
-		if (!item.uom) {
-			item.uom = item.stock_uom;
-		}
+        const addItem = withPerf("pos:add-item", async function addItemMeasured(item, context) {
+                if (!item.uom) {
+                        item.uom = item.stock_uom;
+                }
 		let index = -1;
 		if (!context.new_line) {
 			// For auto_set_batch enabled, we should check if the item code and UOM match only
@@ -226,11 +227,11 @@ export function useItemAddition() {
 								dialog.hide();
 							},
 						});
-						dialog.onhide = () => {
-							if (!new_item.batch_no) {
-								context.setBatchQty(new_item, null, false);
-							}
-						};
+                                                dialog.onhide = () => {
+                                                        if (!new_item.batch_no) {
+                                                                context.setBatchQty(new_item, null, false);
+                                                        }
+                                                };
 						dialog.show();
 					} else {
 						context.setBatchQty(new_item, null, false);
@@ -336,10 +337,10 @@ export function useItemAddition() {
 		) {
 			context.expanded = [new_item.posa_row_id];
 		}
-	};
+        });
 
-	// Create a new item object with default and calculated fields
-	const getNewItem = (item, context) => {
+        // Create a new item object with default and calculated fields
+        const getNewItem = (item, context) => {
 		const new_item = { ...item };
 		new_item.original_item_name = new_item.item_name;
 		new_item.name_overridden = 0;

--- a/frontend/src/posapp/posapp.js
+++ b/frontend/src/posapp/posapp.js
@@ -11,6 +11,9 @@ import themePlugin from "./plugins/theme.js";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
 import Home from "./Home.vue";
+import { attachProfilerHelpers, initLongTaskObserver, isPerfEnabled } from "./utils/perf.js";
+
+attachProfilerHelpers();
 
 // Expose Dexie globally for libraries that expect a global Dexie instance
 if (typeof window !== "undefined" && !window.Dexie) {
@@ -84,10 +87,14 @@ frappe.PosApp.posapp = class {
 		});
 		const app = createApp(Home);
 		app.component("VueDatePicker", VueDatePicker);
-		app.use(eventBus);
-		app.use(vuetify);
-		app.use(themePlugin, { vuetify });
-		app.mount(this.$el[0]);
+                app.use(eventBus);
+                app.use(vuetify);
+                app.use(themePlugin, { vuetify });
+                app.mount(this.$el[0]);
+
+                if (isPerfEnabled()) {
+                        initLongTaskObserver("posapp");
+                }
 
 		if (!document.querySelector('link[rel="manifest"]')) {
 			const link = document.createElement("link");

--- a/frontend/src/posapp/utils/perf.js
+++ b/frontend/src/posapp/utils/perf.js
@@ -1,0 +1,131 @@
+const hasWindow = typeof window !== "undefined";
+const hasPerformance = typeof performance !== "undefined";
+
+export function isPerfEnabled() {
+        return hasWindow && Boolean(window.__PROF__);
+}
+
+function markName(label, suffix) {
+        return `${label}-${suffix}`;
+}
+
+export function perfMarkStart(label) {
+        if (!isPerfEnabled() || !hasPerformance || !performance.mark) {
+                return null;
+        }
+        const start = markName(label, "start");
+        try {
+                performance.mark(start);
+        } catch (err) {
+                console.warn("PERF start mark failed", label, err);
+        }
+        return start;
+}
+
+export function perfMarkEnd(label, startMark) {
+        if (!isPerfEnabled() || !hasPerformance || !performance.mark || !performance.measure) {
+                return;
+        }
+        const end = markName(label, "end");
+        try {
+                performance.mark(end);
+                if (startMark) {
+                        performance.measure(label, startMark, end);
+                } else {
+                        performance.measure(label);
+                }
+        } catch (err) {
+                console.warn("PERF end mark failed", label, err);
+        } finally {
+                if (performance.clearMarks) {
+                        performance.clearMarks(startMark);
+                        performance.clearMarks(end);
+                }
+        }
+}
+
+export function withPerf(label, fn) {
+        return function withPerfWrapper(...args) {
+                const start = perfMarkStart(label);
+                const result = fn.apply(this, args);
+                if (result && typeof result.then === "function") {
+                        return result.finally(() => perfMarkEnd(label, start));
+                }
+                perfMarkEnd(label, start);
+                return result;
+        };
+}
+
+export function scheduleFrame(callback) {
+        const scheduler = typeof requestAnimationFrame === "function" ? requestAnimationFrame : (cb) => setTimeout(cb, 16);
+        return scheduler(callback);
+}
+
+let longTaskCleanup = null;
+
+export function initLongTaskObserver(label = "pos-long-task") {
+        if (!isPerfEnabled() || typeof PerformanceObserver === "undefined") {
+                return () => {};
+        }
+        if (longTaskCleanup) {
+                return longTaskCleanup;
+        }
+        try {
+                const observer = new PerformanceObserver((list) => {
+                        list.getEntries().forEach((entry) => {
+                                console.warn(`%c[PERF][LongTask] ${label}: ${entry.duration.toFixed(1)}ms`, "color:#d97706", entry);
+                        });
+                });
+                observer.observe({ entryTypes: ["longtask"] });
+                longTaskCleanup = () => observer.disconnect();
+        } catch (err) {
+                console.warn("PERF long task observer failed", err);
+                longTaskCleanup = () => {};
+        }
+        return longTaskCleanup;
+}
+
+export function logComponentRender(vm, componentName, phase, details = {}) {
+        if (!isPerfEnabled() || !vm) {
+                return;
+        }
+        const key = "__perfRenderCount";
+        if (!vm[key]) {
+                vm[key] = { mounted: 0, updates: 0 };
+        }
+        if (phase === "mounted") {
+                vm[key].mounted += 1;
+                vm[key].updates = 0;
+        } else {
+                vm[key].updates += 1;
+        }
+        const count = phase === "mounted" ? vm[key].mounted : vm[key].updates;
+        console.info(
+                `%c[PERF][render] ${componentName} ${phase} #${count}`,
+                "color:#2563eb",
+                {
+                        time: hasPerformance ? performance.now() : Date.now(),
+                        ...details,
+                },
+        );
+}
+
+export function attachProfilerHelpers() {
+        if (!hasWindow) {
+                return;
+        }
+        window.__POS_PROFILER__ = window.__POS_PROFILER__ || {
+                enable() {
+                        window.__PROF__ = true;
+                        return initLongTaskObserver();
+                },
+                disable() {
+                        window.__PROF__ = false;
+                        if (longTaskCleanup) {
+                                longTaskCleanup();
+                                longTaskCleanup = null;
+                        }
+                },
+                initLongTaskObserver,
+        };
+}


### PR DESCRIPTION
## Summary
- add a profiler utility that exposes a toggleable long task observer and render counters
- instrument the POS scan, search, add-item, and totals paths with performance marks and light debouncing
- hook the POS shell to initialise profiling helpers when the window toggle is enabled

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d508b97d448326893b98c107192f1f