### PR TITLE
Fix offline item loading when using Pinia store

### DIFF
--- a/frontend/src/posapp/stores/itemsStore.js
+++ b/frontend/src/posapp/stores/itemsStore.js
@@ -16,7 +16,8 @@ import {
     searchStoredItems,
     saveItemsBulk,
     clearStoredItems,
-    setItemsLastSync
+    setItemsLastSync,
+    isOffline
 } from '../../offline/index.js';
 
 const DEFAULT_PAGE_SIZE = 200;
@@ -310,6 +311,19 @@ export const useItemsStore = defineStore('items', () => {
                 }
             }
 
+            const navigatorOffline = typeof navigator !== 'undefined' && navigator && !navigator.onLine;
+            if (navigatorOffline || isOffline()) {
+                const offlineResults = await loadItemsFromOfflineStorage({
+                    searchValue,
+                    normalizedGroup,
+                    limit: resolvedLimit
+                });
+
+                performanceMetrics.value.cachedRequests++;
+                updatePerformanceMetrics(startTime);
+                return offlineResults;
+            }
+
             // Create abort controller
             const abortController = new AbortController();
             abortControllers.value.set(cacheKey, abortController);
@@ -377,10 +391,25 @@ export const useItemsStore = defineStore('items', () => {
             return fetchedItems;
 
         } catch (error) {
-            if (error.name !== 'AbortError') {
-                console.error('Failed to load items:', error);
-                throw error;
+            if (error.name === 'AbortError') {
+                return;
             }
+
+            console.error('Failed to load items:', error);
+
+            const offlineResults = await loadItemsFromOfflineStorage({
+                searchValue,
+                normalizedGroup,
+                limit: resolvedLimit
+            });
+
+            if (Array.isArray(offlineResults) && offlineResults.length) {
+                performanceMetrics.value.cachedRequests++;
+                updatePerformanceMetrics(startTime);
+                return offlineResults;
+            }
+
+            throw error;
         } finally {
             isLoading.value = false;
             if (cacheKey) {
@@ -1354,6 +1383,49 @@ export const useItemsStore = defineStore('items', () => {
         const { cachedRequests, totalRequests: total } = performanceMetrics.value;
         performanceMetrics.value.cacheHitRate = total > 0 ? (cachedRequests / total) * 100 : 0;
     };
+
+    async function loadItemsFromOfflineStorage({ searchValue, normalizedGroup, limit }) {
+        const trimmedSearch = (searchValue || '').trim();
+
+        try {
+            if (!trimmedSearch) {
+                await updateCachedPaginationFromStorage();
+                itemsLoaded.value = items.value.length > 0;
+                filteredItems.value = filterItemsByGroup(items.value, normalizedGroup);
+                cachedPagination.value.loading = false;
+                return items.value;
+            }
+
+            const effectiveLimit = Number.isFinite(limit) && limit > 0
+                ? limit
+                : resolvePageSize(DEFAULT_PAGE_SIZE);
+
+            const storedResults = await searchStoredItems({
+                search: trimmedSearch,
+                itemGroup: normalizedGroup,
+                limit: effectiveLimit,
+                offset: 0
+            });
+
+            const safeResults = Array.isArray(storedResults) ? storedResults : [];
+
+            setItems(safeResults, { replace: true, totalCount: safeResults.length });
+            filteredItems.value = safeResults;
+
+            cachedPagination.value.enabled = false;
+            cachedPagination.value.loading = false;
+            cachedPagination.value.offset = safeResults.length;
+            cachedPagination.value.total = safeResults.length;
+            cachedPagination.value.search = trimmedSearch;
+            cachedPagination.value.group = normalizedGroup;
+
+            itemsLoaded.value = true;
+            return safeResults;
+        } catch (error) {
+            console.warn('Failed to load items from offline storage:', error);
+            return [];
+        }
+    }
 
     const getEstimatedMemoryUsage = () => {
         try {

--- a/frontend/src/posapp/stores/itemsStore.js
+++ b/frontend/src/posapp/stores/itemsStore.js
@@ -1389,11 +1389,17 @@ export const useItemsStore = defineStore('items', () => {
 
         try {
             if (!trimmedSearch) {
-                await updateCachedPaginationFromStorage();
-                itemsLoaded.value = items.value.length > 0;
-                filteredItems.value = filterItemsByGroup(items.value, normalizedGroup);
+                if (!itemsLoaded.value || items.value.length === 0) {
+                    await loadCachedItems();
+                } else {
+                    await updateCachedPaginationFromStorage();
+                }
+
+                const offlineItems = filterItemsByGroup(items.value, normalizedGroup);
+                filteredItems.value = offlineItems;
+                itemsLoaded.value = offlineItems.length > 0 || itemsLoaded.value;
                 cachedPagination.value.loading = false;
-                return items.value;
+                return offlineItems;
             }
 
             const effectiveLimit = Number.isFinite(limit) && limit > 0

--- a/frontend/src/posapp/stores/itemsStore.js
+++ b/frontend/src/posapp/stores/itemsStore.js
@@ -17,7 +17,9 @@ import {
     saveItemsBulk,
     clearStoredItems,
     setItemsLastSync,
-    isOffline
+    isOffline,
+    initPromise,
+    memoryInitPromise
 } from '../../offline/index.js';
 
 const DEFAULT_PAGE_SIZE = 200;
@@ -223,6 +225,30 @@ export const useItemsStore = defineStore('items', () => {
         };
     });
 
+    // Offline initialization guard
+    let offlineReady = false;
+    const ensureOfflineReady = async () => {
+        if (offlineReady) {
+            return true;
+        }
+
+        try {
+            await memoryInitPromise;
+        } catch (error) {
+            console.warn('Offline memory cache failed to initialize:', error);
+            return false;
+        }
+
+        try {
+            await initPromise;
+            offlineReady = true;
+            return true;
+        } catch (error) {
+            console.warn('IndexedDB failed to initialize:', error);
+            return false;
+        }
+    };
+
     // Actions
     const initialize = async (profile, cust = null, priceList = null) => {
         posProfile.value = profile;
@@ -236,6 +262,7 @@ export const useItemsStore = defineStore('items', () => {
         await assessCacheHealth();
 
         // Load cached items if available
+        await ensureOfflineReady();
         await loadCachedItems();
     };
 
@@ -874,6 +901,11 @@ export const useItemsStore = defineStore('items', () => {
             return;
         }
 
+        const ready = await ensureOfflineReady();
+        if (!ready) {
+            return;
+        }
+
         if (!Array.isArray(itemsBatch) || itemsBatch.length === 0) {
             return;
         }
@@ -899,6 +931,11 @@ export const useItemsStore = defineStore('items', () => {
         }
 
         try {
+            const ready = await ensureOfflineReady();
+            if (!ready) {
+                return;
+            }
+
             const storedCount = await getStoredItemsCount().catch(() => 0);
             const resolvedCount = Number.isFinite(storedCount) ? storedCount : 0;
 
@@ -932,6 +969,11 @@ export const useItemsStore = defineStore('items', () => {
         }
 
         if (searchValue && searchValue.trim().length > 0) {
+            return [];
+        }
+
+        const ready = await ensureOfflineReady();
+        if (!ready) {
             return [];
         }
 
@@ -1196,6 +1238,12 @@ export const useItemsStore = defineStore('items', () => {
                 return;
             }
 
+            const ready = await ensureOfflineReady();
+            if (!ready) {
+                itemsLoaded.value = items.value.length > 0;
+                return;
+            }
+
             const cachedCount = await getStoredItemsCount().catch(() => 0);
             const resolvedCount = Number.isFinite(cachedCount) ? cachedCount : 0;
 
@@ -1253,6 +1301,11 @@ export const useItemsStore = defineStore('items', () => {
             return [];
         }
 
+        const ready = await ensureOfflineReady();
+        if (!ready) {
+            return [];
+        }
+
         if (searchTerm.value && searchTerm.value.length >= 2) {
             // Searches fetch a fresh page via searchItems, no incremental append required
             return [];
@@ -1302,6 +1355,12 @@ export const useItemsStore = defineStore('items', () => {
 
     const resetCachedItemsForGroup = async (group) => {
         if (limitSearchEnabled.value || !cachedPagination.value.enabled || !shouldUseIndexedSearch()) {
+            filteredItems.value = filterItemsByGroup(items.value, group);
+            return;
+        }
+
+        const ready = await ensureOfflineReady();
+        if (!ready) {
             filteredItems.value = filterItemsByGroup(items.value, group);
             return;
         }
@@ -1388,6 +1447,13 @@ export const useItemsStore = defineStore('items', () => {
         const trimmedSearch = (searchValue || '').trim();
 
         try {
+            const ready = await ensureOfflineReady();
+            if (!ready) {
+                const fallback = filterItemsByGroup(items.value, normalizedGroup);
+                filteredItems.value = fallback;
+                return fallback;
+            }
+
             if (!trimmedSearch) {
                 if (!itemsLoaded.value || items.value.length === 0) {
                     await loadCachedItems();


### PR DESCRIPTION
## Summary
- detect offline conditions before issuing network item fetches
- reuse IndexedDB-backed search helpers to hydrate the Pinia store when offline or network calls fail
- ensure cached item lists remain available with updated pagination metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac6af58788326ad2a71e2a6e4f947