### PR TITLE
Reduce redundant stock validation calls during cart item checks

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -622,9 +622,10 @@ export default {
                 qty: 1,
 		refresh_interval: null,
 		abortController: null,
-		itemDetailsRequestCache: { key: null, promise: null, result: null },
-		itemDetailsRetryCount: 0,
-		itemDetailsRetryTimeout: null,
+                itemDetailsRequestCache: { key: null, promise: null, result: null },
+                itemDetailsRetryCount: 0,
+                itemDetailsRetryTimeout: null,
+                itemDetailsInFlight: new Map(),
                 selected_currency: "",
                 exchange_rate: 1,
 		prePopulateInProgress: false,
@@ -905,8 +906,76 @@ export default {
                 },
 	},
 
-	methods: {
-		// Performance optimization: Memoized search function
+        methods: {
+                hydrateItemFromCaches(item, options = {}) {
+                        const { includeUoms = false } = options;
+
+                        if (!item || !item.item_code) {
+                                return false;
+                        }
+
+                        let hasCompleteData = true;
+
+                        if (typeof item.actual_qty !== "number") {
+                                if (typeof item.available_qty === "number") {
+                                        item.actual_qty = item.available_qty;
+                                } else {
+                                        const localQty = getLocalStock(item.item_code);
+                                        if (localQty !== null) {
+                                                item.actual_qty = localQty;
+                                        } else {
+                                                hasCompleteData = false;
+                                        }
+                                }
+                        }
+
+                        if (includeUoms) {
+                                if (!Array.isArray(item.item_uoms) || item.item_uoms.length === 0) {
+                                        const cachedUoms = getItemUOMs(item.item_code);
+                                        if (cachedUoms.length > 0) {
+                                                item.item_uoms = cachedUoms;
+                                        } else {
+                                                item.item_uoms = [{ uom: item.stock_uom, conversion_factor: 1.0 }];
+                                                hasCompleteData = false;
+                                        }
+                                }
+                        }
+
+                        if (this.itemCache instanceof Map) {
+                                const cached = this.itemCache.get(item.item_code) || {};
+                                this.itemCache.set(item.item_code, { ...cached, ...item });
+                        }
+
+                        return hasCompleteData;
+                },
+
+                queueItemDetailsFetch(item) {
+                        if (!item || !item.item_code || isOffline()) {
+                                return;
+                        }
+
+                        if (!(this.itemDetailsInFlight instanceof Map)) {
+                                this.itemDetailsInFlight = new Map();
+                        }
+
+                        if (this.itemDetailsInFlight.has(item.item_code)) {
+                                return;
+                        }
+
+                        const pending = this.update_items_details([item])
+                                .catch((error) => {
+                                        if (error?.name !== "AbortError") {
+                                                console.error("Deferred item detail fetch failed", error);
+                                        }
+                                })
+                                .finally(() => {
+                                        this.itemDetailsInFlight.delete(item.item_code);
+                                });
+
+                        this.itemDetailsInFlight.set(item.item_code, pending);
+                },
+
+                // Performance optimization: Memoized search function
                 memoizedSearch(searchTerm, itemGroup) {
                         const cacheKey = `${searchTerm || ""}_${itemGroup || "ALL"}`;
 
@@ -1725,15 +1794,17 @@ export default {
 			}
 			await this.add_item(item);
 		},
-		async add_item(item, options = {}) {
-			const { suppressNegativeWarning = false } = options;
-			item = { ...item };
+                async add_item(item, options = {}) {
+                        const { suppressNegativeWarning = false } = options;
+                        item = { ...item };
 
-			// Handle variant items
-			if (item.has_variants) {
-				await this.handleVariantItem(item);
-				return;
-			}
+                        this.hydrateItemFromCaches(item);
+
+                        // Handle variant items
+                        if (item.has_variants) {
+                                await this.handleVariantItem(item);
+                                return;
+                        }
 
 			// Validate item before adding to cart
 			const requestedQty = this.qty != null ? Math.abs(this.qty) : 1;
@@ -1753,7 +1824,7 @@ export default {
 			}
 
 			// Prepare item for cart
-			await this.prepareItemForCart(item, requestedQty);
+                        this.prepareItemForCart(item, requestedQty);
 
 			// Add item to cart
 			const payload = { ...item };
@@ -1804,18 +1875,16 @@ export default {
 		/**
 		 * Prepare item for adding to cart (UOMs, currency conversion, etc.)
 		 */
-		async prepareItemForCart(item, requestedQty) {
-			// Ensure UOMs are initialized
-			if (!item.item_uoms || item.item_uoms.length === 0) {
-				await this.update_items_details([item]);
-				if (!item.item_uoms || item.item_uoms.length === 0) {
-					item.item_uoms = [{ uom: item.stock_uom, conversion_factor: 1.0 }];
-				}
-			}
+                prepareItemForCart(item, requestedQty) {
+                        const hasCompleteDetails = this.hydrateItemFromCaches(item, { includeUoms: true });
 
-			// Handle multi-currency conversion
-			if (this.pos_profile.posa_allow_multi_currency) {
-				this.applyCurrencyConversionToItem(item);
+                        if (!hasCompleteDetails) {
+                                this.queueItemDetailsFetch(item);
+                        }
+
+                        // Handle multi-currency conversion
+                        if (this.pos_profile.posa_allow_multi_currency) {
+                                this.applyCurrencyConversionToItem(item);
 
 				const base_rate = item.original_currency === this.pos_profile.currency
 					? item.original_rate

--- a/frontend/src/posapp/composables/useCartValidation.js
+++ b/frontend/src/posapp/composables/useCartValidation.js
@@ -9,6 +9,8 @@
 
 import { ref } from 'vue';
 
+import { isOffline } from '../../offline/index.js';
+
 import {
     parseBooleanSetting,
     formatNegativeStockWarning,
@@ -72,10 +74,11 @@ export function useCartValidation() {
             // Allow negative stock items when Allow Negative Stock is enabled
             // This overrides POS Profile's block setting when negative stock is explicitly allowed
             const allowNegativeStock = parseBooleanSetting(stockSettings?.allow_negative_stock);
-            const exceedsAvailable = typeof item.actual_qty === 'number' && requestedQty > item.actual_qty;
-            const blockSale = !allowNegativeStock && exceedsAvailable;
+            const availableQty = typeof item.actual_qty === 'number' ? item.actual_qty : null;
+            const exceedsAvailable = availableQty !== null && requestedQty > availableQty;
+            const enforceStockLimit = blockSaleBeyondAvailableQty && !allowNegativeStock;
 
-            if (blockSale) {
+            if (enforceStockLimit && exceedsAvailable) {
                 if (eventBus) {
                     eventBus.emit("show_message", {
                         title: formatStockShortageError(
@@ -89,24 +92,28 @@ export function useCartValidation() {
                 return false;
             }
 
-            // Step 5: Server-side stock validation
-            const stockValidationResult = await validateStockOnServer(item, requestedQty, posProfile);
+            // Step 5: Server-side stock validation (only when enforcing limits and online)
+            const shouldValidateOnServer = enforceStockLimit && !isOffline() && availableQty === null;
 
-            if (!stockValidationResult.isValid) {
-                if (eventBus) {
-                    eventBus.emit("show_message", {
-                        title: formatStockShortageError(
-                            stockValidationResult.data?.item_name || item.item_name || item.item_code,
-                            stockValidationResult.data?.available_qty ?? item.actual_qty,
-                            stockValidationResult.data?.requested_qty ?? requestedQty
-                        ),
-                        color: "error",
-                    });
+            if (shouldValidateOnServer) {
+                const stockValidationResult = await validateStockOnServer(item, requestedQty, posProfile);
+
+                if (!stockValidationResult.isValid) {
+                    if (eventBus) {
+                        eventBus.emit("show_message", {
+                            title: formatStockShortageError(
+                                stockValidationResult.data?.item_name || item.item_name || item.item_code,
+                                stockValidationResult.data?.available_qty ?? item.actual_qty,
+                                stockValidationResult.data?.requested_qty ?? requestedQty
+                            ),
+                            color: "error",
+                        });
+                    }
+                    return false;
                 }
-                return false;
             }
 
-            if (allowNegativeStock && exceedsAvailable && eventBus && showNegativeStockWarning) {
+            if (!enforceStockLimit && exceedsAvailable && eventBus && showNegativeStockWarning) {
                 eventBus.emit("show_message", {
                     title: formatNegativeStockWarning(
                         item.item_name || item.item_code,
@@ -210,9 +217,12 @@ export function useCartValidation() {
 
         // Allow negative stock items when Allow Negative Stock is enabled
         const allowNegativeStock = parseBooleanSetting(stockSettings?.allow_negative_stock);
+        const availableQty = typeof item.actual_qty === 'number' ? item.actual_qty : null;
+        const exceedsAvailable = availableQty !== null && requestedQty > availableQty;
+        const enforceStockLimit = blockSaleBeyondAvailableQty && !allowNegativeStock;
 
         // Simple negative stock check - only block if negative stock is not allowed
-        if (item.actual_qty < 0 && !allowNegativeStock) {
+        if (availableQty !== null && availableQty < 0 && enforceStockLimit) {
             if (eventBus) {
                 eventBus.emit("show_message", {
                     title: formatStockShortageError(
@@ -226,10 +236,7 @@ export function useCartValidation() {
             return false;
         }
 
-        // Check if requested quantity exceeds available stock
-        const exceedsAvailable = typeof item.actual_qty === 'number' && requestedQty > item.actual_qty;
-        const blockSale = !allowNegativeStock && exceedsAvailable;
-        if (blockSale) {
+        if (enforceStockLimit && exceedsAvailable) {
             if (eventBus) {
                 eventBus.emit("show_message", {
                     title: formatStockShortageError(
@@ -243,7 +250,7 @@ export function useCartValidation() {
             return false;
         }
 
-        if (allowNegativeStock && exceedsAvailable && eventBus && showNegativeStockWarning) {
+        if (!enforceStockLimit && exceedsAvailable && eventBus && showNegativeStockWarning) {
             eventBus.emit("show_message", {
                 title: formatNegativeStockWarning(
                     item.item_name || item.item_code,

--- a/frontend/src/posapp/composables/useCartValidation.js
+++ b/frontend/src/posapp/composables/useCartValidation.js
@@ -9,7 +9,7 @@
 
 import { ref } from 'vue';
 
-import { isOffline } from '../../offline/index.js';
+import { isOffline, getLocalStock } from '../../offline/index.js';
 
 import {
     parseBooleanSetting,
@@ -19,6 +19,8 @@ import {
 export function useCartValidation() {
     const isValidating = ref(false);
     const validationError = ref(null);
+    const validationCache = new Map();
+    const VALIDATION_CACHE_TTL = 5000;
 
     /**
      * Validates if an item can be added to the cart
@@ -74,7 +76,36 @@ export function useCartValidation() {
             // Allow negative stock items when Allow Negative Stock is enabled
             // This overrides POS Profile's block setting when negative stock is explicitly allowed
             const allowNegativeStock = parseBooleanSetting(stockSettings?.allow_negative_stock);
-            const availableQty = typeof item.actual_qty === 'number' ? item.actual_qty : null;
+
+            let availableQty = typeof item.actual_qty === 'number' ? item.actual_qty : null;
+
+            if (availableQty === null && typeof item.available_qty === 'number') {
+                availableQty = item.available_qty;
+                item.actual_qty = availableQty;
+            }
+
+            if (availableQty === null) {
+                const localStockQty = getLocalStock(item.item_code);
+                if (localStockQty !== null) {
+                    availableQty = localStockQty;
+                    item.actual_qty = localStockQty;
+                }
+            }
+
+            if (availableQty === null) {
+                const cachedEntry = validationCache.get(item.item_code);
+                if (cachedEntry && Date.now() - cachedEntry.timestamp < VALIDATION_CACHE_TTL) {
+                    availableQty = cachedEntry.availableQty;
+                }
+            }
+
+            if (availableQty !== null) {
+                validationCache.set(item.item_code, {
+                    availableQty,
+                    timestamp: Date.now(),
+                });
+            }
+
             const exceedsAvailable = availableQty !== null && requestedQty > availableQty;
             const enforceStockLimit = blockSaleBeyondAvailableQty && !allowNegativeStock;
 
@@ -109,7 +140,32 @@ export function useCartValidation() {
                             color: "error",
                         });
                     }
+                    const failedAvailableQty =
+                        typeof stockValidationResult.data?.available_qty === 'number'
+                            ? stockValidationResult.data.available_qty
+                            : null;
+
+                    if (failedAvailableQty !== null) {
+                        validationCache.set(item.item_code, {
+                            availableQty: failedAvailableQty,
+                            timestamp: Date.now(),
+                        });
+                        item.actual_qty = failedAvailableQty;
+                    }
                     return false;
+                }
+
+                const serverAvailableQty =
+                    typeof stockValidationResult.data?.available_qty === 'number'
+                        ? stockValidationResult.data.available_qty
+                        : availableQty;
+
+                if (serverAvailableQty !== null) {
+                    item.actual_qty = serverAvailableQty;
+                    validationCache.set(item.item_code, {
+                        availableQty: serverAvailableQty,
+                        timestamp: Date.now(),
+                    });
                 }
             }
 
@@ -217,7 +273,29 @@ export function useCartValidation() {
 
         // Allow negative stock items when Allow Negative Stock is enabled
         const allowNegativeStock = parseBooleanSetting(stockSettings?.allow_negative_stock);
-        const availableQty = typeof item.actual_qty === 'number' ? item.actual_qty : null;
+
+        let availableQty = typeof item.actual_qty === 'number' ? item.actual_qty : null;
+
+        if (availableQty === null && typeof item.available_qty === 'number') {
+            availableQty = item.available_qty;
+            item.actual_qty = availableQty;
+        }
+
+        if (availableQty === null) {
+            const localStockQty = getLocalStock(item.item_code);
+            if (localStockQty !== null) {
+                availableQty = localStockQty;
+                item.actual_qty = localStockQty;
+            }
+        }
+
+        if (availableQty !== null) {
+            validationCache.set(item.item_code, {
+                availableQty,
+                timestamp: Date.now(),
+            });
+        }
+
         const exceedsAvailable = availableQty !== null && requestedQty > availableQty;
         const enforceStockLimit = blockSaleBeyondAvailableQty && !allowNegativeStock;
 


### PR DESCRIPTION
## Summary
- respect the POS profile block setting when deciding whether to block or warn about stock shortages
- skip server-side stock validation when running offline or when local quantity data is already available
- align the fallback validation path so it matches the streamlined live checks and still raises warnings when stock may go negative

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de3fa38c348326bd2eee62bf26ea4a