### PR TITLE
feat: improve item search matching

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -921,24 +921,68 @@ export default {
 
 			// Filter by search term only if it exists and is long enough
                         if (searchTerm && searchTerm.trim() && searchTerm.trim().length >= 3) {
-                                const term = searchTerm.toLowerCase();
-				filtered = filtered.filter((item) => {
-					const barcodeMatch =
-						(Array.isArray(item.item_barcode) &&
-							item.item_barcode.some(
-								(b) => b.barcode && b.barcode.toLowerCase().includes(term),
-							)) ||
-						(Array.isArray(item.barcodes) &&
-							item.barcodes.some((bc) => String(bc).toLowerCase().includes(term))) ||
-						(item.barcode && String(item.barcode).toLowerCase().includes(term));
+                                const rawTerm = searchTerm.toLowerCase().trim();
+                                const tokens = rawTerm.split(/\s+/).filter(Boolean);
 
-					return (
-						item.item_code.toLowerCase().includes(term) ||
-						item.item_name.toLowerCase().includes(term) ||
-						barcodeMatch
-					);
-				});
-			}
+                                filtered = filtered.filter((item) => {
+                                        if (!item) {
+                                                return false;
+                                        }
+
+                                        const fields = [
+                                                item.item_code,
+                                                item.item_name,
+                                                item.description,
+                                                item.item_group,
+                                        ]
+                                                .filter((value) => typeof value === "string" && value)
+                                                .map((value) => value.toLowerCase());
+
+                                        const barcodeValues = [];
+
+                                        if (item.barcode) {
+                                                barcodeValues.push(String(item.barcode).toLowerCase());
+                                        }
+
+                                        if (Array.isArray(item.item_barcode)) {
+                                                item.item_barcode.forEach((b) => {
+                                                        if (b?.barcode) {
+                                                                barcodeValues.push(String(b.barcode).toLowerCase());
+                                                        }
+                                                });
+                                        }
+
+                                        if (Array.isArray(item.barcodes)) {
+                                                item.barcodes.forEach((bc) => {
+                                                        if (bc) {
+                                                                barcodeValues.push(String(bc).toLowerCase());
+                                                        }
+                                                });
+                                        }
+
+                                        if (Array.isArray(item.attributes)) {
+                                                item.attributes.forEach((attr) => {
+                                                        if (attr?.attribute_value) {
+                                                                fields.push(String(attr.attribute_value).toLowerCase());
+                                                        }
+                                                });
+                                        }
+
+                                        if (item.brand) {
+                                                fields.push(String(item.brand).toLowerCase());
+                                        }
+
+                                        const allValues = fields.concat(barcodeValues);
+
+                                        if (!allValues.length) {
+                                                return false;
+                                        }
+
+                                        return tokens.every((token) =>
+                                                allValues.some((value) => value.includes(token)),
+                                        );
+                                });
+                        }
 
                         perfMarkEnd("pos:search-filter", mark);
                         return filtered;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -979,13 +979,84 @@ export default {
                                         }
 
                                         return tokens.every((token) =>
-                                                allValues.some((value) => value.includes(token)),
+                                                allValues.some((value) => this.tokenMatchesValue(value, token)),
                                         );
                                 });
                         }
 
                         perfMarkEnd("pos:search-filter", mark);
                         return filtered;
+                },
+
+                tokenMatchesValue(value, token) {
+                        if (!value || !token) {
+                                return false;
+                        }
+
+                        if (value.includes(token) || token.includes(value)) {
+                                return true;
+                        }
+
+                        const valueTokens = value.split(/[^a-z0-9]+/i).filter(Boolean);
+
+                        return valueTokens.some((candidate) => {
+                                if (!candidate) {
+                                        return false;
+                                }
+
+                                if (candidate.includes(token) || token.includes(candidate)) {
+                                        return true;
+                                }
+
+                                const distance = this.levenshteinDistance(candidate, token);
+                                const maxLength = Math.max(candidate.length, token.length);
+
+                                if (maxLength <= 2) {
+                                        return distance === 0;
+                                }
+
+                                const threshold = Math.max(1, Math.floor(maxLength / 3));
+                                return distance <= threshold;
+                        });
+                },
+
+                levenshteinDistance(a, b) {
+                        const aLength = a.length;
+                        const bLength = b.length;
+
+                        if (aLength === 0) {
+                                return bLength;
+                        }
+
+                        if (bLength === 0) {
+                                return aLength;
+                        }
+
+                        const matrix = Array.from({ length: bLength + 1 }, () => new Array(aLength + 1).fill(0));
+
+                        for (let i = 0; i <= aLength; i += 1) {
+                                matrix[0][i] = i;
+                        }
+
+                        for (let j = 0; j <= bLength; j += 1) {
+                                matrix[j][0] = j;
+                        }
+
+                        for (let j = 1; j <= bLength; j += 1) {
+                                for (let i = 1; i <= aLength; i += 1) {
+                                        if (b[j - 1] === a[i - 1]) {
+                                                matrix[j][i] = matrix[j - 1][i - 1];
+                                        } else {
+                                                matrix[j][i] = Math.min(
+                                                        matrix[j - 1][i] + 1,
+                                                        matrix[j][i - 1] + 1,
+                                                        matrix[j - 1][i - 1] + 1,
+                                                );
+                                        }
+                                }
+                        }
+
+                        return matrix[bLength][aLength];
                 },
 
 		async fetchServerItemsTimestamp() {


### PR DESCRIPTION
## Summary
- update the item search filter to split the query into tokens so word order no longer matters
- expand the searchable fields (including barcodes, attributes, and brand) to improve partial matches for fuzzy search results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da2e17229c8326826427555658d2ed