### PR TITLE
Optimize offer recalculation scheduling for large invoices

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1377,12 +1377,16 @@ export default {
 		});
 	},
 	// Cleanup event listeners before component is destroyed
-	beforeUnmount() {
-		// Existing cleanup
-		this.eventBus.off("register_pos_profile");
-		this.eventBus.off("add_item");
-		this.eventBus.off("update_customer");
-		this.eventBus.off("fetch_customer_details");
+        beforeUnmount() {
+                if (typeof this.cancelOfferRecalculation === "function") {
+                        this.cancelOfferRecalculation();
+                }
+
+                // Existing cleanup
+                this.eventBus.off("register_pos_profile");
+                this.eventBus.off("add_item");
+                this.eventBus.off("update_customer");
+                this.eventBus.off("fetch_customer_details");
 		this.eventBus.off("clear_invoice");
 		// Cleanup reset_posting_date listener
 		this.eventBus.off("reset_posting_date");

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -3,9 +3,60 @@ import { formatUtils } from "../../format.js";
 /* global __, frappe, flt */
 
 export default {
-	normalizeBrand(brand) {
-		return (brand || "").trim().toLowerCase();
-	},
+        queueOfferRecalculation() {
+                if (this.isApplyingOffer) {
+                        return;
+                }
+
+                const hasWindow = typeof window !== "undefined";
+                const requestFrame = hasWindow && window.requestAnimationFrame
+                        ? window.requestAnimationFrame.bind(window)
+                        : (cb) => setTimeout(cb, 16);
+                const cancelFrame = hasWindow && window.cancelAnimationFrame
+                        ? window.cancelAnimationFrame.bind(window)
+                        : clearTimeout;
+
+                if (this._offerRecalculationHandle) {
+                        cancelFrame(this._offerRecalculationHandle);
+                        this._offerRecalculationHandle = null;
+                }
+
+                this._offerRecalculationHandle = requestFrame(() => {
+                        this._offerRecalculationHandle = null;
+
+                        if (this.isApplyingOffer) {
+                                return;
+                        }
+
+                        this.handelOffers();
+
+                        if (typeof this.$nextTick === "function") {
+                                this.$nextTick(() => {
+                                        if (typeof this.$forceUpdate === "function") {
+                                                this.$forceUpdate();
+                                        }
+                                });
+                        } else if (typeof this.$forceUpdate === "function") {
+                                this.$forceUpdate();
+                        }
+                });
+        },
+
+        cancelOfferRecalculation() {
+                const hasWindow = typeof window !== "undefined";
+                const cancelFrame = hasWindow && window.cancelAnimationFrame
+                        ? window.cancelAnimationFrame.bind(window)
+                        : clearTimeout;
+
+                if (this._offerRecalculationHandle) {
+                                cancelFrame(this._offerRecalculationHandle);
+                                this._offerRecalculationHandle = null;
+                }
+        },
+
+        normalizeBrand(brand) {
+                return (brand || "").trim().toLowerCase();
+        },
 	getItemBrand(item) {
 		let brand = this.normalizeBrand(item.brand);
 		if (brand) {

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -30,23 +30,33 @@ export default {
 			value: this.discount_percentage_offer_name,
 		});
 	},
-	// Watch for items array changes (deep) and re-handle offers
-	items: {
-		deep: true,
-		handler() {
-			if (this.isApplyingOffer) return;
-			this.handelOffers();
-			this.$forceUpdate();
-		},
-	},
-	packed_items: {
-		deep: true,
-		handler() {
-			if (this.isApplyingOffer) return;
-			this.handelOffers();
-			this.$forceUpdate();
-		},
-	},
+        // Watch for items array changes (deep) and re-handle offers
+        items: {
+                deep: true,
+                handler() {
+                        if (typeof this.queueOfferRecalculation === "function") {
+                                this.queueOfferRecalculation();
+                                return;
+                        }
+
+                        if (this.isApplyingOffer) return;
+                        this.handelOffers();
+                        this.$forceUpdate();
+                },
+        },
+        packed_items: {
+                deep: true,
+                handler() {
+                        if (typeof this.queueOfferRecalculation === "function") {
+                                this.queueOfferRecalculation();
+                                return;
+                        }
+
+                        if (this.isApplyingOffer) return;
+                        this.handelOffers();
+                        this.$forceUpdate();
+                },
+        },
 	// Watch for invoice type change and emit
 	invoiceType() {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);


### PR DESCRIPTION
## Summary
- add a queued offer recalculation helper to avoid repeated expensive offer processing
- update invoice watchers to use the queued recalculation method when items change
- cancel any pending recalculation when the invoice component unmounts to avoid leaks

## Testing
- yarn --cwd frontend build *(fails: Rollup could not resolve the "pinia" dependency during the build step)*

------
https://chatgpt.com/codex/tasks/task_e_68db932916b88326a9152735a6287d4d