### PR TITLE
Improve multi-term search in item selector

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -909,7 +909,7 @@ export default {
                                 return [];
                         }
 
-			let filtered = this.items;
+                        let filtered = this.items;
 
 			// Filter by item group
 			if (itemGroup !== "ALL") {
@@ -922,26 +922,69 @@ export default {
 			// Filter by search term only if it exists and is long enough
                         if (searchTerm && searchTerm.trim() && searchTerm.trim().length >= 3) {
                                 const term = searchTerm.toLowerCase();
-				filtered = filtered.filter((item) => {
-					const barcodeMatch =
-						(Array.isArray(item.item_barcode) &&
-							item.item_barcode.some(
-								(b) => b.barcode && b.barcode.toLowerCase().includes(term),
-							)) ||
-						(Array.isArray(item.barcodes) &&
-							item.barcodes.some((bc) => String(bc).toLowerCase().includes(term))) ||
-						(item.barcode && String(item.barcode).toLowerCase().includes(term));
+                                const tokens = term.split(/\s+/).filter(Boolean);
+                                filtered = filtered.filter((item) => {
+                                        const searchFields = this.buildSearchFieldList(item);
 
-					return (
-						item.item_code.toLowerCase().includes(term) ||
-						item.item_name.toLowerCase().includes(term) ||
-						barcodeMatch
-					);
-				});
-			}
+                                        if (!tokens.length) {
+                                                return searchFields.some((field) => field.includes(term));
+                                        }
+
+                                        return tokens.every((token) =>
+                                                searchFields.some((field) => field.includes(token)),
+                                        );
+                                });
+                        }
 
                         perfMarkEnd("pos:search-filter", mark);
                         return filtered;
+                },
+
+                buildSearchFieldList(item) {
+                        const barcodeList = [];
+
+                        if (Array.isArray(item.item_barcode)) {
+                                barcodeList.push(
+                                        ...item.item_barcode
+                                                .map((b) => (b && b.barcode ? b.barcode : null))
+                                                .filter(Boolean),
+                                );
+                        } else if (item.item_barcode) {
+                                barcodeList.push(String(item.item_barcode));
+                        }
+
+                        if (Array.isArray(item.barcodes)) {
+                                barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
+                        }
+
+                        const extraFields = [];
+
+                        if (this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)) {
+                                extraFields.push(
+                                        ...item.serial_no_data
+                                                .map((s) => (s && s.serial_no ? s.serial_no : null))
+                                                .filter(Boolean),
+                                );
+                        }
+
+                        if (this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)) {
+                                extraFields.push(
+                                        ...item.batch_no_data
+                                                .map((b) => (b && b.batch_no ? b.batch_no : null))
+                                                .filter(Boolean),
+                                );
+                        }
+
+                        return [
+                                item.item_code,
+                                item.item_name,
+                                item.barcode,
+                                item.description,
+                                ...barcodeList,
+                                ...extraFields,
+                        ]
+                                .filter(Boolean)
+                                .map((field) => String(field).toLowerCase());
                 },
 
 		async fetchServerItemsTimestamp() {
@@ -3489,37 +3532,21 @@ export default {
 			let filteredItems = [...this.items];
 
 			// Apply search filter only for queries with at least three characters
-			if (searchTerm.length >= 3) {
-				filteredItems = filteredItems.filter((item) => {
-					const barcodeList = [];
-					if (Array.isArray(item.item_barcode)) {
-						barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
-					} else if (item.item_barcode) {
-						barcodeList.push(String(item.item_barcode));
-					}
-					if (Array.isArray(item.barcodes)) {
-						barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
-					}
+                        if (searchTerm.length >= 3) {
+                                const tokens = searchTerm.split(/\s+/).filter(Boolean);
 
-					const searchFields = [
-						item.item_code,
-						item.item_name,
-						item.barcode,
-						item.description,
-						...barcodeList,
-						...(this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)
-							? item.serial_no_data.map((s) => s.serial_no)
-							: []),
-						...(this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
-							? item.batch_no_data.map((b) => b.batch_no)
-							: []),
-					]
-						.filter(Boolean)
-						.map((field) => field.toLowerCase());
+                                filteredItems = filteredItems.filter((item) => {
+                                        const searchFields = this.buildSearchFieldList(item);
 
-					return searchFields.some((field) => field.includes(searchTerm));
-				});
-			}
+                                        if (!tokens.length) {
+                                                return searchFields.some((field) => field.includes(searchTerm));
+                                        }
+
+                                        return tokens.every((token) =>
+                                                searchFields.some((field) => field.includes(token)),
+                                        );
+                                });
+                        }
 
 			// Apply item group filter
 			if (this.item_group !== "ALL") {


### PR DESCRIPTION
## Summary
- allow multi-word search tokens to match non-contiguous text across item attributes
- centralize item search field gathering so both client- and server-backed filters share the same logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3cca35748326acc5e3ed6c819a34