### PR TITLE
Improve POS notification handling to reduce UI slowdowns

### DIFF
--- a/frontend/src/posapp/components/Navbar.vue
+++ b/frontend/src/posapp/components/Navbar.vue
@@ -432,11 +432,7 @@ export default {
                         }
 
                         if (this.currentNotification && this.currentNotification.key === notification.key) {
-                                this.currentNotification.count += notification.count;
-                                this.currentNotification.timeout = Math.max(
-                                        this.currentNotification.timeout,
-                                        notification.timeout,
-                                );
+                                this.mergeNotifications(this.currentNotification, notification);
                                 this.updateActiveNotification();
                                 return;
                         }
@@ -446,13 +442,9 @@ export default {
                         );
 
                         if (existingQueued) {
-                                existingQueued.count += notification.count;
-                                existingQueued.timeout = Math.max(
-                                        existingQueued.timeout,
-                                        notification.timeout,
-                                );
+                                this.mergeNotifications(existingQueued, notification);
                         } else {
-                                this.notificationQueue.push(notification);
+                                this.notificationQueue.push({ ...notification });
                         }
 
                         if (!this.currentNotification && !this.snack) {
@@ -465,14 +457,40 @@ export default {
                         const timeout = typeof data.timeout === "number" && data.timeout >= 0
                                 ? data.timeout
                                 : DEFAULT_SNACK_TIMEOUT;
+                        const summary = typeof data.summary === "string" ? data.summary.trim() : "";
+                        const detail = typeof data.detail === "string" ? data.detail.trim() : "";
+                        const count = Number.isFinite(data.count) && data.count > 0
+                                ? Math.floor(data.count)
+                                : 1;
+                        const providedKey =
+                                (typeof data.groupId === "string" && data.groupId.trim()) ||
+                                (typeof data.groupKey === "string" && data.groupKey.trim()) ||
+                                "";
+
+                        const baseKey = providedKey || `${color}::${summary || title}`;
 
                         return {
                                 title,
                                 color,
                                 timeout,
-                                count: 1,
-                                key: `${color}::${title}`,
+                                count,
+                                key: baseKey,
+                                summary,
+                                latestDetail: detail,
                         };
+                },
+                mergeNotifications(target, incoming) {
+                        target.count += incoming.count;
+                        target.timeout = Math.max(target.timeout, incoming.timeout);
+                        if (incoming.title) {
+                                target.title = incoming.title;
+                        }
+                        if (incoming.summary) {
+                                target.summary = incoming.summary;
+                        }
+                        if (incoming.latestDetail) {
+                                target.latestDetail = incoming.latestDetail;
+                        }
                 },
                 processNextNotification() {
                         if (!this.notificationQueue.length) {
@@ -502,9 +520,20 @@ export default {
                                 return "";
                         }
 
-                        return notification.count > 1
-                                ? `${notification.title} (${notification.count}×)`
-                                : notification.title;
+                        const baseText = notification.summary || notification.title;
+
+                        if (!baseText) {
+                                return notification.title || "";
+                        }
+
+                        const multiplier = notification.count > 1 ? ` (${notification.count}×)` : "";
+                        const detail = notification.latestDetail;
+
+                        if (notification.summary && detail) {
+                                return `${baseText}${multiplier} – ${detail}`;
+                        }
+
+                        return `${baseText}${multiplier}`;
                 },
                 dismissActiveNotification(clearQueue = false) {
                         if (clearQueue) {

--- a/frontend/src/posapp/components/Navbar.vue
+++ b/frontend/src/posapp/components/Navbar.vue
@@ -99,12 +99,16 @@
 			:location="isRtl ? 'top left' : 'top right'"
 		>
 			{{ snackText }}
-			<template v-slot:actions>
-				<v-btn class="pos-themed-button" variant="text" @click="snack = false">{{
-					__("Close")
-				}}</v-btn>
-			</template>
-		</v-snackbar>
+                        <template v-slot:actions>
+                                <v-btn
+                                        class="pos-themed-button"
+                                        variant="text"
+                                        @click="dismissActiveNotification(true)"
+                                >
+                                        {{ __("Close") }}
+                                </v-btn>
+                        </template>
+                </v-snackbar>
 	</nav>
 </template>
 
@@ -126,8 +130,9 @@ import { useRtl } from "../composables/useRtl.js";
 
 const ServerUsageGadget = defineAsyncComponent(() => import("./navbar/ServerUsageGadget.vue"));
 const DatabaseUsageGadget = defineAsyncComponent(() =>
-	import("./navbar/DatabaseUsageGadget.vue"),
+        import("./navbar/DatabaseUsageGadget.vue"),
 );
+const DEFAULT_SNACK_TIMEOUT = 3000;
 
 export default {
 	name: "NavBar",
@@ -196,40 +201,48 @@ export default {
 		},
 	},
 	data() {
-		return {
-			drawer: false,
-			mini: true,
-			item: 0,
-			items: [
-				{ text: "POS", icon: "mdi-network-pos" },
-				{ text: "Payments", icon: "mdi-credit-card" },
-			],
-			company: "POS Awesome",
-			companyImg: posLogo,
-			showAboutDialog: false,
-			showOfflineInvoices: false,
-			freeze: false,
-			freezeTitle: "",
-			freezeMsg: "",
-			snack: false,
-			snackText: "",
-			snackColor: "success",
-			snackTimeout: 3000,
-			clearingCache: false,
-			initialCacheRefreshRequested: false,
-		};
-	},
-	watch: {
-		cacheReady: {
-			handler(newVal) {
-				if (newVal && !this.initialCacheRefreshRequested) {
+                return {
+                        drawer: false,
+                        mini: true,
+                        item: 0,
+                        items: [
+                                { text: "POS", icon: "mdi-network-pos" },
+                                { text: "Payments", icon: "mdi-credit-card" },
+                        ],
+                        company: "POS Awesome",
+                        companyImg: posLogo,
+                        showAboutDialog: false,
+                        showOfflineInvoices: false,
+                        freeze: false,
+                        freezeTitle: "",
+                        freezeMsg: "",
+                        snack: false,
+                        snackText: "",
+                        snackColor: "success",
+                        snackTimeout: DEFAULT_SNACK_TIMEOUT,
+                        notificationQueue: [],
+                        currentNotification: null,
+                        clearQueuedOnClose: false,
+                        clearingCache: false,
+                        initialCacheRefreshRequested: false,
+                };
+        },
+        watch: {
+                cacheReady: {
+                        handler(newVal) {
+                                if (newVal && !this.initialCacheRefreshRequested) {
 					this.initialCacheRefreshRequested = true;
 					this.refreshCacheUsage();
 				}
-			},
-			immediate: true,
-		},
-	},
+                        },
+                        immediate: true,
+                },
+                snack(newVal, oldVal) {
+                        if (!newVal && oldVal) {
+                                this.handleSnackbarClosed();
+                        }
+                },
+        },
 	computed: {
 		appBarColor() {
 			return this.isDark ? this.$vuetify.theme.themes.dark.colors.surface : "white";
@@ -411,16 +424,110 @@ export default {
 		updateAfterDelete() {
 			this.$emit("update-after-delete");
 		},
-		showMessage(data) {
-			this.snackText = data.title;
-			this.snackColor = data.color || "success";
-			this.snack = true;
-		},
-		handleFreeze(data) {
-			this.freezeTitle = data?.title || "";
-			this.freezeMsg = data?.message || "";
-			this.freeze = true;
-		},
+                showMessage(data) {
+                        const notification = this.normalizeNotification(data);
+
+                        if (!notification.title) {
+                                return;
+                        }
+
+                        if (this.currentNotification && this.currentNotification.key === notification.key) {
+                                this.currentNotification.count += notification.count;
+                                this.currentNotification.timeout = Math.max(
+                                        this.currentNotification.timeout,
+                                        notification.timeout,
+                                );
+                                this.updateActiveNotification();
+                                return;
+                        }
+
+                        const existingQueued = this.notificationQueue.find(
+                                (item) => item.key === notification.key,
+                        );
+
+                        if (existingQueued) {
+                                existingQueued.count += notification.count;
+                                existingQueued.timeout = Math.max(
+                                        existingQueued.timeout,
+                                        notification.timeout,
+                                );
+                        } else {
+                                this.notificationQueue.push(notification);
+                        }
+
+                        if (!this.currentNotification && !this.snack) {
+                                this.processNextNotification();
+                        }
+                },
+                normalizeNotification(data = {}) {
+                        const title = typeof data.title === "string" ? data.title.trim() : "";
+                        const color = data.color || "success";
+                        const timeout = typeof data.timeout === "number" && data.timeout >= 0
+                                ? data.timeout
+                                : DEFAULT_SNACK_TIMEOUT;
+
+                        return {
+                                title,
+                                color,
+                                timeout,
+                                count: 1,
+                                key: `${color}::${title}`,
+                        };
+                },
+                processNextNotification() {
+                        if (!this.notificationQueue.length) {
+                                this.currentNotification = null;
+                                return;
+                        }
+
+                        const nextNotification = this.notificationQueue.shift();
+                        this.currentNotification = { ...nextNotification };
+                        this.updateActiveNotification();
+                },
+                updateActiveNotification() {
+                        if (!this.currentNotification) {
+                                return;
+                        }
+
+                        this.snackColor = this.currentNotification.color;
+                        this.snackTimeout = this.currentNotification.timeout;
+                        this.snackText = this.formatNotificationMessage(this.currentNotification);
+
+                        if (!this.snack) {
+                                this.snack = true;
+                        }
+                },
+                formatNotificationMessage(notification) {
+                        if (!notification) {
+                                return "";
+                        }
+
+                        return notification.count > 1
+                                ? `${notification.title} (${notification.count}×)`
+                                : notification.title;
+                },
+                dismissActiveNotification(clearQueue = false) {
+                        if (clearQueue) {
+                                this.clearQueuedOnClose = true;
+                        }
+                        this.snack = false;
+                },
+                handleSnackbarClosed() {
+                        if (this.clearQueuedOnClose) {
+                                this.notificationQueue = [];
+                        }
+                        this.clearQueuedOnClose = false;
+                        this.currentNotification = null;
+
+                        if (this.notificationQueue.length) {
+                                this.$nextTick(() => this.processNextNotification());
+                        }
+                },
+                handleFreeze(data) {
+                        this.freezeTitle = data?.title || "";
+                        this.freezeMsg = data?.message || "";
+                        this.freeze = true;
+                },
 		handleUnfreeze() {
 			this.freeze = false;
 			this.freezeTitle = "";

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -484,11 +484,14 @@ export default {
 			this.add_item(item);
 
 			// Show success feedback
-			this.eventBus.emit("show_message", {
-				title: __(`Item {0} added to invoice`, [item.item_name]),
-				color: "success",
-			});
-		},
+                        this.eventBus.emit("show_message", {
+                                title: __(`Item {0} added to invoice`, [item.item_name]),
+                                summary: __("Items added to invoice"),
+                                detail: item.item_name,
+                                color: "success",
+                                groupId: "invoice-item-added",
+                        });
+                },
 
 		// Show visual feedback when item is being dragged over drop zone
 		showDropFeedback(isDragging) {

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -483,14 +483,6 @@ export default {
 			// Use the existing add_item method to add the dropped item
 			this.add_item(item);
 
-			// Show success feedback
-                        this.eventBus.emit("show_message", {
-                                title: __(`Item {0} added to invoice`, [item.item_name]),
-                                summary: __("Items added to invoice"),
-                                detail: item.item_name,
-                                color: "success",
-                                groupId: "invoice-item-added",
-                        });
                 },
 
 		// Show visual feedback when item is being dragged over drop zone

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3235,22 +3235,45 @@ export default {
 
 			this.awaitingScanResult = true;
 
-			try {
-				// Use existing add_item method with enhanced feedback
-					await this.add_item(newItem, { suppressNegativeWarning: true });
-				this.playScanTone("success");
-				this.scannerLocked = false;
-				this.search_from_scanner = false;
-				this.pendingScanCode = "";
+                        try {
+                                // Use existing add_item method with enhanced feedback
+                                await this.add_item(newItem, {
+                                        suppressNegativeWarning: true,
+                                        skipNotification: true,
+                                });
+                                this.playScanTone("success");
+                                this.scannerLocked = false;
+                                this.search_from_scanner = false;
+                                this.pendingScanCode = "";
 
-				// Show success message
-				frappe.show_alert(
-					{
-						message: `Added: ${item.item_name}`,
-						indicator: "green",
-					},
-					3,
-				);
+                                // Show success message
+                                const itemName =
+                                        newItem.item_name || newItem.item_code || scannedCode || this.__("Item");
+                                const rawPrecision = Number(this.float_precision);
+                                const precision = Number.isInteger(rawPrecision)
+                                        ? Math.min(Math.max(rawPrecision, 0), 6)
+                                        : 2;
+                                const displayQty = Number.isInteger(requestedQty)
+                                        ? requestedQty
+                                        : Number(requestedQty.toFixed(precision));
+
+                                if (this.eventBus?.emit) {
+                                        this.eventBus.emit("show_message", {
+                                                title: this.__("Item {0} added to invoice", [itemName]),
+                                                summary: this.__("Items added to invoice"),
+                                                detail: this.__("{0} (Qty: {1})", [itemName, displayQty]),
+                                                color: "success",
+                                                groupId: "invoice-item-added",
+                                        });
+                                } else if (frappe?.show_alert) {
+                                        frappe.show_alert(
+                                                {
+                                                        message: `Added: ${itemName}`,
+                                                        indicator: "green",
+                                                },
+                                                3,
+                                        );
+                                }
 
                                 // Clear search after successful addition and refocus input
                                 this.clearSearch();

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2929,7 +2929,16 @@ export default {
                                         this.search = code;
 
                                         // Show scanning feedback
-                                        if (frappe?.show_alert) {
+                                        if (this.eventBus?.emit) {
+                                                this.eventBus.emit("show_message", {
+                                                        title: this.__("Scanning for: {0}", [code]),
+                                                        summary: this.__("Scanning items"),
+                                                        detail: code,
+                                                        color: "info",
+                                                        timeout: 2000,
+                                                        groupId: "scanner-progress",
+                                                });
+                                        } else if (frappe?.show_alert) {
                                                 frappe.show_alert(
                                                         {
                                                                 message: `Scanning for: ${code}`,

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -26,19 +26,46 @@ export default {
 		return removeItem(item, this);
 	},
 
-	async add_item(item) {
-		const res = await addItem(item, this);
-		const target = this.items.find(
-			(it) =>
-				it.item_code === item.item_code &&
-				it.uom === (item.uom || it.uom) &&
-				(!it.batch_no || it.batch_no === item.batch_no),
-		);
-		if (target && this.fetch_available_qty) {
-			this.fetch_available_qty(target);
-		}
-		return res;
-	},
+        async add_item(item, options = {}) {
+                const res = await addItem(item, this);
+                const target = this.items.find(
+                        (it) =>
+                                it.item_code === item.item_code &&
+                                it.uom === (item.uom || it.uom) &&
+                                (!it.batch_no || it.batch_no === item.batch_no),
+                );
+                if (target && this.fetch_available_qty) {
+                        this.fetch_available_qty(target);
+                }
+
+                if (!options?.skipNotification && this.eventBus?.emit) {
+                        const rawQty = typeof item?.qty === "number" ? item.qty : parseFloat(item?.qty);
+                        const shouldAnnounce = Number.isFinite(rawQty) ? rawQty > 0 : true;
+
+                        if (shouldAnnounce) {
+                                const addedQty = Number.isFinite(rawQty) ? Math.abs(rawQty) : 1;
+                                const rawPrecision = Number(this.float_precision);
+                                const precision = Number.isInteger(rawPrecision)
+                                        ? Math.min(Math.max(rawPrecision, 0), 6)
+                                        : 2;
+                                const displayQty = Number.isInteger(addedQty)
+                                        ? addedQty
+                                        : Number(addedQty.toFixed(precision));
+                                const itemName = item?.item_name || item?.item_code || __("Item");
+                                const detail = __("{0} (Qty: {1})", [itemName, displayQty]);
+
+                                this.eventBus.emit("show_message", {
+                                        title: __("Item {0} added to invoice", [itemName]),
+                                        summary: __("Items added to invoice"),
+                                        detail,
+                                        color: "success",
+                                        groupId: "invoice-item-added",
+                                });
+                        }
+                }
+
+                return res;
+        },
 
 	// Create a new item object with default and calculated fields
 	get_new_item(item) {


### PR DESCRIPTION
## Summary
- queue navbar snackbar notifications so messages display sequentially
- aggregate duplicate events into a single notification with counts and allow manual queue clearing
- keep default timeouts configurable while preserving existing notification styling

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d6a87127dc83268652012d030e7db4