### PR TITLE
refactor: centralize customer state with pinia store

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -76,6 +76,8 @@ import {
 } from "./composables/useNetwork.js";
 import { useRtl } from "./composables/useRtl.js";
 
+import { useCustomersStore } from "./stores/customersStore.js";
+
 export default {
 	setup() {
 		const { isRtl, rtlStyles, rtlClasses } = useRtl();
@@ -89,6 +91,9 @@ export default {
 	},
 	data: function () {
 		return {
+			customersStore: useCustomersStore(),
+			unsubscribeCustomerProgress: null,
+			unsubscribeCustomerLoaded: null,
 			page: "POS",
 			// POS Profile data
 			posProfile: {},
@@ -476,8 +481,32 @@ export default {
 			this.eventBus.off("pending_invoices_changed");
 			this.eventBus.off("data-loaded");
 		}
+		if (this.unsubscribeCustomerProgress) {
+			this.unsubscribeCustomerProgress();
+			this.unsubscribeCustomerProgress = null;
+		}
+		if (this.unsubscribeCustomerLoaded) {
+			this.unsubscribeCustomerLoaded();
+			this.unsubscribeCustomerLoaded = null;
+		}
 	},
 	created: function () {
+		this.unsubscribeCustomerProgress = this.$watch(
+			() => this.customersStore.loadProgress,
+			(progress) => {
+				setSourceProgress("customers", progress || 0);
+			},
+			{ immediate: true },
+		);
+		this.unsubscribeCustomerLoaded = this.$watch(
+			() => this.customersStore.customersLoaded,
+			(loaded) => {
+				if (loaded) {
+					markSourceLoaded("customers");
+				}
+			},
+			{ immediate: true },
+		);
 		setTimeout(() => {
 			this.remove_frappe_nav();
 		}, 1000);

--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -391,6 +391,8 @@ import {
 import { silentPrint } from "../../plugins/print.js";
 import { useRtl } from "../../composables/useRtl.js";
 
+import { useCustomersStore } from "../../stores/customersStore.js";
+
 export default {
 	mixins: [format],
 	setup() {
@@ -403,6 +405,8 @@ export default {
 	},
 	data: function () {
 		return {
+			customersStore: useCustomersStore(),
+			unsubscribeCustomerSelection: null,
 			dialog: false,
 			pos_profile: "",
 			pos_opening_shift: "",
@@ -1192,22 +1196,29 @@ export default {
 	mounted: function () {
 		this.$nextTick(function () {
 			this.check_opening_entry();
-			this.eventBus.on("update_customer", (customer_name) => {
-				this.clear_all(true);
-				this.customer_name = customer_name;
-				this.fetch_customer_details();
-				this.get_outstanding_invoices();
-				this.get_unallocated_payments();
-				this.get_draft_mpesa_payments_register();
-			});
-			this.eventBus.on("fetch_customer_details", () => {
-				this.fetch_customer_details();
-			});
+			this.unsubscribeCustomerSelection = this.$watch(
+				() => this.customersStore.selectedCustomer,
+				(customer_name, previous) => {
+					if (customer_name !== previous) {
+						this.clear_all(true);
+						this.customer_name = customer_name || "";
+						if (customer_name) {
+							this.fetch_customer_details();
+							this.get_outstanding_invoices();
+							this.get_unallocated_payments();
+							this.get_draft_mpesa_payments_register();
+						}
+					}
+				},
+				{ immediate: true },
+			);
 		});
 	},
 	beforeUnmount() {
-		this.eventBus.off("update_customer");
-		this.eventBus.off("fetch_customer_details");
+		if (this.unsubscribeCustomerSelection) {
+			this.unsubscribeCustomerSelection();
+			this.unsubscribeCustomerSelection = null;
+		}
 		this.eventBus.off("network-online", this.syncPendingPayments);
 		this.eventBus.off("server-online", this.syncPendingPayments);
 	},

--- a/frontend/src/posapp/components/pos/Customer.vue
+++ b/frontend/src/posapp/components/pos/Customer.vue
@@ -143,488 +143,215 @@
 /* global frappe __ */
 import UpdateCustomer from "./UpdateCustomer.vue";
 import Skeleton from "../ui/Skeleton.vue";
-import {
-	db,
-	checkDbHealth,
-	setCustomerStorage,
-	memoryInitPromise,
-	getCustomersLastSync,
-	setCustomersLastSync,
-	getCustomerStorageCount,
-	clearCustomerStorage,
-	isOffline,
-} from "../../../offline/index.js";
-import _ from "lodash";
+import { useCustomersStore } from "../../stores/customersStore.js";
 
 export default {
-	props: {
-		pos_profile: Object,
-	},
+        props: {
+                pos_profile: Object,
+        },
 
-	data: () => ({
-		pos_profile: "",
-		customers: [],
-		customer: "",
-		internalCustomer: null,
-		tempSelectedCustomer: null,
-		isMenuOpen: false,
-		readonly: false,
-		effectiveReadonly: false,
-		customer_info: {},
-		loadingCustomers: false,
-		customers_loaded: false,
-		searchTerm: "",
-		page: 0,
-		pageSize: 200,
-		hasMore: true,
-		nextCustomerStart: null,
-		searchDebounce: null,
-		// Track background loading state and pending searches
-		isCustomerBackgroundLoading: false,
-		pendingCustomerSearch: null,
-		loadProgress: 0,
-		totalCustomerCount: 0,
-		loadedCustomerCount: 0,
-	}),
+        data() {
+                return {
+                        customersStore: useCustomersStore(),
+                        internalCustomer: null,
+                        tempSelectedCustomer: null,
+                        isMenuOpen: false,
+                        customer_info: {},
+                        unsubscribeSelectedCustomer: null,
+                };
+        },
 
-	components: {
-		UpdateCustomer,
-		Skeleton,
-	},
+        components: {
+                UpdateCustomer,
+                Skeleton,
+        },
 
-	computed: {
-		filteredCustomers() {
-			return this.isCustomerBackgroundLoading ? [] : this.customers;
-		},
-	},
+        computed: {
+                filteredCustomers() {
+                        return this.customersStore.filteredCustomers;
+                },
+                loadingCustomers() {
+                        return this.customersStore.loadingCustomers;
+                },
+                isCustomerBackgroundLoading() {
+                        return this.customersStore.isCustomerBackgroundLoading;
+                },
+                effectiveReadonly() {
+                        return this.customersStore.effectiveReadonly;
+                },
+        },
 
-	watch: {
-		readonly(val) {
-			this.effectiveReadonly = val && navigator.onLine;
-		},
-		customers_loaded(val) {
-			if (val) {
-				this.eventBus.emit("customers_loaded");
-			}
-		},
-	},
+        methods: {
+                onCustomerMenuToggle(isOpen) {
+                        this.isMenuOpen = isOpen;
 
-	methods: {
-		// Called when dropdown opens or closes
-		onCustomerMenuToggle(isOpen) {
-			this.isMenuOpen = isOpen;
+                        if (isOpen) {
+                                this.internalCustomer = null;
 
-			if (isOpen) {
-				this.internalCustomer = null;
+                                this.$nextTick(() => {
+                                        setTimeout(() => {
+                                                const dropdown = this.$refs.customerDropdown?.$el?.querySelector(
+                                                        ".v-overlay__content .v-select-list",
+                                                );
+                                                if (dropdown) {
+                                                        dropdown.scrollTop = 0;
+                                                        dropdown.addEventListener("scroll", this.onCustomerScroll);
+                                                }
+                                        }, 50);
+                                });
+                        } else {
+                                const dropdown = this.$refs.customerDropdown?.$el?.querySelector(
+                                        ".v-overlay__content .v-select-list",
+                                );
+                                if (dropdown) {
+                                        dropdown.removeEventListener("scroll", this.onCustomerScroll);
+                                }
+                                if (this.tempSelectedCustomer) {
+                                        this.internalCustomer = this.tempSelectedCustomer;
+                                        this.customersStore.setSelectedCustomer(this.tempSelectedCustomer);
+                                } else if (this.customersStore.selectedCustomer) {
+                                        this.internalCustomer = this.customersStore.selectedCustomer;
+                                }
 
-				this.$nextTick(() => {
-					setTimeout(() => {
-						const dropdown = this.$refs.customerDropdown?.$el?.querySelector(
-							".v-overlay__content .v-select-list",
-						);
-						if (dropdown) {
-							dropdown.scrollTop = 0;
-							dropdown.addEventListener("scroll", this.onCustomerScroll);
-						}
-					}, 50);
-				});
-			} else {
-				const dropdown = this.$refs.customerDropdown?.$el?.querySelector(
-					".v-overlay__content .v-select-list",
-				);
-				if (dropdown) {
-					dropdown.removeEventListener("scroll", this.onCustomerScroll);
-				}
-				if (this.tempSelectedCustomer) {
-					this.internalCustomer = this.tempSelectedCustomer;
-					this.customer = this.tempSelectedCustomer;
-					this.eventBus.emit("update_customer", this.customer);
-				} else if (this.customer) {
-					this.internalCustomer = this.customer;
-				}
+                                this.tempSelectedCustomer = null;
+                        }
+                },
 
-				this.tempSelectedCustomer = null;
-			}
-		},
+                onCustomerScroll(e) {
+                        const el = e.target;
+                        if (el.scrollTop + el.clientHeight >= el.scrollHeight - 50) {
+                                this.loadMoreCustomers();
+                        }
+                },
 
-		onCustomerScroll(e) {
-			const el = e.target;
-			if (el.scrollTop + el.clientHeight >= el.scrollHeight - 50) {
-				this.loadMoreCustomers();
-			}
-		},
+                closeCustomerMenu() {
+                        const dropdown = this.$refs.customerDropdown;
+                        if (dropdown) {
+                                try {
+                                        dropdown.menu = false;
+                                } catch (e) {
+                                        dropdown.$emit?.("update:menu", false);
+                                }
+                                const inputEl = dropdown.$el?.querySelector("input");
+                                if (inputEl) {
+                                        inputEl.blur();
+                                }
+                        }
+                        this.isMenuOpen = false;
+                },
 
-		closeCustomerMenu() {
-			const dropdown = this.$refs.customerDropdown;
-			if (dropdown) {
-				try {
-					dropdown.menu = false;
-				} catch (e) {
-					dropdown.$emit?.("update:menu", false);
-				}
-				const inputEl = dropdown.$el?.querySelector("input");
-				if (inputEl) {
-					inputEl.blur();
-				}
-			}
-			this.isMenuOpen = false;
-		},
+                onCustomerChange(val) {
+                        const current = this.customersStore.selectedCustomer;
+                        if (val && val === current) {
+                                this.internalCustomer = current;
+                                this.eventBus.emit("show_message", {
+                                        title: __("Customer already selected"),
+                                        color: "error",
+                                });
+                                return;
+                        }
 
-		// Called when a customer is selected
-		onCustomerChange(val) {
-			// if user selects the same customer again, show a meaningful error
-			if (val && val === this.customer) {
-				// keep the current selection and notify the user
-				this.internalCustomer = this.customer;
-				this.eventBus.emit("show_message", {
-					title: __("Customer already selected"),
-					color: "error",
-				});
-				return;
-			}
+                        this.tempSelectedCustomer = val;
 
-			this.tempSelectedCustomer = val;
+                        if (this.isMenuOpen && val) {
+                                this.closeCustomerMenu();
+                        } else if (!this.isMenuOpen && val) {
+                                this.customersStore.setSelectedCustomer(val);
+                        }
+                },
 
-			if (this.isMenuOpen && val) {
-				this.closeCustomerMenu();
-			} else if (!this.isMenuOpen && val) {
-				this.customer = val;
-				this.eventBus.emit("update_customer", val);
-			}
-		},
+                onCustomerSearch(val) {
+                        this.customersStore.queueSearch(val);
+                },
 
-		onCustomerSearch(val) {
-			if (this.isCustomerBackgroundLoading) {
-				this.pendingCustomerSearch = val;
-				return;
-			}
-			this.searchDebounce(val);
-		},
+                handleEnter(event) {
+                        const inputText = event.target.value?.toLowerCase() || "";
 
-		// Pressing Enter in input
-		handleEnter(event) {
-			const inputText = event.target.value?.toLowerCase() || "";
+                        const matched = this.customersStore.customers.find((cust) => {
+                                return (
+                                        cust.customer_name?.toLowerCase().includes(inputText) ||
+                                        cust.name?.toLowerCase().includes(inputText)
+                                );
+                        });
 
-			const matched = this.customers.find((cust) => {
-				return (
-					cust.customer_name?.toLowerCase().includes(inputText) ||
-					cust.name?.toLowerCase().includes(inputText)
-				);
-			});
+                        if (matched) {
+                                this.tempSelectedCustomer = matched.name;
+                                this.internalCustomer = matched.name;
+                                this.customersStore.setSelectedCustomer(matched.name);
+                                this.closeCustomerMenu();
+                                if (event?.target?.blur) {
+                                        event.target.blur();
+                                }
+                        }
+                },
 
-			if (matched) {
-				this.tempSelectedCustomer = matched.name;
-				this.internalCustomer = matched.name;
-				this.customer = matched.name;
-				this.eventBus.emit("update_customer", matched.name);
-				this.closeCustomerMenu();
-				if (event?.target?.blur) {
-					event.target.blur();
-				}
-			}
-		},
+                async loadMoreCustomers() {
+                        await this.customersStore.loadMoreCustomers();
+                },
 
-		async searchCustomers(term, append = false) {
-			try {
-				await checkDbHealth();
-				if (!db.isOpen()) await db.open();
-				let collection = db.table("customers");
-				const normalizedTerm = typeof term === "string" ? term.trim().toLowerCase() : "";
-				if (normalizedTerm) {
-					const searchParts = normalizedTerm.split(/\s+/).filter(Boolean);
-					collection = collection.filter((customer) => {
-						if (!customer) {
-							return false;
-						}
+                new_customer() {
+                        this.eventBus.emit("open_update_customer", null);
+                },
 
-						const values = [
-							customer.customer_name,
-							customer.name,
-							customer.mobile_no,
-							customer.email_id,
-							customer.tax_id,
-						]
-							.filter((value) => value !== null && value !== undefined)
-							.map((value) => String(value).toLowerCase());
+                edit_customer() {
+                        this.eventBus.emit("open_update_customer", this.customer_info);
+                },
+        },
 
-						if (!searchParts.length) {
-							return true;
-						}
+        created() {
+                this.customersStore.initialize();
+                this.unsubscribeSelectedCustomer = this.$watch(
+                        () => this.customersStore.selectedCustomer,
+                        (value) => {
+                                if (!this.isMenuOpen) {
+                                        this.internalCustomer = value || null;
+                                }
+                        },
+                        { immediate: true },
+                );
 
-						return searchParts.every((part) => values.some((value) => value.includes(part)));
-					});
-				}
-				const results = await collection
-					.offset(this.page * this.pageSize)
-					.limit(this.pageSize)
-					.toArray();
-				if (append) {
-					this.customers.push(...results);
-				} else {
-					this.customers = results;
-				}
-				this.hasMore = results.length === this.pageSize;
-				if (this.hasMore) {
-					this.page += 1;
-				}
-				return results.length;
-			} catch (e) {
-				console.error("Failed to search customers", e);
-				return 0;
-			}
-		},
+                this.$nextTick(() => {
+                        this.eventBus.on("register_pos_profile", async (pos_profile) => {
+                                await this.customersStore.setPosProfile(pos_profile);
+                        });
 
-		async loadMoreCustomers() {
-			if (this.loadingCustomers) return;
-			const count = await this.searchCustomers(this.searchTerm, true);
-			if (count === this.pageSize) return;
-			if (this.nextCustomerStart) {
-				await this.backgroundLoadCustomers(this.nextCustomerStart, getCustomersLastSync());
-				await this.searchCustomers(this.searchTerm, true);
-			}
-		},
+                        this.eventBus.on("payments_register_pos_profile", async (pos_profile) => {
+                                await this.customersStore.setPosProfile(pos_profile);
+                        });
 
-		async backgroundLoadCustomers(startAfter, syncSince) {
-			const limit = this.pageSize;
-			this.isCustomerBackgroundLoading = true;
-			try {
-				let cursor = startAfter;
-				while (cursor) {
-					const rows = await this.fetchCustomerPage(cursor, syncSince, limit);
-					await setCustomerStorage(rows);
-					this.loadedCustomerCount += rows.length;
-					if (this.totalCustomerCount) {
-						const progress = Math.min(
-							99,
-							Math.round((this.loadedCustomerCount / this.totalCustomerCount) * 100),
-						);
-						this.loadProgress = progress;
-						this.eventBus.emit("data-load-progress", { name: "customers", progress });
-					}
-					if (rows.length === limit) {
-						cursor = rows[rows.length - 1]?.name || null;
-						this.nextCustomerStart = cursor;
-					} else {
-						cursor = null;
-						this.nextCustomerStart = null;
-						setCustomersLastSync(new Date().toISOString());
-						this.loadProgress = 100;
-						this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-						this.eventBus.emit("data-loaded", "customers");
-					}
-				}
-			} catch (err) {
-				console.error("Failed to background load customers", err);
-			} finally {
-				this.isCustomerBackgroundLoading = false;
-				if (this.pendingCustomerSearch !== null) {
-					this.searchDebounce(this.pendingCustomerSearch);
-					if (this.searchDebounce.flush) {
-						this.searchDebounce.flush();
-					}
-					this.pendingCustomerSearch = null;
-				}
-			}
-		},
+                        this.eventBus.on("set_customer", (customer) => {
+                                this.customersStore.setSelectedCustomer(customer);
+                                this.internalCustomer = customer;
+                        });
 
-		async verifyServerCustomerCount() {
-			if (isOffline()) return;
-			try {
-				const localCount = await getCustomerStorageCount();
-				const res = await frappe.call({
-					method: "posawesome.posawesome.api.customers.get_customers_count",
-					args: { pos_profile: this.pos_profile.pos_profile },
-				});
-				const serverCount = res.message || 0;
-				if (typeof serverCount === "number") {
-					this.totalCustomerCount = serverCount;
-					this.loadedCustomerCount = localCount;
-					this.loadProgress = serverCount ? Math.round((localCount / serverCount) * 100) : 0;
-					this.eventBus.emit("data-load-progress", {
-						name: "customers",
-						progress: this.loadProgress,
-					});
-					if (serverCount > localCount) {
-						const syncSince = getCustomersLastSync();
-						const rows = await this.fetchCustomerPage(null, syncSince, this.pageSize);
-						await setCustomerStorage(rows);
-						this.loadedCustomerCount += rows.length;
-						if (this.totalCustomerCount) {
-							this.loadProgress = Math.round(
-								(this.loadedCustomerCount / this.totalCustomerCount) * 100,
-							);
-							this.eventBus.emit("data-load-progress", {
-								name: "customers",
-								progress: this.loadProgress,
-							});
-						}
-						const startAfter =
-							rows.length === this.pageSize ? rows[rows.length - 1]?.name || null : null;
-						if (startAfter) {
-							this.backgroundLoadCustomers(startAfter, syncSince);
-						} else {
-							setCustomersLastSync(new Date().toISOString());
-							this.loadProgress = 100;
-							this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-							this.eventBus.emit("data-loaded", "customers");
-						}
-						await this.searchCustomers(this.searchTerm);
-					} else if (serverCount < localCount) {
-						await clearCustomerStorage();
-						setCustomersLastSync(null);
-						this.customers = [];
-						await this.get_customer_names();
-					}
-				}
-			} catch (err) {
-				console.error("Error verifying customer count:", err);
-			}
-		},
+                        this.eventBus.on("add_customer_to_list", async (customer) => {
+                                await this.customersStore.addOrUpdateCustomer(customer);
+                                this.internalCustomer = customer.name;
+                        });
 
-		fetchCustomerPage(startAfter, modifiedAfter, limit) {
-			return new Promise((resolve, reject) => {
-				frappe.call({
-					method: "posawesome.posawesome.api.customers.get_customer_names",
-					args: {
-						pos_profile: this.pos_profile.pos_profile,
-						modified_after: modifiedAfter,
-						limit,
-						start_after: startAfter,
-					},
-					callback: (r) => resolve(r.message || []),
-					error: (err) => {
-						console.error("Failed to fetch customers", err);
-						reject(err);
-					},
-				});
-			});
-		},
+                        this.eventBus.on("set_customer_readonly", (value) => {
+                                this.customersStore.setReadonlyState(value);
+                        });
 
-		async get_customer_names() {
-			const localCount = await getCustomerStorageCount();
-			if (localCount > 0) {
-				this.customers_loaded = true;
-				await this.searchCustomers(this.searchTerm);
-				await this.verifyServerCustomerCount();
-				return;
-			}
-			const syncSince = getCustomersLastSync();
-			this.loadProgress = 0;
-			this.eventBus.emit("data-load-progress", { name: "customers", progress: 0 });
-			this.loadingCustomers = true;
-			try {
-				// Fetch total customer count for accurate progress
-				try {
-					const countRes = await frappe.call({
-						method: "posawesome.posawesome.api.customers.get_customers_count",
-						args: { pos_profile: this.pos_profile.pos_profile },
-					});
-					this.totalCustomerCount = countRes.message || 0;
-				} catch (e) {
-					console.error("Failed to fetch customer count", e);
-					this.totalCustomerCount = 0;
-				}
+                        this.eventBus.on("set_customer_info_to_edit", (data) => {
+                                this.customer_info = data;
+                        });
 
-				const rows = await this.fetchCustomerPage(null, syncSince, this.pageSize);
-				await setCustomerStorage(rows);
-				this.loadedCustomerCount = rows.length;
-				if (this.totalCustomerCount) {
-					this.loadProgress = Math.round(
-						(this.loadedCustomerCount / this.totalCustomerCount) * 100,
-					);
-					this.eventBus.emit("data-load-progress", {
-						name: "customers",
-						progress: this.loadProgress,
-					});
-				}
-				this.nextCustomerStart =
-					rows.length === this.pageSize ? rows[rows.length - 1]?.name || null : null;
-				if (this.nextCustomerStart) {
-					// Load remaining customers in the background
-					this.backgroundLoadCustomers(this.nextCustomerStart, syncSince);
-				} else {
-					setCustomersLastSync(new Date().toISOString());
-					this.loadProgress = 100;
-					this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-					this.eventBus.emit("data-loaded", "customers");
-				}
-				this.customers_loaded = true;
-			} catch (err) {
-				console.error("Failed to fetch customers:", err);
-			} finally {
-				this.loadingCustomers = false;
-				await this.searchCustomers(this.searchTerm);
-			}
-		},
+                });
+        },
 
-		new_customer() {
-			this.eventBus.emit("open_update_customer", null);
-		},
-
-		edit_customer() {
-			this.eventBus.emit("open_update_customer", this.customer_info);
-		},
-	},
-
-	created() {
-		memoryInitPromise.then(async () => {
-			await this.searchCustomers("");
-			this.effectiveReadonly = this.readonly && navigator.onLine;
-		});
-
-		this.searchDebounce = _.debounce(async (val) => {
-			this.searchTerm = val || "";
-			this.page = 0;
-			this.customers = [];
-			this.hasMore = true;
-			await this.searchCustomers(this.searchTerm);
-		}, 300);
-
-		this.effectiveReadonly = this.readonly && navigator.onLine;
-
-		this.$nextTick(() => {
-			this.eventBus.on("register_pos_profile", async (pos_profile) => {
-				await memoryInitPromise;
-				this.pos_profile = pos_profile;
-				await this.get_customer_names();
-			});
-
-			this.eventBus.on("payments_register_pos_profile", async (pos_profile) => {
-				await memoryInitPromise;
-				this.pos_profile = pos_profile;
-				await this.get_customer_names();
-			});
-
-			this.eventBus.on("set_customer", (customer) => {
-				this.customer = customer;
-				this.internalCustomer = customer;
-			});
-
-			this.eventBus.on("add_customer_to_list", async (customer) => {
-				const index = this.customers.findIndex((c) => c.name === customer.name);
-				if (index !== -1) {
-					this.customers.splice(index, 1, customer);
-				} else {
-					this.customers.push(customer);
-				}
-				await setCustomerStorage([customer]);
-				this.customer = customer.name;
-				this.internalCustomer = customer.name;
-				this.eventBus.emit("update_customer", customer.name);
-			});
-
-			this.eventBus.on("set_customer_readonly", (value) => {
-				this.readonly = value;
-			});
-
-			this.eventBus.on("set_customer_info_to_edit", (data) => {
-				this.customer_info = data;
-			});
-
-			this.eventBus.on("fetch_customer_details", async () => {
-				await this.get_customer_names();
-			});
-		});
-	},
+        beforeUnmount() {
+                if (this.unsubscribeSelectedCustomer) {
+                        this.unsubscribeSelectedCustomer();
+                        this.unsubscribeSelectedCustomer = null;
+                }
+                this.eventBus.off("register_pos_profile");
+                this.eventBus.off("payments_register_pos_profile");
+                this.eventBus.off("set_customer");
+                this.eventBus.off("add_customer_to_list");
+                this.eventBus.off("set_customer_readonly");
+                this.eventBus.off("set_customer_info_to_edit");
+        },
 };
 </script>
+

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -341,13 +341,15 @@ import invoiceWatchers from "./invoiceWatchers";
 import offerMethods from "./invoiceOfferMethods";
 import shortcutMethods from "./invoiceShortcuts";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
 
 export default {
         name: "POSInvoice",
         mixins: [format],
         setup() {
                 const invoiceStore = useInvoiceStore();
-                return { invoiceStore };
+                const customersStore = useCustomersStore();
+                return { invoiceStore, customersStore };
         },
         data() {
                 return {
@@ -370,12 +372,13 @@ export default {
 			posa_coupons: [], // Coupons applied
 			isApplyingOffer: false, // Flag to prevent offer watcher loops
 			allItems: [], // All items for offer logic
-			discount_percentage_offer_name: null, // Track which offer is applied
-			invoiceTypes: ["Invoice", "Order", "Quotation"], // Types of invoices
-			invoiceType: "Invoice", // Current invoice type
-			itemsPerPage: 1000, // Items per page in table
-			itemSearch: "", // Search query for added items
-			expanded: [], // Array of expanded row IDs
+                        discount_percentage_offer_name: null, // Track which offer is applied
+                        invoiceTypes: ["Invoice", "Order", "Quotation"], // Types of invoices
+                        invoiceType: "Invoice", // Current invoice type
+                        itemsPerPage: 1000, // Items per page in table
+                        itemSearch: "", // Search query for added items
+                        expanded: [], // Array of expanded row IDs
+                        unsubscribeCustomerSelection: null,
 			singleExpand: true, // Only one row expanded at a time
 			cancel_dialog: false, // Cancel dialog visibility
 			float_precision: 6, // Float precision for calculations
@@ -1283,19 +1286,13 @@ export default {
 			this.fetch_price_lists();
 			this.update_price_list();
 		});
-		this.eventBus.on("add_item", (item) => {
-			this.add_item(item);
-		});
-		this.eventBus.on("update_customer", (customer) => {
-			this.customer = customer;
-		});
-		this.eventBus.on("fetch_customer_details", () => {
-			this.fetch_customer_details();
-		});
-		this.eventBus.on("clear_invoice", () => {
-			this.clear_invoice();
-			this.eventBus.emit("focus_item_search");
-		});
+                this.eventBus.on("add_item", (item) => {
+                        this.add_item(item);
+                });
+                this.eventBus.on("clear_invoice", () => {
+                        this.clear_invoice();
+                        this.eventBus.emit("focus_item_search");
+                });
 		this.eventBus.on("load_invoice", (data) => {
 			this.load_invoice(data);
 		});
@@ -1358,12 +1355,22 @@ export default {
 				customer: this.customer,
 			});
 		});
-		this.eventBus.on("set_new_line", (data) => {
-			this.new_line = data;
-		});
-		if (this.pos_profile.posa_allow_multi_currency) {
-			this.fetch_available_currencies();
-		}
+                this.eventBus.on("set_new_line", (data) => {
+                        this.new_line = data;
+                });
+                this.unsubscribeCustomerSelection = this.$watch(
+                        () => this.customersStore.selectedCustomer,
+                        (customer) => {
+                                const normalized = customer || "";
+                                if (normalized !== this.customer) {
+                                        this.customer = normalized;
+                                }
+                        },
+                        { immediate: true },
+                );
+                if (this.pos_profile.posa_allow_multi_currency) {
+                        this.fetch_available_currencies();
+                }
 		// Listen for reset_posting_date to reset posting date after invoice submission
 		this.eventBus.on("reset_posting_date", () => {
 			this.posting_date = frappe.datetime.nowdate();
@@ -1381,13 +1388,15 @@ export default {
                 // Existing cleanup
                 this.eventBus.off("register_pos_profile");
                 this.eventBus.off("add_item");
-                this.eventBus.off("update_customer");
-                this.eventBus.off("fetch_customer_details");
                 this.eventBus.off("clear_invoice");
                 // Cleanup reset_posting_date listener
                 this.eventBus.off("reset_posting_date");
                 if (typeof this.cancelScheduledOfferRefresh === "function") {
                         this.cancelScheduledOfferRefresh();
+                }
+                if (this.unsubscribeCustomerSelection) {
+                        this.unsubscribeCustomerSelection();
+                        this.unsubscribeCustomerSelection = null;
                 }
         },
         // Register global keyboard shortcuts when component is created

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -570,6 +570,7 @@ import {
 } from "../../utils/stock.js";
 import placeholderImage from "./placeholder-image.png";
 import Skeleton from "../ui/Skeleton.vue";
+import { useCustomersStore } from "../../stores/customersStore.js";
 
 export default {
 	mixins: [format],
@@ -682,6 +683,9 @@ export default {
                 scanQueuedCode: "",
                 refreshInFlight: false,
                 clearingSearch: false,
+                customersStore: useCustomersStore(),
+                customer: null,
+                unsubscribeCustomerSelection: null,
         }),
 
         watch: {
@@ -3619,9 +3623,13 @@ export default {
 		this.eventBus.on("update_customer_price_list", (data) => {
 			this.customer_price_list = data;
 		});
-		this.eventBus.on("update_customer", (data) => {
-			this.customer = data;
-		});
+		this.unsubscribeCustomerSelection = this.$watch(
+			() => this.customersStore.selectedCustomer,
+			(customer) => {
+				this.customer = customer || null;
+			},
+			{ immediate: true },
+		);
 
 		this.eventBus.on("focus_item_search", () => {
 			this.focusItemSearch();
@@ -3795,7 +3803,10 @@ export default {
 		this.eventBus.off("update_offers_counters");
 		this.eventBus.off("update_coupons_counters");
 		this.eventBus.off("update_customer_price_list");
-		this.eventBus.off("update_customer");
+		if (this.unsubscribeCustomerSelection) {
+			this.unsubscribeCustomerSelection();
+			this.unsubscribeCustomerSelection = null;
+		}
                 this.eventBus.off("force_reload_items");
                 this.eventBus.off("focus_item_search");
                 window.removeEventListener("resize", this.checkItemContainerOverflow);

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -794,13 +794,15 @@ import {
 import renderOfflineInvoiceHTML from "../../../offline_print_template";
 import { silentPrint } from "../../plugins/print.js";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
 
 export default {
         // Using format mixin for shared formatting methods
         mixins: [format],
         setup() {
                 const invoiceStore = useInvoiceStore();
-                return { invoiceStore };
+                const customersStore = useCustomersStore();
+                return { invoiceStore, customersStore };
         },
         data() {
                 return {
@@ -835,8 +837,10 @@ export default {
 			sales_person: "", // Selected sales person
 			addresses: [], // List of customer addresses
 			is_user_editing_paid_change: false, // User interaction flag
-			highlightSubmit: false, // Highlight state for submit button
-		};
+                        highlightSubmit: false, // Highlight state for submit button
+                        lastCustomerName: null,
+                        unsubscribeCustomerSelection: null,
+                };
         },
         computed: {
                 invoice_doc: {
@@ -1165,13 +1169,13 @@ export default {
         },
         methods: {
 		// Go back to invoice view and reset customer readonly
-		back_to_invoice() {
-			this.eventBus.emit("show_payment", "false");
-			this.eventBus.emit("set_customer_readonly", false);
-			this.$nextTick(() => {
-				this.eventBus.emit("focus_item_search");
-			});
-		},
+                back_to_invoice() {
+                        this.eventBus.emit("show_payment", "false");
+                        this.customersStore.setReadonlyState(false);
+                        this.$nextTick(() => {
+                                this.eventBus.emit("focus_item_search");
+                        });
+                },
 		// Highlight and focus the submit button when payment screen opens
 		handleShowPayment(data) {
 			if (data === "true") {
@@ -2176,17 +2180,9 @@ export default {
 					this.is_credit_return = false;
 				}
 			});
-			this.eventBus.on("update_customer", (customer) => {
-				if (this.customer !== customer) {
-					this.customer_credit_dict = [];
-					this.redeem_customer_credit = false;
-					this.is_cashback = true;
-					this.is_credit_return = false;
-				}
-			});
-			this.eventBus.on("set_pos_settings", (data) => {
-				this.pos_settings = data;
-			});
+                        this.eventBus.on("set_pos_settings", (data) => {
+                                this.pos_settings = data;
+                        });
 			this.eventBus.on("set_customer_info_to_edit", (data) => {
 				this.customer_info = data;
 			});
@@ -2199,26 +2195,42 @@ export default {
 				this.is_return = false;
 				this.is_credit_return = false;
 			});
-			// Scroll to top when payment view is shown
-			this.eventBus.on("show_payment", this.handleShowPayment);
-		});
-	},
-	// Lifecycle hook: beforeUnmount
-	beforeUnmount() {
-		// Remove all event listeners
-		this.eventBus.off("send_invoice_doc_payment");
+                        // Scroll to top when payment view is shown
+                        this.eventBus.on("show_payment", this.handleShowPayment);
+                });
+                this.unsubscribeCustomerSelection = this.$watch(
+                        () => this.customersStore.selectedCustomer,
+                        (customer) => {
+                                if (customer !== this.lastCustomerName) {
+                                        this.customer_credit_dict = [];
+                                        this.redeem_customer_credit = false;
+                                        this.is_cashback = true;
+                                        this.is_credit_return = false;
+                                }
+                                this.lastCustomerName = customer || null;
+                        },
+                        { immediate: true },
+                );
+        },
+        // Lifecycle hook: beforeUnmount
+        beforeUnmount() {
+                // Remove all event listeners
+                this.eventBus.off("send_invoice_doc_payment");
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("add_the_new_address");
 		this.eventBus.off("update_invoice_type");
-		this.eventBus.off("update_customer");
-		this.eventBus.off("set_pos_settings");
-		this.eventBus.off("set_customer_info_to_edit");
-		this.eventBus.off("set_mpesa_payment");
-		this.eventBus.off("clear_invoice");
-		this.eventBus.off("network-online", this.syncPendingInvoices);
-		this.eventBus.off("server-online", this.syncPendingInvoices);
-		this.eventBus.off("show_payment", this.handleShowPayment);
-	},
+                this.eventBus.off("set_pos_settings");
+                this.eventBus.off("set_customer_info_to_edit");
+                this.eventBus.off("set_mpesa_payment");
+                this.eventBus.off("clear_invoice");
+                this.eventBus.off("network-online", this.syncPendingInvoices);
+                this.eventBus.off("server-online", this.syncPendingInvoices);
+                this.eventBus.off("show_payment", this.handleShowPayment);
+                if (this.unsubscribeCustomerSelection) {
+                        this.unsubscribeCustomerSelection();
+                        this.unsubscribeCustomerSelection = null;
+                }
+        },
 	// Lifecycle hook: unmounted
 	unmounted() {
 		// Remove keyboard shortcut listener

--- a/frontend/src/posapp/components/pos/Pos.vue
+++ b/frontend/src/posapp/components/pos/Pos.vue
@@ -66,6 +66,7 @@ import {
 import { getCurrentInstance } from "vue";
 import { usePosShift } from "../../composables/usePosShift.js";
 import { useOffers } from "../../composables/useOffers.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
 // Import the cache cleanup function
 import { clearExpiredCustomerBalances } from "../../../offline/index.js";
 import { useResponsive } from "../../composables/useResponsive.js";
@@ -85,15 +86,16 @@ export default {
 		return { ...responsive, ...rtl, ...shift, ...offers };
 	},
 	data: function () {
-		return {
-			dialog: false,
+                return {
+                        dialog: false,
 
-			payment: false,
-			showOffers: false,
-			coupons: false,
-			itemsLoaded: false,
-			customersLoaded: false,
-		};
+                        payment: false,
+                        showOffers: false,
+                        coupons: false,
+                        itemsLoaded: false,
+                        customersStore: useCustomersStore(),
+                        unsubscribeCustomersLoaded: null,
+                };
 	},
 
 	components: {
@@ -122,11 +124,11 @@ export default {
 				this.eventBus.emit("set_pos_settings", doc);
 			});
 		},
-		checkLoadingComplete() {
-			if (this.itemsLoaded && this.customersLoaded) {
-				console.info("Loading completed");
-			}
-		},
+                checkLoadingComplete() {
+                        if (this.itemsLoaded && this.customersStore.customersLoaded) {
+                                console.info("Loading completed");
+                        }
+                },
 	},
 
 	mounted: function () {
@@ -172,28 +174,36 @@ export default {
 				this.submit_closing_pos(data);
 			});
 
-			this.eventBus.on("items_loaded", () => {
-				this.itemsLoaded = true;
-				this.checkLoadingComplete();
-			});
-			this.eventBus.on("customers_loaded", () => {
-				this.customersLoaded = true;
-				this.checkLoadingComplete();
-			});
-		});
-	},
-	beforeUnmount() {
-		this.eventBus.off("close_opening_dialog");
-		this.eventBus.off("register_pos_data");
-		this.eventBus.off("register_pos_profile");
-		this.eventBus.off("LoadPosProfile");
-		this.eventBus.off("show_offers");
-		this.eventBus.off("show_coupons");
-		this.eventBus.off("open_closing_dialog");
-		this.eventBus.off("submit_closing_pos");
-		this.eventBus.off("items_loaded");
-		this.eventBus.off("customers_loaded");
-	},
+                        this.eventBus.on("items_loaded", () => {
+                                this.itemsLoaded = true;
+                                this.checkLoadingComplete();
+                        });
+                });
+                this.unsubscribeCustomersLoaded = this.$watch(
+                        () => this.customersStore.customersLoaded,
+                        (loaded) => {
+                                if (loaded) {
+                                        this.checkLoadingComplete();
+                                }
+                        },
+                        { immediate: true },
+                );
+        },
+        beforeUnmount() {
+                this.eventBus.off("close_opening_dialog");
+                this.eventBus.off("register_pos_data");
+                this.eventBus.off("register_pos_profile");
+                this.eventBus.off("LoadPosProfile");
+                this.eventBus.off("show_offers");
+                this.eventBus.off("show_coupons");
+                this.eventBus.off("open_closing_dialog");
+                this.eventBus.off("submit_closing_pos");
+                this.eventBus.off("items_loaded");
+                if (this.unsubscribeCustomersLoaded) {
+                        this.unsubscribeCustomersLoaded();
+                        this.unsubscribeCustomersLoaded = null;
+                }
+        },
 	// In the created() or mounted() lifecycle hook
 	created() {
 		// Clean up expired customer balance cache on POS load

--- a/frontend/src/posapp/components/pos/PosCoupons.vue
+++ b/frontend/src/posapp/components/pos/PosCoupons.vue
@@ -75,9 +75,14 @@
 
 <script>
 /* global __, frappe */
+import { useCustomersStore } from "../../stores/customersStore.js";
+
 export default {
-	data: () => ({
-		loading: false,
+        data: () => ({
+                customersStore: useCustomersStore(),
+                loading: false,
+                customer: null,
+                unsubscribeCustomerSelection: null,
 		pos_profile: "",
 		customer: "",
 		posa_coupons: [],
@@ -208,36 +213,46 @@ export default {
 		},
 	},
 
-	created: function () {
-		this.$nextTick(function () {
-			this.eventBus.on("register_pos_profile", (data) => {
-				this.pos_profile = data.pos_profile;
-			});
-		});
-		this.eventBus.on("update_customer", (customer) => {
-			if (this.customer != customer) {
-				const to_remove = [];
-				this.posa_coupons.forEach((el) => {
-					if (el.type == "Promotional") {
-						el.customer = customer;
-					} else {
-						to_remove.push(el.coupon);
-					}
-				});
-				this.customer = customer;
-				if (to_remove.length) {
-					this.removeCoupon(to_remove);
-				}
-			}
-			this.setActiveGiftCoupons();
-		});
-		this.eventBus.on("update_pos_coupons", (data) => {
-			this.updatePosCoupons(data);
-		});
-		this.eventBus.on("set_pos_coupons", (data) => {
-			this.posa_coupons = data;
-		});
-	},
+        created: function () {
+                this.$nextTick(function () {
+                        this.eventBus.on("register_pos_profile", (data) => {
+                                this.pos_profile = data.pos_profile;
+                        });
+                });
+                this.unsubscribeCustomerSelection = this.$watch(
+                        () => this.customersStore.selectedCustomer,
+                        (customer) => {
+                                if (this.customer !== customer) {
+                                        const to_remove = [];
+                                        this.posa_coupons.forEach((el) => {
+                                                if (el.type === "Promotional") {
+                                                        el.customer = customer;
+                                                } else {
+                                                        to_remove.push(el.coupon);
+                                                }
+                                        });
+                                        this.customer = customer;
+                                        if (to_remove.length) {
+                                                this.removeCoupon(to_remove);
+                                        }
+                                }
+                                this.setActiveGiftCoupons();
+                        },
+                        { immediate: true },
+                );
+                this.eventBus.on("update_pos_coupons", (data) => {
+                        this.updatePosCoupons(data);
+                });
+                this.eventBus.on("set_pos_coupons", (data) => {
+                        this.posa_coupons = data;
+                });
+        },
+        beforeUnmount() {
+                if (this.unsubscribeCustomerSelection) {
+                        this.unsubscribeCustomerSelection();
+                        this.unsubscribeCustomerSelection = null;
+                }
+        },
 };
 </script>
 

--- a/frontend/src/posapp/components/pos/PosOffers.vue
+++ b/frontend/src/posapp/components/pos/PosOffers.vue
@@ -91,18 +91,21 @@
 <script>
 /* global __, frappe */
 import format from "../../format";
+import { useCustomersStore } from "../../stores/customersStore.js";
 export default {
-	mixins: [format],
-	data: () => ({
-		loading: false,
+        mixins: [format],
+        data: () => ({
+                customersStore: useCustomersStore(),
+                loading: false,
+                customer: null,
 		pos_profile: "",
 		pos_offers: [],
 		allItems: [],
 		groupItemCache: {},
 		discount_percentage_offer_name: null,
 		itemsPerPage: 1000,
-		expanded: [],
-		singleExpand: true,
+                expanded: [],
+                singleExpand: true,
 		items_headers: [
 			{ title: __("Name"), value: "name", align: "start" },
 			{ title: __("Apply On"), value: "apply_on", align: "start" },
@@ -313,26 +316,37 @@ export default {
 		},
 	},
 
-	created: function () {
-		this.$nextTick(function () {
-			this.eventBus.on("register_pos_profile", (data) => {
-				this.pos_profile = data.pos_profile;
-			});
-		});
-		this.eventBus.on("update_customer", (customer) => {
-			if (this.customer != customer) {
-				this.offers = [];
-			}
-		});
-		this.eventBus.on("update_pos_offers", (data) => {
-			this.updatePosOffers(data);
-		});
+        created: function () {
+                this.$nextTick(function () {
+                        this.eventBus.on("register_pos_profile", (data) => {
+                                this.pos_profile = data.pos_profile;
+                        });
+                });
+                this.unsubscribeCustomerSelection = this.$watch(
+                        () => this.customersStore.selectedCustomer,
+                        (customer) => {
+                                if (this.customer !== customer) {
+                                        this.offers = [];
+                                        this.customer = customer;
+                                }
+                        },
+                        { immediate: true },
+                );
+                this.eventBus.on("update_pos_offers", (data) => {
+                        this.updatePosOffers(data);
+                });
 		this.eventBus.on("update_discount_percentage_offer_name", (data) => {
 			this.discount_percentage_offer_name = data.value;
 		});
-		this.eventBus.on("set_all_items", (data) => {
-			this.allItems = data;
-		});
-	},
+                this.eventBus.on("set_all_items", (data) => {
+                        this.allItems = data;
+                });
+        },
+        beforeUnmount() {
+                if (this.unsubscribeCustomerSelection) {
+                        this.unsubscribeCustomerSelection();
+                        this.unsubscribeCustomerSelection = null;
+                }
+        },
 };
 </script>

--- a/frontend/src/posapp/components/pos/UpdateCustomer.vue
+++ b/frontend/src/posapp/components/pos/UpdateCustomer.vue
@@ -210,10 +210,12 @@
 
 <script>
 import { isOffline, saveOfflineCustomer } from "../../../offline/index.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
 
 export default {
-	data: () => ({
-		customerDialog: false,
+        data: () => ({
+                customersStore: useCustomersStore(),
+                customerDialog: false,
 		confirmDialog: false,
 		pos_profile: "",
 		customer_id: "",
@@ -467,12 +469,12 @@ export default {
 				}
 			}
 		},
-		submit_dialog() {
-			const vm = this;
-			if (!this.customer_name) {
-				frappe.throw(__("Customer Name is required"));
-				return;
-			}
+                async submit_dialog() {
+                        const vm = this;
+                        if (!this.customer_name) {
+                                frappe.throw(__("Customer Name is required"));
+                                return;
+                        }
 
 			if (!this.group) {
 				frappe.throw(__("Customer group is required"));
@@ -560,15 +562,15 @@ export default {
 				method: this.customer_id ? "update" : "create",
 			};
 
-			if (isOffline()) {
-				saveOfflineCustomer({ args: apiArgs });
-				vm.eventBus.emit("show_message", { title: __("Customer saved offline"), color: "warning" });
-				args.name = this.customer_name;
-				vm.eventBus.emit("add_customer_to_list", args);
-				vm.eventBus.emit("set_customer", args.name);
-				vm.close_dialog();
-				return;
-			}
+                        if (isOffline()) {
+                                saveOfflineCustomer({ args: apiArgs });
+                                vm.eventBus.emit("show_message", { title: __("Customer saved offline"), color: "warning" });
+                                args.name = this.customer_name;
+                                await vm.customersStore.addOrUpdateCustomer(args);
+                                vm.customersStore.setSelectedCustomer(args.name);
+                                vm.close_dialog();
+                                return;
+                        }
 
 			frappe.call({
 				method: "posawesome.posawesome.api.customers.create_customer",
@@ -583,13 +585,13 @@ export default {
 							title: text,
 							color: "success",
 						});
-						args.name = r.message.name;
-						frappe.utils.play_sound("submit");
-						vm.eventBus.emit("add_customer_to_list", args);
-						vm.eventBus.emit("set_customer", r.message.name);
-						vm.eventBus.emit("fetch_customer_details");
-						vm.close_dialog();
-					} else {
+                                                args.name = r.message.name;
+                                                frappe.utils.play_sound("submit");
+                                                await vm.customersStore.addOrUpdateCustomer(args);
+                                                vm.customersStore.setSelectedCustomer(r.message.name);
+                                                await vm.customersStore.refreshCustomers();
+                                                vm.close_dialog();
+                                        } else {
 						frappe.utils.play_sound("error");
 						vm.eventBus.emit("show_message", {
 							title: __("Customer creation failed."),

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -169,11 +169,11 @@ export default {
 			// Only set customer readonly if this is a return with reference to an invoice
 			if (data.return_against) {
 				console.log("Return has reference to invoice:", data.return_against);
-				this.eventBus.emit("set_customer_readonly", true);
+				this.customersStore.setReadonlyState(true);
 			} else {
 				console.log("Return without invoice reference, customer can be selected");
 				// Allow customer selection for returns without invoice
-				this.eventBus.emit("set_customer_readonly", false);
+				this.customersStore.setReadonlyState(false);
 			}
 			this.invoiceType = "Return";
 			this.invoiceTypes = ["Return"];
@@ -286,7 +286,7 @@ export default {
 	// Start a new order (or return order) with provided data
 	async new_order(data = {}) {
 		let old_invoice = null;
-		this.eventBus.emit("set_customer_readonly", false);
+		this.customersStore.setReadonlyState(false);
 		this.expanded = [];
 		this.posa_offers = [];
 		this.eventBus.emit("set_pos_coupons", []);
@@ -305,10 +305,10 @@ export default {
 				// For return without invoice case, check if there's a return_against
 				// Only set customer readonly if this is a return with reference to an invoice
 				if (data.return_against) {
-					this.eventBus.emit("set_customer_readonly", true);
+					this.customersStore.setReadonlyState(true);
 				} else {
 					// Allow customer selection for returns without invoice
-					this.eventBus.emit("set_customer_readonly", false);
+					this.customersStore.setReadonlyState(false);
 				}
 				this.invoiceType = "Return";
 				this.invoiceTypes = ["Return"];

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -3,13 +3,15 @@ import { clearPriceListCache } from "../../../offline/index.js";
 
 export default {
 	// Watch for customer change and update related data
-	customer() {
-		this.close_payments();
-		this.eventBus.emit("set_customer", this.customer);
-		this.fetch_customer_details();
-		this.fetch_customer_balance();
-		this.set_delivery_charges();
-	},
+        customer() {
+                this.close_payments();
+                if (this.customersStore) {
+                        this.customersStore.setSelectedCustomer(this.customer || "");
+                }
+                this.fetch_customer_details();
+                this.fetch_customer_balance();
+                this.set_delivery_charges();
+        },
 	// Watch for customer_info change and emit to edit form
 	customer_info() {
 		this.eventBus.emit("set_customer_info_to_edit", this.customer_info);

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -3,9 +3,12 @@ import _ from "lodash";
 import { useBundles } from "./useBundles.js";
 import { withPerf } from "../utils/perf.js";
 
+import { useCustomersStore } from "../stores/customersStore.js";
+
 /* global frappe, __ */
 
 export function useItemAddition() {
+        const customersStore = useCustomersStore();
         const runAsyncTask = (task, contextLabel) => {
                 Promise.resolve().then(() => {
                         try {
@@ -496,7 +499,7 @@ export function useItemAddition() {
 		// Always reset to default customer after invoice
 		context.customer = context.pos_profile.customer;
 
-		context.eventBus.emit("set_customer_readonly", false);
+		customersStore.setReadonlyState(false);
 		context.invoiceType = context.pos_profile.posa_default_sales_order ? "Order" : "Invoice";
 		context.invoiceTypes = ["Invoice", "Order", "Quotation"];
 

--- a/frontend/src/posapp/stores/customersStore.js
+++ b/frontend/src/posapp/stores/customersStore.js
@@ -1,0 +1,404 @@
+/**
+ * Pinia store responsible for managing customer state in the POS.
+ * Extracted from the legacy Customer component so that other modules
+ * can subscribe to the same source of truth instead of relying on the
+ * global event bus.
+ */
+
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import debounce from 'lodash/debounce';
+import {
+    db,
+    checkDbHealth,
+    setCustomerStorage,
+    memoryInitPromise,
+    getCustomersLastSync,
+    setCustomersLastSync,
+    getCustomerStorageCount,
+    clearCustomerStorage,
+    isOffline
+} from '../../offline/index.js';
+
+const DEFAULT_PAGE_SIZE = 200;
+
+export const useCustomersStore = defineStore('customers', () => {
+    const posProfile = ref(null);
+    const customers = ref([]);
+    const customersLoaded = ref(false);
+    const loadingCustomers = ref(false);
+    const isCustomerBackgroundLoading = ref(false);
+    const pendingCustomerSearch = ref(null);
+
+    const searchTerm = ref('');
+    const page = ref(0);
+    const pageSize = ref(DEFAULT_PAGE_SIZE);
+    const hasMore = ref(true);
+    const nextCustomerStart = ref(null);
+
+    const loadProgress = ref(0);
+    const totalCustomerCount = ref(0);
+    const loadedCustomerCount = ref(0);
+
+    const selectedCustomer = ref('');
+    const readonly = ref(false);
+    const effectiveReadonly = ref(false);
+
+    const isInitialized = ref(false);
+    const searchHandler = ref(null);
+
+    const filteredCustomers = computed(() => {
+        return isCustomerBackgroundLoading.value ? [] : customers.value;
+    });
+
+    const updateEffectiveReadonly = () => {
+        effectiveReadonly.value = readonly.value && navigator.onLine;
+    };
+
+    const ensureSearchHandler = () => {
+        if (!searchHandler.value) {
+            searchHandler.value = debounce(async (term) => {
+                await performSearch(term ?? '');
+            }, 300);
+        }
+        return searchHandler.value;
+    };
+
+    const resetSearchState = (term = '') => {
+        searchTerm.value = term ?? '';
+        page.value = 0;
+        hasMore.value = true;
+        customers.value = [];
+    };
+
+    const ensureDatabaseReady = async () => {
+        await memoryInitPromise;
+        await checkDbHealth();
+        if (!db.isOpen()) {
+            await db.open();
+        }
+    };
+
+    const searchCustomers = async (term = searchTerm.value, append = false) => {
+        await ensureDatabaseReady();
+
+        const normalizedTerm = typeof term === 'string' ? term.trim().toLowerCase() : '';
+        let collection = db.table('customers');
+
+        if (normalizedTerm) {
+            const searchParts = normalizedTerm.split(/\s+/).filter(Boolean);
+            collection = collection.filter((customer) => {
+                if (!customer) {
+                    return false;
+                }
+
+                const values = [
+                    customer.customer_name,
+                    customer.name,
+                    customer.mobile_no,
+                    customer.email_id,
+                    customer.tax_id
+                ]
+                    .filter((value) => value !== null && value !== undefined)
+                    .map((value) => String(value).toLowerCase());
+
+                if (!searchParts.length) {
+                    return true;
+                }
+
+                return searchParts.every((part) => values.some((value) => value.includes(part)));
+            });
+        }
+
+        const offset = append ? page.value * pageSize.value : 0;
+        const results = await collection.offset(offset).limit(pageSize.value).toArray();
+
+        if (append) {
+            customers.value = [...customers.value, ...results];
+        } else {
+            customers.value = results;
+        }
+
+        hasMore.value = results.length === pageSize.value;
+        if (hasMore.value) {
+            page.value += 1;
+        }
+
+        return results.length;
+    };
+
+    const performSearch = async (term) => {
+        const normalized = typeof term === 'string' ? term : '';
+        resetSearchState(normalized);
+        return searchCustomers(normalized, false);
+    };
+
+    const queueSearch = (term) => {
+        if (isCustomerBackgroundLoading.value) {
+            pendingCustomerSearch.value = term ?? '';
+            return;
+        }
+        ensureSearchHandler()(term);
+    };
+
+    const loadMoreCustomers = async () => {
+        if (loadingCustomers.value) {
+            return;
+        }
+        const count = await searchCustomers(searchTerm.value, true);
+        if (count === pageSize.value) {
+            return;
+        }
+        if (nextCustomerStart.value) {
+            await backgroundLoadCustomers(nextCustomerStart.value, getCustomersLastSync());
+            await searchCustomers(searchTerm.value, true);
+        }
+    };
+
+    const fetchCustomerPage = (startAfter, modifiedAfter, limit) => {
+        return new Promise((resolve, reject) => {
+            frappe.call({
+                method: 'posawesome.posawesome.api.customers.get_customer_names',
+                args: {
+                    pos_profile: posProfile.value?.pos_profile,
+                    modified_after: modifiedAfter,
+                    limit,
+                    start_after: startAfter
+                },
+                callback: (r) => resolve(r.message || []),
+                error: (err) => {
+                    console.error('Failed to fetch customers', err);
+                    reject(err);
+                }
+            });
+        });
+    };
+
+    const backgroundLoadCustomers = async (startAfter, syncSince) => {
+        if (!posProfile.value) {
+            return;
+        }
+
+        const limit = pageSize.value;
+        isCustomerBackgroundLoading.value = true;
+        try {
+            let cursor = startAfter;
+            while (cursor) {
+                const rows = await fetchCustomerPage(cursor, syncSince, limit);
+                await setCustomerStorage(rows);
+                loadedCustomerCount.value += rows.length;
+                if (totalCustomerCount.value) {
+                    const progress = Math.min(
+                        99,
+                        Math.round((loadedCustomerCount.value / totalCustomerCount.value) * 100)
+                    );
+                    loadProgress.value = progress;
+                }
+                if (rows.length === limit) {
+                    cursor = rows[rows.length - 1]?.name || null;
+                    nextCustomerStart.value = cursor;
+                } else {
+                    cursor = null;
+                    nextCustomerStart.value = null;
+                    setCustomersLastSync(new Date().toISOString());
+                    loadProgress.value = 100;
+                }
+            }
+        } catch (err) {
+            console.error('Failed to background load customers', err);
+        } finally {
+            isCustomerBackgroundLoading.value = false;
+            if (pendingCustomerSearch.value !== null) {
+                const term = pendingCustomerSearch.value;
+                pendingCustomerSearch.value = null;
+                await performSearch(term);
+            }
+        }
+    };
+
+    const verifyServerCustomerCount = async () => {
+        if (!posProfile.value || isOffline()) {
+            return;
+        }
+        try {
+            const localCount = await getCustomerStorageCount();
+            const res = await frappe.call({
+                method: 'posawesome.posawesome.api.customers.get_customers_count',
+                args: { pos_profile: posProfile.value.pos_profile }
+            });
+            const serverCount = res.message || 0;
+            if (typeof serverCount === 'number') {
+                totalCustomerCount.value = serverCount;
+                loadedCustomerCount.value = localCount;
+                loadProgress.value = serverCount ? Math.round((localCount / serverCount) * 100) : 0;
+                if (serverCount > localCount) {
+                    const syncSince = getCustomersLastSync();
+                    const rows = await fetchCustomerPage(null, syncSince, pageSize.value);
+                    await setCustomerStorage(rows);
+                    loadedCustomerCount.value += rows.length;
+                    if (totalCustomerCount.value) {
+                        loadProgress.value = Math.round(
+                            (loadedCustomerCount.value / totalCustomerCount.value) * 100
+                        );
+                    }
+                    const startAfter = rows.length === pageSize.value ? rows[rows.length - 1]?.name || null : null;
+                    if (startAfter) {
+                        backgroundLoadCustomers(startAfter, syncSince);
+                    } else {
+                        setCustomersLastSync(new Date().toISOString());
+                        loadProgress.value = 100;
+                    }
+                    await searchCustomers(searchTerm.value);
+                } else if (serverCount < localCount) {
+                    await clearCustomerStorage();
+                    setCustomersLastSync(null);
+                    customers.value = [];
+                    customersLoaded.value = false;
+                    await getCustomerNames();
+                }
+            }
+        } catch (err) {
+            console.error('Error verifying customer count:', err);
+        }
+    };
+
+    const getCustomerNames = async () => {
+        if (!posProfile.value) {
+            return;
+        }
+
+        const localCount = await getCustomerStorageCount();
+        if (localCount > 0) {
+            customersLoaded.value = true;
+            await performSearch(searchTerm.value);
+            await verifyServerCustomerCount();
+            return;
+        }
+
+        const syncSince = getCustomersLastSync();
+        loadProgress.value = 0;
+        loadingCustomers.value = true;
+        try {
+            try {
+                const countRes = await frappe.call({
+                    method: 'posawesome.posawesome.api.customers.get_customers_count',
+                    args: { pos_profile: posProfile.value.pos_profile }
+                });
+                totalCustomerCount.value = countRes.message || 0;
+            } catch (e) {
+                console.error('Failed to fetch customer count', e);
+                totalCustomerCount.value = 0;
+            }
+
+            const rows = await fetchCustomerPage(null, syncSince, pageSize.value);
+            await setCustomerStorage(rows);
+            loadedCustomerCount.value = rows.length;
+            if (totalCustomerCount.value) {
+                loadProgress.value = Math.round(
+                    (loadedCustomerCount.value / totalCustomerCount.value) * 100
+                );
+            }
+
+            nextCustomerStart.value = rows.length === pageSize.value ? rows[rows.length - 1]?.name || null : null;
+            if (nextCustomerStart.value) {
+                backgroundLoadCustomers(nextCustomerStart.value, syncSince);
+            } else {
+                setCustomersLastSync(new Date().toISOString());
+                loadProgress.value = 100;
+            }
+            customersLoaded.value = true;
+        } catch (err) {
+            console.error('Failed to fetch customers:', err);
+        } finally {
+            loadingCustomers.value = false;
+            await performSearch(searchTerm.value);
+        }
+    };
+
+    const initialize = async () => {
+        if (isInitialized.value) {
+            return;
+        }
+        await ensureDatabaseReady();
+        await searchCustomers('');
+        updateEffectiveReadonly();
+        isInitialized.value = true;
+    };
+
+    const setPosProfile = async (profile) => {
+        posProfile.value = profile;
+        if (profile) {
+            await initialize();
+            await getCustomerNames();
+        }
+    };
+
+    const setSelectedCustomer = (customerName) => {
+        selectedCustomer.value = customerName || '';
+    };
+
+    const addOrUpdateCustomer = async (customer) => {
+        if (!customer) {
+            return;
+        }
+        const index = customers.value.findIndex((c) => c.name === customer.name);
+        if (index !== -1) {
+            const updated = [...customers.value];
+            updated.splice(index, 1, customer);
+            customers.value = updated;
+        } else {
+            customers.value = [...customers.value, customer];
+        }
+        await setCustomerStorage([customer]);
+        setSelectedCustomer(customer.name);
+    };
+
+    const setReadonlyState = (value) => {
+        readonly.value = Boolean(value);
+        updateEffectiveReadonly();
+    };
+
+    const refreshCustomers = async () => {
+        await getCustomerNames();
+    };
+
+    return {
+        // state
+        posProfile,
+        customers,
+        customersLoaded,
+        loadingCustomers,
+        isCustomerBackgroundLoading,
+        pendingCustomerSearch,
+        searchTerm,
+        page,
+        pageSize,
+        hasMore,
+        nextCustomerStart,
+        loadProgress,
+        totalCustomerCount,
+        loadedCustomerCount,
+        selectedCustomer,
+        readonly,
+        effectiveReadonly,
+
+        // computed
+        filteredCustomers,
+
+        // actions
+        initialize,
+        setPosProfile,
+        searchCustomers,
+        performSearch,
+        queueSearch,
+        loadMoreCustomers,
+        verifyServerCustomerCount,
+        getCustomerNames,
+        backgroundLoadCustomers,
+        fetchCustomerPage,
+        setSelectedCustomer,
+        addOrUpdateCustomer,
+        setReadonlyState,
+        refreshCustomers
+    };
+});

--- a/frontend/src/posapp/stores/index.js
+++ b/frontend/src/posapp/stores/index.js
@@ -8,6 +8,7 @@ import { createPinia } from 'pinia';
 export const pinia = createPinia();
 
 // Export stores
+export { useCustomersStore } from './customersStore.js';
 export { useItemsStore } from './itemsStore.js';
 export { useInvoiceStore } from './invoiceStore.js';
 export { useUpdateStore, formatBuildVersion } from './updateStore.js';


### PR DESCRIPTION
## Summary
- add a dedicated Pinia store that manages customer caching, paging, selection and sync progress
- migrate customer consuming views to read/write through the store instead of relying on the global event bus
- update supporting utilities and screens to react to the store (loading indicators, readonly flags, refresh flows)

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddeb42b034832685fef0db155018bf