### PR TITLE
feat: centralize invoice state in pinia

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -196,12 +196,10 @@
 					<ItemsTable
 						ref="itemsTable"
 						:headers="items_headers"
-						:items="items"
 						v-model:expanded="expanded"
 						:itemsPerPage="itemsPerPage"
 						:itemSearch="itemSearch"
 						:pos_profile="pos_profile"
-						:invoice_doc="invoice_doc"
 						:invoiceType="invoiceType"
 						:stock_settings="stock_settings"
 						:displayCurrency="displayCurrency"
@@ -342,18 +340,22 @@ import invoiceComputed from "./invoiceComputed";
 import invoiceWatchers from "./invoiceWatchers";
 import offerMethods from "./invoiceOfferMethods";
 import shortcutMethods from "./invoiceShortcuts";
+import { useInvoiceStore } from "../../stores/invoiceStore.js";
 
 export default {
-	name: "POSInvoice",
-	mixins: [format],
-	data() {
-		return {
-			// POS profile settings
-			pos_profile: "",
-			pos_opening_shift: "",
-			stock_settings: "",
-			invoice_doc: "",
-			return_doc: "",
+        name: "POSInvoice",
+        mixins: [format],
+        setup() {
+                const invoiceStore = useInvoiceStore();
+                return { invoiceStore };
+        },
+        data() {
+                return {
+                        // POS profile settings
+                        pos_profile: "",
+                        pos_opening_shift: "",
+                        stock_settings: "",
+                        return_doc: "",
 			customer: "",
 			customer_info: "",
 			customer_balance: 0,
@@ -361,9 +363,7 @@ export default {
 			additional_discount: 0,
 			additional_discount_percentage: 0,
 			total_tax: 0,
-			items: [], // List of invoice items
-			packed_items: [], // Packed items for bundles
-			packed_dialog_items: [], // Packed items displayed in dialog
+                        packed_dialog_items: [], // Packed items displayed in dialog
 			show_packed_dialog: false, // Packing list dialog visibility
 			posOffers: [], // All available offers
 			posa_offers: [], // Offers applied to this invoice
@@ -428,9 +428,33 @@ export default {
 		CancelSaleDialog,
 		ItemsTable,
 	},
-	computed: {
-		...invoiceComputed,
-	},
+        computed: {
+                items: {
+                        get() {
+                                return this.invoiceStore.items;
+                        },
+                        set(value) {
+                                this.invoiceStore.setItems(value);
+                        },
+                },
+                invoice_doc: {
+                        get() {
+                                return this.invoiceStore.invoiceDoc;
+                        },
+                        set(value) {
+                                this.invoiceStore.setInvoiceDoc(value);
+                        },
+                },
+                packed_items: {
+                        get() {
+                                return this.invoiceStore.packedItems;
+                        },
+                        set(value) {
+                                this.invoiceStore.setPackedItems(value);
+                        },
+                },
+                ...invoiceComputed,
+        },
 
 	methods: {
 		...shortcutMethods,
@@ -1363,13 +1387,14 @@ export default {
 		// Cleanup reset_posting_date listener
 		this.eventBus.off("reset_posting_date");
 	},
-	// Register global keyboard shortcuts when component is created
-	created() {
-		document.addEventListener("keydown", this.shortOpenPayment.bind(this));
-		document.addEventListener("keydown", this.shortDeleteFirstItem.bind(this));
-		document.addEventListener("keydown", this.shortOpenFirstItem.bind(this));
-		document.addEventListener("keydown", this.shortSelectDiscount.bind(this));
-	},
+        // Register global keyboard shortcuts when component is created
+        created() {
+                this.invoiceStore.clear();
+                document.addEventListener("keydown", this.shortOpenPayment.bind(this));
+                document.addEventListener("keydown", this.shortDeleteFirstItem.bind(this));
+                document.addEventListener("keydown", this.shortOpenFirstItem.bind(this));
+                document.addEventListener("keydown", this.shortSelectDiscount.bind(this));
+        },
 	// Remove global keyboard shortcuts when component is unmounted
 	unmounted() {
 		document.removeEventListener("keydown", this.shortOpenPayment);

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -654,18 +654,21 @@
 import _ from "lodash";
 import { logComponentRender } from "../../utils/perf.js";
 import { parseBooleanSetting } from "../../utils/stock.js";
+import { useInvoiceStore } from "../../stores/invoiceStore.js";
 export default {
-	name: "ItemsTable",
-	props: {
-		headers: Array,
-		items: Array,
-		expanded: Array,
-		itemsPerPage: Number,
-		itemSearch: String,
-		pos_profile: Object,
-		invoice_doc: Object,
-		invoiceType: String,
-		stock_settings: Object,
+        name: "ItemsTable",
+        setup() {
+                const invoiceStore = useInvoiceStore();
+                return { invoiceStore };
+        },
+        props: {
+                headers: Array,
+                expanded: Array,
+                itemsPerPage: Number,
+                itemSearch: String,
+                pos_profile: Object,
+                invoiceType: String,
+                stock_settings: Object,
 		displayCurrency: String,
 		formatFloat: Function,
 		formatCurrency: Function,
@@ -708,9 +711,15 @@ export default {
 			lastUpdateTime: 0,
 		};
 	},
-	computed: {
-		// Dynamic container styles based on parent
-		containerStyles() {
+        computed: {
+                items() {
+                        return this.invoiceStore.items;
+                },
+                invoice_doc() {
+                        return this.invoiceStore.invoiceDoc || {};
+                },
+                // Dynamic container styles based on parent
+                containerStyles() {
 			return {
 				height: "calc(100% - 80px)",
 				maxHeight: "calc(100% - 80px)",

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -45,7 +45,7 @@
 					</v-col>
 
 					<!-- Paid Change (if applicable) -->
-					<v-col cols="7" v-if="credit_change > 0 && !invoice_doc.is_return">
+                                        <v-col cols="7" v-if="invoice_doc && credit_change > 0 && !invoice_doc.is_return">
 						<v-text-field
 							variant="solo"
 							color="primary"
@@ -62,7 +62,7 @@
 					</v-col>
 
 					<!-- Credit Change (if applicable) -->
-					<v-col cols="5" v-if="credit_change > 0 && !invoice_doc.is_return">
+                                        <v-col cols="5" v-if="invoice_doc && credit_change > 0 && !invoice_doc.is_return">
 						<v-text-field
 							variant="solo"
 							color="primary"
@@ -309,7 +309,7 @@
 							persistent-placeholder
 						></v-text-field>
 					</v-col>
-					<v-col v-if="invoice_doc.rounded_total" cols="6">
+                                        <v-col v-if="invoice_doc && invoice_doc.rounded_total" cols="6">
 						<v-text-field
 							density="compact"
 							variant="solo"
@@ -446,14 +446,15 @@
 
 				<!-- Switches for Write Off and Credit Sale -->
 				<v-row class="pa-1" align="start" no-gutters>
-					<v-col
-						cols="6"
-						v-if="
-							pos_profile.posa_allow_write_off_change &&
-							credit_change > 0 &&
-							!invoice_doc.is_return
-						"
-					>
+                                        <v-col
+                                                cols="6"
+                                                v-if="
+                                                        invoice_doc &&
+                                                        pos_profile.posa_allow_write_off_change &&
+                                                        credit_change > 0 &&
+                                                        !invoice_doc.is_return
+                                                "
+                                        >
 						<v-switch
 							v-model="is_write_off_change"
 							flat
@@ -461,10 +462,13 @@
 							class="my-0 pa-1"
 						></v-switch>
 					</v-col>
-					<v-col cols="6" v-if="pos_profile.posa_allow_credit_sale && !invoice_doc.is_return">
+                                        <v-col
+                                                cols="6"
+                                                v-if="invoice_doc && pos_profile.posa_allow_credit_sale && !invoice_doc.is_return"
+                                        >
 						<v-switch v-model="is_credit_sale" :label="frappe._('Credit Sale?')"></v-switch>
 					</v-col>
-					<v-col cols="6" v-if="invoice_doc.is_return && pos_profile.use_cashback">
+                                        <v-col cols="6" v-if="invoice_doc && invoice_doc.is_return && pos_profile.use_cashback">
 						<v-switch
 							v-model="is_cashback"
 							flat
@@ -472,7 +476,7 @@
 							class="my-0 pa-1"
 						></v-switch>
 					</v-col>
-					<v-col cols="6" v-if="invoice_doc.is_return">
+                                        <v-col cols="6" v-if="invoice_doc && invoice_doc.is_return">
 						<v-switch
 							v-model="is_credit_return"
 							flat
@@ -516,7 +520,7 @@
 							</v-chip>
 						</div>
 					</v-col>
-					<v-col cols="6" v-if="!invoice_doc.is_return && pos_profile.use_customer_credit">
+                                        <v-col cols="6" v-if="invoice_doc && !invoice_doc.is_return && pos_profile.use_customer_credit">
 						<v-switch
 							v-model="redeem_customer_credit"
 							flat
@@ -875,13 +879,17 @@ export default {
 			return diff >= 0 ? diff : 0;
 		},
 
-		// Calculate change to be given back to customer
-		credit_change() {
-			// For multi-currency, use grand_total instead of rounded_total
-			let invoice_total;
-			if (
-				this.pos_profile.posa_allow_multi_currency &&
-				this.invoice_doc.currency !== this.pos_profile.currency
+                // Calculate change to be given back to customer
+                credit_change() {
+                        if (!this.invoice_doc) {
+                                return 0;
+                        }
+
+                        // For multi-currency, use grand_total instead of rounded_total
+                        let invoice_total;
+                        if (
+                                this.pos_profile.posa_allow_multi_currency &&
+                                this.invoice_doc.currency !== this.pos_profile.currency
 			) {
 				invoice_total = this.flt(this.invoice_doc.grand_total, this.currency_precision);
 			} else {
@@ -895,8 +903,8 @@ export default {
 			let change = this.flt(this.total_payments - invoice_total, this.currency_precision);
 
 			// Ensure change is not negative
-			return change > 0 ? change : 0;
-		},
+                        return change > 0 ? change : 0;
+                },
 
 		// Label for the difference field (To Be Paid/Change)
 		diff_label() {
@@ -913,21 +921,23 @@ export default {
 			return this.formatCurrency(this.diff_payment, this.displayCurrency);
 		},
 		// Calculate available loyalty points amount in selected currency
-		available_points_amount() {
-			let amount = 0;
-			if (this.customer_info.loyalty_points) {
-				// Convert loyalty points to amount in base currency (PKR)
-				amount = this.customer_info.loyalty_points * this.customer_info.conversion_factor;
+                available_points_amount() {
+                        let amount = 0;
+                        const doc = this.invoice_doc;
 
-				// Convert to selected currency if needed
-				if (this.invoice_doc.currency !== this.pos_profile.currency) {
-					// Convert PKR to USD by dividing
-					amount = this.flt(
-						amount / (this.invoice_doc.conversion_rate || 1),
-						this.currency_precision,
-					);
-				}
-			}
+                        if (this.customer_info.loyalty_points && doc) {
+                                // Convert loyalty points to amount in base currency (PKR)
+                                amount = this.customer_info.loyalty_points * this.customer_info.conversion_factor;
+
+                                // Convert to selected currency if needed
+                                if (doc.currency !== this.pos_profile.currency) {
+                                        // Convert PKR to USD by dividing
+                                        amount = this.flt(
+                                                amount / (doc.conversion_rate || 1),
+                                                this.currency_precision,
+                                        );
+                                }
+                        }
 			return amount;
 		},
 		// Calculate total available customer credit

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -82,9 +82,11 @@
 
 				<v-divider></v-divider>
 
-				<!-- Payment Inputs (All Payment Methods) -->
-				<div v-if="is_cashback">
-					<v-row class="payments pa-1" v-for="payment in invoice_doc.payments" :key="payment.name">
+                                <!-- Payment Inputs (All Payment Methods) -->
+                                <div
+                                        v-if="is_cashback && invoice_doc && Array.isArray(invoice_doc.payments)"
+                                >
+                                        <v-row class="payments pa-1" v-for="payment in invoice_doc.payments" :key="payment.name">
 						<v-col cols="6" v-if="!is_mpesa_c2b_payment(payment)">
 							<v-text-field
 								density="compact"

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -222,11 +222,11 @@
 
 				<v-divider></v-divider>
 
-				<!-- Invoice Totals (Net, Tax, Total, Discount, Grand, Rounded) -->
-				<v-row class="pa-1">
-					<v-col cols="6">
-						<v-text-field
-							density="compact"
+                                <!-- Invoice Totals (Net, Tax, Total, Discount, Grand, Rounded) -->
+                                <v-row v-if="invoice_doc" class="pa-1">
+                                        <v-col cols="6">
+                                                <v-text-field
+                                                        density="compact"
 							variant="solo"
 							color="primary"
 							:label="frappe._('Net Total')"

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -716,8 +716,8 @@
 import format, { formatUtils } from "../../format";
 import { parseBooleanSetting } from "../../utils/stock.js";
 import {
-	saveOfflineInvoice,
-	syncOfflineInvoices,
+        saveOfflineInvoice,
+        syncOfflineInvoices,
 	getPendingOfflineInvoiceCount,
 	isOffline,
 	getSalesPersonsStorage,
@@ -727,17 +727,21 @@ import {
 
 import renderOfflineInvoiceHTML from "../../../offline_print_template";
 import { silentPrint } from "../../plugins/print.js";
+import { useInvoiceStore } from "../../stores/invoiceStore.js";
 
 export default {
-	// Using format mixin for shared formatting methods
-	mixins: [format],
-	data() {
-		return {
-			loading: false, // UI loading state
-			pos_profile: "", // POS profile settings
-			pos_settings: "", // POS settings
-			invoice_doc: "", // Current invoice document
-			stock_settings: "", // Stock settings
+        // Using format mixin for shared formatting methods
+        mixins: [format],
+        setup() {
+                const invoiceStore = useInvoiceStore();
+                return { invoiceStore };
+        },
+        data() {
+                return {
+                        loading: false, // UI loading state
+                        pos_profile: "", // POS profile settings
+                        pos_settings: "", // POS settings
+                        stock_settings: "", // Stock settings
 			invoiceType: "Invoice", // Type of invoice
 			is_return: false, // Is this a return invoice?
 			loyalty_amount: 0, // Loyalty points to redeem
@@ -767,14 +771,23 @@ export default {
 			is_user_editing_paid_change: false, // User interaction flag
 			highlightSubmit: false, // Highlight state for submit button
 		};
-	},
-	computed: {
-		// Get currency symbol for given or current currency
-		currencySymbol() {
-			return (currency) => {
-				return get_currency_symbol(currency || this.invoice_doc.currency);
-			};
-		},
+        },
+        computed: {
+                invoice_doc: {
+                        get() {
+                                return this.invoiceStore.invoiceDoc;
+                        },
+                        set(value) {
+                                this.invoiceStore.setInvoiceDoc(value);
+                        },
+                },
+                // Get currency symbol for given or current currency
+                currencySymbol() {
+                        return (currency) => {
+                                const fallbackCurrency = this.invoice_doc ? this.invoice_doc.currency : undefined;
+                                return get_currency_symbol(currency || fallbackCurrency);
+                        };
+                },
 		// Display currency for invoice
 		displayCurrency() {
 			return this.invoice_doc ? this.invoice_doc.currency : "";
@@ -797,30 +810,32 @@ export default {
 			}
 
 			// Add loyalty amount (convert if needed)
-			if (this.loyalty_amount) {
-				// Loyalty points are stored in base currency (PKR)
-				if (this.invoice_doc.currency !== this.pos_profile.currency) {
-					// Convert to selected currency (e.g. USD) by dividing
-					total += this.flt(
-						this.loyalty_amount / (this.invoice_doc.conversion_rate || 1),
-						this.currency_precision,
-					);
-				} else {
-					total += parseFloat(formatUtils.fromArabicNumerals(String(this.loyalty_amount))) || 0;
-				}
-			}
+                        const doc = this.invoice_doc;
 
-			// Add redeemed customer credit (convert if needed)
-			if (this.redeemed_customer_credit) {
-				// Customer credit is stored in base currency (PKR)
-				if (this.invoice_doc.currency !== this.pos_profile.currency) {
-					// Convert to selected currency (e.g. USD) by dividing
-					total += this.flt(
-						this.redeemed_customer_credit / (this.invoice_doc.conversion_rate || 1),
-						this.currency_precision,
-					);
-				} else {
-					total +=
+                        if (this.loyalty_amount && doc) {
+                                // Loyalty points are stored in base currency (PKR)
+                                if (doc.currency && doc.currency !== this.pos_profile.currency) {
+                                        // Convert to selected currency (e.g. USD) by dividing
+                                        total += this.flt(
+                                                this.loyalty_amount / (doc.conversion_rate || 1),
+                                                this.currency_precision,
+                                        );
+                                } else {
+                                        total += parseFloat(formatUtils.fromArabicNumerals(String(this.loyalty_amount))) || 0;
+                                }
+                        }
+
+                        // Add redeemed customer credit (convert if needed)
+                        if (this.redeemed_customer_credit && doc) {
+                                // Customer credit is stored in base currency (PKR)
+                                if (doc.currency && doc.currency !== this.pos_profile.currency) {
+                                        // Convert to selected currency (e.g. USD) by dividing
+                                        total += this.flt(
+                                                this.redeemed_customer_credit / (doc.conversion_rate || 1),
+                                                this.currency_precision,
+                                        );
+                                } else {
+                                        total +=
 						parseFloat(formatUtils.fromArabicNumerals(String(this.redeemed_customer_credit))) ||
 						0;
 				}
@@ -954,10 +969,13 @@ export default {
 				this.credit_change = this.flt(newVal - changeLimit, this.currency_precision);
 			}
 		},
-		// Watch loyalty_amount to handle loyalty points redemption
-		loyalty_amount(value) {
-			if (value > this.available_points_amount) {
-				this.invoice_doc.loyalty_amount = 0;
+                // Watch loyalty_amount to handle loyalty points redemption
+                loyalty_amount(value) {
+                        if (!this.invoice_doc) {
+                                return;
+                        }
+                        if (value > this.available_points_amount) {
+                                this.invoice_doc.loyalty_amount = 0;
 				this.invoice_doc.redeem_loyalty_points = 0;
 				this.invoice_doc.loyalty_points = 0;
 				this.loyalty_amount = 0;
@@ -990,10 +1008,13 @@ export default {
 			},
 			deep: true,
 		},
-		// Watch sales_person to update sales_team
-		sales_person(newVal) {
-			if (newVal) {
-				this.invoice_doc.sales_team = [
+                // Watch sales_person to update sales_team
+                sales_person(newVal) {
+                        if (!this.invoice_doc) {
+                                return;
+                        }
+                        if (newVal) {
+                                this.invoice_doc.sales_team = [
 					{
 						sales_person: newVal,
 						allocated_percentage: 100,
@@ -1005,10 +1026,13 @@ export default {
 				console.log("Cleared sales_team");
 			}
 		},
-		// Watch is_credit_sale to reset cash payments
-		is_credit_sale(newVal) {
-			if (newVal) {
-				// If credit sale is enabled, set cash payment to 0
+                // Watch is_credit_sale to reset cash payments
+                is_credit_sale(newVal) {
+                        if (!this.invoice_doc) {
+                                return;
+                        }
+                        if (newVal) {
+                                // If credit sale is enabled, set cash payment to 0
 				this.invoice_doc.payments.forEach((payment) => {
 					if (payment.mode_of_payment.toLowerCase() === "cash") {
 						payment.amount = 0;
@@ -1023,10 +1047,13 @@ export default {
 				});
 			}
 		},
-		// Watch is_credit_return to toggle cashback payments
-		is_credit_return(newVal) {
-			if (newVal) {
-				this.is_cashback = false;
+                // Watch is_credit_return to toggle cashback payments
+                is_credit_return(newVal) {
+                        if (!this.invoice_doc) {
+                                return;
+                        }
+                        if (newVal) {
+                                this.is_cashback = false;
 				// Clear any payment amounts
 				this.invoice_doc.payments.forEach((payment) => {
 					payment.amount = 0;

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -337,7 +337,7 @@
 						/>
 					</v-col>
 					<!-- Shipping Address Selection (if delivery date is set) -->
-					<v-col cols="12" v-if="invoice_doc.posa_delivery_date">
+                                        <v-col cols="12" v-if="invoice_doc && invoice_doc.posa_delivery_date">
 						<v-autocomplete
 							density="compact"
 							clearable
@@ -945,14 +945,18 @@ export default {
 			return this.customer_credit_dict.reduce((total, row) => total + this.flt(row.total_credit), 0);
 		},
 		// Validate if payment can be submitted
-		vaildatPayment() {
-			if (this.pos_profile.posa_allow_sales_order) {
-				if (this.invoiceType === "Order" && !this.invoice_doc.posa_delivery_date) {
-					return true;
-				}
-			}
-			return false;
-		},
+                vaildatPayment() {
+                        if (!this.pos_profile.posa_allow_sales_order) {
+                                return false;
+                        }
+
+                        if (this.invoiceType !== "Order") {
+                                return false;
+                        }
+
+                        const doc = this.invoice_doc;
+                        return !doc || !doc.posa_delivery_date;
+                },
 		// Should request payment field be shown?
 		request_payment_field() {
 			return (

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -1,17 +1,26 @@
 /* global flt, __, get_currency_symbol */
 import { perfMarkStart, perfMarkEnd } from "../../utils/perf.js";
 
-import { parseBooleanSetting } from '../../utils/stock.js';
+import { parseBooleanSetting } from "../../utils/stock.js";
 
 export default {
         // Calculate total quantity of all items
         total_qty() {
                 const mark = perfMarkStart("pos:totals-total_qty");
                 this.close_payments();
-                let qty = 0;
-                this.items.forEach((item) => {
-                        qty += flt(item.qty);
-                });
+                const store = this.invoiceStore;
+                const storeValue = store?.totalQty?.value ?? store?.totalQty;
+                let qty;
+
+                if (typeof storeValue === "number" && !Number.isNaN(storeValue)) {
+                        qty = storeValue;
+                } else {
+                        qty = 0;
+                        this.items.forEach((item) => {
+                                qty += flt(item.qty);
+                        });
+                }
+
                 const result = this.flt(qty, this.float_precision);
                 perfMarkEnd("pos:totals-total_qty", mark);
                 return result;
@@ -19,13 +28,22 @@ export default {
         // Calculate total amount for all items (handles returns)
         Total() {
                 const mark = perfMarkStart("pos:totals-gross");
-                let sum = 0;
-                this.items.forEach((item) => {
-                        // For returns, use absolute value for correct calculation
-                        const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
-                        const rate = flt(item.rate);
-                        sum += qty * rate;
-                });
+                const store = this.invoiceStore;
+                const storeValue = store?.grossTotal?.value ?? store?.grossTotal;
+                let sum;
+
+                if (typeof storeValue === "number" && !Number.isNaN(storeValue)) {
+                        sum = this.isReturnInvoice ? Math.abs(storeValue) : storeValue;
+                } else {
+                        sum = 0;
+                        this.items.forEach((item) => {
+                                // For returns, use absolute value for correct calculation
+                                const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
+                                const rate = flt(item.rate);
+                                sum += qty * rate;
+                        });
+                }
+
                 const result = this.flt(sum, this.currency_precision);
                 perfMarkEnd("pos:totals-gross", mark);
                 return result;
@@ -34,17 +52,24 @@ export default {
         subtotal() {
                 const mark = perfMarkStart("pos:totals-subtotal");
                 this.close_payments();
-                let sum = 0;
-                this.items.forEach((item) => {
-                        // For returns, use absolute value for correct calculation
-                        const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
-                        const rate = flt(item.rate);
-			sum += qty * rate;
-		});
+                const store = this.invoiceStore;
+                const storeValue = store?.grossTotal?.value ?? store?.grossTotal;
+                let sum = typeof storeValue === "number" && !Number.isNaN(storeValue) ? storeValue : 0;
 
-		// Subtract additional discount
-		const additional_discount = this.flt(this.additional_discount);
-		sum -= additional_discount;
+                if (!(typeof storeValue === "number" && !Number.isNaN(storeValue))) {
+                        this.items.forEach((item) => {
+                                // For returns, use absolute value for correct calculation
+                                const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
+                                const rate = flt(item.rate);
+                                sum += qty * rate;
+                        });
+                } else if (this.isReturnInvoice) {
+                        sum = Math.abs(sum);
+                }
+
+                // Subtract additional discount
+                const additional_discount = this.flt(this.additional_discount);
+                sum -= additional_discount;
 
 		// Add delivery charges
 		const delivery_charges = this.flt(this.delivery_charges_rate);
@@ -57,15 +82,24 @@ export default {
         // Calculate total discount amount for all items
         total_items_discount_amount() {
                 const mark = perfMarkStart("pos:totals-discount");
-                let sum = 0;
-                this.items.forEach((item) => {
-                        // For returns, use absolute value for correct calculation
-                        if (this.isReturnInvoice) {
-                                sum += Math.abs(flt(item.qty)) * flt(item.discount_amount);
-			} else {
-				sum += flt(item.qty) * flt(item.discount_amount);
-			}
-		});
+                const store = this.invoiceStore;
+                const storeValue = store?.discountTotal?.value ?? store?.discountTotal;
+                let sum;
+
+                if (typeof storeValue === "number" && !Number.isNaN(storeValue)) {
+                        sum = this.isReturnInvoice ? Math.abs(storeValue) : storeValue;
+                } else {
+                        sum = 0;
+                        this.items.forEach((item) => {
+                                // For returns, use absolute value for correct calculation
+                                if (this.isReturnInvoice) {
+                                        sum += Math.abs(flt(item.qty)) * flt(item.discount_amount);
+                                } else {
+                                        sum += flt(item.qty) * flt(item.discount_amount);
+                                }
+                        });
+                }
+
                 const result = this.flt(sum, this.float_precision);
                 perfMarkEnd("pos:totals-discount", mark);
                 return result;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1012,7 +1012,7 @@ export default {
 				return;
 			}
 
-			let invoice_doc;
+                        let invoice_doc;
                         if (
                                 this.invoiceType === "Order" &&
                                 this.pos_profile.posa_create_only_sales_order &&
@@ -1021,7 +1021,11 @@ export default {
                         ) {
 				console.log("Building local Sales Order doc for payment");
 				invoice_doc = this.get_invoice_doc();
-			} else if (this.invoice_doc.doctype == "Sales Order" && this.invoiceType === "Invoice") {
+                        } else if (
+                                this.invoice_doc &&
+                                this.invoice_doc.doctype === "Sales Order" &&
+                                this.invoiceType === "Invoice"
+                        ) {
 				console.log("Processing Sales Order payment");
 				invoice_doc = await this.process_invoice_from_order();
 			} else {
@@ -1164,7 +1168,8 @@ export default {
 		}
 
 		// For return with reference to existing invoice
-		if (this.invoice_doc.is_return && this.invoice_doc.return_against) {
+                const currentInvoice = this.invoice_doc;
+                if (currentInvoice && currentInvoice.is_return && currentInvoice.return_against) {
 			console.log("Return doc:", this.invoice_doc);
 			console.log("Current items:", this.items);
 
@@ -1174,10 +1179,10 @@ export default {
 					frappe.call({
 						method: "frappe.client.get",
 						args: {
-							doctype: this.pos_profile.create_pos_invoice_instead_of_sales_invoice
-								? "POS Invoice"
-								: "Sales Invoice",
-							name: this.invoice_doc.return_against,
+                                                        doctype: this.pos_profile.create_pos_invoice_instead_of_sales_invoice
+                                                                ? "POS Invoice"
+                                                                : "Sales Invoice",
+                                                        name: currentInvoice.return_against,
 						},
 						callback: (r) => {
 							if (r.message) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -356,11 +356,13 @@ export default {
 	},
 
 	// Build the invoice document object for backend submission
-	get_invoice_doc() {
-		let doc = {};
-		if (this.invoice_doc.name) {
-			doc = { ...this.invoice_doc };
-		}
+        get_invoice_doc() {
+                let doc = {};
+                const sourceDoc = this.invoice_doc || {};
+
+                if (sourceDoc.name) {
+                        doc = { ...sourceDoc };
+                }
 
 		// Always set these fields first
 		if (this.invoiceType === "Quotation") {
@@ -379,16 +381,16 @@ export default {
 		doc.posa_show_custom_name_marker_on_print = this.pos_profile.posa_show_custom_name_marker_on_print;
 
 		// Currency related fields
-		doc.currency = this.selected_currency || this.pos_profile.currency;
-		doc.conversion_rate =
-			(this.invoice_doc && this.invoice_doc.conversion_rate) || this.conversion_rate || 1;
+                doc.currency = this.selected_currency || this.pos_profile.currency;
+                doc.conversion_rate =
+                        (sourceDoc && sourceDoc.conversion_rate) || this.conversion_rate || 1;
 
-		// Use actual price list currency if available
-		doc.price_list_currency = this.price_list_currency || doc.currency;
+                // Use actual price list currency if available
+                doc.price_list_currency = this.price_list_currency || doc.currency;
 
-		doc.plc_conversion_rate =
-			(this.invoice_doc && this.invoice_doc.plc_conversion_rate) ||
-			(doc.price_list_currency === doc.currency ? 1 : this.exchange_rate);
+                doc.plc_conversion_rate =
+                        (sourceDoc && sourceDoc.plc_conversion_rate) ||
+                        (doc.price_list_currency === doc.currency ? 1 : this.exchange_rate);
 
 		// Other fields
 		doc.campaign = doc.campaign || this.pos_profile.campaign;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1011,12 +1011,12 @@ export default {
 			}
 
 			let invoice_doc;
-			if (
-				this.invoiceType === "Order" &&
-				this.pos_profile.posa_create_only_sales_order &&
-				!this.new_delivery_date &&
-				!this.invoice_doc.posa_delivery_date
-			) {
+                        if (
+                                this.invoiceType === "Order" &&
+                                this.pos_profile.posa_create_only_sales_order &&
+                                !this.new_delivery_date &&
+                                !(this.invoice_doc && this.invoice_doc.posa_delivery_date)
+                        ) {
 				console.log("Building local Sales Order doc for payment");
 				invoice_doc = this.get_invoice_doc();
 			} else if (this.invoice_doc.doctype == "Sales Order" && this.invoiceType === "Invoice") {

--- a/frontend/src/posapp/stores/index.js
+++ b/frontend/src/posapp/stores/index.js
@@ -9,6 +9,7 @@ export const pinia = createPinia();
 
 // Export stores
 export { useItemsStore } from './itemsStore.js';
+export { useInvoiceStore } from './invoiceStore.js';
 export { useUpdateStore, formatBuildVersion } from './updateStore.js';
 
 export default pinia;

--- a/frontend/src/posapp/stores/invoiceStore.js
+++ b/frontend/src/posapp/stores/invoiceStore.js
@@ -1,0 +1,201 @@
+/**
+ * Centralized invoice state management using Pinia.
+ * Handles large invoice datasets efficiently and keeps totals in sync.
+ */
+
+import { defineStore } from 'pinia';
+import { computed, ref, watch } from 'vue';
+
+const toNumber = (value) => {
+    if (value == null) {
+        return 0;
+    }
+
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : 0;
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim();
+        if (!normalized) {
+            return 0;
+        }
+        const parsed = Number.parseFloat(normalized);
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
+
+    return 0;
+};
+
+const cloneItem = (item) => ({ ...item });
+
+export const useInvoiceStore = defineStore('invoice', () => {
+    const invoiceDoc = ref(null);
+    const items = ref([]);
+    const packedItems = ref([]);
+    const metadata = ref({
+        lastUpdated: Date.now(),
+        changeVersion: 0
+    });
+
+    const touch = () => {
+        metadata.value = {
+            lastUpdated: Date.now(),
+            changeVersion: metadata.value.changeVersion + 1
+        };
+    };
+
+    const normalizeDoc = (doc) => {
+        if (!doc) {
+            return null;
+        }
+
+        if (typeof doc === 'string') {
+            return doc.trim() ? { name: doc } : null;
+        }
+
+        return { ...doc };
+    };
+
+    const setInvoiceDoc = (doc) => {
+        invoiceDoc.value = normalizeDoc(doc);
+        touch();
+    };
+
+    const mergeInvoiceDoc = (patch = {}) => {
+        const current = invoiceDoc.value ? { ...invoiceDoc.value } : {};
+        invoiceDoc.value = Object.assign(current, patch || {});
+        touch();
+    };
+
+    const setItems = (list) => {
+        items.value = Array.isArray(list) ? list.map(cloneItem) : [];
+        touch();
+    };
+
+    const replaceItemAt = (index, item) => {
+        if (index < 0 || index >= items.value.length) {
+            return;
+        }
+
+        const updated = items.value.slice();
+        updated[index] = cloneItem(item);
+        items.value = updated;
+        touch();
+    };
+
+    const upsertItem = (item) => {
+        if (!item) {
+            return;
+        }
+
+        const rowId = item.posa_row_id;
+        if (!rowId) {
+            items.value = [...items.value, cloneItem(item)];
+            touch();
+            return;
+        }
+
+        const index = items.value.findIndex((entry) => entry.posa_row_id === rowId);
+        if (index === -1) {
+            items.value = [...items.value, cloneItem(item)];
+        } else {
+            const updated = items.value.slice();
+            updated[index] = { ...updated[index], ...item };
+            items.value = updated;
+        }
+        touch();
+    };
+
+    const removeItemByRowId = (rowId) => {
+        if (!rowId) {
+            return;
+        }
+
+        const filtered = items.value.filter((item) => item.posa_row_id !== rowId);
+        if (filtered.length !== items.value.length) {
+            items.value = filtered;
+            touch();
+        }
+    };
+
+    const clearItems = () => {
+        if (items.value.length) {
+            items.value = [];
+            touch();
+        }
+    };
+
+    const setPackedItems = (list) => {
+        packedItems.value = Array.isArray(list) ? list.map(cloneItem) : [];
+        touch();
+    };
+
+    const clear = () => {
+        invoiceDoc.value = null;
+        items.value = [];
+        packedItems.value = [];
+        touch();
+    };
+
+    const totalQty = computed(() => {
+        return items.value.reduce((sum, item) => sum + toNumber(item.qty), 0);
+    });
+
+    const grossTotal = computed(() => {
+        return items.value.reduce(
+            (sum, item) => sum + toNumber(item.qty) * toNumber(item.rate),
+            0
+        );
+    });
+
+    const discountTotal = computed(() => {
+        return items.value.reduce((sum, item) => {
+            const qty = Math.abs(toNumber(item.qty));
+            return sum + qty * toNumber(item.discount_amount || 0);
+        }, 0);
+    });
+
+    const itemsCount = computed(() => items.value.length);
+
+    const itemsMap = computed(() => {
+        const map = new Map();
+        items.value.forEach((item, index) => {
+            if (item && item.posa_row_id) {
+                map.set(item.posa_row_id, { index, item });
+            }
+        });
+        return map;
+    });
+
+    watch(
+        items,
+        () => {
+            touch();
+        },
+        { deep: true }
+    );
+
+    return {
+        invoiceDoc,
+        items,
+        packedItems,
+        metadata,
+        totalQty,
+        grossTotal,
+        discountTotal,
+        itemsCount,
+        itemsMap,
+        setInvoiceDoc,
+        mergeInvoiceDoc,
+        setItems,
+        replaceItemAt,
+        upsertItem,
+        removeItemByRowId,
+        clearItems,
+        setPackedItems,
+        clear
+    };
+});
+
+export default useInvoiceStore;


### PR DESCRIPTION
## Summary
- add a dedicated Pinia invoice store to manage invoice documents, items, and aggregate metadata
- refactor Invoice, ItemsTable, and Payments components to source invoice data from the shared store and guard store-driven watchers
- reuse store-provided totals inside invoiceComputed helpers to avoid repeated per-component calculations

## Testing
- yarn --cwd frontend build

------
https://chatgpt.com/codex/tasks/task_e_68dad9d43be48326918d2e51277802b7