### PR TITLE
refactor: centralize customer state in store

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -65,28 +65,35 @@ import {
 } from "../offline/index.js";
 import { silentPrint } from "./plugins/print.js";
 import {
-	setupNetworkListeners,
-	checkNetworkConnectivity,
-	detectHostType,
-	performConnectivityChecks,
-	checkFrappePing,
-	checkCurrentOrigin,
-	checkExternalConnectivity,
-	checkWebSocketConnectivity,
+        setupNetworkListeners,
+        checkNetworkConnectivity,
+        detectHostType,
+        performConnectivityChecks,
+        checkFrappePing,
+        checkCurrentOrigin,
+        checkExternalConnectivity,
+        checkWebSocketConnectivity,
 } from "./composables/useNetwork.js";
 import { useRtl } from "./composables/useRtl.js";
+import { useCustomersStore } from "./stores/customersStore.js";
+import { storeToRefs } from "pinia";
 
 export default {
-	setup() {
-		const { isRtl, rtlStyles, rtlClasses } = useRtl();
-		const { overlayVisible } = useLoading();
-		return {
-			isRtl,
-			rtlStyles,
-			rtlClasses,
-			globalLoading: overlayVisible,
-		};
-	},
+        setup() {
+                const { isRtl, rtlStyles, rtlClasses } = useRtl();
+                const { overlayVisible } = useLoading();
+                const customersStore = useCustomersStore();
+                const { loadProgress: customerLoadProgress, customersLoaded } = storeToRefs(customersStore);
+                return {
+                        isRtl,
+                        rtlStyles,
+                        rtlClasses,
+                        globalLoading: overlayVisible,
+                        customersStore,
+                        customerLoadProgress,
+                        customersLoaded,
+                };
+        },
 	data: function () {
 		return {
 			page: "POS",
@@ -156,11 +163,31 @@ export default {
 		// Initialize cache ready state early from stored value
 		this.cacheReady = isCacheReady();
 		initLoadingSources(["init", "items", "customers"]);
-		this.initializeData();
-		this.setupNetworkListeners();
-		this.setupEventListeners();
-		this.handleRefreshCacheUsage();
-	},
+                this.initializeData();
+                this.setupNetworkListeners();
+                this.setupEventListeners();
+                this.handleRefreshCacheUsage();
+                this.unwatchCustomerProgress = this.$watch(
+                        () => this.customerLoadProgress,
+                        (val) => {
+                                if (typeof val === "number") {
+                                        setSourceProgress("customers", val);
+                                }
+                        },
+                );
+                this.unwatchCustomerLoaded = this.$watch(
+                        () => this.customersLoaded,
+                        (val) => {
+                                if (val) {
+                                        markSourceLoaded("customers");
+                                }
+                        },
+                        { immediate: true },
+                );
+                if (typeof this.customerLoadProgress === "number") {
+                        setSourceProgress("customers", this.customerLoadProgress);
+                }
+        },
 	methods: {
 		setupNetworkListeners,
 		checkNetworkConnectivity,
@@ -242,12 +269,16 @@ export default {
 					this.lastInvoiceId = invoiceId;
 				});
 
-				this.eventBus.on("data-loaded", (name) => {
-					markSourceLoaded(name);
-				});
-				this.eventBus.on("data-load-progress", ({ name, progress }) => {
-					setSourceProgress(name, progress);
-				});
+                                this.eventBus.on("data-loaded", (name) => {
+                                        if (name !== "customers") {
+                                                markSourceLoaded(name);
+                                        }
+                                });
+                                this.eventBus.on("data-load-progress", ({ name, progress }) => {
+                                        if (name !== "customers") {
+                                                setSourceProgress(name, progress);
+                                        }
+                                });
 
 				// Allow other components to trigger printing
 				this.eventBus.on("print_last_invoice", () => {
@@ -471,12 +502,20 @@ export default {
 			});
 		},
 	},
-	beforeUnmount() {
-		if (this.eventBus) {
-			this.eventBus.off("pending_invoices_changed");
-			this.eventBus.off("data-loaded");
-		}
-	},
+        beforeUnmount() {
+                if (this.eventBus) {
+                        this.eventBus.off("pending_invoices_changed");
+                        this.eventBus.off("data-loaded");
+                }
+                if (typeof this.unwatchCustomerProgress === "function") {
+                        this.unwatchCustomerProgress();
+                        this.unwatchCustomerProgress = null;
+                }
+                if (typeof this.unwatchCustomerLoaded === "function") {
+                        this.unwatchCustomerLoaded();
+                        this.unwatchCustomerLoaded = null;
+                }
+        },
 	created: function () {
 		setTimeout(() => {
 			this.remove_frappe_nav();

--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -390,17 +390,24 @@ import {
 } from "../../../offline/index.js";
 import { silentPrint } from "../../plugins/print.js";
 import { useRtl } from "../../composables/useRtl.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
 
 export default {
 	mixins: [format],
-	setup() {
-		const { isRtl, rtlStyles, rtlClasses } = useRtl();
-		return {
-			isRtl,
-			rtlStyles,
-			rtlClasses,
-		};
-	},
+        setup() {
+                const { isRtl, rtlStyles, rtlClasses } = useRtl();
+                const customersStore = useCustomersStore();
+                const { selectedCustomer, customerRefreshKey } = storeToRefs(customersStore);
+                return {
+                        isRtl,
+                        rtlStyles,
+                        rtlClasses,
+                        customersStore,
+                        selectedCustomer,
+                        customerRefreshKey,
+                };
+        },
 	data: function () {
 		return {
 			dialog: false,
@@ -551,12 +558,30 @@ export default {
 		};
 	},
 
-	components: {
-		Customer,
-		UpdateCustomer,
-	},
+        components: {
+                Customer,
+                UpdateCustomer,
+        },
 
-	methods: {
+        watch: {
+                selectedCustomer(newVal, oldVal) {
+                        if (newVal && newVal !== oldVal) {
+                                this.clear_all(true);
+                                this.customer_name = newVal;
+                                this.fetch_customer_details();
+                                this.get_outstanding_invoices();
+                                this.get_unallocated_payments();
+                                this.get_draft_mpesa_payments_register();
+                        }
+                },
+                customerRefreshKey() {
+                        if (this.selectedCustomer) {
+                                this.fetch_customer_details();
+                        }
+                },
+        },
+
+        methods: {
 		async check_opening_entry() {
 			var vm = this;
 			await initPromise;
@@ -662,22 +687,22 @@ export default {
 			if (isOffline()) {
 				try {
 					const list = await getCustomerStorage();
-					const cached = (list || []).find(
-						(c) => c.name === vm.customer_name || c.customer_name === vm.customer_name,
-					);
-					if (cached) {
-						vm.customer_info = { ...cached };
-						vm.set_mpesa_search_params();
-						vm.eventBus.emit("set_customer_info_to_edit", vm.customer_info);
-						return;
-					}
+                                const cached = (list || []).find(
+                                        (c) => c.name === vm.customer_name || c.customer_name === vm.customer_name,
+                                );
+                                if (cached) {
+                                        vm.customer_info = { ...cached };
+                                        vm.set_mpesa_search_params();
+                                        vm.customersStore.setCustomerInfo(vm.customer_info);
+                                        return;
+                                }
 					const queued = (getOfflineCustomers() || [])
 						.map((e) => e.args)
 						.find((c) => c.customer_name === vm.customer_name);
 					if (queued) {
-						vm.customer_info = { ...queued, name: queued.customer_name };
-						vm.set_mpesa_search_params();
-						vm.eventBus.emit("set_customer_info_to_edit", vm.customer_info);
+                                        vm.customer_info = { ...queued, name: queued.customer_name };
+                                        vm.set_mpesa_search_params();
+                                        vm.customersStore.setCustomerInfo(vm.customer_info);
 					}
 				} catch (error) {
 					console.error("Failed to fetch cached customer", error);
@@ -693,26 +718,26 @@ export default {
 					},
 				});
 				const message = r.message;
-				if (!r.exc) {
-					vm.customer_info = {
-						...message,
-					};
-					vm.set_mpesa_search_params();
-					vm.eventBus.emit("set_customer_info_to_edit", vm.customer_info);
-				}
+                                if (!r.exc) {
+                                        vm.customer_info = {
+                                                ...message,
+                                        };
+                                        vm.set_mpesa_search_params();
+                                        vm.customersStore.setCustomerInfo(vm.customer_info);
+                                }
 			} catch (error) {
 				console.error("Failed to fetch customer details", error);
 			}
 		},
-		onInvoiceSelected(event) {
-			if (event && event.item && event.item.customer) {
-				this.eventBus.emit("set_customer", event.item.customer);
-				// Force UI to update total calculations
-				this.$nextTick(() => {
-					this.$forceUpdate();
-				});
-			}
-		},
+                onInvoiceSelected(event) {
+                        if (event && event.item && event.item.customer) {
+                                this.customersStore.setSelectedCustomer(event.item.customer);
+                                // Force UI to update total calculations
+                                this.$nextTick(() => {
+                                        this.$forceUpdate();
+                                });
+                        }
+                },
 		get_outstanding_invoices() {
 			this.invoices_loading = true;
 			// Reset selection completely
@@ -1062,9 +1087,9 @@ export default {
 				// Add this invoice to selection - support multiple selection
 				this.selected_invoices.push(item);
 
-				if (item.customer && !this.customer_name) {
-					this.eventBus.emit("set_customer", item.customer);
-				}
+                                if (item.customer && !this.customer_name) {
+                                        this.customersStore.setSelectedCustomer(item.customer);
+                                }
 			}
 
 			// Force UI update
@@ -1189,28 +1214,15 @@ export default {
 		this.eventBus.on("server-online", this.syncPendingPayments);
 	},
 
-	mounted: function () {
-		this.$nextTick(function () {
-			this.check_opening_entry();
-			this.eventBus.on("update_customer", (customer_name) => {
-				this.clear_all(true);
-				this.customer_name = customer_name;
-				this.fetch_customer_details();
-				this.get_outstanding_invoices();
-				this.get_unallocated_payments();
-				this.get_draft_mpesa_payments_register();
-			});
-			this.eventBus.on("fetch_customer_details", () => {
-				this.fetch_customer_details();
-			});
-		});
-	},
-	beforeUnmount() {
-		this.eventBus.off("update_customer");
-		this.eventBus.off("fetch_customer_details");
-		this.eventBus.off("network-online", this.syncPendingPayments);
-		this.eventBus.off("server-online", this.syncPendingPayments);
-	},
+        mounted: function () {
+                this.$nextTick(function () {
+                        this.check_opening_entry();
+                });
+        },
+        beforeUnmount() {
+                this.eventBus.off("network-online", this.syncPendingPayments);
+                this.eventBus.off("server-online", this.syncPendingPayments);
+        },
 };
 </script>
 

--- a/frontend/src/posapp/components/pos/Customer.vue
+++ b/frontend/src/posapp/components/pos/Customer.vue
@@ -143,78 +143,67 @@
 /* global frappe __ */
 import UpdateCustomer from "./UpdateCustomer.vue";
 import Skeleton from "../ui/Skeleton.vue";
-import {
-	db,
-	checkDbHealth,
-	setCustomerStorage,
-	memoryInitPromise,
-	getCustomersLastSync,
-	setCustomersLastSync,
-	getCustomerStorageCount,
-	clearCustomerStorage,
-	isOffline,
-} from "../../../offline/index.js";
 import _ from "lodash";
+import { memoryInitPromise } from "../../../offline/index.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
 
 export default {
-	props: {
-		pos_profile: Object,
-	},
+        props: {
+                pos_profile: Object,
+        },
 
-	data: () => ({
-		pos_profile: "",
-		customers: [],
-		customer: "",
-		internalCustomer: null,
-		tempSelectedCustomer: null,
-		isMenuOpen: false,
-		readonly: false,
-		effectiveReadonly: false,
-		customer_info: {},
-		loadingCustomers: false,
-		customers_loaded: false,
-		searchTerm: "",
-		page: 0,
-		pageSize: 200,
-		hasMore: true,
-		nextCustomerStart: null,
-		searchDebounce: null,
-		// Track background loading state and pending searches
-		isCustomerBackgroundLoading: false,
-		pendingCustomerSearch: null,
-		loadProgress: 0,
-		totalCustomerCount: 0,
-		loadedCustomerCount: 0,
-	}),
+        components: {
+                UpdateCustomer,
+                Skeleton,
+        },
 
-	components: {
-		UpdateCustomer,
-		Skeleton,
-	},
+        setup() {
+                const customersStore = useCustomersStore();
+                const storeRefs = storeToRefs(customersStore);
 
-	computed: {
-		filteredCustomers() {
-			return this.isCustomerBackgroundLoading ? [] : this.customers;
-		},
-	},
+                return {
+                        customersStore,
+                        ...storeRefs,
+                };
+        },
 
-	watch: {
-		readonly(val) {
-			this.effectiveReadonly = val && navigator.onLine;
-		},
-		customers_loaded(val) {
-			if (val) {
-				this.eventBus.emit("customers_loaded");
-			}
-		},
-	},
+        data: () => ({
+                internalCustomer: null,
+                tempSelectedCustomer: null,
+                isMenuOpen: false,
+                searchDebounce: null,
+        }),
 
-	methods: {
-		// Called when dropdown opens or closes
-		onCustomerMenuToggle(isOpen) {
-			this.isMenuOpen = isOpen;
+        watch: {
+                pos_profile: {
+                        immediate: true,
+                        handler(val) {
+                                if (val) {
+                                        const currentProfile = this.customersStore.posProfile;
+                                        this.customersStore.setPosProfile(val);
+                                        if (!currentProfile || currentProfile?.name !== val?.name) {
+                                                this.customersStore.get_customer_names();
+                                        }
+                                }
+                        },
+                },
+                selectedCustomer: {
+                        immediate: true,
+                        handler(val) {
+                                if (!this.isMenuOpen) {
+                                        this.internalCustomer = val || null;
+                                }
+                        },
+                },
+        },
 
-			if (isOpen) {
+        methods: {
+                // Called when dropdown opens or closes
+                onCustomerMenuToggle(isOpen) {
+                        this.isMenuOpen = isOpen;
+
+                        if (isOpen) {
 				this.internalCustomer = null;
 
 				this.$nextTick(() => {
@@ -228,24 +217,23 @@ export default {
 						}
 					}, 50);
 				});
-			} else {
-				const dropdown = this.$refs.customerDropdown?.$el?.querySelector(
-					".v-overlay__content .v-select-list",
-				);
-				if (dropdown) {
-					dropdown.removeEventListener("scroll", this.onCustomerScroll);
-				}
-				if (this.tempSelectedCustomer) {
-					this.internalCustomer = this.tempSelectedCustomer;
-					this.customer = this.tempSelectedCustomer;
-					this.eventBus.emit("update_customer", this.customer);
-				} else if (this.customer) {
-					this.internalCustomer = this.customer;
-				}
+                        } else {
+                                const dropdown = this.$refs.customerDropdown?.$el?.querySelector(
+                                        ".v-overlay__content .v-select-list",
+                                );
+                                if (dropdown) {
+                                        dropdown.removeEventListener("scroll", this.onCustomerScroll);
+                                }
+                                if (this.tempSelectedCustomer) {
+                                        this.internalCustomer = this.tempSelectedCustomer;
+                                        this.customersStore.setSelectedCustomer(this.tempSelectedCustomer);
+                                } else if (this.selectedCustomer) {
+                                        this.internalCustomer = this.selectedCustomer;
+                                }
 
-				this.tempSelectedCustomer = null;
-			}
-		},
+                                this.tempSelectedCustomer = null;
+                        }
+                },
 
 		onCustomerScroll(e) {
 			const el = e.target;
@@ -268,363 +256,103 @@ export default {
 				}
 			}
 			this.isMenuOpen = false;
-		},
+                },
 
-		// Called when a customer is selected
-		onCustomerChange(val) {
-			// if user selects the same customer again, show a meaningful error
-			if (val && val === this.customer) {
-				// keep the current selection and notify the user
-				this.internalCustomer = this.customer;
-				this.eventBus.emit("show_message", {
-					title: __("Customer already selected"),
-					color: "error",
-				});
-				return;
+                // Called when a customer is selected
+                onCustomerChange(val) {
+                        // if user selects the same customer again, show a meaningful error
+                        if (val && val === this.selectedCustomer) {
+                                // keep the current selection and notify the user
+                                this.internalCustomer = this.selectedCustomer;
+                                this.eventBus.emit("show_message", {
+                                        title: __("Customer already selected"),
+                                        color: "error",
+                                });
+                                return;
 			}
 
 			this.tempSelectedCustomer = val;
 
-			if (this.isMenuOpen && val) {
-				this.closeCustomerMenu();
-			} else if (!this.isMenuOpen && val) {
-				this.customer = val;
-				this.eventBus.emit("update_customer", val);
-			}
-		},
+                        if (this.isMenuOpen && val) {
+                                this.closeCustomerMenu();
+                        } else if (!this.isMenuOpen && val) {
+                                this.customersStore.setSelectedCustomer(val);
+                        }
+                },
 
-		onCustomerSearch(val) {
-			if (this.isCustomerBackgroundLoading) {
-				this.pendingCustomerSearch = val;
-				return;
-			}
-			this.searchDebounce(val);
-		},
+                onCustomerSearch(val) {
+                        if (this.isCustomerBackgroundLoading) {
+                                this.customersStore.queueSearchWhileLoading(val);
+                                return;
+                        }
+                        this.searchDebounce(val);
+                },
 
-		// Pressing Enter in input
-		handleEnter(event) {
-			const inputText = event.target.value?.toLowerCase() || "";
+                async loadMoreCustomers() {
+                        await this.customersStore.loadMoreCustomers();
+                },
 
-			const matched = this.customers.find((cust) => {
-				return (
-					cust.customer_name?.toLowerCase().includes(inputText) ||
-					cust.name?.toLowerCase().includes(inputText)
-				);
-			});
+                // Pressing Enter in input
+                handleEnter(event) {
+                        const inputText = event.target.value?.toLowerCase() || "";
 
-			if (matched) {
-				this.tempSelectedCustomer = matched.name;
-				this.internalCustomer = matched.name;
-				this.customer = matched.name;
-				this.eventBus.emit("update_customer", matched.name);
-				this.closeCustomerMenu();
-				if (event?.target?.blur) {
-					event.target.blur();
-				}
-			}
-		},
+                        const matched = this.customers.find((cust) => {
+                                return (
+                                        cust.customer_name?.toLowerCase().includes(inputText) ||
+                                        cust.name?.toLowerCase().includes(inputText)
+                                );
+                        });
 
-		async searchCustomers(term, append = false) {
-			try {
-				await checkDbHealth();
-				if (!db.isOpen()) await db.open();
-				let collection = db.table("customers");
-				const normalizedTerm = typeof term === "string" ? term.trim().toLowerCase() : "";
-				if (normalizedTerm) {
-					const searchParts = normalizedTerm.split(/\s+/).filter(Boolean);
-					collection = collection.filter((customer) => {
-						if (!customer) {
-							return false;
-						}
+                        if (matched) {
+                                this.tempSelectedCustomer = matched.name;
+                                this.internalCustomer = matched.name;
+                                this.customersStore.setSelectedCustomer(matched.name);
+                                this.closeCustomerMenu();
+                                if (event?.target?.blur) {
+                                        event.target.blur();
+                                }
+                        }
+                },
+                new_customer() {
+                        this.eventBus.emit("open_update_customer", null);
+                },
 
-						const values = [
-							customer.customer_name,
-							customer.name,
-							customer.mobile_no,
-							customer.email_id,
-							customer.tax_id,
-						]
-							.filter((value) => value !== null && value !== undefined)
-							.map((value) => String(value).toLowerCase());
+                edit_customer() {
+                        this.eventBus.emit("open_update_customer", this.customerInfo);
+                },
+        },
 
-						if (!searchParts.length) {
-							return true;
-						}
+        created() {
+                memoryInitPromise.then(async () => {
+                        await this.customersStore.searchCustomers("");
+                });
 
-						return searchParts.every((part) => values.some((value) => value.includes(part)));
-					});
-				}
-				const results = await collection
-					.offset(this.page * this.pageSize)
-					.limit(this.pageSize)
-					.toArray();
-				if (append) {
-					this.customers.push(...results);
-				} else {
-					this.customers = results;
-				}
-				this.hasMore = results.length === this.pageSize;
-				if (this.hasMore) {
-					this.page += 1;
-				}
-				return results.length;
-			} catch (e) {
-				console.error("Failed to search customers", e);
-				return 0;
-			}
-		},
+                this.searchDebounce = _.debounce(async (val) => {
+                        await this.customersStore.setSearchTerm(val || "");
+                }, 300);
 
-		async loadMoreCustomers() {
-			if (this.loadingCustomers) return;
-			const count = await this.searchCustomers(this.searchTerm, true);
-			if (count === this.pageSize) return;
-			if (this.nextCustomerStart) {
-				await this.backgroundLoadCustomers(this.nextCustomerStart, getCustomersLastSync());
-				await this.searchCustomers(this.searchTerm, true);
-			}
-		},
+                this.$nextTick(() => {
+                        this.eventBus.on("register_pos_profile", async (pos_profile) => {
+                                await memoryInitPromise;
+                                this.customersStore.setPosProfile(pos_profile);
+                                await this.customersStore.get_customer_names();
+                        });
 
-		async backgroundLoadCustomers(startAfter, syncSince) {
-			const limit = this.pageSize;
-			this.isCustomerBackgroundLoading = true;
-			try {
-				let cursor = startAfter;
-				while (cursor) {
-					const rows = await this.fetchCustomerPage(cursor, syncSince, limit);
-					await setCustomerStorage(rows);
-					this.loadedCustomerCount += rows.length;
-					if (this.totalCustomerCount) {
-						const progress = Math.min(
-							99,
-							Math.round((this.loadedCustomerCount / this.totalCustomerCount) * 100),
-						);
-						this.loadProgress = progress;
-						this.eventBus.emit("data-load-progress", { name: "customers", progress });
-					}
-					if (rows.length === limit) {
-						cursor = rows[rows.length - 1]?.name || null;
-						this.nextCustomerStart = cursor;
-					} else {
-						cursor = null;
-						this.nextCustomerStart = null;
-						setCustomersLastSync(new Date().toISOString());
-						this.loadProgress = 100;
-						this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-						this.eventBus.emit("data-loaded", "customers");
-					}
-				}
-			} catch (err) {
-				console.error("Failed to background load customers", err);
-			} finally {
-				this.isCustomerBackgroundLoading = false;
-				if (this.pendingCustomerSearch !== null) {
-					this.searchDebounce(this.pendingCustomerSearch);
-					if (this.searchDebounce.flush) {
-						this.searchDebounce.flush();
-					}
-					this.pendingCustomerSearch = null;
-				}
-			}
-		},
+                        this.eventBus.on("payments_register_pos_profile", async (pos_profile) => {
+                                await memoryInitPromise;
+                                this.customersStore.setPosProfile(pos_profile);
+                                await this.customersStore.get_customer_names();
+                        });
 
-		async verifyServerCustomerCount() {
-			if (isOffline()) return;
-			try {
-				const localCount = await getCustomerStorageCount();
-				const res = await frappe.call({
-					method: "posawesome.posawesome.api.customers.get_customers_count",
-					args: { pos_profile: this.pos_profile.pos_profile },
-				});
-				const serverCount = res.message || 0;
-				if (typeof serverCount === "number") {
-					this.totalCustomerCount = serverCount;
-					this.loadedCustomerCount = localCount;
-					this.loadProgress = serverCount ? Math.round((localCount / serverCount) * 100) : 0;
-					this.eventBus.emit("data-load-progress", {
-						name: "customers",
-						progress: this.loadProgress,
-					});
-					if (serverCount > localCount) {
-						const syncSince = getCustomersLastSync();
-						const rows = await this.fetchCustomerPage(null, syncSince, this.pageSize);
-						await setCustomerStorage(rows);
-						this.loadedCustomerCount += rows.length;
-						if (this.totalCustomerCount) {
-							this.loadProgress = Math.round(
-								(this.loadedCustomerCount / this.totalCustomerCount) * 100,
-							);
-							this.eventBus.emit("data-load-progress", {
-								name: "customers",
-								progress: this.loadProgress,
-							});
-						}
-						const startAfter =
-							rows.length === this.pageSize ? rows[rows.length - 1]?.name || null : null;
-						if (startAfter) {
-							this.backgroundLoadCustomers(startAfter, syncSince);
-						} else {
-							setCustomersLastSync(new Date().toISOString());
-							this.loadProgress = 100;
-							this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-							this.eventBus.emit("data-loaded", "customers");
-						}
-						await this.searchCustomers(this.searchTerm);
-					} else if (serverCount < localCount) {
-						await clearCustomerStorage();
-						setCustomersLastSync(null);
-						this.customers = [];
-						await this.get_customer_names();
-					}
-				}
-			} catch (err) {
-				console.error("Error verifying customer count:", err);
-			}
-		},
+                        this.eventBus.on("set_customer_readonly", (value) => {
+                                this.customersStore.setReadonly(value);
+                        });
 
-		fetchCustomerPage(startAfter, modifiedAfter, limit) {
-			return new Promise((resolve, reject) => {
-				frappe.call({
-					method: "posawesome.posawesome.api.customers.get_customer_names",
-					args: {
-						pos_profile: this.pos_profile.pos_profile,
-						modified_after: modifiedAfter,
-						limit,
-						start_after: startAfter,
-					},
-					callback: (r) => resolve(r.message || []),
-					error: (err) => {
-						console.error("Failed to fetch customers", err);
-						reject(err);
-					},
-				});
-			});
-		},
+                        this.eventBus.on("set_customer_info_to_edit", (data) => {
+                                this.customersStore.setCustomerInfo(data);
+                        });
 
-		async get_customer_names() {
-			const localCount = await getCustomerStorageCount();
-			if (localCount > 0) {
-				this.customers_loaded = true;
-				await this.searchCustomers(this.searchTerm);
-				await this.verifyServerCustomerCount();
-				return;
-			}
-			const syncSince = getCustomersLastSync();
-			this.loadProgress = 0;
-			this.eventBus.emit("data-load-progress", { name: "customers", progress: 0 });
-			this.loadingCustomers = true;
-			try {
-				// Fetch total customer count for accurate progress
-				try {
-					const countRes = await frappe.call({
-						method: "posawesome.posawesome.api.customers.get_customers_count",
-						args: { pos_profile: this.pos_profile.pos_profile },
-					});
-					this.totalCustomerCount = countRes.message || 0;
-				} catch (e) {
-					console.error("Failed to fetch customer count", e);
-					this.totalCustomerCount = 0;
-				}
-
-				const rows = await this.fetchCustomerPage(null, syncSince, this.pageSize);
-				await setCustomerStorage(rows);
-				this.loadedCustomerCount = rows.length;
-				if (this.totalCustomerCount) {
-					this.loadProgress = Math.round(
-						(this.loadedCustomerCount / this.totalCustomerCount) * 100,
-					);
-					this.eventBus.emit("data-load-progress", {
-						name: "customers",
-						progress: this.loadProgress,
-					});
-				}
-				this.nextCustomerStart =
-					rows.length === this.pageSize ? rows[rows.length - 1]?.name || null : null;
-				if (this.nextCustomerStart) {
-					// Load remaining customers in the background
-					this.backgroundLoadCustomers(this.nextCustomerStart, syncSince);
-				} else {
-					setCustomersLastSync(new Date().toISOString());
-					this.loadProgress = 100;
-					this.eventBus.emit("data-load-progress", { name: "customers", progress: 100 });
-					this.eventBus.emit("data-loaded", "customers");
-				}
-				this.customers_loaded = true;
-			} catch (err) {
-				console.error("Failed to fetch customers:", err);
-			} finally {
-				this.loadingCustomers = false;
-				await this.searchCustomers(this.searchTerm);
-			}
-		},
-
-		new_customer() {
-			this.eventBus.emit("open_update_customer", null);
-		},
-
-		edit_customer() {
-			this.eventBus.emit("open_update_customer", this.customer_info);
-		},
-	},
-
-	created() {
-		memoryInitPromise.then(async () => {
-			await this.searchCustomers("");
-			this.effectiveReadonly = this.readonly && navigator.onLine;
-		});
-
-		this.searchDebounce = _.debounce(async (val) => {
-			this.searchTerm = val || "";
-			this.page = 0;
-			this.customers = [];
-			this.hasMore = true;
-			await this.searchCustomers(this.searchTerm);
-		}, 300);
-
-		this.effectiveReadonly = this.readonly && navigator.onLine;
-
-		this.$nextTick(() => {
-			this.eventBus.on("register_pos_profile", async (pos_profile) => {
-				await memoryInitPromise;
-				this.pos_profile = pos_profile;
-				await this.get_customer_names();
-			});
-
-			this.eventBus.on("payments_register_pos_profile", async (pos_profile) => {
-				await memoryInitPromise;
-				this.pos_profile = pos_profile;
-				await this.get_customer_names();
-			});
-
-			this.eventBus.on("set_customer", (customer) => {
-				this.customer = customer;
-				this.internalCustomer = customer;
-			});
-
-			this.eventBus.on("add_customer_to_list", async (customer) => {
-				const index = this.customers.findIndex((c) => c.name === customer.name);
-				if (index !== -1) {
-					this.customers.splice(index, 1, customer);
-				} else {
-					this.customers.push(customer);
-				}
-				await setCustomerStorage([customer]);
-				this.customer = customer.name;
-				this.internalCustomer = customer.name;
-				this.eventBus.emit("update_customer", customer.name);
-			});
-
-			this.eventBus.on("set_customer_readonly", (value) => {
-				this.readonly = value;
-			});
-
-			this.eventBus.on("set_customer_info_to_edit", (data) => {
-				this.customer_info = data;
-			});
-
-			this.eventBus.on("fetch_customer_details", async () => {
-				await this.get_customer_names();
-			});
-		});
-	},
+                });
+        },
 };
 </script>

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -341,13 +341,23 @@ import invoiceWatchers from "./invoiceWatchers";
 import offerMethods from "./invoiceOfferMethods";
 import shortcutMethods from "./invoiceShortcuts";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
 
 export default {
         name: "POSInvoice",
         mixins: [format],
         setup() {
                 const invoiceStore = useInvoiceStore();
-                return { invoiceStore };
+                const customersStore = useCustomersStore();
+                const { selectedCustomer, customerRefreshKey, customerInfo } = storeToRefs(customersStore);
+                return {
+                        invoiceStore,
+                        customersStore,
+                        selectedCustomer,
+                        customerRefreshKey,
+                        storeCustomerInfo: customerInfo,
+                };
         },
         data() {
                 return {
@@ -1283,15 +1293,9 @@ export default {
 			this.fetch_price_lists();
 			this.update_price_list();
 		});
-		this.eventBus.on("add_item", (item) => {
-			this.add_item(item);
-		});
-		this.eventBus.on("update_customer", (customer) => {
-			this.customer = customer;
-		});
-		this.eventBus.on("fetch_customer_details", () => {
-			this.fetch_customer_details();
-		});
+                this.eventBus.on("add_item", (item) => {
+                        this.add_item(item);
+                });
 		this.eventBus.on("clear_invoice", () => {
 			this.clear_invoice();
 			this.eventBus.emit("focus_item_search");
@@ -1381,8 +1385,6 @@ export default {
                 // Existing cleanup
                 this.eventBus.off("register_pos_profile");
                 this.eventBus.off("add_item");
-                this.eventBus.off("update_customer");
-                this.eventBus.off("fetch_customer_details");
                 this.eventBus.off("clear_invoice");
                 // Cleanup reset_posting_date listener
                 this.eventBus.off("reset_posting_date");
@@ -1405,7 +1407,28 @@ export default {
 		document.removeEventListener("keydown", this.shortOpenFirstItem);
 		document.removeEventListener("keydown", this.shortSelectDiscount);
 	},
-	watch: invoiceWatchers,
+        watch: {
+                ...invoiceWatchers,
+                selectedCustomer(val) {
+                        if (val !== this.customer) {
+                                this.customer = val || "";
+                        }
+                },
+                storeCustomerInfo(val) {
+                        if (val && typeof val === "object") {
+                                if (val !== this.customer_info) {
+                                        this.customer_info = { ...val };
+                                }
+                        } else if (!val && Object.keys(this.customer_info || {}).length) {
+                                this.customer_info = {};
+                        }
+                },
+                customerRefreshKey() {
+                        if (this.customer) {
+                                this.fetch_customer_details();
+                        }
+                },
+        },
 };
 </script>
 

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -560,6 +560,8 @@ import {
 import { useResponsive } from "../../composables/useResponsive.js";
 import { useRtl } from "../../composables/useRtl.js";
 import { useFlyAnimation } from "../../composables/useFlyAnimation.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
 import { withPerf, perfMarkStart, perfMarkEnd, scheduleFrame } from "../../utils/perf.js";
 import { useCartValidation } from "../../composables/useCartValidation.js";
 import { useItemsIntegration } from "../../composables/useItemsIntegration.js";
@@ -580,18 +582,23 @@ export default {
                 const cartValidation = useCartValidation();
 
 		// Initialize Pinia store integration
-		const itemsIntegration = useItemsIntegration({
-			enableDebounce: true,
-			debounceDelay: 300
-		});
+                const itemsIntegration = useItemsIntegration({
+                        enableDebounce: true,
+                        debounceDelay: 300
+                });
+                const customersStore = useCustomersStore();
+                const { selectedCustomer, customerRefreshKey } = storeToRefs(customersStore);
 
-		return {
-			...responsive,
-			...rtl,
-			fly,
-			cartValidation,
-			...itemsIntegration
-		};
+                return {
+                        ...responsive,
+                        ...rtl,
+                        fly,
+                        cartValidation,
+                        ...itemsIntegration,
+                        customersStore,
+                        selectedCustomer,
+                        customerRefreshKey
+                };
         },
         components: {
                 CameraScanner,
@@ -685,6 +692,16 @@ export default {
         }),
 
         watch: {
+                selectedCustomer(newVal, oldVal) {
+                        if (newVal !== oldVal && newVal !== this.customer) {
+                                this.customer = newVal || "";
+                        }
+                },
+                customerRefreshKey() {
+                        if (typeof this.refreshPricesForVisibleItems === "function") {
+                                this.refreshPricesForVisibleItems();
+                        }
+                },
                 showManualScanInput(newVal) {
                         if (newVal) {
                                 this.queueManualScanFocus();
@@ -3616,12 +3633,9 @@ export default {
 			this.couponsCount = data.couponsCount;
 			this.appliedCouponsCount = data.appliedCouponsCount;
 		});
-		this.eventBus.on("update_customer_price_list", (data) => {
-			this.customer_price_list = data;
-		});
-		this.eventBus.on("update_customer", (data) => {
-			this.customer = data;
-		});
+                this.eventBus.on("update_customer_price_list", (data) => {
+                        this.customer_price_list = data;
+                });
 
 		this.eventBus.on("focus_item_search", () => {
 			this.focusItemSearch();
@@ -3793,9 +3807,8 @@ export default {
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("update_cur_items_details");
 		this.eventBus.off("update_offers_counters");
-		this.eventBus.off("update_coupons_counters");
-		this.eventBus.off("update_customer_price_list");
-		this.eventBus.off("update_customer");
+                this.eventBus.off("update_coupons_counters");
+                this.eventBus.off("update_customer_price_list");
                 this.eventBus.off("force_reload_items");
                 this.eventBus.off("focus_item_search");
                 window.removeEventListener("resize", this.checkItemContainerOverflow);

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -794,13 +794,23 @@ import {
 import renderOfflineInvoiceHTML from "../../../offline_print_template";
 import { silentPrint } from "../../plugins/print.js";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
 
 export default {
         // Using format mixin for shared formatting methods
         mixins: [format],
         setup() {
                 const invoiceStore = useInvoiceStore();
-                return { invoiceStore };
+                const customersStore = useCustomersStore();
+                const { selectedCustomer, customerRefreshKey, customerInfo } = storeToRefs(customersStore);
+                return {
+                        invoiceStore,
+                        customersStore,
+                        selectedCustomer,
+                        customerRefreshKey,
+                        storeCustomerInfo: customerInfo,
+                };
         },
         data() {
                 return {
@@ -1026,12 +1036,41 @@ export default {
 			);
 		},
 	},
-	watch: {
-		// Watch diff_payment to update paid_change
-		diff_payment(newVal) {
-			if (!this.is_user_editing_paid_change) {
-				this.paid_change = -newVal;
-			}
+        watch: {
+                selectedCustomer(newVal, oldVal) {
+                        if (!newVal || newVal === oldVal) {
+                                return;
+                        }
+                        if (this.invoice_doc && this.invoice_doc.customer !== newVal) {
+                                this.customer_credit_dict = [];
+                                this.redeem_customer_credit = false;
+                                this.is_cashback = true;
+                                this.is_credit_return = false;
+                        }
+                        this.clear_all(true);
+                        this.customer_name = newVal;
+                        this.fetch_customer_details();
+                        this.get_outstanding_invoices();
+                        this.get_unallocated_payments();
+                        this.get_draft_mpesa_payments_register();
+                },
+                customerRefreshKey() {
+                        if (this.selectedCustomer) {
+                                this.fetch_customer_details();
+                        }
+                },
+                storeCustomerInfo(val) {
+                        if (val && typeof val === "object") {
+                                this.customer_info = { ...val };
+                        } else if (!val) {
+                                this.customer_info = {};
+                        }
+                },
+                // Watch diff_payment to update paid_change
+                diff_payment(newVal) {
+                        if (!this.is_user_editing_paid_change) {
+                                this.paid_change = -newVal;
+                        }
 		},
 		// Watch paid_change to validate and update credit_change
 		paid_change(newVal) {
@@ -2176,20 +2215,9 @@ export default {
 					this.is_credit_return = false;
 				}
 			});
-			this.eventBus.on("update_customer", (customer) => {
-				if (this.customer !== customer) {
-					this.customer_credit_dict = [];
-					this.redeem_customer_credit = false;
-					this.is_cashback = true;
-					this.is_credit_return = false;
-				}
-			});
-			this.eventBus.on("set_pos_settings", (data) => {
-				this.pos_settings = data;
-			});
-			this.eventBus.on("set_customer_info_to_edit", (data) => {
-				this.customer_info = data;
-			});
+                        this.eventBus.on("set_pos_settings", (data) => {
+                                this.pos_settings = data;
+                        });
 			this.eventBus.on("set_mpesa_payment", (data) => {
 				this.set_mpesa_payment(data);
 			});
@@ -2210,9 +2238,7 @@ export default {
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("add_the_new_address");
 		this.eventBus.off("update_invoice_type");
-		this.eventBus.off("update_customer");
 		this.eventBus.off("set_pos_settings");
-		this.eventBus.off("set_customer_info_to_edit");
 		this.eventBus.off("set_mpesa_payment");
 		this.eventBus.off("clear_invoice");
 		this.eventBus.off("network-online", this.syncPendingInvoices);

--- a/frontend/src/posapp/components/pos/Pos.vue
+++ b/frontend/src/posapp/components/pos/Pos.vue
@@ -70,20 +70,24 @@ import { useOffers } from "../../composables/useOffers.js";
 import { clearExpiredCustomerBalances } from "../../../offline/index.js";
 import { useResponsive } from "../../composables/useResponsive.js";
 import { useRtl } from "../../composables/useRtl.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
 
 export default {
 	setup() {
 		const instance = getCurrentInstance();
-		const responsive = useResponsive();
-		const rtl = useRtl();
-		const shift = usePosShift(() => {
-			if (instance && instance.proxy) {
-				instance.proxy.dialog = true;
-			}
-		});
-		const offers = useOffers();
-		return { ...responsive, ...rtl, ...shift, ...offers };
-	},
+                const responsive = useResponsive();
+                const rtl = useRtl();
+                const shift = usePosShift(() => {
+                        if (instance && instance.proxy) {
+                                instance.proxy.dialog = true;
+                        }
+                });
+                const offers = useOffers();
+                const customersStore = useCustomersStore();
+                const { customersLoaded } = storeToRefs(customersStore);
+                return { ...responsive, ...rtl, ...shift, ...offers, customersStore, customersLoadedRef: customersLoaded };
+        },
 	data: function () {
 		return {
 			dialog: false,
@@ -172,28 +176,37 @@ export default {
 				this.submit_closing_pos(data);
 			});
 
-			this.eventBus.on("items_loaded", () => {
-				this.itemsLoaded = true;
-				this.checkLoadingComplete();
-			});
-			this.eventBus.on("customers_loaded", () => {
-				this.customersLoaded = true;
-				this.checkLoadingComplete();
-			});
-		});
-	},
-	beforeUnmount() {
-		this.eventBus.off("close_opening_dialog");
-		this.eventBus.off("register_pos_data");
-		this.eventBus.off("register_pos_profile");
+                        this.eventBus.on("items_loaded", () => {
+                                this.itemsLoaded = true;
+                                this.checkLoadingComplete();
+                        });
+                });
+                this.unwatchCustomers = this.$watch(
+                        () => this.customersLoadedRef,
+                        (val) => {
+                                this.customersLoaded = !!val;
+                                if (val) {
+                                        this.checkLoadingComplete();
+                                }
+                        },
+                        { immediate: true },
+                );
+        },
+        beforeUnmount() {
+                this.eventBus.off("close_opening_dialog");
+                this.eventBus.off("register_pos_data");
+                this.eventBus.off("register_pos_profile");
 		this.eventBus.off("LoadPosProfile");
 		this.eventBus.off("show_offers");
 		this.eventBus.off("show_coupons");
 		this.eventBus.off("open_closing_dialog");
 		this.eventBus.off("submit_closing_pos");
-		this.eventBus.off("items_loaded");
-		this.eventBus.off("customers_loaded");
-	},
+                this.eventBus.off("items_loaded");
+                if (typeof this.unwatchCustomers === "function") {
+                        this.unwatchCustomers();
+                        this.unwatchCustomers = null;
+                }
+        },
 	// In the created() or mounted() lifecycle hook
 	created() {
 		// Clean up expired customer balance cache on POS load

--- a/frontend/src/posapp/components/pos/PosCoupons.vue
+++ b/frontend/src/posapp/components/pos/PosCoupons.vue
@@ -75,8 +75,16 @@
 
 <script>
 /* global __, frappe */
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
+
 export default {
-	data: () => ({
+        setup() {
+                const customersStore = useCustomersStore();
+                const { selectedCustomer } = storeToRefs(customersStore);
+                return { customersStore, selectedCustomer };
+        },
+        data: () => ({
 		loading: false,
 		pos_profile: "",
 		customer: "",
@@ -198,42 +206,42 @@ export default {
 		},
 	},
 
-	watch: {
-		posa_coupons: {
-			deep: true,
-			handler() {
-				this.updateInvoice();
-				this.updateCounters();
-			},
-		},
-	},
+        watch: {
+                posa_coupons: {
+                        deep: true,
+                        handler() {
+                                this.updateInvoice();
+                                this.updateCounters();
+                        },
+                },
+                selectedCustomer(newVal, oldVal) {
+                        if (newVal !== oldVal && this.customer !== newVal) {
+                                const to_remove = [];
+                                this.posa_coupons.forEach((el) => {
+                                        if (el.type == "Promotional") {
+                                                el.customer = newVal;
+                                        } else {
+                                                to_remove.push(el.coupon);
+                                        }
+                                });
+                                this.customer = newVal;
+                                if (to_remove.length) {
+                                        this.removeCoupon(to_remove);
+                                }
+                        }
+                        this.setActiveGiftCoupons();
+                },
+        },
 
-	created: function () {
-		this.$nextTick(function () {
-			this.eventBus.on("register_pos_profile", (data) => {
-				this.pos_profile = data.pos_profile;
-			});
-		});
-		this.eventBus.on("update_customer", (customer) => {
-			if (this.customer != customer) {
-				const to_remove = [];
-				this.posa_coupons.forEach((el) => {
-					if (el.type == "Promotional") {
-						el.customer = customer;
-					} else {
-						to_remove.push(el.coupon);
-					}
-				});
-				this.customer = customer;
-				if (to_remove.length) {
-					this.removeCoupon(to_remove);
-				}
-			}
-			this.setActiveGiftCoupons();
-		});
-		this.eventBus.on("update_pos_coupons", (data) => {
-			this.updatePosCoupons(data);
-		});
+        created: function () {
+                this.$nextTick(function () {
+                        this.eventBus.on("register_pos_profile", (data) => {
+                                this.pos_profile = data.pos_profile;
+                        });
+                });
+                this.eventBus.on("update_pos_coupons", (data) => {
+                        this.updatePosCoupons(data);
+                });
 		this.eventBus.on("set_pos_coupons", (data) => {
 			this.posa_coupons = data;
 		});

--- a/frontend/src/posapp/components/pos/PosOffers.vue
+++ b/frontend/src/posapp/components/pos/PosOffers.vue
@@ -91,16 +91,24 @@
 <script>
 /* global __, frappe */
 import format from "../../format";
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
 export default {
-	mixins: [format],
-	data: () => ({
-		loading: false,
-		pos_profile: "",
-		pos_offers: [],
-		allItems: [],
-		groupItemCache: {},
-		discount_percentage_offer_name: null,
-		itemsPerPage: 1000,
+        mixins: [format],
+        setup() {
+                const customersStore = useCustomersStore();
+                const { selectedCustomer } = storeToRefs(customersStore);
+                return { customersStore, selectedCustomer };
+        },
+        data: () => ({
+                loading: false,
+                pos_profile: "",
+                pos_offers: [],
+                allItems: [],
+                groupItemCache: {},
+                discount_percentage_offer_name: null,
+                customer: "",
+                itemsPerPage: 1000,
 		expanded: [],
 		singleExpand: true,
 		items_headers: [
@@ -302,16 +310,21 @@ export default {
 		},
 	},
 
-	watch: {
-		pos_offers: {
-			deep: true,
-			handler() {
-				this.handelOffers();
-				this.updateCounters();
-				this.updatePosCoupuns();
-			},
-		},
-	},
+        watch: {
+                pos_offers: {
+                        deep: true,
+                        handler() {
+                                this.handelOffers();
+                                this.updateCounters();
+                                this.updatePosCoupuns();
+                        },
+                },
+                selectedCustomer(newVal, oldVal) {
+                        if (newVal !== oldVal) {
+                                this.offers = [];
+                        }
+                },
+        },
 
 	created: function () {
 		this.$nextTick(function () {
@@ -319,14 +332,9 @@ export default {
 				this.pos_profile = data.pos_profile;
 			});
 		});
-		this.eventBus.on("update_customer", (customer) => {
-			if (this.customer != customer) {
-				this.offers = [];
-			}
-		});
-		this.eventBus.on("update_pos_offers", (data) => {
-			this.updatePosOffers(data);
-		});
+                this.eventBus.on("update_pos_offers", (data) => {
+                        this.updatePosOffers(data);
+                });
 		this.eventBus.on("update_discount_percentage_offer_name", (data) => {
 			this.discount_percentage_offer_name = data.value;
 		});

--- a/frontend/src/posapp/components/pos/UpdateCustomer.vue
+++ b/frontend/src/posapp/components/pos/UpdateCustomer.vue
@@ -210,9 +210,16 @@
 
 <script>
 import { isOffline, saveOfflineCustomer } from "../../../offline/index.js";
+import { useCustomersStore } from "../../stores/customersStore.js";
+import { storeToRefs } from "pinia";
 
 export default {
-	data: () => ({
+        setup() {
+                const customersStore = useCustomersStore();
+                const { selectedCustomer } = storeToRefs(customersStore);
+                return { customersStore, selectedCustomer };
+        },
+        data: () => ({
 		customerDialog: false,
 		confirmDialog: false,
 		pos_profile: "",
@@ -467,8 +474,8 @@ export default {
 				}
 			}
 		},
-		submit_dialog() {
-			const vm = this;
+                async submit_dialog() {
+                        const vm = this;
 			if (!this.customer_name) {
 				frappe.throw(__("Customer Name is required"));
 				return;
@@ -560,15 +567,16 @@ export default {
 				method: this.customer_id ? "update" : "create",
 			};
 
-			if (isOffline()) {
-				saveOfflineCustomer({ args: apiArgs });
-				vm.eventBus.emit("show_message", { title: __("Customer saved offline"), color: "warning" });
-				args.name = this.customer_name;
-				vm.eventBus.emit("add_customer_to_list", args);
-				vm.eventBus.emit("set_customer", args.name);
-				vm.close_dialog();
-				return;
-			}
+                        if (isOffline()) {
+                                saveOfflineCustomer({ args: apiArgs });
+                                vm.eventBus.emit("show_message", { title: __("Customer saved offline"), color: "warning" });
+                                args.name = this.customer_name;
+                                await vm.customersStore.addOrUpdateCustomer(args);
+                                vm.customersStore.setSelectedCustomer(args.name);
+                                vm.customersStore.triggerCustomerRefresh();
+                                vm.close_dialog();
+                                return;
+                        }
 
 			frappe.call({
 				method: "posawesome.posawesome.api.customers.create_customer",
@@ -583,12 +591,12 @@ export default {
 							title: text,
 							color: "success",
 						});
-						args.name = r.message.name;
-						frappe.utils.play_sound("submit");
-						vm.eventBus.emit("add_customer_to_list", args);
-						vm.eventBus.emit("set_customer", r.message.name);
-						vm.eventBus.emit("fetch_customer_details");
-						vm.close_dialog();
+                                                args.name = r.message.name;
+                                                frappe.utils.play_sound("submit");
+                                                await vm.customersStore.addOrUpdateCustomer(args);
+                                                vm.customersStore.setSelectedCustomer(r.message.name);
+                                                vm.customersStore.triggerCustomerRefresh();
+                                                vm.close_dialog();
 					} else {
 						frappe.utils.play_sound("error");
 						vm.eventBus.emit("show_message", {

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -3,17 +3,21 @@ import { clearPriceListCache } from "../../../offline/index.js";
 
 export default {
 	// Watch for customer change and update related data
-	customer() {
-		this.close_payments();
-		this.eventBus.emit("set_customer", this.customer);
-		this.fetch_customer_details();
-		this.fetch_customer_balance();
-		this.set_delivery_charges();
-	},
-	// Watch for customer_info change and emit to edit form
-	customer_info() {
-		this.eventBus.emit("set_customer_info_to_edit", this.customer_info);
-	},
+        customer() {
+                this.close_payments();
+                if (this.customersStore && this.customer !== this.selectedCustomer) {
+                        this.customersStore.setSelectedCustomer(this.customer);
+                }
+                this.fetch_customer_details();
+                this.fetch_customer_balance();
+                this.set_delivery_charges();
+        },
+        // Watch for customer_info change and emit to edit form
+        customer_info() {
+                if (this.customersStore) {
+                        this.customersStore.setCustomerInfo(this.customer_info);
+                }
+        },
 	// Watch for expanded row change and update item detail
 	expanded(data_value) {
 		if (data_value.length > 0) {

--- a/frontend/src/posapp/stores/customersStore.js
+++ b/frontend/src/posapp/stores/customersStore.js
@@ -1,0 +1,414 @@
+/**
+ * Pinia store responsible for managing customers in the POS application.
+ * Centralizes customer caching, search, and background sync state so that
+ * multiple components can reactively consume customer information without
+ * relying on the legacy event bus.
+ */
+
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import {
+        db,
+        checkDbHealth,
+        setCustomerStorage,
+        memoryInitPromise,
+        getCustomersLastSync,
+        setCustomersLastSync,
+        getCustomerStorageCount,
+        clearCustomerStorage,
+        isOffline,
+} from '../../offline/index.js';
+
+const DEFAULT_PAGE_SIZE = 200;
+
+/* global frappe */
+export const useCustomersStore = defineStore('customers', () => {
+        const posProfile = ref(null);
+        const customers = ref([]);
+        const searchTerm = ref('');
+        const page = ref(0);
+        const pageSize = ref(DEFAULT_PAGE_SIZE);
+        const hasMore = ref(true);
+        const nextCustomerStart = ref(null);
+        const loadingCustomers = ref(false);
+        const customersLoaded = ref(false);
+        const isCustomerBackgroundLoading = ref(false);
+        const pendingCustomerSearch = ref(null);
+        const loadProgress = ref(0);
+        const totalCustomerCount = ref(0);
+        const loadedCustomerCount = ref(0);
+        const selectedCustomer = ref('');
+        const readonly = ref(false);
+        const customerInfo = ref({});
+        const customerRefreshKey = ref(0);
+
+        const filteredCustomers = computed(() =>
+                isCustomerBackgroundLoading.value ? [] : customers.value,
+        );
+
+        const effectiveReadonly = computed(() => {
+                if (typeof navigator === 'undefined') {
+                        return readonly.value;
+                }
+                return readonly.value && navigator.onLine;
+        });
+
+        const setPosProfile = (profile) => {
+                posProfile.value = profile || null;
+        };
+
+        const setReadonly = (value) => {
+                readonly.value = Boolean(value);
+        };
+
+        const setCustomerInfo = (info) => {
+                customerInfo.value = info || {};
+        };
+
+        const setSelectedCustomer = (customerName) => {
+                selectedCustomer.value = customerName || '';
+        };
+
+        const resetPagination = () => {
+                page.value = 0;
+                hasMore.value = true;
+                nextCustomerStart.value = null;
+        };
+
+        const assignCustomers = (records, append) => {
+                if (append) {
+                        customers.value = [...customers.value, ...records];
+                } else {
+                        customers.value = records;
+                }
+
+                hasMore.value = records.length === pageSize.value;
+                if (hasMore.value) {
+                        page.value += 1;
+                }
+        };
+
+        const fetchCustomerPage = (startAfter, modifiedAfter, limit) =>
+                new Promise((resolve, reject) => {
+                        frappe.call({
+                                method: 'posawesome.posawesome.api.customers.get_customer_names',
+                                args: {
+                                        pos_profile: posProfile.value?.pos_profile,
+                                        modified_after: modifiedAfter,
+                                        limit,
+                                        start_after: startAfter,
+                                },
+                                callback: (r) => resolve(r.message || []),
+                                error: (err) => {
+                                        console.error('Failed to fetch customers', err);
+                                        reject(err);
+                                },
+                        });
+                });
+
+        const searchCustomers = async (term = searchTerm.value, append = false) => {
+                await memoryInitPromise;
+
+                try {
+                        await checkDbHealth();
+                        if (!db.isOpen()) {
+                                await db.open();
+                        }
+
+                        let collection = db.table('customers');
+                        const normalizedTerm = typeof term === 'string' ? term.trim().toLowerCase() : '';
+
+                        if (normalizedTerm) {
+                                const searchParts = normalizedTerm.split(/\s+/).filter(Boolean);
+
+                                collection = collection.filter((customer) => {
+                                        if (!customer) {
+                                                return false;
+                                        }
+
+                                        const values = [
+                                                customer.customer_name,
+                                                customer.name,
+                                                customer.mobile_no,
+                                                customer.email_id,
+                                                customer.tax_id,
+                                        ]
+                                                .filter((value) => value !== null && value !== undefined)
+                                                .map((value) => String(value).toLowerCase());
+
+                                        if (!searchParts.length) {
+                                                return true;
+                                        }
+
+                                        return searchParts.every((part) =>
+                                                values.some((value) => value.includes(part)),
+                                        );
+                                });
+                        }
+
+                        const results = await collection
+                                .offset(page.value * pageSize.value)
+                                .limit(pageSize.value)
+                                .toArray();
+
+                        assignCustomers(results, append);
+                        return results.length;
+                } catch (err) {
+                        console.error('Failed to search customers', err);
+                        return 0;
+                }
+        };
+
+        const setSearchTerm = async (term) => {
+                searchTerm.value = typeof term === 'string' ? term : '';
+                resetPagination();
+                customers.value = [];
+                return searchCustomers(searchTerm.value);
+        };
+
+        const loadMoreCustomers = async () => {
+                if (loadingCustomers.value) {
+                        return;
+                }
+
+                const count = await searchCustomers(searchTerm.value, true);
+                if (count === pageSize.value) {
+                        return;
+                }
+
+                if (nextCustomerStart.value) {
+                        await backgroundLoadCustomers(nextCustomerStart.value, getCustomersLastSync());
+                        await searchCustomers(searchTerm.value, true);
+                }
+        };
+
+        const backgroundLoadCustomers = async (startAfter, syncSince) => {
+                if (!posProfile.value) {
+                        return;
+                }
+
+                const limit = pageSize.value;
+                isCustomerBackgroundLoading.value = true;
+
+                try {
+                        let cursor = startAfter;
+                        while (cursor) {
+                                const rows = await fetchCustomerPage(cursor, syncSince, limit);
+                                await setCustomerStorage(rows);
+                                loadedCustomerCount.value += rows.length;
+
+                                if (totalCustomerCount.value) {
+                                        const progress = Math.min(
+                                                99,
+                                                Math.round((loadedCustomerCount.value / totalCustomerCount.value) * 100),
+                                        );
+                                        loadProgress.value = progress;
+                                }
+
+                                if (rows.length === limit) {
+                                        cursor = rows[rows.length - 1]?.name || null;
+                                        nextCustomerStart.value = cursor;
+                                } else {
+                                        cursor = null;
+                                        nextCustomerStart.value = null;
+                                        setCustomersLastSync(new Date().toISOString());
+                                        loadProgress.value = 100;
+                                        customersLoaded.value = true;
+                                }
+                        }
+                } catch (err) {
+                        console.error('Failed to background load customers', err);
+                } finally {
+                        isCustomerBackgroundLoading.value = false;
+
+                        if (pendingCustomerSearch.value !== null) {
+                                const value = pendingCustomerSearch.value;
+                                pendingCustomerSearch.value = null;
+                                await setSearchTerm(value);
+                        }
+                }
+        };
+
+        const verifyServerCustomerCount = async () => {
+                if (isOffline()) {
+                        return;
+                }
+
+                try {
+                        const localCount = await getCustomerStorageCount();
+                        const res = await frappe.call({
+                                method: 'posawesome.posawesome.api.customers.get_customers_count',
+                                args: { pos_profile: posProfile.value?.pos_profile },
+                        });
+                        const serverCount = res.message || 0;
+
+                        if (typeof serverCount === 'number') {
+                                totalCustomerCount.value = serverCount;
+                                loadedCustomerCount.value = localCount;
+                                loadProgress.value = serverCount
+                                        ? Math.round((localCount / serverCount) * 100)
+                                        : 0;
+
+                                if (serverCount > localCount) {
+                                        const syncSince = getCustomersLastSync();
+                                        const rows = await fetchCustomerPage(null, syncSince, pageSize.value);
+                                        await setCustomerStorage(rows);
+                                        loadedCustomerCount.value += rows.length;
+
+                                        if (totalCustomerCount.value) {
+                                                loadProgress.value = Math.round(
+                                                        (loadedCustomerCount.value / totalCustomerCount.value) * 100,
+                                                );
+                                        }
+
+                                        const startAfter =
+                                                rows.length === pageSize.value
+                                                        ? rows[rows.length - 1]?.name || null
+                                                        : null;
+
+                                        if (startAfter) {
+                                                await backgroundLoadCustomers(startAfter, syncSince);
+                                        } else {
+                                                setCustomersLastSync(new Date().toISOString());
+                                                loadProgress.value = 100;
+                                                customersLoaded.value = true;
+                                        }
+
+                                        await searchCustomers(searchTerm.value);
+                                } else if (serverCount < localCount) {
+                                        await clearCustomerStorage();
+                                        setCustomersLastSync(null);
+                                        customers.value = [];
+                                        resetPagination();
+                                        await get_customer_names();
+                                }
+                        }
+                } catch (err) {
+                        console.error('Error verifying customer count:', err);
+                }
+        };
+
+        const get_customer_names = async () => {
+                if (!posProfile.value) {
+                        return;
+                }
+
+                const localCount = await getCustomerStorageCount();
+                if (localCount > 0) {
+                        customersLoaded.value = true;
+                        await searchCustomers(searchTerm.value);
+                        await verifyServerCustomerCount();
+                        return;
+                }
+
+                const syncSince = getCustomersLastSync();
+                loadProgress.value = 0;
+                loadingCustomers.value = true;
+
+                try {
+                        try {
+                                const countRes = await frappe.call({
+                                        method: 'posawesome.posawesome.api.customers.get_customers_count',
+                                        args: { pos_profile: posProfile.value?.pos_profile },
+                                });
+                                totalCustomerCount.value = countRes.message || 0;
+                        } catch (e) {
+                                console.error('Failed to fetch customer count', e);
+                                totalCustomerCount.value = 0;
+                        }
+
+                        const rows = await fetchCustomerPage(null, syncSince, pageSize.value);
+                        await setCustomerStorage(rows);
+                        loadedCustomerCount.value = rows.length;
+
+                        if (totalCustomerCount.value) {
+                                loadProgress.value = Math.round(
+                                        (loadedCustomerCount.value / totalCustomerCount.value) * 100,
+                                );
+                        }
+
+                        nextCustomerStart.value =
+                                rows.length === pageSize.value ? rows[rows.length - 1]?.name || null : null;
+
+                        if (nextCustomerStart.value) {
+                                backgroundLoadCustomers(nextCustomerStart.value, syncSince);
+                        } else {
+                                setCustomersLastSync(new Date().toISOString());
+                                loadProgress.value = 100;
+                                customersLoaded.value = true;
+                        }
+
+                        customersLoaded.value = true;
+                } catch (err) {
+                        console.error('Failed to fetch customers:', err);
+                } finally {
+                        loadingCustomers.value = false;
+                        await searchCustomers(searchTerm.value);
+                }
+        };
+
+        const queueSearchWhileLoading = (value) => {
+                pendingCustomerSearch.value = value;
+        };
+
+        const addOrUpdateCustomer = async (customer) => {
+                if (!customer || !customer.name) {
+                        return;
+                }
+
+                const index = customers.value.findIndex((c) => c.name === customer.name);
+                if (index !== -1) {
+                                customers.value = [
+                                        ...customers.value.slice(0, index),
+                                        customer,
+                                        ...customers.value.slice(index + 1),
+                                ];
+                } else {
+                        customers.value = [...customers.value, customer];
+                }
+
+                await setCustomerStorage([customer]);
+                setSelectedCustomer(customer.name);
+                customerRefreshKey.value += 1;
+        };
+
+        return {
+                // state
+                posProfile,
+                customers,
+                searchTerm,
+                page,
+                pageSize,
+                hasMore,
+                nextCustomerStart,
+                loadingCustomers,
+                customersLoaded,
+                isCustomerBackgroundLoading,
+                pendingCustomerSearch,
+                loadProgress,
+                totalCustomerCount,
+                loadedCustomerCount,
+                selectedCustomer,
+                readonly,
+                customerInfo,
+                customerRefreshKey,
+                filteredCustomers,
+                effectiveReadonly,
+                // actions
+                setPosProfile,
+                setReadonly,
+                setCustomerInfo,
+                setSelectedCustomer,
+                setSearchTerm,
+                searchCustomers,
+                loadMoreCustomers,
+                backgroundLoadCustomers,
+                verifyServerCustomerCount,
+                get_customer_names,
+                queueSearchWhileLoading,
+                addOrUpdateCustomer,
+                triggerCustomerRefresh: () => {
+                        customerRefreshKey.value += 1;
+                },
+        };
+});

--- a/frontend/src/posapp/stores/index.js
+++ b/frontend/src/posapp/stores/index.js
@@ -10,6 +10,7 @@ export const pinia = createPinia();
 // Export stores
 export { useItemsStore } from './itemsStore.js';
 export { useInvoiceStore } from './invoiceStore.js';
+export { useCustomersStore } from './customersStore.js';
 export { useUpdateStore, formatBuildVersion } from './updateStore.js';
 
 export default pinia;


### PR DESCRIPTION
## Summary
- add a dedicated Pinia customers store that handles cached searches, background sync, and selection state
- migrate customer-consuming components to use the shared store instead of event bus messaging
- update application bootstrapping to track customer load progress from the store

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddeb42b034832685fef0db155018bf