### PR TITLE
Improve item search to support order-agnostic fuzzy matching

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -909,7 +909,7 @@ export default {
                                 return [];
                         }
 
-                        let filtered = this.items;
+			let filtered = this.items;
 
 			// Filter by item group
 			if (itemGroup !== "ALL") {
@@ -922,69 +922,26 @@ export default {
 			// Filter by search term only if it exists and is long enough
                         if (searchTerm && searchTerm.trim() && searchTerm.trim().length >= 3) {
                                 const term = searchTerm.toLowerCase();
-                                const tokens = term.split(/\s+/).filter(Boolean);
-                                filtered = filtered.filter((item) => {
-                                        const searchFields = this.buildSearchFieldList(item);
+				filtered = filtered.filter((item) => {
+					const barcodeMatch =
+						(Array.isArray(item.item_barcode) &&
+							item.item_barcode.some(
+								(b) => b.barcode && b.barcode.toLowerCase().includes(term),
+							)) ||
+						(Array.isArray(item.barcodes) &&
+							item.barcodes.some((bc) => String(bc).toLowerCase().includes(term))) ||
+						(item.barcode && String(item.barcode).toLowerCase().includes(term));
 
-                                        if (!tokens.length) {
-                                                return searchFields.some((field) => field.includes(term));
-                                        }
-
-                                        return tokens.every((token) =>
-                                                searchFields.some((field) => field.includes(token)),
-                                        );
-                                });
-                        }
+					return (
+						item.item_code.toLowerCase().includes(term) ||
+						item.item_name.toLowerCase().includes(term) ||
+						barcodeMatch
+					);
+				});
+			}
 
                         perfMarkEnd("pos:search-filter", mark);
                         return filtered;
-                },
-
-                buildSearchFieldList(item) {
-                        const barcodeList = [];
-
-                        if (Array.isArray(item.item_barcode)) {
-                                barcodeList.push(
-                                        ...item.item_barcode
-                                                .map((b) => (b && b.barcode ? b.barcode : null))
-                                                .filter(Boolean),
-                                );
-                        } else if (item.item_barcode) {
-                                barcodeList.push(String(item.item_barcode));
-                        }
-
-                        if (Array.isArray(item.barcodes)) {
-                                barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
-                        }
-
-                        const extraFields = [];
-
-                        if (this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)) {
-                                extraFields.push(
-                                        ...item.serial_no_data
-                                                .map((s) => (s && s.serial_no ? s.serial_no : null))
-                                                .filter(Boolean),
-                                );
-                        }
-
-                        if (this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)) {
-                                extraFields.push(
-                                        ...item.batch_no_data
-                                                .map((b) => (b && b.batch_no ? b.batch_no : null))
-                                                .filter(Boolean),
-                                );
-                        }
-
-                        return [
-                                item.item_code,
-                                item.item_name,
-                                item.barcode,
-                                item.description,
-                                ...barcodeList,
-                                ...extraFields,
-                        ]
-                                .filter(Boolean)
-                                .map((field) => String(field).toLowerCase());
                 },
 
 		async fetchServerItemsTimestamp() {
@@ -3532,21 +3489,37 @@ export default {
 			let filteredItems = [...this.items];
 
 			// Apply search filter only for queries with at least three characters
-                        if (searchTerm.length >= 3) {
-                                const tokens = searchTerm.split(/\s+/).filter(Boolean);
+			if (searchTerm.length >= 3) {
+				filteredItems = filteredItems.filter((item) => {
+					const barcodeList = [];
+					if (Array.isArray(item.item_barcode)) {
+						barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
+					} else if (item.item_barcode) {
+						barcodeList.push(String(item.item_barcode));
+					}
+					if (Array.isArray(item.barcodes)) {
+						barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
+					}
 
-                                filteredItems = filteredItems.filter((item) => {
-                                        const searchFields = this.buildSearchFieldList(item);
+					const searchFields = [
+						item.item_code,
+						item.item_name,
+						item.barcode,
+						item.description,
+						...barcodeList,
+						...(this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)
+							? item.serial_no_data.map((s) => s.serial_no)
+							: []),
+						...(this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
+							? item.batch_no_data.map((b) => b.batch_no)
+							: []),
+					]
+						.filter(Boolean)
+						.map((field) => field.toLowerCase());
 
-                                        if (!tokens.length) {
-                                                return searchFields.some((field) => field.includes(searchTerm));
-                                        }
-
-                                        return tokens.every((token) =>
-                                                searchFields.some((field) => field.includes(token)),
-                                        );
-                                });
-                        }
+					return searchFields.some((field) => field.includes(searchTerm));
+				});
+			}
 
 			// Apply item group filter
 			if (this.item_group !== "ALL") {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -909,7 +909,7 @@ export default {
                                 return [];
                         }
 
-			let filtered = this.items;
+                        let filtered = this.items;
 
 			// Filter by item group
 			if (itemGroup !== "ALL") {
@@ -922,26 +922,69 @@ export default {
 			// Filter by search term only if it exists and is long enough
                         if (searchTerm && searchTerm.trim() && searchTerm.trim().length >= 3) {
                                 const term = searchTerm.toLowerCase();
-				filtered = filtered.filter((item) => {
-					const barcodeMatch =
-						(Array.isArray(item.item_barcode) &&
-							item.item_barcode.some(
-								(b) => b.barcode && b.barcode.toLowerCase().includes(term),
-							)) ||
-						(Array.isArray(item.barcodes) &&
-							item.barcodes.some((bc) => String(bc).toLowerCase().includes(term))) ||
-						(item.barcode && String(item.barcode).toLowerCase().includes(term));
+                                const tokens = term.split(/\s+/).filter(Boolean);
+                                filtered = filtered.filter((item) => {
+                                        const searchFields = this.buildSearchFieldList(item);
 
-					return (
-						item.item_code.toLowerCase().includes(term) ||
-						item.item_name.toLowerCase().includes(term) ||
-						barcodeMatch
-					);
-				});
-			}
+                                        if (!tokens.length) {
+                                                return searchFields.some((field) => field.includes(term));
+                                        }
+
+                                        return tokens.every((token) =>
+                                                searchFields.some((field) => field.includes(token)),
+                                        );
+                                });
+                        }
 
                         perfMarkEnd("pos:search-filter", mark);
                         return filtered;
+                },
+
+                buildSearchFieldList(item) {
+                        const barcodeList = [];
+
+                        if (Array.isArray(item.item_barcode)) {
+                                barcodeList.push(
+                                        ...item.item_barcode
+                                                .map((b) => (b && b.barcode ? b.barcode : null))
+                                                .filter(Boolean),
+                                );
+                        } else if (item.item_barcode) {
+                                barcodeList.push(String(item.item_barcode));
+                        }
+
+                        if (Array.isArray(item.barcodes)) {
+                                barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
+                        }
+
+                        const extraFields = [];
+
+                        if (this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)) {
+                                extraFields.push(
+                                        ...item.serial_no_data
+                                                .map((s) => (s && s.serial_no ? s.serial_no : null))
+                                                .filter(Boolean),
+                                );
+                        }
+
+                        if (this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)) {
+                                extraFields.push(
+                                        ...item.batch_no_data
+                                                .map((b) => (b && b.batch_no ? b.batch_no : null))
+                                                .filter(Boolean),
+                                );
+                        }
+
+                        return [
+                                item.item_code,
+                                item.item_name,
+                                item.barcode,
+                                item.description,
+                                ...barcodeList,
+                                ...extraFields,
+                        ]
+                                .filter(Boolean)
+                                .map((field) => String(field).toLowerCase());
                 },
 
 		async fetchServerItemsTimestamp() {
@@ -3489,37 +3532,21 @@ export default {
 			let filteredItems = [...this.items];
 
 			// Apply search filter only for queries with at least three characters
-			if (searchTerm.length >= 3) {
-				filteredItems = filteredItems.filter((item) => {
-					const barcodeList = [];
-					if (Array.isArray(item.item_barcode)) {
-						barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
-					} else if (item.item_barcode) {
-						barcodeList.push(String(item.item_barcode));
-					}
-					if (Array.isArray(item.barcodes)) {
-						barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
-					}
+                        if (searchTerm.length >= 3) {
+                                const tokens = searchTerm.split(/\s+/).filter(Boolean);
 
-					const searchFields = [
-						item.item_code,
-						item.item_name,
-						item.barcode,
-						item.description,
-						...barcodeList,
-						...(this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)
-							? item.serial_no_data.map((s) => s.serial_no)
-							: []),
-						...(this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
-							? item.batch_no_data.map((b) => b.batch_no)
-							: []),
-					]
-						.filter(Boolean)
-						.map((field) => field.toLowerCase());
+                                filteredItems = filteredItems.filter((item) => {
+                                        const searchFields = this.buildSearchFieldList(item);
 
-					return searchFields.some((field) => field.includes(searchTerm));
-				});
-			}
+                                        if (!tokens.length) {
+                                                return searchFields.some((field) => field.includes(searchTerm));
+                                        }
+
+                                        return tokens.every((token) =>
+                                                searchFields.some((field) => field.includes(token)),
+                                        );
+                                });
+                        }
 
 			// Apply item group filter
 			if (this.item_group !== "ALL") {

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import json
+from typing import Iterable, List
 
 import frappe
 from erpnext.stock.doctype.batch.batch import (
@@ -15,6 +16,45 @@ from frappe.utils.background_jobs import enqueue
 from frappe.utils.caching import redis_cache
 
 from .utils import HAS_VARIANTS_EXCLUSION, get_item_groups, expand_item_groups
+
+
+def _dict_to_filters_list(filters_dict: dict) -> List[List[object]]:
+    """Convert frappe.get_all-style filter dicts into list-based filters."""
+
+    filters_list: List[List[object]] = []
+    for field, condition in (filters_dict or {}).items():
+        if isinstance(condition, (list, tuple)):
+            if len(condition) == 0:
+                continue
+            if len(condition) == 1:
+                filters_list.append([field, "=", condition[0]])
+            elif len(condition) == 2:
+                filters_list.append([field, condition[0], condition[1]])
+            else:
+                filters_list.append(list(condition))
+        else:
+            filters_list.append([field, "=", condition])
+    return filters_list
+
+
+def _build_search_term_filters(search_terms: Iterable[str]) -> List[List[object]]:
+    """Return filters that ensure all search terms are matched order-agnostically."""
+
+    term_filters: List[List[object]] = []
+    for raw_term in search_terms:
+        term = cstr(raw_term).strip()
+        if not term:
+            continue
+        like_term = f"%{frappe.db.escape_like(term)}%"
+        term_filters.append(
+            [
+                "or",
+                ["name", "like", like_term],
+                ["item_name", "like", like_term],
+                ["item_code", "like", like_term],
+            ]
+        )
+    return term_filters
 
 
 def normalize_brand(brand: str) -> str:
@@ -193,6 +233,18 @@ def get_items(
 
         result = []
 
+        search_terms: List[str] = []
+        if search_value:
+            normalized_value = " ".join(cstr(search_value).split())
+            if normalized_value:
+                seen_terms = set()
+                for term in normalized_value.split(" "):
+                    lowered = term.lower()
+                    if lowered in seen_terms:
+                        continue
+                    seen_terms.add(lowered)
+                    search_terms.append(term)
+
         # Build ORM filters
         filters = {"disabled": 0, "is_sales_item": 1, "is_fixed_asset": 0}
         if start_after:
@@ -246,6 +298,11 @@ def get_items(
         if pos_profile.get("posa_hide_variants_items"):
             filters["variant_of"] = ["is", "not set"]
 
+        term_filters = _build_search_term_filters(search_terms)
+        filters_for_query = _dict_to_filters_list(filters)
+        if term_filters:
+            filters_for_query.extend(term_filters)
+
         # Determine limit
         limit_page_length = None
         limit_start = None
@@ -288,7 +345,7 @@ def get_items(
         while True:
             items_data = frappe.get_all(
                 "Item",
-                filters=filters,
+                filters=filters_for_query,
                 or_filters=or_filters if or_filters else None,
                 fields=fields,
                 limit_start=page_start,
@@ -299,7 +356,7 @@ def get_items(
             if not items_data and item_code_for_search and page_start == (limit_start or 0):
                 items_data = frappe.get_all(
                     "Item",
-                    filters=filters,
+                    filters=filters_for_query,
                     or_filters=[
                         ["name", "like", f"%{item_code_for_search}%"],
                         ["item_name", "like", f"%{item_code_for_search}%"],


### PR DESCRIPTION
## Summary
- add helper utilities to translate filters and build multi-term LIKE queries
- update the item lookup logic to require each search token to match irrespective of order

## Testing
- pytest posawesome/posawesome/api/test_items_numeric_code.py *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68da2e17229c8326826427555658d2ed