### PR TITLE
Add lazy cached item loading and virtualized selector grid

### DIFF
--- a/frontend/src/offline.js
+++ b/frontend/src/offline.js
@@ -992,20 +992,22 @@ export async function getStoredItems() {
 }
 
 export async function searchStoredItems({ search = "", itemGroup = "", limit = 100, offset = 0 } = {}) {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		let collection = db.table("items");
-		if (itemGroup && itemGroup.toLowerCase() !== "all") {
-			collection = collection.where("item_group").equalsIgnoreCase(itemGroup);
-		}
-		if (search) {
-			const term = search.toLowerCase();
-			collection = collection.filter((it) => {
-				const nameMatch = it.item_name && it.item_name.toLowerCase().includes(term);
-				const codeMatch = it.item_code && it.item_code.toLowerCase().includes(term);
-				const barcodeMatch = Array.isArray(it.item_barcode)
-					? it.item_barcode.some((b) => b.barcode && b.barcode.toLowerCase() === term)
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) await db.open();
+                const normalizedGroup = typeof itemGroup === "string" ? itemGroup.trim() : "";
+                let collection = db.table("items");
+                if (normalizedGroup && normalizedGroup.toLowerCase() !== "all") {
+                        collection = collection.where("item_group").equalsIgnoreCase(normalizedGroup);
+                }
+                const normalizedSearch = typeof search === "string" ? search.trim() : "";
+                if (normalizedSearch) {
+                        const term = normalizedSearch.toLowerCase();
+                        collection = collection.filter((it) => {
+                                const nameMatch = it.item_name && it.item_name.toLowerCase().includes(term);
+                                const codeMatch = it.item_code && it.item_code.toLowerCase().includes(term);
+                                const barcodeMatch = Array.isArray(it.item_barcode)
+                                        ? it.item_barcode.some((b) => b.barcode && b.barcode.toLowerCase() === term)
 					: it.item_barcode && String(it.item_barcode).toLowerCase().includes(term);
 				return nameMatch || codeMatch || barcodeMatch;
 			});

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -272,30 +272,36 @@
 				<v-row class="items">
 					<v-col cols="12" class="pt-0 mt-0">
 						<div v-if="items_view == 'card'" class="items-card-container">
-							<div v-if="loading" class="items-card-grid">
-								<Skeleton v-for="n in 8" :key="n" class="mb-4" height="120" />
-							</div>
-							<div
-								v-else
-								class="items-card-grid"
-								ref="itemsContainer"
-								@scroll.passive="onCardScroll"
-								:class="{ 'item-container': isOverflowing }"
-							>
-								<div
-									v-for="item in filtered_items"
-									:key="item.item_code"
-									class="card-item-card"
-									@click="select_item($event, item)"
-									:draggable="true"
-									@dragstart="onDragStart($event, item)"
-									@dragend="onDragEnd"
-								>
-									<div class="card-item-image-container">
-										<v-img
-											:src="item.image || placeholderImage"
-											class="card-item-image"
-											aspect-ratio="1"
+                                                <div v-if="loading" class="items-card-grid">
+                                                        <div class="items-card-grid-inner">
+                                                                <Skeleton v-for="n in 8" :key="n" class="mb-4" height="120" />
+                                                        </div>
+                                                </div>
+                                                <div
+                                                        v-else
+                                                        class="items-card-grid"
+                                                        ref="itemsContainer"
+                                                        @scroll.passive="onCardScroll"
+                                                        :class="{ 'item-container': isOverflowing }"
+                                                >
+                                                        <div
+                                                                class="items-card-grid-inner"
+                                                                :style="virtual_card_padding_style"
+                                                        >
+                                                                <div
+                                                                        v-for="item in virtual_card_items"
+                                                                        :key="item.item_code"
+                                                                        class="card-item-card"
+                                                                        @click="select_item($event, item)"
+                                                                        :draggable="true"
+                                                                        @dragstart="onDragStart($event, item)"
+                                                                        @dragend="onDragEnd"
+                                                                >
+                                                                        <div class="card-item-image-container">
+                                                                                <v-img
+                                                                                        :src="item.image || placeholderImage"
+                                                                                        class="card-item-image"
+                                                                                        aspect-ratio="1"
 											:alt="item.item_name"
 										>
 											<template v-slot:placeholder>
@@ -377,10 +383,10 @@
 													}}
 												</span>
 												<span class="stock-uom">{{ item.stock_uom || "" }}</span>
-											</div>
-										</div>
-									</div>
-								</div>
+                                                                        </div>
+                                                                </div>
+                                                        </div>
+                                                </div>
 							</div>
 						</div>
 						<div v-else class="items-table-container">
@@ -599,9 +605,15 @@ export default {
 		search: "",
 		first_search: "",
 		search_backup: "",
-		// Limit the displayed items to avoid overly large lists
-		itemsPerPage: 50,
-		offersCount: 0,
+                // Limit the displayed items to avoid overly large lists
+                itemsPerPage: 50,
+                virtualStart: 0,
+                virtualEnd: 0,
+                virtualPaddingTop: 0,
+                virtualPaddingBottom: 0,
+                virtualItemHeight: 240,
+                virtualOverscan: 12,
+                offersCount: 0,
 		appliedOffersCount: 0,
 		couponsCount: 0,
 		appliedCouponsCount: 0,
@@ -808,13 +820,13 @@ export default {
 		new_line() {
 			this.eventBus.emit("set_new_line", this.new_line);
 		},
-		item_group(newValue, oldValue) {
-			if (this.pos_profile && this.pos_profile.pose_use_limit_search && newValue !== oldValue) {
-				if (this.pos_profile && (!this.pos_profile.posa_local_storage || !this.storageAvailable)) {
-					this.get_items(true);
-				} else {
-					this.get_items();
-				}
+                item_group(newValue, oldValue) {
+                        if (this.usesLimitSearch && newValue !== oldValue) {
+                                if (this.pos_profile && (!this.pos_profile.posa_local_storage || !this.storageAvailable)) {
+                                        this.get_items(true);
+                                } else {
+                                        this.get_items();
+                                }
 			} else if (this.pos_profile && this.pos_profile.posa_local_storage && newValue !== oldValue) {
 				if (this.storageAvailable) {
 					this.loadVisibleItems(true);
@@ -825,13 +837,9 @@ export default {
 		},
 		filtered_items(new_value, old_value) {
 			// Update item details if items changed
-			if (
-				this.pos_profile &&
-				!this.pos_profile.pose_use_limit_search &&
-				new_value.length !== old_value.length
-			) {
-				this.update_items_details(new_value);
-			}
+                        if (!this.usesLimitSearch && new_value.length !== old_value.length) {
+                                this.update_items_details(new_value);
+                        }
 			this.$nextTick(this.checkItemContainerOverflow);
 		},
 		// Automatically search when the query has at least 3 characters
@@ -843,7 +851,7 @@ export default {
                         const oldLen = (oldVal || "").trim().length;
 
                         // When limit search is enabled, wait for an explicit Enter key press
-                        if (this.pos_profile?.pose_use_limit_search) {
+                        if (this.usesLimitSearch) {
                                 if (oldLen >= 3 && newLen === 0) {
                                         // Reset items only when search is fully cleared
                                         this.clearSearch();
@@ -877,25 +885,131 @@ export default {
 			// Maintain the configured items per page on resize
 			this.itemsPerPage = this.items_per_page;
 		},
-		items_loaded(val) {
-			if (val) {
-				this.eventBus.emit("items_loaded");
-				this.eventBus.emit("data-loaded", "items");
-			}
-		},
-		items_view() {
-			this.$nextTick(() => {
-				if (this.items_view === "card") {
-					this.checkItemContainerOverflow();
-				} else {
-					this.isOverflowing = false;
-				}
-			});
-		},
+                items_loaded(val) {
+                        if (val) {
+                                this.eventBus.emit("items_loaded");
+                                this.eventBus.emit("data-loaded", "items");
+                                this.$nextTick(() => {
+                                        if (this.items_view === "card") {
+                                                this.resetVirtualWindow();
+                                        }
+                                });
+                        } else {
+                                this.virtualStart = 0;
+                                this.virtualEnd = 0;
+                                this.virtualPaddingTop = 0;
+                                this.virtualPaddingBottom = 0;
+                        }
+                },
+                filtered_items() {
+                        if (this.items_view === "card") {
+                                this.$nextTick(() => {
+                                        if (this.virtualEnd === 0) {
+                                                this.resetVirtualWindow();
+                                        } else {
+                                                this.updateVirtualWindow();
+                                        }
+                                });
+                        }
+                },
+                items_view() {
+                        this.$nextTick(() => {
+                                if (this.items_view === "card") {
+                                        this.checkItemContainerOverflow();
+                                        this.resetVirtualWindow();
+                                } else {
+                                        this.isOverflowing = false;
+                                }
+                        });
+                },
 	},
 
-	methods: {
-		// Performance optimization: Memoized search function
+        methods: {
+                resetVirtualWindow() {
+                        if (this.items_view !== "card") {
+                                this.virtualStart = 0;
+                                this.virtualEnd = 0;
+                                this.virtualPaddingTop = 0;
+                                this.virtualPaddingBottom = 0;
+                                return;
+                        }
+
+                        const container = this.$refs.itemsContainer;
+                        const viewportHeight = container ? container.clientHeight : 0;
+                        const itemHeight = this.virtualItemHeight;
+                        const overscan = this.virtualOverscan;
+
+                        const visibleCount = Math.ceil((viewportHeight || itemHeight * 3) / itemHeight) + overscan * 2;
+                        const total = this.filtered_items.length;
+
+                        this.virtualStart = 0;
+                        this.virtualEnd = Math.min(total, visibleCount);
+                        this.virtualPaddingTop = 0;
+                        this.virtualPaddingBottom = Math.max(total - this.virtualEnd, 0) * itemHeight;
+                },
+                updateVirtualWindow() {
+                        if (this.items_view !== "card") {
+                                return;
+                        }
+
+                        const container = this.$refs.itemsContainer;
+                        if (!container) {
+                                return;
+                        }
+
+                        const total = this.filtered_items.length;
+                        if (total === 0) {
+                                this.virtualStart = 0;
+                                this.virtualEnd = 0;
+                                this.virtualPaddingTop = 0;
+                                this.virtualPaddingBottom = 0;
+                                return;
+                        }
+
+                        const itemHeight = this.virtualItemHeight;
+                        const overscan = this.virtualOverscan;
+                        const scrollTop = container.scrollTop;
+                        const viewportHeight = container.clientHeight || itemHeight * 3;
+
+                        const start = Math.max(Math.floor(scrollTop / itemHeight) - overscan, 0);
+                        const visibleCount = Math.ceil(viewportHeight / itemHeight) + overscan * 2;
+                        const maxStart = Math.max(total - 1, 0);
+                        const startIndex = Math.min(start, maxStart);
+                        const end = Math.min(startIndex + visibleCount, total);
+
+                        this.virtualStart = startIndex;
+                        this.virtualEnd = end;
+                        this.virtualPaddingTop = startIndex * itemHeight;
+                        this.virtualPaddingBottom = Math.max(total - end, 0) * itemHeight;
+                },
+                async requestNextItemsPage() {
+                        if (typeof this.append_cached_items_page !== "function") {
+                                if (typeof this.loadVisibleItems === "function") {
+                                        this.loadVisibleItems();
+                                }
+                                return;
+                        }
+
+                        if (!this.cachedPagination || !this.cachedPagination.enabled) {
+                                return;
+                        }
+                        if (this.cachedPagination.loading) {
+                                return;
+                        }
+
+                        const searchTerm = this.get_search(this.first_search);
+                        try {
+                                await this.append_cached_items_page({
+                                        search: searchTerm,
+                                        group: this.item_group,
+                                });
+                        } catch (error) {
+                                console.warn("Failed to append cached items page:", error);
+                        } finally {
+                                this.$nextTick(() => this.updateVirtualWindow());
+                        }
+                },
+                // Performance optimization: Memoized search function
                 memoizedSearch(searchTerm, itemGroup) {
                         const cacheKey = `${searchTerm || ""}_${itemGroup || "ALL"}`;
 
@@ -977,27 +1091,29 @@ export default {
 		},
 
 		// Optimized scroll handler with throttling
-		onCardScroll() {
-			if (this.scrollThrottle) return;
+                onCardScroll() {
+                        if (this.scrollThrottle) return;
 
-			this.scrollThrottle = requestAnimationFrame(() => {
-				try {
-					const el = this.$refs.itemsContainer;
-					if (!el) return;
+                        this.scrollThrottle = requestAnimationFrame(() => {
+                                try {
+                                        const el = this.$refs.itemsContainer;
+                                        if (!el) return;
 
-					const scrollTop = el.scrollTop;
-					const clientHeight = el.clientHeight;
-					const scrollHeight = el.scrollHeight;
+                                        const scrollTop = el.scrollTop;
+                                        const clientHeight = el.clientHeight;
+                                        const scrollHeight = el.scrollHeight;
 
-					// Only trigger load more if we're near the bottom
-					if (scrollTop + clientHeight >= scrollHeight - 50) {
-						this.currentPage += 1;
-						this.loadVisibleItems();
-					}
+                                        this.updateVirtualWindow();
 
-					this.lastScrollTop = scrollTop;
-				} catch (error) {
-					console.error("Error in card scroll handler:", error);
+                                        // Only trigger load more if we're near the bottom
+                                        if (scrollTop + clientHeight >= scrollHeight - 50) {
+                                                this.currentPage += 1;
+                                                this.requestNextItemsPage();
+                                        }
+
+                                        this.lastScrollTop = scrollTop;
+                                } catch (error) {
+                                        console.error("Error in card scroll handler:", error);
 				} finally {
 					this.scrollThrottle = null;
 				}
@@ -1127,13 +1243,15 @@ export default {
 				return;
 			}
 
-			const stickyHeader = el.closest(".dynamic-padding")?.querySelector(".sticky-header");
-			const headerHeight = stickyHeader ? stickyHeader.offsetHeight : 0;
-			const availableHeight = containerHeight - headerHeight;
+                        const stickyHeader = el.closest(".dynamic-padding")?.querySelector(".sticky-header");
+                        const headerHeight = stickyHeader ? stickyHeader.offsetHeight : 0;
+                        const availableHeight = containerHeight - headerHeight;
 
-			el.style.maxHeight = `${availableHeight}px`;
-			this.isOverflowing = el.scrollHeight > availableHeight;
-		},
+                        el.style.maxHeight = `${availableHeight}px`;
+                        this.isOverflowing = el.scrollHeight > availableHeight;
+
+                        this.updateVirtualWindow();
+                },
 
 		async fetchItemDetails(items) {
 			if (!items || items.length === 0) {
@@ -1301,12 +1419,12 @@ export default {
 					updates.forEach(({ item, upd }) => Object.assign(item, upd));
 					updateLocalStockCache(details);
 					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
-					if (
-						vm.pos_profile &&
-						vm.pos_profile.posa_local_storage &&
-						vm.storageAvailable &&
-						!vm.pos_profile.pose_use_limit_search
-					) {
+                                        if (
+                                                vm.pos_profile &&
+                                                vm.pos_profile.posa_local_storage &&
+                                                vm.storageAvailable &&
+                                                !vm.usesLimitSearch
+                                        ) {
 						try {
 							await saveItemsBulk(details);
 						} catch (e) {
@@ -1333,24 +1451,33 @@ export default {
 		show_coupons() {
 			this.eventBus.emit("show_coupons", "true");
 		},
-		async initializeItems() {
-			await this.ensureStorageHealth();
+                async initializeItems() {
+                        await this.ensureStorageHealth();
                         if (
                                 this.pos_profile &&
                                 this.pos_profile.posa_local_storage &&
                                 this.storageAvailable &&
-                                !this.pos_profile.pose_use_limit_search
+                                !this.usesLimitSearch
                         ) {
-				const localCount = await getStoredItemsCount();
-				if (localCount > 0) {
-					await this.loadVisibleItems(true);
-					this.items_loaded = true;
-					await this.verifyServerItemCount();
-					return;
-				}
-			}
-			await this.get_items(true);
-		},
+                                const localCount = await getStoredItemsCount();
+                                if (localCount > 0) {
+                                        await this.loadVisibleItems(true);
+                                        this.items_loaded = true;
+                                        await this.verifyServerItemCount();
+                                        return;
+                                }
+                        }
+                        await this.get_items(true);
+
+                        if (
+                                this.pos_profile &&
+                                this.pos_profile.posa_local_storage &&
+                                this.storageAvailable &&
+                                !this.usesLimitSearch
+                        ) {
+                                await this.verifyServerItemCount();
+                        }
+                },
 		async forceReloadItems() {
 			console.log("[ItemsSelector] forceReloadItems called");
 			// Clear cached price list items so the reload always
@@ -1373,40 +1500,75 @@ export default {
 			await this.get_items(true);
 			console.log("[ItemsSelector] forceReloadItems finished");
 		},
-		async verifyServerItemCount() {
-			if (isOffline()) {
-				console.log("[ItemsSelector] offline, skipping server item count check");
-				return;
-			}
-			try {
-				const localCount = await getStoredItemsCount();
-				console.log("[ItemsSelector] verifying server item count", { localCount });
-				const profileGroups = (this.pos_profile?.item_groups || []).map((g) => g.item_group);
-				const res = await frappe.call({
-					method: "posawesome.posawesome.api.items.get_items_count",
-					args: {
-						pos_profile: JSON.stringify(this.pos_profile),
-						item_groups: profileGroups,
-					},
-				});
-				const serverCount = res.message || 0;
-				console.log("[ItemsSelector] server item count result", { serverCount });
-				if (typeof serverCount === "number") {
-					this.totalItemCount = serverCount;
-					this.loadProgress = serverCount ? Math.round((localCount / serverCount) * 100) : 0;
-					if (serverCount > localCount) {
-						const lastSync = getItemsLastSync();
-						const requestToken = ++this.items_request_token;
-						await this.backgroundLoadItems(null, lastSync, false, requestToken, localCount);
-					} else if (serverCount < localCount) {
-						console.log("[ItemsSelector] local cache has extra items, forcing reload");
-						await this.forceReloadItems();
-					}
-				}
-			} catch (err) {
-				console.error("Error checking item count:", err);
-			}
-		},
+                async verifyServerItemCount() {
+                        if (this.usesLimitSearch) {
+                                console.log("[ItemsSelector] limit search enabled, skipping background reconciliation");
+                                return;
+                        }
+                        if (
+                                !this.pos_profile ||
+                                !this.pos_profile.posa_local_storage ||
+                                !this.storageAvailable
+                        ) {
+                                console.log("[ItemsSelector] local caching disabled, skipping background reconciliation");
+                                return;
+                        }
+                        if (this.isBackgroundLoading) {
+                                console.log("[ItemsSelector] background load already in progress, skipping reconciliation");
+                                return;
+                        }
+                        if (isOffline()) {
+                                console.log("[ItemsSelector] offline, skipping server item count check");
+                                return;
+                        }
+                        try {
+                                const localCount = await getStoredItemsCount();
+                                console.log("[ItemsSelector] verifying server item count", { localCount });
+                                const profileGroups = (this.pos_profile?.item_groups || []).map((g) => g.item_group);
+                                const res = await frappe.call({
+                                        method: "posawesome.posawesome.api.items.get_items_count",
+                                        args: {
+                                                pos_profile: JSON.stringify(this.pos_profile),
+                                                item_groups: profileGroups,
+                                        },
+                                });
+                                const serverCount = res.message || 0;
+                                console.log("[ItemsSelector] server item count result", { serverCount });
+                                if (typeof serverCount === "number") {
+                                        this.totalItemCount = serverCount;
+                                        if (serverCount <= localCount) {
+                                                this.loadProgress = serverCount
+                                                        ? Math.min(100, Math.round((localCount / serverCount) * 100))
+                                                        : 100;
+                                                this.eventBus.emit("data-load-progress", {
+                                                        name: "items",
+                                                        progress: this.loadProgress,
+                                                });
+                                                if (serverCount < localCount) {
+                                                        console.log(
+                                                                "[ItemsSelector] local cache has extra items, forcing reload"
+                                                        );
+                                                        await this.forceReloadItems();
+                                                }
+                                                return;
+                                        }
+
+                                        this.loadProgress = serverCount
+                                                ? Math.round((localCount / serverCount) * 100)
+                                                : 0;
+                                        this.eventBus.emit("data-load-progress", {
+                                                name: "items",
+                                                progress: this.loadProgress,
+                                        });
+
+                                        const lastSync = getItemsLastSync();
+                                        const requestToken = ++this.items_request_token;
+                                        await this.backgroundLoadItems(null, lastSync, false, requestToken, localCount);
+                                }
+                        } catch (err) {
+                                console.error("Error checking item count:", err);
+                        }
+                },
 		async get_items(force_server = false) {
 			if (this.isBackgroundLoading) {
 				if (this.pendingGetItems) {
@@ -1444,7 +1606,7 @@ export default {
 			const vm = this;
 
                         // Respect POS profile search limit when limit search is enabled
-                        const usingLimitSearch = !!vm.pos_profile?.pose_use_limit_search;
+                        const usingLimitSearch = vm.usesLimitSearch;
                         if (usingLimitSearch) {
                                 vm.itemsPageLimit = parseInt(vm.pos_profile.posa_search_limit) || vm.itemsPageLimit;
                         }
@@ -1537,22 +1699,22 @@ export default {
 				vm.eventBus.emit("set_all_items", vm.items);
 				console.log("[ItemsSelector] set_all_items emitted", { itemsLength: vm.items.length });
 
-				const hasMore = !vm.pos_profile.pose_use_limit_search && items.length === vm.itemsPageLimit;
+                                const hasMore = !vm.usesLimitSearch && items.length === vm.itemsPageLimit;
 				vm.loadProgress = vm.totalItemCount
 					? Math.round((items.length / vm.totalItemCount) * 100)
 					: 100;
 				vm.eventBus.emit("data-load-progress", { name: "items", progress: vm.loadProgress });
 				console.log("[ItemsSelector] data-load-progress emitted", { progress: vm.loadProgress });
 
-				if (
-					vm.pos_profile &&
-					vm.pos_profile.posa_local_storage &&
-					vm.storageAvailable &&
-					!vm.pos_profile.pose_use_limit_search
-				) {
-					try {
-						if (force_server) {
-							console.log("[ItemsSelector] clearing local items before save");
+                                if (
+                                        vm.pos_profile &&
+                                        vm.pos_profile.posa_local_storage &&
+                                        vm.storageAvailable &&
+                                        !vm.usesLimitSearch
+                                ) {
+                                        try {
+                                                if (force_server) {
+                                                        console.log("[ItemsSelector] clearing local items before save");
 							await clearStoredItems();
 						}
 						await saveItemsBulk(items);
@@ -1565,14 +1727,21 @@ export default {
 
 				await savePriceListItems(vm.customer_price_list || vm.pos_profile.selling_price_list, items);
 
-				if (hasMore) {
-					const last = items[items.length - 1]?.item_name || null;
-					console.log("[ItemsSelector] more items available, starting background load", {
-						last,
-						requestToken,
-					});
-					this.backgroundLoadItems(last, null, false, requestToken, items.length);
-				}
+                                if (hasMore) {
+                                        const last = items[items.length - 1]?.item_name || null;
+                                        console.log("[ItemsSelector] more items available, starting background load", {
+                                                last,
+                                                requestToken,
+                                        });
+                                        this.backgroundLoadItems(last, null, false, requestToken, items.length);
+                                } else if (
+                                        vm.pos_profile &&
+                                        vm.pos_profile.posa_local_storage &&
+                                        vm.storageAvailable &&
+                                        !vm.usesLimitSearch
+                                ) {
+                                        await vm.verifyServerItemCount();
+                                }
 			} catch (error) {
 				console.error("Failed to load items:", error);
 				frappe.msgprint(__("Failed to load items. Please try again."));
@@ -1688,12 +1857,12 @@ export default {
 								console.log("[ItemsSelector] background load set_all_items emitted", {
 									length: this.items.length,
 								});
-								if (
-									this.pos_profile &&
-									this.pos_profile.posa_local_storage &&
-									this.storageAvailable &&
-									!this.pos_profile.pose_use_limit_search
-								) {
+                                                                if (
+                                                                        this.pos_profile &&
+                                                                        this.pos_profile.posa_local_storage &&
+                                                                        this.storageAvailable &&
+                                                                        !this.usesLimitSearch
+                                                                ) {
 									try {
 										if (clearBefore) {
 											await clearStoredItems();
@@ -1804,12 +1973,12 @@ export default {
 						console.log("[ItemsSelector] background load set_all_items emitted", {
 							length: this.items.length,
 						});
-						if (
-							this.pos_profile &&
-							this.pos_profile.posa_local_storage &&
-							this.storageAvailable &&
-							!this.pos_profile.pose_use_limit_search
-						) {
+                                                if (
+                                                        this.pos_profile &&
+                                                        this.pos_profile.posa_local_storage &&
+                                                        this.storageAvailable &&
+                                                        !this.usesLimitSearch
+                                                ) {
 							try {
 								if (clearBefore) {
 									await clearStoredItems();
@@ -2214,7 +2383,7 @@ export default {
 
 			const fromScanner = vm.search_from_scanner;
 
-                        if (vm.pos_profile && vm.pos_profile.pose_use_limit_search) {
+                        if (vm.usesLimitSearch) {
                                 const shouldForceServer =
                                         !vm.pos_profile.posa_local_storage ||
                                         !vm.storageAvailable ||
@@ -2440,12 +2609,12 @@ export default {
 					updateLocalStockCache(details);
 					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
 
-					if (
-						vm.pos_profile &&
-						vm.pos_profile.posa_local_storage &&
-						vm.storageAvailable &&
-						!vm.pos_profile.pose_use_limit_search
-					) {
+                                        if (
+                                                vm.pos_profile &&
+                                                vm.pos_profile.posa_local_storage &&
+                                                vm.storageAvailable &&
+                                                !vm.usesLimitSearch
+                                        ) {
 						try {
 							await saveItemsBulk(details);
 						} catch (e) {
@@ -3516,20 +3685,36 @@ export default {
 		},
 	},
 
-	computed: {
-		blockSaleBeyondAvailableQty() {
-			return (
-				Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty) &&
-				!this.isNegativeStockEnabled()
-			);
+        computed: {
+                usesLimitSearch() {
+                        const rawValue =
+                                this.pos_profile?.pose_use_limit_search ??
+                                this.pos_profile?.posa_use_limit_search;
+
+                        if (typeof rawValue === "string") {
+                                const normalized = rawValue.trim().toLowerCase();
+                                return normalized === "1" || normalized === "true" || normalized === "yes";
+                        }
+
+                        if (typeof rawValue === "number") {
+                                return rawValue === 1;
+                        }
+
+                        return Boolean(rawValue);
+                },
+                blockSaleBeyondAvailableQty() {
+                        return (
+                                Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty) &&
+                                !this.isNegativeStockEnabled()
+                        );
 		},
 		headers() {
 			return this.getItemsHeaders();
 		},
-		filtered_items() {
-			if (!this.items || this.items.length === 0) {
-				return [];
-			}
+                filtered_items() {
+                        if (!this.items || this.items.length === 0) {
+                                return [];
+                        }
 
 			const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
 			let filteredItems = [...this.items];
@@ -3586,18 +3771,44 @@ export default {
 			}
 
 			// Apply pagination
-			const limit = this.enable_custom_items_per_page ? this.items_per_page : this.itemsPerPage;
-			filteredItems = filteredItems.slice(0, limit);
+                        if (this.enable_custom_items_per_page) {
+                                filteredItems = filteredItems.slice(0, this.items_per_page);
+                        }
 
 			// Ensure quantities are defined
-			filteredItems.forEach((item) => {
-				if (item.actual_qty === undefined || item.actual_qty === null) {
-					item.actual_qty = 0;
-				}
-			});
+                        filteredItems.forEach((item) => {
+                                if (item.actual_qty === undefined || item.actual_qty === null) {
+                                        item.actual_qty = 0;
+                                }
+                        });
 
-			return filteredItems;
-		},
+                        return filteredItems;
+                },
+                virtual_card_items() {
+                        if (this.items_view !== "card") {
+                                return this.filtered_items;
+                        }
+
+                        return this.filtered_items.slice(
+                                this.virtualStart,
+                                this.virtualEnd > 0 ? this.virtualEnd : this.filtered_items.length
+                        );
+                },
+                virtual_card_padding_style() {
+                        const basePadding = 16;
+                        if (this.items_view !== "card") {
+                                return {
+                                        padding: `${basePadding}px`,
+                                };
+                        }
+
+                        return {
+                                paddingTop: `${basePadding + this.virtualPaddingTop}px`,
+                                paddingBottom: `${basePadding + this.virtualPaddingBottom}px`,
+                                paddingLeft: `${basePadding}px`,
+                                paddingRight: `${basePadding}px`,
+                        };
+                },
 		debounce_search: {
 			get() {
 				return this.first_search;
@@ -3843,11 +4054,16 @@ export default {
 			this.scan_barcoud();
 		}
 
-		// Apply the configured items per page on mount
-		this.itemsPerPage = this.items_per_page;
-		window.addEventListener("resize", this.checkItemContainerOverflow);
-		this.$nextTick(this.checkItemContainerOverflow);
-	},
+                // Apply the configured items per page on mount
+                this.itemsPerPage = this.items_per_page;
+                window.addEventListener("resize", this.checkItemContainerOverflow);
+                window.addEventListener("resize", this.updateVirtualWindow);
+                this.$nextTick(() => {
+                        this.checkItemContainerOverflow();
+                        this.resetVirtualWindow();
+                        this.updateVirtualWindow();
+                });
+        },
 
 	beforeUnmount() {
 		// Clear interval when component is destroyed
@@ -3894,12 +4110,13 @@ export default {
 		this.eventBus.off("update_cur_items_details");
 		this.eventBus.off("update_offers_counters");
 		this.eventBus.off("update_coupons_counters");
-		this.eventBus.off("update_customer_price_list");
-		this.eventBus.off("update_customer");
-		this.eventBus.off("force_reload_items");
-		this.eventBus.off("focus_item_search");
-		window.removeEventListener("resize", this.checkItemContainerOverflow);
-	},
+                this.eventBus.off("update_customer_price_list");
+                this.eventBus.off("update_customer");
+                this.eventBus.off("force_reload_items");
+                this.eventBus.off("focus_item_search");
+                window.removeEventListener("resize", this.checkItemContainerOverflow);
+                window.removeEventListener("resize", this.updateVirtualWindow);
+        },
 };
 </script>
 
@@ -4112,20 +4329,26 @@ export default {
 	-moz-osx-font-smoothing: grayscale;
 }
 
-/* Enhanced Card View Grid Layout - 3 items per row */
+/* Enhanced Card View Grid Layout - virtualization-ready container */
 .items-card-grid {
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	gap: 16px;
-	padding: 16px;
-	height: calc(100% - 80px);
-	overflow-y: auto;
-	scrollbar-width: thin;
-	scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
-	/* Performance optimizations */
-	contain: layout style;
-	will-change: scroll-position;
-	transform: translate3d(0, 0, 0);
+        height: calc(100% - 80px);
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+        /* Performance optimizations */
+        contain: layout style;
+        will-change: scroll-position;
+        transform: translate3d(0, 0, 0);
+}
+
+.items-card-grid-inner {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+        padding: 16px;
+        box-sizing: border-box;
+        width: 100%;
+        min-height: 100%;
 }
 
 .items-card-grid::-webkit-scrollbar {
@@ -4534,11 +4757,11 @@ export default {
 
 /* Responsive breakpoints */
 @media (max-width: 1200px) {
-	.items-card-grid {
-		grid-template-columns: repeat(2, 1fr);
-		gap: 12px;
-		padding: 12px;
-	}
+        .items-card-grid-inner {
+                grid-template-columns: repeat(2, 1fr);
+                gap: 12px;
+                padding: 12px;
+        }
 }
 
 @media (max-width: 768px) {
@@ -4556,11 +4779,11 @@ export default {
 		font-size: 0.875rem !important;
 	}
 
-	.items-card-grid {
-		grid-template-columns: 1fr;
-		gap: 10px;
-		padding: 10px;
-	}
+        .items-card-grid-inner {
+                grid-template-columns: 1fr;
+                gap: 10px;
+                padding: 10px;
+        }
 
 	.card-item-image-container {
 		height: 100px;

--- a/frontend/src/posapp/composables/useItemsIntegration.js
+++ b/frontend/src/posapp/composables/useItemsIntegration.js
@@ -24,6 +24,7 @@ export function useItemsIntegration(options = {}) {
         isLoading,
         isBackgroundLoading,
         loadProgress,
+        cachedPagination,
         totalItemCount,
         itemsLoaded,
         searchTerm,
@@ -80,6 +81,14 @@ export function useItemsIntegration(options = {}) {
             forceServer,
             searchValue: searchTerm.value,
             groupFilter: itemGroup.value
+        });
+    };
+
+    const append_cached_items_page = async (options = {}) => {
+        const { search = searchTerm.value, group = itemGroup.value } = options;
+        return await itemsStore.appendCachedItemsPage({
+            search,
+            group
         });
     };
 
@@ -231,6 +240,7 @@ export function useItemsIntegration(options = {}) {
         isLoading,
         isBackgroundLoading,
         loadProgress,
+        cachedPagination,
         totalItemCount,
         itemsLoaded,
         searchTerm,
@@ -271,6 +281,7 @@ export function useItemsIntegration(options = {}) {
         search_onchange,
         update_items_details,
         memoizedSearch,
+        append_cached_items_page,
 
         // Helper methods
         findItemByCode,

--- a/frontend/src/posapp/stores/itemsStore.js
+++ b/frontend/src/posapp/stores/itemsStore.js
@@ -10,9 +10,16 @@ import {
     clearPriceListCache,
     saveItemDetailsCache,
     isStockCacheReady,
-    searchStoredItems,
-    getItemsLastSync
+    getItemsLastSync,
+    getAllStoredItems,
+    getStoredItemsCount,
+    searchStoredItems
 } from '../../offline/index.js';
+
+const LAZY_CACHE_THRESHOLD = 2000;
+const CACHE_PAGE_SIZE = 200;
+const SEARCH_PAGE_SIZE = 200;
+const MIN_SEARCH_LENGTH = 2;
 
 export const useItemsStore = defineStore('items', () => {
     // Core state
@@ -61,6 +68,23 @@ export const useItemsStore = defineStore('items', () => {
     // Request management
     const requestToken = ref(0);
     const abortControllers = ref(new Map());
+    const cachedPagination = ref({
+        enabled: false,
+        pageSize: CACHE_PAGE_SIZE,
+        pagesLoaded: 0,
+        totalCount: 0,
+        loading: false
+    });
+
+    const resetCachedPagination = () => {
+        cachedPagination.value = {
+            enabled: false,
+            pageSize: CACHE_PAGE_SIZE,
+            pagesLoaded: 0,
+            totalCount: 0,
+            loading: false
+        };
+    };
 
     // Multi-layer cache system
     const cache = ref({
@@ -116,6 +140,7 @@ export const useItemsStore = defineStore('items', () => {
         await assessCacheHealth();
 
         // Load cached items if available
+        resetCachedPagination();
         await loadCachedItems();
     };
 
@@ -154,18 +179,25 @@ export const useItemsStore = defineStore('items', () => {
             forceServer = false,
             searchValue = '',
             groupFilter = 'ALL',
-            priceList = null
+            priceList = null,
+            limit = null
         } = options;
 
         const startTime = performance.now();
         const currentRequestToken = ++requestToken.value;
+        let cacheKey;
 
         try {
             isLoading.value = true;
             performanceMetrics.value.totalRequests++;
 
+            const normalizedGroup =
+                typeof groupFilter === 'string' && groupFilter.length > 0
+                    ? groupFilter
+                    : 'ALL';
+
             // Generate cache key
-            const cacheKey = generateCacheKey(searchValue, groupFilter, priceList);
+            cacheKey = generateCacheKey(searchValue, normalizedGroup, priceList);
 
             // Check cache first unless forced to server
             if (!forceServer) {
@@ -183,18 +215,26 @@ export const useItemsStore = defineStore('items', () => {
             abortControllers.value.set(cacheKey, abortController);
 
             // Fetch from server
+            const args = {
+                pos_profile: JSON.stringify(posProfile.value),
+                price_list: priceList || activePriceList.value,
+                item_group:
+                    normalizedGroup !== 'ALL'
+                        ? normalizedGroup.toLowerCase()
+                        : '',
+                search_value: searchValue || '',
+                customer: customer.value,
+                include_image: 1,
+                item_groups: posProfile.value?.item_groups?.map(g => g.item_group) || []
+            };
+
+            if (Number.isFinite(limit) && limit > 0) {
+                args.limit = limit;
+            }
+
             const response = await frappe.call({
                 method: 'posawesome.posawesome.api.items.get_items',
-                args: {
-                    pos_profile: JSON.stringify(posProfile.value),
-                    price_list: priceList || activePriceList.value,
-                    item_group: groupFilter !== 'ALL' ? groupFilter.toLowerCase() : '',
-                    search_value: searchValue || '',
-                    customer: customer.value,
-                    limit: 200,
-                    include_image: 1,
-                    item_groups: posProfile.value?.item_groups?.map(g => g.item_group) || []
-                },
+                args,
                 signal: abortController.signal
             });
 
@@ -206,7 +246,7 @@ export const useItemsStore = defineStore('items', () => {
             const fetchedItems = response.message || [];
 
             // Update state
-            setItems(fetchedItems);
+            setItems(fetchedItems, { updateTotal: true });
             itemsLoaded.value = true;
 
             // Cache the results
@@ -227,22 +267,33 @@ export const useItemsStore = defineStore('items', () => {
             }
         } finally {
             isLoading.value = false;
-            abortControllers.value.delete(cacheKey);
+            if (cacheKey) {
+                abortControllers.value.delete(cacheKey);
+            }
         }
     };
 
-    const searchItems = async (term) => {
+    const searchItems = async (term, options = {}) => {
+        const { groupOverride = itemGroup.value } = options;
+
         searchTerm.value = term;
         lastSearch.value = term;
 
-        if (!term || term.length < 2) {
+        const normalizedGroup =
+            typeof groupOverride === 'string' && groupOverride.length > 0
+                ? groupOverride
+                : 'ALL';
+
+        if (!term || term.length < MIN_SEARCH_LENGTH) {
             // Reset to all items if search is too short
-            filteredItems.value = filterItemsByGroup(items.value, itemGroup.value);
-            return;
+            filteredItems.value = applyFilters(items.value, {
+                group: normalizedGroup,
+                search: term
+            });
+            return filteredItems.value;
         }
 
-        // Check memory cache first
-        const cacheKey = `search_${term}_${itemGroup.value}`;
+        const cacheKey = `search_${term}_${normalizedGroup}`;
         const cached = getCachedSearchResult(cacheKey);
         if (cached) {
             filteredItems.value = cached;
@@ -250,22 +301,44 @@ export const useItemsStore = defineStore('items', () => {
             return cached;
         }
 
+        const useIndexedSearch = Boolean(
+            posProfile.value?.posa_local_storage &&
+            (cachedPagination.value.enabled || totalItemCount.value > 0)
+        );
+
+        if (useIndexedSearch) {
+            try {
+                const offlineResults = await searchStoredItems({
+                    search: term,
+                    itemGroup: normalizedGroup,
+                    limit: SEARCH_PAGE_SIZE,
+                    offset: 0
+                });
+
+                if (offlineResults.length > 0) {
+                    setCachedSearchResult(cacheKey, offlineResults);
+                    filteredItems.value = offlineResults;
+                    performanceMetrics.value.searchMisses++;
+                    return offlineResults;
+                }
+            } catch (error) {
+                console.warn('Indexed search failed:', error);
+            }
+        }
+
         try {
             // Search in current items first
-            let searchResults = performLocalSearch(term, items.value);
+            let searchResults = performLocalSearch(term, applyFilters(items.value, { group: normalizedGroup, search: '' }));
 
             // If no results and term is specific enough, search server
             if (searchResults.length === 0 && term.length >= 3) {
                 await loadItems({
                     searchValue: term,
-                    groupFilter: itemGroup.value,
+                    groupFilter: normalizedGroup,
                     forceServer: true
                 });
-                searchResults = performLocalSearch(term, items.value);
+                searchResults = performLocalSearch(term, applyFilters(items.value, { group: normalizedGroup, search: '' }));
             }
-
-            // Apply group filter
-            searchResults = filterItemsByGroup(searchResults, itemGroup.value);
 
             // Cache the search result
             setCachedSearchResult(cacheKey, searchResults);
@@ -285,12 +358,12 @@ export const useItemsStore = defineStore('items', () => {
     const filterByGroup = (group) => {
         itemGroup.value = group;
 
-        if (searchTerm.value) {
+        if (searchTerm.value && searchTerm.value.length >= MIN_SEARCH_LENGTH) {
             // Re-run search with new group filter
-            searchItems(searchTerm.value);
+            searchItems(searchTerm.value, { groupOverride: group });
         } else {
             // Just filter current items
-            filteredItems.value = filterItemsByGroup(items.value, group);
+            filteredItems.value = applyFilters(items.value, { group });
         }
     };
 
@@ -374,7 +447,7 @@ export const useItemsStore = defineStore('items', () => {
                 if (searchTerm.value) {
                     await searchItems(searchTerm.value);
                 } else {
-                    filteredItems.value = filterItemsByGroup(items.value, itemGroup.value);
+                    filteredItems.value = applyFilters(items.value);
                 }
 
                 // Clear search cache to force refresh
@@ -392,45 +465,125 @@ export const useItemsStore = defineStore('items', () => {
     };
 
     // Helper functions
-    const setItems = (newItems) => {
-        items.value = newItems;
-        totalItemCount.value = newItems.length;
-        updateIndexes(newItems);
+    const clearIndexes = () => {
+        itemsMap.value.clear();
+        barcodeIndex.value.clear();
+    };
 
-        // Update filtered items based on current filters
-        if (searchTerm.value) {
-            filteredItems.value = performLocalSearch(searchTerm.value, newItems);
-        } else {
-            filteredItems.value = filterItemsByGroup(newItems, itemGroup.value);
+    const setItems = (newItems, { append = false, updateTotal = false } = {}) => {
+        const incomingItems = Array.isArray(newItems)
+            ? newItems.filter(item => item && item.item_code)
+            : [];
+
+        let combinedItems = incomingItems;
+
+        if (append && items.value.length) {
+            const merged = [...items.value];
+            const indexByCode = new Map();
+            merged.forEach((item, idx) => {
+                indexByCode.set(item.item_code, idx);
+            });
+
+            incomingItems.forEach(item => {
+                const existingIndex = indexByCode.get(item.item_code);
+                if (typeof existingIndex === 'number') {
+                    merged[existingIndex] = { ...merged[existingIndex], ...item };
+                } else {
+                    indexByCode.set(item.item_code, merged.length);
+                    merged.push(item);
+                }
+            });
+
+            combinedItems = merged;
         }
+
+        if (!append) {
+            items.value = combinedItems;
+        } else {
+            items.value = combinedItems;
+        }
+
+        clearIndexes();
+        updateIndexes(items.value);
+
+        if (updateTotal) {
+            totalItemCount.value = items.value.length;
+        } else if (!append) {
+            totalItemCount.value = Math.max(totalItemCount.value, items.value.length);
+        }
+
+        filteredItems.value = applyFilters(items.value);
     };
 
     const updateIndexes = (itemList) => {
         itemList.forEach(item => {
+            if (!item || !item.item_code) {
+                return;
+            }
+
             itemsMap.value.set(item.item_code, item);
-            if (item.barcode) {
-                barcodeIndex.value.set(item.barcode, item);
+
+            const registerBarcode = (code) => {
+                if (!code) return;
+                barcodeIndex.value.set(String(code), item);
+            };
+
+            registerBarcode(item.barcode);
+
+            if (Array.isArray(item.barcodes)) {
+                item.barcodes.forEach(registerBarcode);
+            }
+
+            if (Array.isArray(item.item_barcode)) {
+                item.item_barcode.forEach(entry => registerBarcode(entry?.barcode));
             }
         });
     };
 
     const performLocalSearch = (term, itemList) => {
-        const searchTerm = term.toLowerCase();
+        const loweredTerm = term.toLowerCase();
         return itemList.filter(item => {
-            return (
-                item.item_code.toLowerCase().includes(searchTerm) ||
-                item.item_name.toLowerCase().includes(searchTerm) ||
-                (item.barcode && item.barcode.toLowerCase().includes(searchTerm)) ||
-                (item.description && item.description.toLowerCase().includes(searchTerm))
-            );
+            const codeMatch = item.item_code?.toLowerCase().includes(loweredTerm);
+            const nameMatch = item.item_name?.toLowerCase().includes(loweredTerm);
+            const descriptionMatch = item.description?.toLowerCase().includes(loweredTerm);
+
+            let barcodeMatch = false;
+            if (item.barcode) {
+                barcodeMatch = item.barcode.toLowerCase().includes(loweredTerm);
+            }
+
+            if (!barcodeMatch && Array.isArray(item.barcodes)) {
+                barcodeMatch = item.barcodes.some(code => String(code).toLowerCase().includes(loweredTerm));
+            }
+
+            if (!barcodeMatch && Array.isArray(item.item_barcode)) {
+                barcodeMatch = item.item_barcode.some(entry => entry?.barcode?.toLowerCase().includes(loweredTerm));
+            }
+
+            return codeMatch || nameMatch || descriptionMatch || barcodeMatch;
         });
     };
 
     const filterItemsByGroup = (itemList, group) => {
-        if (group === 'ALL') {
+        if (!group || group === 'ALL') {
             return itemList;
         }
-        return itemList.filter(item => item.item_group === group);
+
+        const normalizedGroup = group.toLowerCase();
+        return itemList.filter(item => (item.item_group || '').toLowerCase() === normalizedGroup);
+    };
+
+    const applyFilters = (sourceItems, { search = null, group = null } = {}) => {
+        const activeGroup = group ?? itemGroup.value;
+        const activeSearch = search ?? searchTerm.value;
+
+        let filtered = filterItemsByGroup(sourceItems, activeGroup);
+
+        if (activeSearch && activeSearch.length >= MIN_SEARCH_LENGTH) {
+            filtered = performLocalSearch(activeSearch, filtered);
+        }
+
+        return filtered;
     };
 
     const generateCacheKey = (search, group, priceList) => {
@@ -536,11 +689,7 @@ export const useItemsStore = defineStore('items', () => {
         });
 
         // Update filtered items
-        if (searchTerm.value) {
-            filteredItems.value = performLocalSearch(searchTerm.value, items.value);
-        } else {
-            filteredItems.value = filterItemsByGroup(items.value, itemGroup.value);
-        }
+        filteredItems.value = applyFilters(items.value);
     };
 
     const backgroundLoadItemDetails = async (itemList) => {
@@ -637,13 +786,101 @@ export const useItemsStore = defineStore('items', () => {
 
     const loadCachedItems = async () => {
         try {
-            const cached = await searchStoredItems('', itemGroup.value);
-            if (cached && cached.length > 0) {
-                setItems(cached);
+            const cachedCount = await getStoredItemsCount().catch(() => 0);
+            const resolvedCount = Number.isFinite(cachedCount) ? cachedCount : 0;
+
+            totalItemCount.value = resolvedCount;
+
+            if (resolvedCount === 0) {
+                resetCachedPagination();
+                filteredItems.value = applyFilters(items.value);
+                return;
+            }
+
+            const shouldLazyLoad = resolvedCount > LAZY_CACHE_THRESHOLD;
+            const pageSize = CACHE_PAGE_SIZE;
+
+            cachedPagination.value = {
+                enabled: shouldLazyLoad,
+                pageSize,
+                pagesLoaded: 0,
+                totalCount: resolvedCount,
+                loading: false
+            };
+
+            let initialItems = [];
+
+            if (shouldLazyLoad) {
+                initialItems = await searchStoredItems({
+                    limit: pageSize,
+                    offset: 0
+                }).catch(() => []);
+                if (initialItems.length > 0) {
+                    cachedPagination.value.pagesLoaded = 1;
+                }
+            } else {
+                initialItems = await getAllStoredItems().catch(() => []);
+                cachedPagination.value.enabled = false;
+                cachedPagination.value.pagesLoaded = initialItems.length > 0 ? 1 : 0;
+            }
+
+            if (initialItems.length > 0) {
+                setItems(initialItems, { updateTotal: !shouldLazyLoad });
                 itemsLoaded.value = true;
+            } else {
+                itemsLoaded.value = false;
+                filteredItems.value = applyFilters(items.value);
             }
         } catch (error) {
             console.warn('Failed to load cached items:', error);
+            resetCachedPagination();
+        }
+    };
+
+    const appendCachedItemsPage = async ({ search = '', group = 'ALL' } = {}) => {
+        const pagination = cachedPagination.value;
+
+        if (!pagination.enabled || pagination.loading) {
+            return [];
+        }
+
+        if (items.value.length >= pagination.totalCount) {
+            pagination.enabled = false;
+            return [];
+        }
+
+        pagination.loading = true;
+
+        try {
+            const offset = pagination.pagesLoaded * pagination.pageSize;
+            const normalizedGroup = typeof group === 'string' && group.length > 0 ? group : 'ALL';
+            const normalizedSearch = typeof search === 'string' ? search : '';
+
+            const nextItems = await searchStoredItems({
+                search: normalizedSearch,
+                itemGroup: normalizedGroup,
+                limit: pagination.pageSize,
+                offset
+            }).catch(() => []);
+
+            if (nextItems.length > 0) {
+                setItems(nextItems, { append: true });
+                pagination.pagesLoaded += 1;
+
+                if (items.value.length >= pagination.totalCount) {
+                    pagination.enabled = false;
+                }
+            } else {
+                pagination.enabled = false;
+            }
+
+            return nextItems;
+        } catch (error) {
+            console.warn('Failed to append cached items page:', error);
+            pagination.enabled = false;
+            return [];
+        } finally {
+            pagination.loading = false;
         }
     };
 
@@ -665,6 +902,8 @@ export const useItemsStore = defineStore('items', () => {
 
         // Clear persistent cache
         await clearPriceListCache();
+
+        resetCachedPagination();
     };
 
     const clearSearchCache = () => {
@@ -744,6 +983,7 @@ export const useItemsStore = defineStore('items', () => {
         isLoading,
         isBackgroundLoading,
         loadProgress,
+        cachedPagination,
         totalItemCount,
         itemsLoaded,
         searchTerm,
@@ -763,6 +1003,7 @@ export const useItemsStore = defineStore('items', () => {
         // Actions
         initialize,
         loadItems,
+        loadItemGroups,
         searchItems,
         filterByGroup,
         updatePriceList,
@@ -772,7 +1013,8 @@ export const useItemsStore = defineStore('items', () => {
         addScannedItem,
         clearAllCaches,
         clearSearchCache,
-        assessCacheHealth
+        assessCacheHealth,
+        appendCachedItemsPage
     };
 });
 

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -9,17 +9,72 @@ from erpnext.stock.doctype.batch.batch import (
     get_batch_qty,
 )
 from erpnext.stock.get_item_details import get_item_details
-from frappe import _
+from frappe import _, as_json
 from frappe.utils import cstr, flt, get_datetime, nowdate
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.caching import redis_cache
 
-from .utils import HAS_VARIANTS_EXCLUSION, get_item_groups, expand_item_groups
+from .utils import (
+    HAS_VARIANTS_EXCLUSION,
+    expand_item_groups,
+    get_active_pos_profile,
+    get_item_groups,
+)
 
 
 def normalize_brand(brand: str) -> str:
     """Return a normalized representation of a brand name."""
     return cstr(brand).strip().lower()
+
+
+def _ensure_pos_profile(pos_profile):
+    """Return a ``(profile_dict, profile_json)`` tuple for the given input.
+
+    The POS profile parameter can arrive as a JSON string, a python ``dict``,
+    a bare profile name or even ``None`` (when the frontend has not yet loaded
+    the active profile). This helper normalises those inputs so downstream code
+    can rely on a fully populated dictionary and a JSON serialised
+    representation of the same profile. If no valid profile can be resolved a
+    user-facing validation error is raised.
+    """
+
+    profile_dict = None
+    profile_json = None
+
+    if isinstance(pos_profile, dict):
+        profile_dict = pos_profile
+        profile_json = as_json(pos_profile)
+    elif isinstance(pos_profile, str):
+        raw_value = pos_profile.strip()
+        if raw_value:
+            try:
+                decoded_value = json.loads(raw_value)
+            except Exception:
+                decoded_value = raw_value
+
+            if isinstance(decoded_value, dict):
+                profile_dict = decoded_value
+                profile_json = raw_value
+            elif isinstance(decoded_value, str):
+                if decoded_value:
+                    profile_doc = frappe.get_doc("POS Profile", decoded_value)
+                    profile_dict = profile_doc.as_dict()
+                else:
+                    profile_dict = get_active_pos_profile()
+            elif decoded_value is None:
+                profile_dict = get_active_pos_profile()
+        else:
+            profile_dict = get_active_pos_profile()
+    elif pos_profile is None:
+        profile_dict = get_active_pos_profile()
+
+    if profile_dict and not profile_json:
+        profile_json = as_json(profile_dict)
+
+    if not profile_dict or not profile_json:
+        frappe.throw(_("POS profile data is missing or invalid."))
+
+    return profile_dict, profile_json
 
 
 def get_stock_availability(item_code, warehouse):
@@ -103,7 +158,7 @@ def get_items(
     include_image=False,
     item_groups=None,
 ):
-    _pos_profile = json.loads(pos_profile)
+    _pos_profile, pos_profile_json = _ensure_pos_profile(pos_profile)
     use_price_list = _pos_profile.get("posa_use_server_cache")
     pos_profile_name = _pos_profile.get("name")
     warehouse = _pos_profile.get("warehouse")
@@ -137,7 +192,7 @@ def get_items(
         item_groups_tuple,
     ):
         return _get_items(
-            pos_profile,
+            pos_profile_json,
             price_list,
             item_group,
             search_value,
@@ -384,7 +439,7 @@ def get_items(
         )
     else:
         return _get_items(
-            pos_profile,
+            pos_profile_json,
             price_list,
             item_group,
             search_value,
@@ -410,7 +465,7 @@ def get_items_groups():
 
 @frappe.whitelist()
 def get_items_count(pos_profile, item_groups=None):
-    pos_profile = json.loads(pos_profile)
+    pos_profile, _ = _ensure_pos_profile(pos_profile)
     if isinstance(item_groups, str):
         try:
             item_groups = json.loads(item_groups)
@@ -427,7 +482,7 @@ def get_items_count(pos_profile, item_groups=None):
 @frappe.whitelist()
 def get_item_variants(pos_profile, parent_item_code, price_list=None, customer=None):
     """Return variants of an item along with attribute metadata."""
-    pos_profile = json.loads(pos_profile)
+    pos_profile, pos_profile_json = _ensure_pos_profile(pos_profile)
     price_list = price_list or pos_profile.get("selling_price_list")
 
     fields = [
@@ -458,7 +513,7 @@ def get_item_variants(pos_profile, parent_item_code, price_list=None, customer=N
         return {"variants": [], "attributes_meta": {}}
 
     details = get_items_details(
-        json.dumps(pos_profile),
+        pos_profile_json,
         json.dumps(items_data),
         price_list=price_list,
         customer=customer,
@@ -512,7 +567,7 @@ def get_items_details(pos_profile, items_data, price_list=None, customer=None):
     for offline selection without additional round trips per item.
     """
 
-    pos_profile = json.loads(pos_profile)
+    pos_profile, _ = _ensure_pos_profile(pos_profile)
     items_data = json.loads(items_data)
 
     warehouse = pos_profile.get("warehouse")


### PR DESCRIPTION
## Summary
- remove the fixed 200 item limit by adding lazy offline pagination, Dexie-backed search, and paged hydration to the Pinia item store
- expose the pagination helpers through the Pinia integration and virtualize the item selector card grid to render only the visible window while requesting more cached pages on demand

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c99f5dac83269ad32fed5dde2522