### PR TITLE
Improve POS notification handling to reduce UI slowdowns

### DIFF
--- a/frontend/src/posapp/components/Navbar.vue
+++ b/frontend/src/posapp/components/Navbar.vue
@@ -99,12 +99,16 @@
 			:location="isRtl ? 'top left' : 'top right'"
 		>
 			{{ snackText }}
-			<template v-slot:actions>
-				<v-btn class="pos-themed-button" variant="text" @click="snack = false">{{
-					__("Close")
-				}}</v-btn>
-			</template>
-		</v-snackbar>
+                        <template v-slot:actions>
+                                <v-btn
+                                        class="pos-themed-button"
+                                        variant="text"
+                                        @click="dismissActiveNotification(true)"
+                                >
+                                        {{ __("Close") }}
+                                </v-btn>
+                        </template>
+                </v-snackbar>
 	</nav>
 </template>
 
@@ -126,8 +130,9 @@ import { useRtl } from "../composables/useRtl.js";
 
 const ServerUsageGadget = defineAsyncComponent(() => import("./navbar/ServerUsageGadget.vue"));
 const DatabaseUsageGadget = defineAsyncComponent(() =>
-	import("./navbar/DatabaseUsageGadget.vue"),
+        import("./navbar/DatabaseUsageGadget.vue"),
 );
+const DEFAULT_SNACK_TIMEOUT = 3000;
 
 export default {
 	name: "NavBar",
@@ -196,40 +201,48 @@ export default {
 		},
 	},
 	data() {
-		return {
-			drawer: false,
-			mini: true,
-			item: 0,
-			items: [
-				{ text: "POS", icon: "mdi-network-pos" },
-				{ text: "Payments", icon: "mdi-credit-card" },
-			],
-			company: "POS Awesome",
-			companyImg: posLogo,
-			showAboutDialog: false,
-			showOfflineInvoices: false,
-			freeze: false,
-			freezeTitle: "",
-			freezeMsg: "",
-			snack: false,
-			snackText: "",
-			snackColor: "success",
-			snackTimeout: 3000,
-			clearingCache: false,
-			initialCacheRefreshRequested: false,
-		};
-	},
-	watch: {
-		cacheReady: {
-			handler(newVal) {
-				if (newVal && !this.initialCacheRefreshRequested) {
+                return {
+                        drawer: false,
+                        mini: true,
+                        item: 0,
+                        items: [
+                                { text: "POS", icon: "mdi-network-pos" },
+                                { text: "Payments", icon: "mdi-credit-card" },
+                        ],
+                        company: "POS Awesome",
+                        companyImg: posLogo,
+                        showAboutDialog: false,
+                        showOfflineInvoices: false,
+                        freeze: false,
+                        freezeTitle: "",
+                        freezeMsg: "",
+                        snack: false,
+                        snackText: "",
+                        snackColor: "success",
+                        snackTimeout: DEFAULT_SNACK_TIMEOUT,
+                        notificationQueue: [],
+                        currentNotification: null,
+                        clearQueuedOnClose: false,
+                        clearingCache: false,
+                        initialCacheRefreshRequested: false,
+                };
+        },
+        watch: {
+                cacheReady: {
+                        handler(newVal) {
+                                if (newVal && !this.initialCacheRefreshRequested) {
 					this.initialCacheRefreshRequested = true;
 					this.refreshCacheUsage();
 				}
-			},
-			immediate: true,
-		},
-	},
+                        },
+                        immediate: true,
+                },
+                snack(newVal, oldVal) {
+                        if (!newVal && oldVal) {
+                                this.handleSnackbarClosed();
+                        }
+                },
+        },
 	computed: {
 		appBarColor() {
 			return this.isDark ? this.$vuetify.theme.themes.dark.colors.surface : "white";
@@ -411,16 +424,139 @@ export default {
 		updateAfterDelete() {
 			this.$emit("update-after-delete");
 		},
-		showMessage(data) {
-			this.snackText = data.title;
-			this.snackColor = data.color || "success";
-			this.snack = true;
-		},
-		handleFreeze(data) {
-			this.freezeTitle = data?.title || "";
-			this.freezeMsg = data?.message || "";
-			this.freeze = true;
-		},
+                showMessage(data) {
+                        const notification = this.normalizeNotification(data);
+
+                        if (!notification.title) {
+                                return;
+                        }
+
+                        if (this.currentNotification && this.currentNotification.key === notification.key) {
+                                this.mergeNotifications(this.currentNotification, notification);
+                                this.updateActiveNotification();
+                                return;
+                        }
+
+                        const existingQueued = this.notificationQueue.find(
+                                (item) => item.key === notification.key,
+                        );
+
+                        if (existingQueued) {
+                                this.mergeNotifications(existingQueued, notification);
+                        } else {
+                                this.notificationQueue.push({ ...notification });
+                        }
+
+                        if (!this.currentNotification && !this.snack) {
+                                this.processNextNotification();
+                        }
+                },
+                normalizeNotification(data = {}) {
+                        const title = typeof data.title === "string" ? data.title.trim() : "";
+                        const color = data.color || "success";
+                        const timeout = typeof data.timeout === "number" && data.timeout >= 0
+                                ? data.timeout
+                                : DEFAULT_SNACK_TIMEOUT;
+                        const summary = typeof data.summary === "string" ? data.summary.trim() : "";
+                        const detail = typeof data.detail === "string" ? data.detail.trim() : "";
+                        const count = Number.isFinite(data.count) && data.count > 0
+                                ? Math.floor(data.count)
+                                : 1;
+                        const providedKey =
+                                (typeof data.groupId === "string" && data.groupId.trim()) ||
+                                (typeof data.groupKey === "string" && data.groupKey.trim()) ||
+                                "";
+
+                        const baseKey = providedKey || `${color}::${summary || title}`;
+
+                        return {
+                                title,
+                                color,
+                                timeout,
+                                count,
+                                key: baseKey,
+                                summary,
+                                latestDetail: detail,
+                        };
+                },
+                mergeNotifications(target, incoming) {
+                        target.count += incoming.count;
+                        target.timeout = Math.max(target.timeout, incoming.timeout);
+                        if (incoming.title) {
+                                target.title = incoming.title;
+                        }
+                        if (incoming.summary) {
+                                target.summary = incoming.summary;
+                        }
+                        if (incoming.latestDetail) {
+                                target.latestDetail = incoming.latestDetail;
+                        }
+                },
+                processNextNotification() {
+                        if (!this.notificationQueue.length) {
+                                this.currentNotification = null;
+                                return;
+                        }
+
+                        const nextNotification = this.notificationQueue.shift();
+                        this.currentNotification = { ...nextNotification };
+                        this.updateActiveNotification();
+                },
+                updateActiveNotification() {
+                        if (!this.currentNotification) {
+                                return;
+                        }
+
+                        this.snackColor = this.currentNotification.color;
+                        this.snackTimeout = this.currentNotification.timeout;
+                        this.snackText = this.formatNotificationMessage(this.currentNotification);
+
+                        if (!this.snack) {
+                                this.snack = true;
+                        }
+                },
+                formatNotificationMessage(notification) {
+                        if (!notification) {
+                                return "";
+                        }
+
+                        const baseText = notification.summary || notification.title;
+
+                        if (!baseText) {
+                                return notification.title || "";
+                        }
+
+                        const multiplier = notification.count > 1 ? ` (${notification.count}×)` : "";
+                        const detail = notification.latestDetail;
+
+                        if (notification.summary && detail) {
+                                return `${baseText}${multiplier} – ${detail}`;
+                        }
+
+                        return `${baseText}${multiplier}`;
+                },
+                dismissActiveNotification(clearQueue = false) {
+                        if (clearQueue) {
+                                this.clearQueuedOnClose = true;
+                        }
+                        this.snack = false;
+                },
+                handleSnackbarClosed() {
+                        if (this.clearQueuedOnClose) {
+                                this.notificationQueue = [];
+                        }
+                        this.clearQueuedOnClose = false;
+                        this.currentNotification = null;
+
+                        if (this.notificationQueue.length) {
+                                this.$nextTick(() => this.processNextNotification());
+                        }
+                },
+                handleFreeze(data) {
+                        this.freezeTitle = data?.title || "";
+                        this.freezeMsg = data?.message || "";
+                        this.freeze = true;
+                },
 		handleUnfreeze() {
 			this.freeze = false;
 			this.freezeTitle = "";

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -483,12 +483,8 @@ export default {
 			// Use the existing add_item method to add the dropped item
 			this.add_item(item);
 
-			// Show success feedback
-			this.eventBus.emit("show_message", {
-				title: __(`Item {0} added to invoice`, [item.item_name]),
-				color: "success",
-			});
-		},
+                        // Feedback for item addition now handled centrally via invoice item methods
+                },
 
 		// Show visual feedback when item is being dragged over drop zone
 		showDropFeedback(isDragging) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2929,7 +2929,16 @@ export default {
                                         this.search = code;
 
                                         // Show scanning feedback
-                                        if (frappe?.show_alert) {
+                                        if (this.eventBus?.emit) {
+                                                this.eventBus.emit("show_message", {
+                                                        title: this.__("Scanning for: {0}", [code]),
+                                                        summary: this.__("Scanning items"),
+                                                        detail: code,
+                                                        color: "info",
+                                                        timeout: 2000,
+                                                        groupId: "scanner-progress",
+                                                });
+                                        } else if (frappe?.show_alert) {
                                                 frappe.show_alert(
                                                         {
                                                                 message: `Scanning for: ${code}`,

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -26,19 +26,44 @@ export default {
 		return removeItem(item, this);
 	},
 
-	async add_item(item) {
-		const res = await addItem(item, this);
-		const target = this.items.find(
-			(it) =>
-				it.item_code === item.item_code &&
-				it.uom === (item.uom || it.uom) &&
-				(!it.batch_no || it.batch_no === item.batch_no),
-		);
-		if (target && this.fetch_available_qty) {
-			this.fetch_available_qty(target);
-		}
-		return res;
-	},
+        async add_item(item) {
+                const matchItem = (candidate) =>
+                        candidate.item_code === item.item_code &&
+                        candidate.uom === (item.uom || candidate.uom) &&
+                        (!candidate.batch_no || candidate.batch_no === item.batch_no);
+
+                const existing = this.items.find(matchItem);
+                const previousQty = typeof existing?.qty === "number" ? existing.qty : 0;
+
+                const res = await addItem(item, this);
+
+                const target = this.items.find(matchItem);
+
+                if (target) {
+                        if (this.fetch_available_qty) {
+                                this.fetch_available_qty(target);
+                        }
+
+                        const updatedQty = typeof target.qty === "number" ? target.qty : previousQty;
+                        const deltaQty = Math.abs(updatedQty - previousQty);
+
+                        if (this.eventBus?.emit && deltaQty > 0) {
+                                const itemName = target.item_name || item.item_name || target.item_code || item.item_code;
+                                const eventCount = Math.max(1, Math.round(deltaQty) || 1);
+
+                                this.eventBus.emit("show_message", {
+                                        title: __(`Item {0} added to invoice`, [itemName]),
+                                        summary: __("Items added to invoice"),
+                                        detail: itemName,
+                                        color: "success",
+                                        groupId: "invoice-item-added",
+                                        count: eventCount,
+                                });
+                        }
+                }
+
+                return res;
+        },
 
 	// Create a new item object with default and calculated fields
 	get_new_item(item) {


### PR DESCRIPTION
## Summary
- queue navbar snackbar notifications so messages display sequentially
- aggregate duplicate events into a single notification with counts and allow manual queue clearing
- extend grouping metadata so rapid item additions and scanning feedback reuse the shared queue instead of flooding alerts, and emit item-added notifications centrally so every entry point coalesces
- keep default timeouts configurable while preserving existing notification styling

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d6a87127dc83268652012d030e7db4