### PR TITLE
feat: batch validate multi-item additions

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -622,9 +622,13 @@ export default {
                 qty: 1,
 		refresh_interval: null,
 		abortController: null,
-		itemDetailsRequestCache: { key: null, promise: null, result: null },
-		itemDetailsRetryCount: 0,
-		itemDetailsRetryTimeout: null,
+                itemDetailsRequestCache: new Map(),
+                itemDetailsRetryCount: 0,
+                itemDetailsRetryTimeout: null,
+                pendingDetailItems: new Map(),
+                pendingDetailResolvers: [],
+                pendingDetailFrame: null,
+                detailBatchInFlight: false,
                 selected_currency: "",
                 exchange_rate: 1,
 		prePopulateInProgress: false,
@@ -1202,72 +1206,79 @@ export default {
                         this.scheduleCardMetricsUpdate();
                 },
 
-		async fetchItemDetails(items) {
-			if (!items || items.length === 0) {
-				return [];
-			}
+                async fetchItemDetails(items) {
+                        if (!items || items.length === 0) {
+                                return [];
+                        }
 
-			const key = [
-				this.pos_profile.name,
-				this.active_price_list,
-				items.map((i) => i.item_code).join(","),
-			].join(":");
+                        const key = [
+                                this.pos_profile.name,
+                                this.active_price_list,
+                                items
+                                        .map((i) => i.item_code)
+                                        .filter(Boolean)
+                                        .sort()
+                                        .join(","),
+                        ].join(":");
 
-			if (this.itemDetailsRequestCache.key === key && this.itemDetailsRequestCache.result) {
-				return this.itemDetailsRequestCache.result;
-			}
+                        const cachedEntry = this.itemDetailsRequestCache.get(key);
+                        if (cachedEntry?.result) {
+                                return cachedEntry.result;
+                        }
 
-			if (this.itemDetailsRequestCache.key === key && this.itemDetailsRequestCache.promise) {
-				return this.itemDetailsRequestCache.promise;
-			}
+                        if (cachedEntry?.promise) {
+                                return cachedEntry.promise;
+                        }
 
-			this.cancelItemDetailsRequest();
-			this.itemDetailsRequestCache.key = key;
+                        this.cancelItemDetailsRequest();
 
-			this.abortController = new AbortController();
-			const requestPromise = frappe.call({
-				method: "posawesome.posawesome.api.items.get_items_details",
-				args: {
-					pos_profile: JSON.stringify(this.pos_profile),
-					items_data: JSON.stringify(items),
-					price_list: this.active_price_list,
-				},
-				freeze: false,
-				signal: this.abortController.signal,
-			});
+                        this.abortController = new AbortController();
+                        const requestPromise = frappe.call({
+                                method: "posawesome.posawesome.api.items.get_items_details",
+                                args: {
+                                        pos_profile: JSON.stringify(this.pos_profile),
+                                        items_data: JSON.stringify(items),
+                                        price_list: this.active_price_list,
+                                },
+                                freeze: false,
+                                signal: this.abortController.signal,
+                        });
 
-			this.itemDetailsRequestCache.promise = requestPromise;
+                        this.itemDetailsRequestCache.set(key, { promise: requestPromise, result: null });
 
-			try {
-				const r = await requestPromise;
-				const msg = (r && r.message) || [];
-				if (this.itemDetailsRequestCache.key === key) {
-					this.itemDetailsRequestCache.result = msg;
-				}
-				return msg;
-			} catch (err) {
-				if (err.name !== "AbortError") {
-					console.error("Error fetching item details:", err);
-				}
-				throw err;
-			} finally {
-				if (this.itemDetailsRequestCache.key === key) {
-					this.itemDetailsRequestCache.promise = null;
-				}
-				this.abortController = null;
-			}
-		},
-		cancelItemDetailsRequest() {
-			if (this.abortController) {
-				this.abortController.abort();
-				this.abortController = null;
-			}
-			if (this.itemDetailsRequestCache) {
-				this.itemDetailsRequestCache.key = null;
-				this.itemDetailsRequestCache.promise = null;
-				this.itemDetailsRequestCache.result = null;
-			}
-		},
+                        try {
+                                const r = await requestPromise;
+                                const msg = (r && r.message) || [];
+                                const entry = this.itemDetailsRequestCache.get(key);
+                                if (entry) {
+                                        entry.result = msg;
+                                        entry.promise = null;
+                                        this.itemDetailsRequestCache.set(key, entry);
+                                }
+                                return msg;
+                        } catch (err) {
+                                if (err.name !== "AbortError") {
+                                        console.error("Error fetching item details:", err);
+                                }
+                                throw err;
+                        } finally {
+                                const entry = this.itemDetailsRequestCache.get(key);
+                                if (entry && !entry.result) {
+                                        entry.promise = null;
+                                        this.itemDetailsRequestCache.set(key, entry);
+                                }
+                                this.abortController = null;
+                        }
+                },
+                cancelItemDetailsRequest() {
+                        if (this.abortController) {
+                                this.abortController.abort();
+                                this.abortController = null;
+                        }
+                        if (this.itemDetailsRequestCache) {
+                                this.itemDetailsRequestCache.clear();
+                        }
+                },
                 async refreshPricesForVisibleItems() {
                         const vm = this;
                         if (!vm.displayedItems || vm.displayedItems.length === 0) return;
@@ -2155,45 +2166,199 @@ export default {
                         this.qty = 1;
                         this.focusItemSearch();
                 },
-		async update_items_details(items) {
-			const vm = this;
-			if (!items || !items.length) return;
+                async update_items_details(items) {
+                        if (!items || !items.length) return;
 
-			// reset any pending retry timer
-			if (vm.itemDetailsRetryTimeout) {
-				clearTimeout(vm.itemDetailsRetryTimeout);
-				vm.itemDetailsRetryTimeout = null;
-			}
+                        // reset any pending retry timer
+                        if (this.itemDetailsRetryTimeout) {
+                                clearTimeout(this.itemDetailsRetryTimeout);
+                                this.itemDetailsRetryTimeout = null;
+                        }
 
-			const itemCodes = items.map((it) => it.item_code);
-			const cacheResult = await getCachedItemDetails(
-				vm.pos_profile.name,
-				vm.active_price_list,
-				itemCodes,
-			);
-			cacheResult.cached.forEach((det) => {
-				const item = items.find((it) => it.item_code === det.item_code);
-				if (item) {
-					Object.assign(item, {
-						actual_qty: det.actual_qty,
-						has_batch_no: det.has_batch_no,
-						has_serial_no: det.has_serial_no,
-					});
-					if (det.item_uoms && det.item_uoms.length > 0) {
-						item.item_uoms = det.item_uoms;
-						saveItemUOMs(item.item_code, det.item_uoms);
-					}
-					if (det.rate !== undefined) {
-						const force = vm.pos_profile?.posa_force_price_from_customer_price_list !== false;
-						const price = det.price_list_rate ?? det.rate ?? 0;
-						if (force || price) {
-							item.rate = price;
-							item.price_list_rate = price;
-						}
-					}
-					if (det.currency) {
-						item.currency = det.currency;
-					}
+                        const validItems = items.filter((item) => item && item.item_code);
+                        if (!validItems.length) {
+                                return;
+                        }
+
+                        validItems.forEach((item) => this.primeItemFromLocalCache(item));
+
+                        validItems.forEach((item) => {
+                                if (!this.pendingDetailItems.has(item.item_code)) {
+                                        this.pendingDetailItems.set(item.item_code, new Set());
+                                }
+                                this.pendingDetailItems.get(item.item_code).add(item);
+                        });
+
+                        this.schedulePendingDetailFlush();
+
+                        return new Promise((resolve, reject) => {
+                                this.pendingDetailResolvers.push({ resolve, reject });
+                        });
+                },
+                schedulePendingDetailFlush() {
+                        if (this.pendingDetailFrame) {
+                                return;
+                        }
+
+                        const callback = () => {
+                                this.pendingDetailFrame = null;
+                                this.flushPendingItemDetails();
+                        };
+
+                        if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+                                const id = window.requestAnimationFrame(callback);
+                                this.pendingDetailFrame = { type: "raf", id };
+                        } else {
+                                const id = setTimeout(callback, 16);
+                                this.pendingDetailFrame = { type: "timeout", id };
+                        }
+                },
+                clearPendingDetailFrame() {
+                        if (!this.pendingDetailFrame) {
+                                return;
+                        }
+
+                        const { type, id } = this.pendingDetailFrame;
+                        if (type === "raf" && typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+                                window.cancelAnimationFrame(id);
+                        } else if (type === "timeout") {
+                                clearTimeout(id);
+                        }
+                        this.pendingDetailFrame = null;
+                },
+                async flushPendingItemDetails() {
+                        if (this.detailBatchInFlight) {
+                                this.schedulePendingDetailFlush();
+                                return;
+                        }
+
+                        const pendingMap = this.pendingDetailItems;
+                        const resolvers = this.pendingDetailResolvers;
+
+                        if (!pendingMap || pendingMap.size === 0) {
+                                while (resolvers.length) {
+                                        const resolver = resolvers.shift();
+                                        if (resolver?.resolve) {
+                                                resolver.resolve();
+                                        }
+                                }
+                                return;
+                        }
+
+                        this.pendingDetailItems = new Map();
+                        this.pendingDetailResolvers = [];
+
+                        const items = [];
+                        pendingMap.forEach((set) => {
+                                set.forEach((item) => {
+                                        if (item && item.item_code) {
+                                                items.push(item);
+                                        }
+                                });
+                        });
+
+                        if (!items.length) {
+                                while (resolvers.length) {
+                                        const resolver = resolvers.shift();
+                                        if (resolver?.resolve) {
+                                                resolver.resolve();
+                                        }
+                                }
+                                return;
+                        }
+
+                        const start = typeof performance !== "undefined" && performance?.now
+                                ? performance.now()
+                                : Date.now();
+
+                        this.detailBatchInFlight = true;
+
+                        const batchPromise = this.processItemDetailsBatch(items)
+                                .then(() => {
+                                        resolvers.forEach((resolver) => resolver?.resolve && resolver.resolve());
+                                })
+                                .catch((error) => {
+                                        resolvers.forEach((resolver) => resolver?.reject && resolver.reject(error));
+                                        return Promise.reject(error);
+                                })
+                                .finally(() => {
+                                        const end = typeof performance !== "undefined" && performance?.now
+                                                ? performance.now()
+                                                : Date.now();
+                                        const duration = Math.round((end - start) * 10) / 10;
+                                        console.info(
+                                                `[ItemsSelector] item details batch (${items.length} item${
+                                                        items.length === 1 ? "" : "s"
+                                                }) completed in ${duration}ms`,
+                                        );
+                                        this.detailBatchInFlight = false;
+                                        if (this.pendingDetailItems.size > 0) {
+                                                this.schedulePendingDetailFlush();
+                                        }
+                                });
+
+                        try {
+                                await batchPromise;
+                        } catch (error) {
+                                console.debug("Item detail batch failed", error);
+                        }
+                },
+                async processItemDetailsBatch(items) {
+                        const vm = this;
+                        if (!items || !items.length) return;
+
+                        const itemsByCode = new Map();
+                        const uniqueItems = [];
+
+                        items.forEach((item) => {
+                                if (!item || !item.item_code) {
+                                        return;
+                                }
+                                if (!itemsByCode.has(item.item_code)) {
+                                        itemsByCode.set(item.item_code, new Set());
+                                        uniqueItems.push(item);
+                                }
+                                itemsByCode.get(item.item_code).add(item);
+                        });
+
+                        if (!uniqueItems.length) {
+                                return;
+                        }
+
+                        const itemCodes = uniqueItems.map((it) => it.item_code);
+                        const cacheResult = await getCachedItemDetails(
+                                vm.pos_profile.name,
+                                vm.active_price_list,
+                                itemCodes,
+                        );
+
+                        cacheResult.cached.forEach((det) => {
+                                const targets = itemsByCode.get(det.item_code);
+                                if (!targets || targets.size === 0) {
+                                        return;
+                                }
+
+                                targets.forEach((item) => {
+                                        Object.assign(item, {
+                                                actual_qty: det.actual_qty,
+                                                has_batch_no: det.has_batch_no,
+                                                has_serial_no: det.has_serial_no,
+                                        });
+                                        if (det.item_uoms && det.item_uoms.length > 0) {
+                                                item.item_uoms = det.item_uoms;
+                                                saveItemUOMs(item.item_code, det.item_uoms);
+                                        }
+                                        if (det.rate !== undefined) {
+                                                const force = vm.pos_profile?.posa_force_price_from_customer_price_list !== false;
+                                                const price = det.price_list_rate ?? det.rate ?? 0;
+                                                if (force || price) {
+                                                        item.rate = price;
+                                                        item.price_list_rate = price;
+                                                }
+                                        }
+                                        if (det.currency) {
+                                                item.currency = det.currency;
+                                        }
 
                                         if (!item.original_rate) {
                                                 item.original_rate = item.rate;
@@ -2202,102 +2367,130 @@ export default {
 
                                         vm.indexItem(item);
                                         vm.applyCurrencyConversionToItem(item);
+                                });
+                        });
+
+                        let allCached = cacheResult.missing.length === 0;
+                        uniqueItems.forEach((item) => {
+                                const targets = itemsByCode.get(item.item_code);
+                                if (!targets || targets.size === 0) {
+                                        return;
+                                }
+
+                                const localQty = getLocalStock(item.item_code);
+                                if (localQty !== null) {
+                                        targets.forEach((target) => {
+                                                target.actual_qty = localQty;
+                                        });
+                                } else {
+                                        allCached = false;
+                                }
+
+                                const needsUom = Array.from(targets).some(
+                                        (target) => !target.item_uoms || target.item_uoms.length === 0,
+                                );
+                                if (needsUom) {
+                                        const cachedUoms = getItemUOMs(item.item_code);
+                                        if (cachedUoms.length > 0) {
+                                                targets.forEach((target) => {
+                                                        target.item_uoms = cachedUoms;
+                                                });
+                                        } else if (isOffline()) {
+                                                targets.forEach((target) => {
+                                                        if (!target.item_uoms || target.item_uoms.length === 0) {
+                                                                target.item_uoms = [
+                                                                        { uom: target.stock_uom, conversion_factor: 1.0 },
+                                                                ];
+                                                        }
+                                                });
+                                        } else {
+                                                allCached = false;
+                                        }
                                 }
                         });
 
-			let allCached = cacheResult.missing.length === 0;
-			items.forEach((item) => {
-				const localQty = getLocalStock(item.item_code);
-				if (localQty !== null) {
-					item.actual_qty = localQty;
-				} else {
-					allCached = false;
-				}
+                        if (isOffline() || allCached) {
+                                vm.itemDetailsRetryCount = 0;
+                                return;
+                        }
 
-				if (!item.item_uoms || item.item_uoms.length === 0) {
-					const cachedUoms = getItemUOMs(item.item_code);
-					if (cachedUoms.length > 0) {
-						item.item_uoms = cachedUoms;
-					} else if (isOffline()) {
-						item.item_uoms = [{ uom: item.stock_uom, conversion_factor: 1.0 }];
-					} else {
-						allCached = false;
-					}
-				}
-			});
+                        const itemsToFetch = uniqueItems.filter(
+                                (it) => cacheResult.missing.includes(it.item_code) && !it.has_variants,
+                        );
 
-			// When offline or everything is cached, skip server call
-			if (isOffline() || allCached) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                        if (itemsToFetch.length === 0) {
+                                vm.itemDetailsRetryCount = 0;
+                                return;
+                        }
 
-			const itemsToFetch = items.filter(
-				(it) => cacheResult.missing.includes(it.item_code) && !it.has_variants,
-			);
+                        try {
+                                const details = await vm.fetchItemDetails(itemsToFetch);
+                                if (details && details.length) {
+                                        vm.itemDetailsRetryCount = 0;
+                                        let qtyChanged = false;
+                                        const updatesByCode = new Map();
 
-			if (itemsToFetch.length === 0) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                                        details.forEach((updated_item) => {
+                                                const targets = itemsByCode.get(updated_item.item_code);
+                                                if (!targets || targets.size === 0) {
+                                                        return;
+                                                }
 
-			try {
-				const details = await vm.fetchItemDetails(itemsToFetch);
-				if (details && details.length) {
-					vm.itemDetailsRetryCount = 0;
-					let qtyChanged = false;
-					let updatedItems = [];
+                                                const firstTarget = targets.values().next().value;
+                                                const prev_qty = firstTarget?.actual_qty ?? 0;
 
-					items.forEach((item) => {
-						const updated_item = details.find((element) => element.item_code == item.item_code);
-						if (updated_item) {
-							const prev_qty = item.actual_qty;
+                                                const updates = {
+                                                        actual_qty: updated_item.actual_qty,
+                                                        has_batch_no: updated_item.has_batch_no,
+                                                        has_serial_no: updated_item.has_serial_no,
+                                                        batch_no_data:
+                                                                updated_item.batch_no_data && updated_item.batch_no_data.length > 0
+                                                                        ? updated_item.batch_no_data
+                                                                        : firstTarget.batch_no_data,
+                                                        serial_no_data:
+                                                                updated_item.serial_no_data && updated_item.serial_no_data.length > 0
+                                                                        ? updated_item.serial_no_data
+                                                                        : firstTarget.serial_no_data,
+                                                        item_uoms:
+                                                                updated_item.item_uoms && updated_item.item_uoms.length > 0
+                                                                        ? updated_item.item_uoms
+                                                                        : firstTarget.item_uoms,
+                                                        rate:
+                                                                updated_item.rate !== undefined
+                                                                        ? updated_item.rate
+                                                                        : firstTarget.rate,
+                                                        price_list_rate:
+                                                                updated_item.price_list_rate !== undefined
+                                                                        ? updated_item.price_list_rate
+                                                                        : firstTarget.price_list_rate,
+                                                        currency: updated_item.currency || firstTarget.currency,
+                                                };
 
-							updatedItems.push({
-								item: item,
-								updates: {
-									actual_qty: updated_item.actual_qty,
-									has_batch_no: updated_item.has_batch_no,
-									has_serial_no: updated_item.has_serial_no,
-									batch_no_data:
-										updated_item.batch_no_data && updated_item.batch_no_data.length > 0
-											? updated_item.batch_no_data
-											: item.batch_no_data,
-									serial_no_data:
-										updated_item.serial_no_data && updated_item.serial_no_data.length > 0
-											? updated_item.serial_no_data
-											: item.serial_no_data,
-									item_uoms:
-										updated_item.item_uoms && updated_item.item_uoms.length > 0
-											? updated_item.item_uoms
-											: item.item_uoms,
-									rate: updated_item.rate !== undefined ? updated_item.rate : item.rate,
-									price_list_rate:
-										updated_item.price_list_rate !== undefined
-											? updated_item.price_list_rate
-											: item.price_list_rate,
-									currency: updated_item.currency || item.currency,
-								},
-							});
+                                                if (prev_qty > 0 && updated_item.actual_qty === 0) {
+                                                        qtyChanged = true;
+                                                }
 
-							if (prev_qty > 0 && updated_item.actual_qty === 0) {
-								qtyChanged = true;
-							}
+                                                if (updated_item.item_uoms && updated_item.item_uoms.length > 0) {
+                                                        saveItemUOMs(updated_item.item_code, updated_item.item_uoms);
+                                                }
 
-							if (updated_item.item_uoms && updated_item.item_uoms.length > 0) {
-								saveItemUOMs(item.item_code, updated_item.item_uoms);
-							}
-						}
-					});
-
-                                        updatedItems.forEach(({ item, updates }) => {
-                                                Object.assign(item, updates);
-                                                vm.indexItem(item);
-                                                vm.applyCurrencyConversionToItem(item);
+                                                updatesByCode.set(updated_item.item_code, updates);
                                         });
 
-					updateLocalStockCache(details);
-					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
+                                        updatesByCode.forEach((updates, code) => {
+                                                const targets = itemsByCode.get(code);
+                                                if (!targets) {
+                                                        return;
+                                                }
+                                                targets.forEach((item) => {
+                                                        Object.assign(item, updates);
+                                                        vm.indexItem(item);
+                                                        vm.applyCurrencyConversionToItem(item);
+                                                });
+                                        });
+
+                                        updateLocalStockCache(details);
+                                        saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
 
                                         if (
                                                 vm.pos_profile &&
@@ -2305,54 +2498,80 @@ export default {
                                                 vm.storageAvailable &&
                                                 !vm.usesLimitSearch
                                         ) {
-						try {
-							await saveItemsBulk(details);
-						} catch (e) {
-							console.error("Failed to persist item details", e);
-							vm.markStorageUnavailable && vm.markStorageUnavailable();
-						}
-					}
+                                                try {
+                                                        await saveItemsBulk(details);
+                                                } catch (e) {
+                                                        console.error("Failed to persist item details", e);
+                                                        vm.markStorageUnavailable && vm.markStorageUnavailable();
+                                                }
+                                        }
 
-					if (qtyChanged) {
-						vm.$forceUpdate();
-					}
-				}
-			} catch (err) {
-				if (err.name !== "AbortError") {
-					console.error("Error fetching item details:", err);
-					items.forEach((item) => {
-						const localQty = getLocalStock(item.item_code);
-						if (localQty !== null) {
-							item.actual_qty = localQty;
-						}
-						if (!item.item_uoms || item.item_uoms.length === 0) {
-							const cached = getItemUOMs(item.item_code);
-							if (cached.length > 0) {
-								item.item_uoms = cached;
-							}
-						}
-					});
+                                        if (qtyChanged) {
+                                                vm.$forceUpdate();
+                                        }
+                                }
+                        } catch (err) {
+                                if (err.name !== "AbortError") {
+                                        console.error("Error fetching item details:", err);
+                                        itemsByCode.forEach((targets, code) => {
+                                                const localQty = getLocalStock(code);
+                                                if (localQty !== null) {
+                                                        targets.forEach((item) => {
+                                                                item.actual_qty = localQty;
+                                                        });
+                                                }
+                                                targets.forEach((item) => {
+                                                        if (!item.item_uoms || item.item_uoms.length === 0) {
+                                                                const cached = getItemUOMs(code);
+                                                                if (cached.length > 0) {
+                                                                        item.item_uoms = cached;
+                                                                }
+                                                        }
+                                                });
+                                        });
 
-					if (!isOffline()) {
-						vm.itemDetailsRetryCount += 1;
-						const delay = Math.min(32000, 1000 * Math.pow(2, vm.itemDetailsRetryCount - 1));
-						vm.itemDetailsRetryTimeout = setTimeout(() => {
-							vm.update_items_details(items);
-						}, delay);
-					}
-				}
-			}
+                                        if (!isOffline()) {
+                                                vm.itemDetailsRetryCount += 1;
+                                                const delay = Math.min(32000, 1000 * Math.pow(2, vm.itemDetailsRetryCount - 1));
+                                                vm.itemDetailsRetryTimeout = setTimeout(() => {
+                                                        const retryItems = Array.from(itemsByCode.values()).reduce(
+                                                                (acc, set) => acc.concat(Array.from(set)),
+                                                                [],
+                                                        );
+                                                        vm.update_items_details(retryItems);
+                                                }, delay);
+                                        }
+                                }
+                        }
 
-			// Cleanup on component destroy
-			this.cleanupBeforeDestroy = () => {
-				if (vm.abortController) {
-					vm.abortController.abort();
-				}
-			};
-		},
-		update_cur_items_details() {
-			if (this.displayedItems && this.displayedItems.length > 0) {
-				this.update_items_details(this.displayedItems);
+                        vm.cleanupBeforeDestroy = () => {
+                                if (vm.abortController) {
+                                        vm.abortController.abort();
+                                }
+                        };
+                },
+                primeItemFromLocalCache(item) {
+                        if (!item || !item.item_code) {
+                                return;
+                        }
+
+                        const localQty = getLocalStock(item.item_code);
+                        if (localQty !== null) {
+                                item.actual_qty = localQty;
+                        }
+
+                        if (!item.item_uoms || item.item_uoms.length === 0) {
+                                const cachedUoms = getItemUOMs(item.item_code);
+                                if (cachedUoms.length > 0) {
+                                        item.item_uoms = cachedUoms;
+                                } else if (isOffline()) {
+                                        item.item_uoms = [{ uom: item.stock_uom, conversion_factor: 1.0 }];
+                                }
+                        }
+                },
+                update_cur_items_details() {
+                        if (this.displayedItems && this.displayedItems.length > 0) {
+                                this.update_items_details(this.displayedItems);
 			}
 		},
 		async prePopulateStockCache(items) {
@@ -3893,15 +4112,21 @@ export default {
 			clearInterval(this.refresh_interval);
 		}
 
-		if (this.itemDetailsRetryTimeout) {
-			clearTimeout(this.itemDetailsRetryTimeout);
-		}
-		this.itemDetailsRetryCount = 0;
+                if (this.itemDetailsRetryTimeout) {
+                        clearTimeout(this.itemDetailsRetryTimeout);
+                }
+                this.itemDetailsRetryCount = 0;
 
-		// Call cleanup function for abort controller
-		if (this.cleanupBeforeDestroy) {
-			this.cleanupBeforeDestroy();
-		}
+                this.clearPendingDetailFrame();
+                if (this.pendingDetailItems) {
+                        this.pendingDetailItems.clear();
+                }
+                this.pendingDetailResolvers = [];
+
+                // Call cleanup function for abort controller
+                if (this.cleanupBeforeDestroy) {
+                        this.cleanupBeforeDestroy();
+                }
 
 		// Detach scanner if it was attached
 		if (document._scannerAttached) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -687,6 +687,9 @@ export default {
                 awaitingScanResult: false,
                 scanDebounceId: null,
                 scanQueuedCode: "",
+                scanProcessingQueue: [],
+                processingScanQueue: false,
+                pendingScanQueuePromise: null,
                 refreshInFlight: false,
                 clearingSearch: false,
         }),
@@ -1698,19 +1701,19 @@ export default {
 
 			return items_headers;
 		},
-		select_item(event, item) {
-			const targets = document.querySelectorAll(".items-table-container");
-			const target = targets[targets.length - 1];
-			const source = event.currentTarget?.querySelector?.(".card-item-image") || event.currentTarget;
-			if (target && source && this.fly) {
-				this.fly(source, target, this.flyConfig);
-			}
-			this.add_item(item);
-		},
-		async click_item_row(event, { item }) {
-			const targets = document.querySelectorAll(".items-table-container");
-			const target = targets[targets.length - 1];
-			if (target && this.fly) {
+                select_item(event, item) {
+                        const targets = document.querySelectorAll(".items-table-container");
+                        const target = targets[targets.length - 1];
+                        const source = event.currentTarget?.querySelector?.(".card-item-image") || event.currentTarget;
+                        if (target && source && this.fly) {
+                                this.fly(source, target, this.flyConfig);
+                        }
+                        this.add_item(item, { source: "item-card" });
+                },
+                async click_item_row(event, { item }) {
+                        const targets = document.querySelectorAll(".items-table-container");
+                        const target = targets[targets.length - 1];
+                        if (target && this.fly) {
 				const placeholder = document.createElement("div");
 				placeholder.style.width = "40px";
 				placeholder.style.height = "40px";
@@ -1720,47 +1723,117 @@ export default {
 				placeholder.style.top = `${event.clientY - 20}px`;
 				placeholder.style.left = `${event.clientX - 20}px`;
 				document.body.appendChild(placeholder);
-				this.fly(placeholder, target, this.flyConfig);
-				placeholder.remove();
-			}
-			await this.add_item(item);
-		},
-		async add_item(item, options = {}) {
-			const { suppressNegativeWarning = false } = options;
-			item = { ...item };
+                                this.fly(placeholder, target, this.flyConfig);
+                                placeholder.remove();
+                        }
+                        await this.add_item(item, { source: "item-row" });
+                },
+                async add_item(item, options = {}) {
+                        const items = Array.isArray(item) ? item : [item];
+                        return this.addItems(items, options);
+                },
+                async addItems(items, options = {}) {
+                        if (!Array.isArray(items) || items.length === 0) {
+                                return { valid: [], invalid: [], warnings: [] };
+                        }
 
-			// Handle variant items
-			if (item.has_variants) {
-				await this.handleVariantItem(item);
-				return;
-			}
+                        const {
+                                suppressNegativeWarning = false,
+                                source = "manual",
+                                useProvidedQty = true,
+                                aggregate = items.length > 1,
+                                scannedCodes = [],
+                        } = options;
 
-			// Validate item before adding to cart
-			const requestedQty = this.qty != null ? Math.abs(this.qty) : 1;
-			const isValid = await this.cartValidation.validateCartItem(
-				item,
-				requestedQty,
-				this.pos_profile,
-				this.stock_settings,
-				this.eventBus,
-				this.blockSaleBeyondAvailableQty,
-				!suppressNegativeWarning
-			);
+                        const normalizedEntries = items.map((originalItem, index) => {
+                                const cloned = { ...originalItem };
+                                const rawQty =
+                                        useProvidedQty && typeof cloned.qty === "number"
+                                                ? cloned.qty
+                                                : this.qty != null
+                                                        ? this.qty
+                                                        : cloned.qty;
+                                const requestedQty = Math.abs(rawQty ?? 1) || 1;
 
-			if (!isValid) {
-				// Validation failed, error message already shown by validator
-				return;
-			}
+                                return {
+                                        item: cloned,
+                                        qty: requestedQty,
+                                        suppressNegativeWarning,
+                                        meta: {
+                                                index,
+                                                source,
+                                                scannedCode: Array.isArray(scannedCodes)
+                                                        ? scannedCodes[index]
+                                                        : scannedCodes,
+                                        },
+                                };
+                        });
 
-			// Prepare item for cart
-			await this.prepareItemForCart(item, requestedQty);
+                        if (normalizedEntries.length === 1 && normalizedEntries[0].item?.has_variants) {
+                                await this.handleVariantItem(normalizedEntries[0].item);
+                                return { valid: [], invalid: normalizedEntries, warnings: [] };
+                        }
 
-			// Add item to cart
-			const payload = { ...item };
-			delete payload._barcode_qty;
-			this.eventBus.emit("add_item", payload);
-			this.qty = 1;
-		},
+                        const validationResult = await this.cartValidation.validateCartItems(
+                                normalizedEntries,
+                                this.pos_profile,
+                                this.stock_settings,
+                                this.eventBus,
+                                this.blockSaleBeyondAvailableQty,
+                                !suppressNegativeWarning,
+                                aggregate,
+                        );
+
+                        if (aggregate && validationResult.invalid.length > 0) {
+                                const errorMessage = this.buildAggregatedErrorMessage(validationResult.invalid);
+                                if (source === "scan") {
+                                        this.showScanError({
+                                                message: this.__("Some scanned items could not be added"),
+                                                code: validationResult.invalid
+                                                        .map((entry) => entry.meta?.scannedCode || "")
+                                                        .filter(Boolean)
+                                                        .join(", "),
+                                                details: errorMessage,
+                                        });
+                                } else if (this.eventBus?.emit) {
+                                        this.eventBus.emit("show_message", {
+                                                title: this.__("Some items could not be added"),
+                                                summary: this.__("Cart validation"),
+                                                detail: errorMessage,
+                                                color: "error",
+                                                timeout: 6000,
+                                                groupId: "cart-validation-errors",
+                                        });
+                                }
+                        }
+
+                        if (aggregate && validationResult.warnings.length > 0 && this.eventBus?.emit) {
+                                const warningMessage = validationResult.warnings
+                                        .map((entry) => entry.message)
+                                        .filter(Boolean)
+                                        .join("\n");
+                                if (warningMessage) {
+                                        this.eventBus.emit("show_message", {
+                                                title: this.__("Negative stock warning"),
+                                                detail: warningMessage,
+                                                color: "warning",
+                                                timeout: 5000,
+                                                groupId: "cart-validation-warnings",
+                                        });
+                                }
+                        }
+
+                        for (const entry of validationResult.valid) {
+                                await this.prepareItemForCart(entry.item, entry.qty);
+                                const payload = { ...entry.item };
+                                delete payload._barcode_qty;
+                                this.eventBus.emit("add_item", payload);
+                        }
+
+                        this.qty = 1;
+
+                        return validationResult;
+                },
 
 		/**
 		 * Handle variant item selection
@@ -2969,153 +3042,187 @@ export default {
                         }
                         return index.get(normalized) || index.get(normalized.toLowerCase()) || null;
                 },
-		async addScannedItemToInvoice(item, scannedCode, qtyFromBarcode = null) {
-			console.log("Adding scanned item to invoice:", item, scannedCode);
+                async addScannedItemToInvoice(item, scannedCode, qtyFromBarcode = null) {
+                        console.log("Adding scanned item to invoice:", item, scannedCode);
 
-			// Clone the item to avoid mutating list data
-			const newItem = { ...item };
+                        const newItem = { ...item };
 
-			// If the scanned barcode has a specific UOM, apply it
-			if (Array.isArray(newItem.item_barcode)) {
-				const barcodeMatch = newItem.item_barcode.find((b) => b.barcode === scannedCode);
-				if (barcodeMatch && barcodeMatch.posa_uom) {
-					newItem.uom = barcodeMatch.posa_uom;
+                        if (Array.isArray(newItem.item_barcode)) {
+                                const barcodeMatch = newItem.item_barcode.find((b) => b.barcode === scannedCode);
+                                if (barcodeMatch && barcodeMatch.posa_uom) {
+                                        newItem.uom = barcodeMatch.posa_uom;
 
-					// Try fetching the rate for this UOM from the active price list
-					try {
-						const res = await frappe.call({
-							method: "posawesome.posawesome.api.items.get_price_for_uom",
-							args: {
-								item_code: newItem.item_code,
-								price_list: this.active_price_list,
-								uom: barcodeMatch.posa_uom,
-							},
-						});
-						if (res.message) {
-							const price = parseFloat(res.message);
-							newItem.rate = price;
-							newItem.price_list_rate = price;
-							newItem.base_rate = price;
-							newItem.base_price_list_rate = price;
-							newItem._manual_rate_set = true;
-							newItem.skip_force_update = true;
-						}
-					} catch (e) {
-						console.error("Failed to fetch UOM price", e);
-					}
-				}
-			}
+                                        try {
+                                                const res = await frappe.call({
+                                                        method: "posawesome.posawesome.api.items.get_price_for_uom",
+                                                        args: {
+                                                                item_code: newItem.item_code,
+                                                                price_list: this.active_price_list,
+                                                                uom: barcodeMatch.posa_uom,
+                                                        },
+                                                });
+                                                if (res.message) {
+                                                        const price = parseFloat(res.message);
+                                                        newItem.rate = price;
+                                                        newItem.price_list_rate = price;
+                                                        newItem.base_rate = price;
+                                                        newItem.base_price_list_rate = price;
+                                                        newItem._manual_rate_set = true;
+                                                        newItem.skip_force_update = true;
+                                                }
+                                        } catch (e) {
+                                                console.error("Failed to fetch UOM price", e);
+                                        }
+                                }
+                        }
 
-			// Apply quantity from scale barcode if available
-			if (qtyFromBarcode !== null && !isNaN(qtyFromBarcode)) {
-				newItem.qty = qtyFromBarcode;
-				newItem._barcode_qty = true;
-			}
+                        if (qtyFromBarcode !== null && !isNaN(qtyFromBarcode)) {
+                                newItem.qty = qtyFromBarcode;
+                                newItem._barcode_qty = true;
+                        }
 
-			const requestedQtyRaw =
-				qtyFromBarcode !== null && !isNaN(qtyFromBarcode) ? qtyFromBarcode : (newItem.qty ?? 1);
-			const requestedQty = Math.abs(requestedQtyRaw || 1);
-			const availableQty =
-				typeof newItem.available_qty === "number"
-					? newItem.available_qty
-					: typeof newItem.actual_qty === "number"
-						? newItem.actual_qty
-						: null;
+                        const requestedQtyRaw =
+                                qtyFromBarcode !== null && !isNaN(qtyFromBarcode)
+                                        ? qtyFromBarcode
+                                        : newItem.qty ?? 1;
+                        newItem.qty = Math.abs(requestedQtyRaw || 1);
 
-			if (availableQty !== null && availableQty < requestedQty) {
-				const formattedAvailable = this.format_number
-					? this.format_number(availableQty, this.hide_qty_decimals ? 0 : this.float_precision)
-					: availableQty;
-				const formattedRequested = this.format_number
-					? this.format_number(requestedQty, this.hide_qty_decimals ? 0 : this.float_precision)
-					: requestedQty;
-				const negativeStockEnabled = this.isNegativeStockEnabled();
-				const shouldBlock =
-					!negativeStockEnabled &&
-					(this.blockSaleBeyondAvailableQty || availableQty <= 0);
+                        this.scanProcessingQueue.push({
+                                item: newItem,
+                                scannedCode,
+                        });
 
-				if (shouldBlock) {
-					this.showScanError({
-						message: formatStockShortageError(
-							newItem.item_name || newItem.item_code || scannedCode,
-							availableQty,
-							requestedQty
-						),
-						code: scannedCode,
-						details: this.__("Adjust the quantity or enable negative stock to continue."),
-					});
-					return;
-				}
+                        return this.flushScanQueue();
+                },
+                async flushScanQueue() {
+                        if (this.processingScanQueue) {
+                                return this.pendingScanQueuePromise;
+                        }
 
-				if (negativeStockEnabled) {
-					this.eventBus.emit("show_message", {
-						title: formatNegativeStockWarning(
-							newItem.item_name || newItem.item_code || scannedCode,
-							availableQty,
-							requestedQty
-						),
-						color: "warning",
-					});
-				}
-			}
+                        this.processingScanQueue = true;
+                        this.pendingScanQueuePromise = (async () => {
+                                try {
+                                        while (this.scanProcessingQueue.length > 0) {
+                                                const batch = this.scanProcessingQueue.splice(0);
+                                                if (!batch.length) {
+                                                        continue;
+                                                }
 
-			this.awaitingScanResult = true;
+                                                const aggregate = batch.length > 1;
+                                                const items = batch.map((entry) => entry.item);
+                                                const scannedCodes = batch.map((entry) => entry.scannedCode);
 
-                        try {
-                                // Use existing add_item method with enhanced feedback
-                                await this.add_item(newItem, {
-                                        suppressNegativeWarning: true,
-                                        skipNotification: true,
-                                });
+                                                this.awaitingScanResult = true;
+
+                                                const result = await this.addItems(items, {
+                                                        suppressNegativeWarning: true,
+                                                        source: "scan",
+                                                        useProvidedQty: true,
+                                                        aggregate,
+                                                        scannedCodes,
+                                                });
+
+                                                this.handleScanBatchResult(result, batch, aggregate);
+                                        }
+                                } finally {
+                                        if (!this.scanErrorDialog) {
+                                                this.awaitingScanResult = false;
+                                        }
+                                        this.processingScanQueue = false;
+                                        this.pendingScanQueuePromise = null;
+                                }
+                        })();
+
+                        return this.pendingScanQueuePromise;
+                },
+                handleScanBatchResult(result, batch, aggregate) {
+                        const safeResult = result || {};
+                        const valid = Array.isArray(safeResult.valid) ? safeResult.valid : [];
+                        const invalid = Array.isArray(safeResult.invalid) ? safeResult.invalid : [];
+                        const hasErrors = invalid.length > 0;
+
+                        if (valid.length > 0) {
                                 this.playScanTone("success");
-                                this.scannerLocked = false;
-                                this.search_from_scanner = false;
-                                this.pendingScanCode = "";
 
-                                // Show success message
-                                const itemName =
-                                        newItem.item_name || newItem.item_code || scannedCode || this.__("Item");
-                                const rawPrecision = Number(this.float_precision);
-                                const precision = Number.isInteger(rawPrecision)
-                                        ? Math.min(Math.max(rawPrecision, 0), 6)
-                                        : 2;
-                                const displayQty = Number.isInteger(requestedQty)
-                                        ? requestedQty
-                                        : Number(requestedQty.toFixed(precision));
+                                if (!hasErrors) {
+                                        this.scannerLocked = false;
+                                        this.pendingScanCode = "";
+                                }
+
+                                this.search_from_scanner = false;
+
+                                const successLines = valid.map((entry) => {
+                                        const itemName =
+                                                entry.item?.item_name ||
+                                                entry.item?.item_code ||
+                                                this.__("Item");
+                                        const numericQtyRaw =
+                                                typeof entry.qty === "number"
+                                                        ? entry.qty
+                                                        : parseFloat(entry.qty ?? entry.item?.qty ?? 1);
+                                        const numericQty = Number.isFinite(numericQtyRaw) ? numericQtyRaw : 1;
+                                        const rawPrecision = Number(this.float_precision);
+                                        const precision = Number.isInteger(rawPrecision)
+                                                ? Math.min(Math.max(rawPrecision, 0), 6)
+                                                : 2;
+                                        const displayQty = Number.isInteger(numericQty)
+                                                ? numericQty
+                                                : Number(numericQty.toFixed(precision));
+                                        return `${itemName} (${this.__("Qty")}: ${displayQty})`;
+                                });
+
+                                const detailMessage = successLines.join("\n");
 
                                 if (this.eventBus?.emit) {
+                                        const firstItemName =
+                                                valid[0]?.item?.item_name ||
+                                                valid[0]?.item?.item_code ||
+                                                this.__("Item");
                                         this.eventBus.emit("show_message", {
-                                                title: this.__("Item {0} added to invoice", [itemName]),
+                                                title:
+                                                        valid.length === 1
+                                                                ? this.__("Item {0} added to invoice", [firstItemName])
+                                                                : this.__("{0} items added to invoice", [valid.length]),
                                                 summary: this.__("Items added to invoice"),
-                                                detail: this.__("{0} (Qty: {1})", [itemName, displayQty]),
+                                                detail: detailMessage,
                                                 color: "success",
                                                 groupId: "invoice-item-added",
                                         });
                                 } else if (frappe?.show_alert) {
                                         frappe.show_alert(
                                                 {
-                                                        message: `Added: ${itemName}`,
+                                                        message: detailMessage || this.__("Item added"),
                                                         indicator: "green",
                                                 },
                                                 3,
                                         );
                                 }
 
-                                // Clear search after successful addition and refocus input
-                                this.clearSearch();
-                                this.focusItemSearch();
-                        } finally {
-                                this.awaitingScanResult = false;
+                                if (!this.scanErrorDialog && !hasErrors) {
+                                        this.clearSearch();
+                                        this.focusItemSearch();
+                                }
+                        }
+
+                        if (!aggregate && invalid.length > 0) {
+                                const failed = invalid[0];
+                                const code = failed?.meta?.scannedCode || batch?.[0]?.scannedCode || "";
+                                const message = failed?.message || this.__("Unable to add scanned item.");
+                                this.showScanError({
+                                        message,
+                                        code,
+                                        details: failed?.message || "",
+                                });
                         }
                 },
 		isNegativeStockEnabled() {
 			return parseBooleanSetting(this.stock_settings?.allow_negative_stock);
 		},
-		showMultipleItemsDialog(items, scannedCode) {
-			// Create a dialog to let user choose from multiple matches
-			const dialog = new frappe.ui.Dialog({
-				title: __("Multiple Items Found"),
-				fields: [
+                showMultipleItemsDialog(items, scannedCode) {
+                        // Create a dialog to let user choose from multiple matches
+                        const dialog = new frappe.ui.Dialog({
+                                title: __("Multiple Items Found"),
+                                fields: [
 					{
 						fieldtype: "HTML",
 						fieldname: "items_html",
@@ -3136,11 +3243,29 @@ export default {
 						this.addScannedItemToInvoice(item, scannedCode);
 						dialog.hide();
 					});
-				});
-			}, 100);
-		},
-		generateItemSelectionHTML(items, scannedCode) {
-			let html = `<div class="mb-3"><strong>Scanned Code:</strong> ${scannedCode}</div>`;
+                                });
+                        }, 100);
+                },
+                buildAggregatedErrorMessage(entries) {
+                        if (!Array.isArray(entries) || entries.length === 0) {
+                                return "";
+                        }
+
+                        const lines = entries.map((entry) => {
+                                const label =
+                                        entry?.item?.item_name ||
+                                        entry?.item?.item_code ||
+                                        (entry?.meta?.scannedCode
+                                                ? `${this.__("Code")} ${entry.meta.scannedCode}`
+                                                : this.__("Item"));
+                                const reason = entry?.message || this.__("Validation failed");
+                                return `• ${label}: ${reason}`;
+                        });
+
+                        return lines.join("\n");
+                },
+                generateItemSelectionHTML(items, scannedCode) {
+                        let html = `<div class="mb-3"><strong>Scanned Code:</strong> ${scannedCode}</div>`;
 			html += '<div class="item-selection-list">';
 
 			items.forEach((item, index) => {
@@ -3873,9 +3998,10 @@ export default {
 }
 
 .scan-error-dialog .scan-error-details {
-	margin-top: 12px;
-	color: rgba(0, 0, 0, 0.72);
-	line-height: 1.4;
+        margin-top: 12px;
+        color: rgba(0, 0, 0, 0.72);
+        line-height: 1.4;
+        white-space: pre-line;
 }
 
 :deep(.v-theme--dark) .scan-error-dialog .scan-error-code {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1,4 +1,5 @@
 /* global __, frappe, flt */
+import throttle from "lodash/throttle";
 import {
 	isOffline,
 	saveCustomerBalance,
@@ -15,6 +16,36 @@ import { useBatchSerial } from "../../composables/useBatchSerial.js";
 import { useDiscounts } from "../../composables/useDiscounts.js";
 import { useItemAddition } from "../../composables/useItemAddition.js";
 import { useStockUtils } from "../../composables/useStockUtils.js";
+
+const totalsRecalcSchedulers = new WeakMap();
+
+const scheduleTotalsRecalc = (vm) => {
+	if (!vm) {
+		return;
+	}
+
+	let runner = totalsRecalcSchedulers.get(vm);
+	if (!runner) {
+		runner = throttle(
+			() => {
+				if (typeof vm.update_totals === "function") {
+					vm.update_totals();
+				} else if (typeof vm.recalculate_totals === "function") {
+					vm.recalculate_totals();
+				}
+
+				if (typeof vm.$forceUpdate === "function") {
+					vm.$forceUpdate();
+				}
+			},
+			50,
+			{ leading: false, trailing: true },
+		);
+		totalsRecalcSchedulers.set(vm, runner);
+	}
+
+	runner();
+};
 
 const { setSerialNo, setBatchQty } = useBatchSerial();
 const { updateDiscountAmount, calcPrices, calcItemPrice } = useDiscounts();
@@ -1373,226 +1404,256 @@ export default {
 		}
 	},
 
-        // Update details for a single item (fetch from backend)
-        async update_item_detail(item, force_update = false) {
-                console.log("update_item_detail request", {
-                        code: item ? item.item_code : undefined,
-                        force_update,
-                });
-                if (!item || !item.item_code) {
-                        return;
-                }
+        
+	// Update details for a single item (fetch from backend)
+	async update_item_detail(item, force_update = false) {
+	        console.log("update_item_detail request", {
+	                code: item ? item.item_code : undefined,
+	                force_update,
+	        });
+	        if (!item || !item.item_code) {
+	                return;
+	        }
 
-                // If a manual rate was set (e.g. via explicit UOM pricing), don't
-                // overwrite it on expand unless explicitly forced.
-                if (item._manual_rate_set && !force_update) {
-                        return;
-                }
+	        // If a manual rate was set (e.g. via explicit UOM pricing), don't
+	        // overwrite it on expand unless explicitly forced.
+	        if (item._manual_rate_set && !force_update) {
+	                return;
+	        }
 
-                if (force_update) {
-                        item._detailSynced = false;
-                }
+	        const existingPromise = item._detailInFlight;
+	        if (existingPromise) {
+	                if (!force_update) {
+	                        return existingPromise;
+	                }
+	                try {
+	                        await existingPromise;
+	                } catch (error) {
+	                        console.debug("Waiting existing detail fetch failed", error);
+	                }
+	        }
 
-                if (item._detailInFlight || (!force_update && item._detailSynced)) {
-                        return;
-                }
+	        if (force_update) {
+	                item._detailSynced = false;
+	        }
 
-                item._detailInFlight = true;
-                const vm = this;
+	        if (!force_update && item._detailSynced) {
+	                return existingPromise;
+	        }
 
-                try {
-                        const currentDoc = vm.get_invoice_doc();
-                        const response = await frappe.call({
-                                method: "posawesome.posawesome.api.items.get_item_detail",
-                                args: {
-                                        warehouse: item.warehouse || vm.pos_profile.warehouse,
-                                        doc: currentDoc,
-                                        price_list: vm.selected_price_list || vm.pos_profile.selling_price_list,
-                                        item: {
-                                                item_code: item.item_code,
-                                                customer: vm.customer,
-                                                doctype: currentDoc.doctype,
-                                                name: currentDoc.name || `New ${currentDoc.doctype} 1`,
-                                                company: vm.pos_profile.company,
-                                                conversion_rate: 1,
-                                                currency: vm.pos_profile.currency,
-                                                qty: item.qty,
-                                                price_list_rate: item.base_price_list_rate ?? item.price_list_rate ?? 0,
-                                                child_docname: `New ${currentDoc.doctype} Item 1`,
-                                                cost_center: vm.pos_profile.cost_center,
-                                                pos_profile: vm.pos_profile.name,
-                                                uom: item.uom,
-                                                tax_category: "",
-                                                transaction_type: "selling",
-                                                update_stock: vm.pos_profile.update_stock,
-                                                price_list: vm.get_price_list(),
-                                                has_batch_no: item.has_batch_no,
-                                                has_serial_no: item.has_serial_no,
-                                                serial_no: item.serial_no,
-                                                batch_no: item.batch_no,
-                                                is_stock_item: item.is_stock_item,
-                                        },
-                                },
-                        });
+	        const vm = this;
+	        let requestPromise;
 
-                        const data = response?.message;
-                        if (!data) {
-                                return;
-                        }
+	        const execute = async () => {
+	                try {
+	                        const currentDoc = vm.get_invoice_doc();
+	                        const response = await frappe.call({
+	                                method: "posawesome.posawesome.api.items.get_item_detail",
+	                                args: {
+	                                        warehouse: item.warehouse || vm.pos_profile.warehouse,
+	                                        doc: currentDoc,
+	                                        price_list: vm.selected_price_list || vm.pos_profile.selling_price_list,
+	                                        item: {
+	                                                item_code: item.item_code,
+	                                                customer: vm.customer,
+	                                                doctype: currentDoc.doctype,
+	                                                name: currentDoc.name || `New ${currentDoc.doctype} 1`,
+	                                                company: vm.pos_profile.company,
+	                                                conversion_rate: 1,
+	                                                currency: vm.pos_profile.currency,
+	                                                qty: item.qty,
+	                                                price_list_rate: item.base_price_list_rate ?? item.price_list_rate ?? 0,
+	                                                child_docname: `New ${currentDoc.doctype} Item 1`,
+	                                                cost_center: vm.pos_profile.cost_center,
+	                                                pos_profile: vm.pos_profile.name,
+	                                                uom: item.uom,
+	                                                tax_category: "",
+	                                                transaction_type: "selling",
+	                                                update_stock: vm.pos_profile.update_stock,
+	                                                price_list: vm.get_price_list(),
+	                                                has_batch_no: item.has_batch_no,
+	                                                has_serial_no: item.has_serial_no,
+	                                                serial_no: item.serial_no,
+	                                                batch_no: item.batch_no,
+	                                                is_stock_item: item.is_stock_item,
+	                                        },
+	                                },
+	                        });
 
-                        if (!item.warehouse) {
-                                item.warehouse = vm.pos_profile.warehouse;
-                        }
-                        if (data.price_list_currency) {
-                                vm.price_list_currency = data.price_list_currency;
-                        }
+	                        const data = response?.message;
+	                        if (!data) {
+	                                return;
+	                        }
 
-                        if (!item.original_currency) {
-                                item.original_currency =
-                                        data.price_list_currency || vm.price_list_currency || vm.selected_currency;
-                        }
-                        if (!item.original_rate) {
-                                item.original_rate = data.price_list_rate;
-                        }
-                        if (data.serial_no_data) {
-                                item.serial_no_data = data.serial_no_data;
-                        }
-                        if (data.batch_no_data) {
-                                item.batch_no_data = data.batch_no_data;
-                        }
-                        if (
-                                item.has_batch_no &&
-                                vm.pos_profile.posa_auto_set_batch &&
-                                !item.batch_no &&
-                                Array.isArray(data.batch_no_data) &&
-                                data.batch_no_data.length > 0
-                        ) {
-                                item.batch_no_data = data.batch_no_data;
-                                vm.set_batch_qty(item, null, false);
-                        }
+	                        if (!item.warehouse) {
+	                                item.warehouse = vm.pos_profile.warehouse;
+	                        }
+	                        if (data.price_list_currency) {
+	                                vm.price_list_currency = data.price_list_currency;
+	                        }
 
-                        if (!item.locked_price) {
-                                if (force_update || !item.base_rate) {
-                                        if (data.price_list_rate !== 0 || !item.base_price_list_rate) {
-                                                item.base_price_list_rate = data.price_list_rate;
-                                                if (!item.posa_offer_applied) {
-                                                        item.base_rate = data.price_list_rate;
-                                                }
-                                        }
-                                }
+	                        if (!item.original_currency) {
+	                                item.original_currency =
+	                                        data.price_list_currency || vm.price_list_currency || vm.selected_currency;
+	                        }
+	                        if (!item.original_rate) {
+	                                item.original_rate = data.price_list_rate;
+	                        }
+	                        if (data.serial_no_data) {
+	                                item.serial_no_data = data.serial_no_data;
+	                        }
+	                        if (data.batch_no_data) {
+	                                item.batch_no_data = data.batch_no_data;
+	                        }
+	                        if (
+	                                item.has_batch_no &&
+	                                vm.pos_profile.posa_auto_set_batch &&
+	                                !item.batch_no &&
+	                                Array.isArray(data.batch_no_data) &&
+	                                data.batch_no_data.length > 0
+	                        ) {
+	                                item.batch_no_data = data.batch_no_data;
+	                                vm.set_batch_qty(item, null, false);
+	                        }
 
-                                if (!item.posa_offer_applied) {
-                                        const companyCurrency = vm.pos_profile.currency;
-                                        const baseCurrency = companyCurrency;
+	                        if (!item.locked_price) {
+	                                if (force_update || !item.base_rate) {
+	                                        if (data.price_list_rate !== 0 || !item.base_price_list_rate) {
+	                                                item.base_price_list_rate = data.price_list_rate;
+	                                                if (!item.posa_offer_applied) {
+	                                                        item.base_rate = data.price_list_rate;
+	                                                }
+	                                        }
+	                                }
 
-                                        if (vm.selected_currency === vm.price_list_currency && vm.selected_currency !== companyCurrency) {
-                                                const conv = vm.conversion_rate || 1;
-                                                item.price_list_rate = vm.flt(
-                                                        item.base_price_list_rate / conv,
-                                                        vm.currency_precision,
-                                                );
+	                                if (force_update || !item.rate) {
+	                                        if (data.price_list_rate !== 0 || !item.price_list_rate) {
+	                                                item.price_list_rate = data.price_list_rate;
+	                                        }
+	                                        if (!item.posa_offer_applied) {
+	                                                item.rate = data.price_list_rate;
+	                                        }
+	                                }
 
-                                                if (!item._manual_rate_set) {
-                                                        item.rate = vm.flt(item.base_rate / conv, vm.currency_precision);
-                                                }
-                                        } else if (vm.selected_currency !== baseCurrency) {
-                                                const exchange_rate = vm.exchange_rate || 1;
-                                                item.price_list_rate = vm.flt(
-                                                        item.base_price_list_rate * exchange_rate,
-                                                        vm.currency_precision,
-                                                );
+	                                if (vm.selected_currency && vm.selected_currency !== vm.pos_profile.currency) {
+	                                        const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
+	                                        if (vm.selected_currency === baseCurrency) {
+	                                                const conv = vm.conversion_rate || 1;
+	                                                item.price_list_rate = vm.flt(
+	                                                        item.base_price_list_rate / conv,
+	                                                        vm.currency_precision,
+	                                                );
 
-                                                item.rate = vm.flt(item.base_rate * exchange_rate, vm.currency_precision);
-                                        } else {
-                                                item.price_list_rate = item.base_price_list_rate;
+	                                                if (!item._manual_rate_set) {
+	                                                        item.rate = vm.flt(item.base_rate / conv, vm.currency_precision);
+	                                                }
+	                                        } else if (vm.selected_currency !== baseCurrency) {
+	                                                const exchange_rate = vm.exchange_rate || 1;
+	                                                item.price_list_rate = vm.flt(
+	                                                        item.base_price_list_rate * exchange_rate,
+	                                                        vm.currency_precision,
+	                                                );
 
-                                                if (!item._manual_rate_set) {
-                                                        item.rate = item.base_rate;
-                                                }
-                                        }
-                                } else {
-                                        const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
-                                        if (vm.selected_currency !== baseCurrency) {
-                                                item.price_list_rate = vm.flt(
-                                                        item.base_rate * vm.exchange_rate,
-                                                        vm.currency_precision,
-                                                );
-                                        } else {
-                                                item.price_list_rate = item.base_rate;
-                                        }
-                                }
+	                                                item.rate = vm.flt(item.base_rate * exchange_rate, vm.currency_precision);
+	                                        } else {
+	                                                item.price_list_rate = item.base_price_list_rate;
 
-                                if (
-                                        !item.posa_offer_applied &&
-                                        vm.pos_profile.posa_apply_customer_discount &&
-                                        vm.customer_info.posa_discount > 0 &&
-                                        vm.customer_info.posa_discount <= 100 &&
-                                        item.posa_is_offer == 0 &&
-                                        !item.posa_is_replace
-                                ) {
-                                        const discount_percent =
-                                                item.max_discount > 0
-                                                        ? Math.min(item.max_discount, vm.customer_info.posa_discount)
-                                                        : vm.customer_info.posa_discount;
+	                                                if (!item._manual_rate_set) {
+	                                                        item.rate = item.base_rate;
+	                                                }
+	                                        }
+	                                } else {
+	                                        const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
+	                                        if (vm.selected_currency !== baseCurrency) {
+	                                                item.price_list_rate = vm.flt(
+	                                                        item.base_rate * vm.exchange_rate,
+	                                                        vm.currency_precision,
+	                                                );
+	                                        } else {
+	                                                item.price_list_rate = item.base_rate;
+	                                        }
+	                                }
 
-                                        item.discount_percentage = discount_percent;
+	                                if (
+	                                        !item.posa_offer_applied &&
+	                                        vm.pos_profile.posa_apply_customer_discount &&
+	                                        vm.customer_info.posa_discount > 0 &&
+	                                        vm.customer_info.posa_discount <= 100 &&
+	                                        item.posa_is_offer == 0 &&
+	                                        !item.posa_is_replace
+	                                ) {
+	                                        const discount_percent =
+	                                                item.max_discount > 0
+	                                                        ? Math.min(item.max_discount, vm.customer_info.posa_discount)
+	                                                        : vm.customer_info.posa_discount;
 
-                                        const discount_amount = vm.flt(
-                                                (item.price_list_rate * discount_percent) / 100,
-                                                vm.currency_precision,
-                                        );
-                                        item.discount_amount = discount_amount;
+	                                        item.discount_percentage = discount_percent;
 
-                                        item.base_discount_amount = vm.flt(
-                                                (item.base_price_list_rate * discount_percent) / 100,
-                                                vm.currency_precision,
-                                        );
+	                                        const discount_amount = vm.flt(
+	                                                (item.price_list_rate * discount_percent) / 100,
+	                                                vm.currency_precision,
+	                                        );
+	                                        item.discount_amount = discount_amount;
 
-                                        item.rate = vm.flt(item.price_list_rate - discount_amount, vm.currency_precision);
-                                        item.base_rate = vm.flt(
-                                                item.base_price_list_rate - item.base_discount_amount,
-                                                vm.currency_precision,
-                                        );
-                                }
-                        }
+	                                        item.base_discount_amount = vm.flt(
+	                                                (item.base_price_list_rate * discount_percent) / 100,
+	                                                vm.currency_precision,
+	                                        );
 
-                        item.last_purchase_rate = data.last_purchase_rate;
-                        item.projected_qty = data.projected_qty;
-                        item.reserved_qty = data.reserved_qty;
-                        item.conversion_factor = data.conversion_factor;
-                        item.stock_qty = data.stock_qty;
-                        item.actual_qty = data.actual_qty;
-                        item.stock_uom = data.stock_uom;
-                        item.has_serial_no = data.has_serial_no;
-                        item.has_batch_no = data.has_batch_no;
+	                                        item.rate = vm.flt(item.price_list_rate - discount_amount, vm.currency_precision);
+	                                        item.base_rate = vm.flt(
+	                                                item.base_price_list_rate - item.base_discount_amount,
+	                                                vm.currency_precision,
+	                                        );
+	                                }
+	                        }
 
-                        item.amount = vm.flt(item.qty * item.rate, vm.currency_precision);
-                        item.base_amount = vm.flt(item.qty * item.base_rate, vm.currency_precision);
+	                        item.last_purchase_rate = data.last_purchase_rate;
+	                        item.projected_qty = data.projected_qty;
+	                        item.reserved_qty = data.reserved_qty;
+	                        item.conversion_factor = data.conversion_factor;
+	                        item.stock_qty = data.stock_qty;
+	                        item.actual_qty = data.actual_qty;
+	                        item.stock_uom = data.stock_uom;
+	                        item.has_serial_no = data.has_serial_no;
+	                        item.has_batch_no = data.has_batch_no;
 
-                        console.log(`Updated rates for ${item.item_code} on expand:`, {
-                                base_rate: item.base_rate,
-                                rate: item.rate,
-                                base_price_list_rate: item.base_price_list_rate,
-                                price_list_rate: item.price_list_rate,
-                                exchange_rate: vm.exchange_rate,
-                                selected_currency: vm.selected_currency,
-                                default_currency: vm.pos_profile.currency,
-                        });
+	                        item.amount = vm.flt(item.qty * item.rate, vm.currency_precision);
+	                        item.base_amount = vm.flt(item.qty * item.base_rate, vm.currency_precision);
 
-                        item._detailSynced = true;
-                        vm.$forceUpdate();
-                } catch (error) {
-                        console.error("Error updating item detail:", error);
-                        vm.eventBus.emit("show_message", {
-                                title: __("Error updating item details"),
-                                color: "error",
-                        });
-                } finally {
-                        item._detailInFlight = false;
-                }
-        },
+	                        console.log(`Updated rates for ${item.item_code} on expand:`, {
+	                                base_rate: item.base_rate,
+	                                rate: item.rate,
+	                                base_price_list_rate: item.base_price_list_rate,
+	                                price_list_rate: item.price_list_rate,
+	                                exchange_rate: vm.exchange_rate,
+	                                selected_currency: vm.selected_currency,
+	                                default_currency: vm.pos_profile.currency,
+	                        });
 
-        // Fetch customer details (info, price list, etc)
+	                        item._detailSynced = true;
+	                        scheduleTotalsRecalc(vm);
+	                } catch (error) {
+	                        console.error("Error updating item detail:", error);
+	                        vm.eventBus.emit("show_message", {
+	                                title: __("Error updating item details"),
+	                                color: "error",
+	                        });
+	                        throw error;
+	                } finally {
+	                        if (item._detailInFlight === requestPromise) {
+	                                item._detailInFlight = null;
+	                        }
+	                }
+	        };
+
+	        requestPromise = execute();
+	        item._detailInFlight = requestPromise;
+	        requestPromise.catch(() => {});
+	        return requestPromise;
+	},
+
+// Fetch customer details (info, price list, etc)
 	async fetch_customer_details() {
 		var vm = this;
 		if (!this.customer) return;
@@ -1812,32 +1873,75 @@ export default {
 	async fetch_available_qty(item) {
 		if (!item || !item.item_code || !item.warehouse) return;
 		const key = `${item.item_code}:${item.warehouse}:${item.batch_no || ""}:${item.uom}`;
-		const cached = this.available_stock_cache[key];
+		const cache = this.available_stock_cache || (this.available_stock_cache = {});
 		const now = Date.now();
-		if (cached && now - cached.ts < 60000) {
-			item.available_qty = cached.qty;
-			this.update_qty_limits(item);
-			return;
+		const entry = cache[key];
+
+		if (entry?.promise) {
+			if (entry.qty !== undefined) {
+				item.available_qty = entry.qty;
+				this.update_qty_limits(item);
+				scheduleTotalsRecalc(this);
+			}
+			try {
+				return await entry.promise;
+			} catch (error) {
+				return entry.qty ?? 0;
+			}
 		}
-		try {
-			const r = await frappe.call({
-				method: "posawesome.posawesome.api.items.get_available_qty",
-				args: {
-					items: JSON.stringify([
-						{
-							item_code: item.item_code,
-							warehouse: item.warehouse,
-							batch_no: item.batch_no,
-						},
-					]),
-				},
-			});
-			const qty = r.message && r.message.length ? flt(r.message[0].available_qty) : 0;
-			this.available_stock_cache[key] = { qty, ts: now };
-			item.available_qty = qty;
+
+		if (entry && entry.qty !== undefined) {
+			item.available_qty = entry.qty;
 			this.update_qty_limits(item);
-		} catch (e) {
-			console.error("Failed to fetch available qty", e);
+			scheduleTotalsRecalc(this);
+			if (now - entry.ts < 60000) {
+				return entry.qty;
+			}
+		}
+
+		let requestPromise;
+		const execute = async () => {
+			try {
+				const r = await frappe.call({
+					method: "posawesome.posawesome.api.items.get_available_qty",
+					args: {
+						items: JSON.stringify([
+							{
+								item_code: item.item_code,
+								warehouse: item.warehouse,
+								batch_no: item.batch_no,
+							},
+						]),
+					},
+				});
+				const qty = r.message && r.message.length ? flt(r.message[0].available_qty) : 0;
+				cache[key] = { qty, ts: Date.now() };
+				item.available_qty = qty;
+				this.update_qty_limits(item);
+				scheduleTotalsRecalc(this);
+				return qty;
+			} catch (e) {
+				console.error("Failed to fetch available qty", e);
+				throw e;
+			} finally {
+				const current = cache[key];
+				if (current && current.promise === requestPromise) {
+					delete current.promise;
+				}
+			}
+		};
+
+		requestPromise = execute();
+		cache[key] = {
+			qty: entry?.qty,
+			ts: entry?.ts ?? 0,
+			promise: requestPromise,
+		};
+
+		try {
+			return await requestPromise;
+		} catch (error) {
+			return cache[key]?.qty ?? 0;
 		}
 	},
 

--- a/frontend/src/posapp/composables/useCartValidation.js
+++ b/frontend/src/posapp/composables/useCartValidation.js
@@ -37,105 +37,23 @@ export function useCartValidation() {
         blockSaleBeyondAvailableQty = false,
         showNegativeStockWarning = true
     ) {
-        isValidating.value = true;
-        validationError.value = null;
+        const result = await validateCartItems(
+            [
+                {
+                    item,
+                    qty: requestedQty,
+                    suppressNegativeWarning: !showNegativeStockWarning,
+                },
+            ],
+            posProfile,
+            stockSettings,
+            eventBus,
+            blockSaleBeyondAvailableQty,
+            showNegativeStockWarning,
+            false,
+        );
 
-        try {
-            // Step 1: Basic item validation
-            if (!item || !item.item_code) {
-                throw new Error('Invalid item data');
-            }
-
-            // Step 2: Check if item has variants (should not be added directly)
-            if (item.has_variants) {
-                if (eventBus) {
-                    eventBus.emit("show_message", {
-                        title: __("This is an item template. Please choose a variant."),
-                        color: "warning",
-                    });
-                }
-                return false;
-            }
-
-            // Step 3: Zero stock validation (if enabled)
-            if (item.actual_qty === 0 && posProfile?.posa_display_items_in_stock) {
-                if (eventBus) {
-                    eventBus.emit("show_message", {
-                        title: `No stock available for ${item.item_name}`,
-                        color: "warning",
-                    });
-                }
-                return false;
-            }
-
-            // Step 4: Client-side quantity validation (before server call)
-            // Allow negative stock items when Allow Negative Stock is enabled
-            // This overrides POS Profile's block setting when negative stock is explicitly allowed
-            const allowNegativeStock = parseBooleanSetting(stockSettings?.allow_negative_stock);
-            const exceedsAvailable = typeof item.actual_qty === 'number' && requestedQty > item.actual_qty;
-            const blockSale = !allowNegativeStock && exceedsAvailable;
-
-            if (blockSale) {
-                if (eventBus) {
-                    eventBus.emit("show_message", {
-                        title: formatStockShortageError(
-                            item.item_name || item.item_code,
-                            item.actual_qty,
-                            requestedQty
-                        ),
-                        color: "error",
-                    });
-                }
-                return false;
-            }
-
-            // Step 5: Server-side stock validation
-            const stockValidationResult = await validateStockOnServer(item, requestedQty, posProfile);
-
-            if (!stockValidationResult.isValid) {
-                if (eventBus) {
-                    eventBus.emit("show_message", {
-                        title: formatStockShortageError(
-                            stockValidationResult.data?.item_name || item.item_name || item.item_code,
-                            stockValidationResult.data?.available_qty ?? item.actual_qty,
-                            stockValidationResult.data?.requested_qty ?? requestedQty
-                        ),
-                        color: "error",
-                    });
-                }
-                return false;
-            }
-
-            if (allowNegativeStock && exceedsAvailable && eventBus && showNegativeStockWarning) {
-                eventBus.emit("show_message", {
-                    title: formatNegativeStockWarning(
-                        item.item_name || item.item_code,
-                        item.actual_qty,
-                        requestedQty
-                    ),
-                    color: "warning",
-                });
-            }
-
-            return true;
-
-        } catch (error) {
-            console.error('Cart validation error:', error);
-            validationError.value = error.message;
-
-            // Fallback validation for network/API errors
-            return performFallbackValidation(
-                item,
-                requestedQty,
-                stockSettings,
-                eventBus,
-                blockSaleBeyondAvailableQty,
-                showNegativeStockWarning
-            );
-
-        } finally {
-            isValidating.value = false;
-        }
+        return result.invalid.length === 0;
     }
 
     /**
@@ -272,34 +190,227 @@ export function useCartValidation() {
         stockSettings,
         eventBus,
         blockSaleBeyondAvailableQty = false,
-        showNegativeStockWarning = true
+        showNegativeStockWarning = true,
+        aggregate = false
     ) {
-        const validItems = [];
-        const invalidItems = [];
+        isValidating.value = true;
+        validationError.value = null;
 
-        for (const item of items) {
-            const isValid = await validateCartItem(
-                item.item || item,
-                item.qty || 1,
-                posProfile,
-                stockSettings,
-                eventBus,
-                blockSaleBeyondAvailableQty,
-                showNegativeStockWarning
-            );
-
-            if (isValid) {
-                validItems.push(item);
-            } else {
-                invalidItems.push(item);
-            }
-        }
-
-        return {
-            valid: validItems,
-            invalid: invalidItems,
-            hasErrors: invalidItems.length > 0
+        const results = {
+            valid: [],
+            invalid: [],
+            warnings: [],
+            errors: [],
+            hasErrors: false,
         };
+
+        const aggregateNotifications = Boolean(aggregate);
+        const allowNegativeStock = parseBooleanSetting(stockSettings?.allow_negative_stock);
+        const serverCandidates = [];
+        const candidatesMeta = [];
+
+        try {
+            for (const rawEntry of items) {
+                const entry = {
+                    ...(rawEntry || {}),
+                };
+
+                const item = entry.item || rawEntry;
+                const requestedQty = Math.abs(entry.qty ?? entry.requestedQty ?? 1) || 1;
+
+                if (!item || !item.item_code) {
+                    const message = __('Invalid item data');
+                    entry.item = item;
+                    entry.qty = requestedQty;
+                    entry.message = message;
+                    results.invalid.push(entry);
+                    results.errors.push(message);
+                    continue;
+                }
+
+                entry.item = item;
+                entry.qty = requestedQty;
+
+                if (item.has_variants) {
+                    const message = __("This is an item template. Please choose a variant.");
+                    entry.message = message;
+                    results.invalid.push(entry);
+                    results.errors.push(message);
+                    continue;
+                }
+
+                if (item.actual_qty === 0 && posProfile?.posa_display_items_in_stock) {
+                    const message = __("No stock available for {0}", [item.item_name || item.item_code]);
+                    entry.message = message;
+                    results.invalid.push(entry);
+                    results.errors.push(message);
+                    if (!aggregateNotifications && eventBus) {
+                        eventBus.emit("show_message", {
+                            title: message,
+                            color: "warning",
+                        });
+                    }
+                    continue;
+                }
+
+                const exceedsAvailable =
+                    typeof item.actual_qty === 'number' && requestedQty > item.actual_qty;
+                const shouldBlock = !allowNegativeStock && exceedsAvailable;
+
+                if (shouldBlock) {
+                    const message = formatStockShortageError(
+                        item.item_name || item.item_code,
+                        item.actual_qty,
+                        requestedQty
+                    );
+                    entry.message = message;
+                    results.invalid.push(entry);
+                    results.errors.push(message);
+                    if (!aggregateNotifications && eventBus) {
+                        eventBus.emit("show_message", {
+                            title: message,
+                            color: "error",
+                        });
+                    }
+                    continue;
+                }
+
+                const serverPayload = {
+                    item_code: item.item_code,
+                    item_name: item.item_name,
+                    warehouse: posProfile?.warehouse || item.warehouse,
+                    qty: Math.abs(requestedQty),
+                    stock_qty: Math.abs(requestedQty),
+                    actual_qty: item.actual_qty,
+                    uom: item.stock_uom || item.uom || 'Nos',
+                };
+
+                serverCandidates.push(serverPayload);
+                candidatesMeta.push({
+                    entry,
+                    exceedsAvailable,
+                });
+            }
+
+            if (!serverCandidates.length) {
+                results.hasErrors = results.invalid.length > 0;
+                return results;
+            }
+
+            let issues = [];
+
+            try {
+                const response = await frappe.call({
+                    method: "posawesome.posawesome.api.invoices.validate_cart_items",
+                    args: {
+                        items: JSON.stringify(serverCandidates),
+                        pos_profile: posProfile?.name,
+                    },
+                });
+
+                if (Array.isArray(response?.message)) {
+                    issues = response.message;
+                }
+            } catch (error) {
+                console.error('Server stock validation failed:', error);
+                validationError.value = error.message;
+
+                for (const { entry } of candidatesMeta) {
+                    const fallbackIsValid = performFallbackValidation(
+                        entry.item,
+                        entry.qty,
+                        stockSettings,
+                        aggregateNotifications ? null : eventBus,
+                        blockSaleBeyondAvailableQty,
+                        showNegativeStockWarning
+                    );
+
+                    if (fallbackIsValid) {
+                        results.valid.push(entry);
+                    } else {
+                        const message = formatStockShortageError(
+                            entry.item.item_name || entry.item.item_code,
+                            entry.item.actual_qty,
+                            entry.qty
+                        );
+                        entry.message = message;
+                        results.invalid.push(entry);
+                        results.errors.push(message);
+                        if (!aggregateNotifications && eventBus) {
+                            eventBus.emit("show_message", {
+                                title: message,
+                                color: "error",
+                            });
+                        }
+                    }
+                }
+
+                results.hasErrors = results.invalid.length > 0;
+                return results;
+            }
+
+            const issueMap = new Map();
+            for (const issue of issues) {
+                const key = `${issue.item_code || ''}::${issue.warehouse || ''}`;
+                issueMap.set(key, issue);
+            }
+
+            candidatesMeta.forEach(({ entry, exceedsAvailable }, index) => {
+                const payload = serverCandidates[index];
+                const key = `${payload.item_code || ''}::${payload.warehouse || ''}`;
+                const issue = issueMap.get(key);
+
+                if (issue) {
+                    const available = issue.available_qty ?? entry.item.actual_qty;
+                    const requested = issue.requested_qty ?? entry.qty;
+                    const message = formatStockShortageError(
+                        issue.item_name || entry.item.item_name || payload.item_code,
+                        available,
+                        requested
+                    );
+                    entry.message = message;
+                    entry.issue = issue;
+                    results.invalid.push(entry);
+                    results.errors.push(message);
+
+                    if (!aggregateNotifications && eventBus) {
+                        eventBus.emit("show_message", {
+                            title: message,
+                            color: "error",
+                        });
+                    }
+
+                    return;
+                }
+
+                if (allowNegativeStock && exceedsAvailable) {
+                    const warningMessage = formatNegativeStockWarning(
+                        entry.item.item_name || entry.item.item_code,
+                        entry.item.actual_qty,
+                        entry.qty
+                    );
+
+                    if (!aggregateNotifications && eventBus && showNegativeStockWarning) {
+                        eventBus.emit("show_message", {
+                            title: warningMessage,
+                            color: "warning",
+                        });
+                    } else if (showNegativeStockWarning) {
+                        results.warnings.push({
+                            ...entry,
+                            message: warningMessage,
+                        });
+                    }
+                }
+
+                results.valid.push(entry);
+            });
+
+            results.hasErrors = results.invalid.length > 0;
+            return results;
+        } finally {
+            isValidating.value = false;
+        }
     }
 
     return {

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -6,26 +6,68 @@ import { withPerf } from "../utils/perf.js";
 /* global frappe, __ */
 
 export function useItemAddition() {
-        const runAsyncTask = (task, contextLabel) => {
-                Promise.resolve().then(() => {
-                        try {
-                                const result = typeof task === "function" ? task() : null;
-                                if (result && typeof result.then === "function") {
-                                        result.catch((error) => {
-                                                console.error(
-                                                        `Async task failed${contextLabel ? ` (${contextLabel})` : ""}:`,
-                                                        error,
-                                                );
-                                        });
-                                }
-                        } catch (error) {
-                                console.error(
-                                        `Async task threw synchronously${contextLabel ? ` (${contextLabel})` : ""}:`,
-                                        error,
-                                );
-                        }
-                });
-        };
+	const pendingItemTaskKeys = new Map();
+
+	const getItemRequestKey = (item, context) => {
+		if (!item || !item.item_code) {
+			return null;
+		}
+		const warehouse = item.warehouse || context?.pos_profile?.warehouse || "";
+		const batch = item.batch_no || "";
+		return `${item.item_code}::${warehouse}::${batch}`;
+	};
+
+	const runAsyncTask = (task, contextLabel, requestKey) => {
+		if (requestKey) {
+			const existing = pendingItemTaskKeys.get(requestKey);
+			if (existing) {
+				return existing;
+			}
+		}
+
+		let scheduled = Promise.resolve().then(() => {
+			let result;
+			try {
+				result = typeof task === "function" ? task() : null;
+			} catch (error) {
+				console.error(
+					`Async task threw synchronously${contextLabel ? ` (${contextLabel})` : ""}:`,
+					error,
+				);
+				throw error;
+			}
+
+			if (result && typeof result.then === "function") {
+				return result.catch((error) => {
+					console.error(
+						`Async task failed${contextLabel ? ` (${contextLabel})` : ""}:`,
+						error,
+					);
+					throw error;
+				});
+			}
+
+			return result;
+		});
+
+		scheduled = scheduled.finally(() => {
+			if (requestKey) {
+				pendingItemTaskKeys.delete(requestKey);
+			}
+		});
+
+		if (requestKey) {
+			pendingItemTaskKeys.set(requestKey, scheduled);
+		}
+
+		scheduled.catch(() => {});
+		return scheduled;
+	};
+
+	const scheduleItemTask = (task, contextLabel, item, context) => {
+		const key = getItemRequestKey(item, context);
+		return runAsyncTask(task, contextLabel, key);
+	};
 
         // Remove item from invoice
         const removeItem = (item, context) => {
@@ -77,11 +119,21 @@ export function useItemAddition() {
 			};
 			context.packed_items.push(child);
                         if (context.update_item_detail) {
-                                runAsyncTask(() => context.update_item_detail(child, false), "update_item_detail:bundle_child");
+                                scheduleItemTask(
+                                        () => context.update_item_detail(child, false),
+                                        "update_item_detail:bundle_child",
+                                        child,
+                                        context,
+                                );
                                 context.calc_stock_qty && context.calc_stock_qty(child, child.qty);
                         }
                         if (context.fetch_available_qty) {
-                                runAsyncTask(() => context.fetch_available_qty(child), "fetch_available_qty:bundle_child");
+                                scheduleItemTask(
+                                        () => context.fetch_available_qty(child),
+                                        "fetch_available_qty:bundle_child",
+                                        child,
+                                        context,
+                                );
                         }
 		}
 	};
@@ -194,16 +246,20 @@ export function useItemAddition() {
                                 runAsyncTask(() => expandBundle(new_item, context), "expand_bundle");
                                 // Skip recalculation to preserve the manually set rate
                                 if (context.update_item_detail) {
-                                        runAsyncTask(
+                                        scheduleItemTask(
                                                 () => context.update_item_detail(new_item, false),
                                                 "update_item_detail:new",
+                                                new_item,
+                                                context,
                                         );
                                 }
 
                                 if (context.fetch_available_qty) {
-                                        runAsyncTask(
+                                        scheduleItemTask(
                                                 () => context.fetch_available_qty(new_item),
                                                 "fetch_available_qty:new",
+                                                new_item,
+                                                context,
                                         );
                                 }
 
@@ -260,9 +316,11 @@ export function useItemAddition() {
 				const cur_item = context.items[index];
 				const previousQty = cur_item.qty;
                                 if (context.update_items_details) {
-                                        runAsyncTask(
+                                        scheduleItemTask(
                                                 () => context.update_items_details([cur_item]),
                                                 "update_items_details:merge_new",
+                                                cur_item,
+                                                context,
                                         );
                                 }
 				// Merge serial numbers if any
@@ -298,9 +356,11 @@ export function useItemAddition() {
                                 }
 
                                 if (context.fetch_available_qty) {
-                                        runAsyncTask(
+                                        scheduleItemTask(
                                                 () => context.fetch_available_qty(cur_item),
                                                 "fetch_available_qty:merge_new",
+                                                cur_item,
+                                                context,
                                         );
                                 }
                                 if (cur_item.qty > previousQty) {
@@ -311,9 +371,11 @@ export function useItemAddition() {
 			const cur_item = context.items[index];
 			const previousQty = cur_item.qty;
                         if (context.update_items_details) {
-                                runAsyncTask(
+                                scheduleItemTask(
                                         () => context.update_items_details([cur_item]),
                                         "update_items_details:existing",
+                                        cur_item,
+                                        context,
                                 );
                         }
 			// Serial number logic for existing item


### PR DESCRIPTION
## Summary
- add a shared addItems handler to ItemsSelector so single and multi-item flows reuse cart validation and produce combined user feedback
- queue hardware scan events and flush them in batches, emitting aggregated success/error messaging and formatting dialog details for multi-item failures
- refactor useCartValidation to validate several items in one server call while returning structured errors and warnings for callers

## Testing
- yarn --cwd frontend build *(fails: Rollup could not resolve optional dependency `pinia` in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6eebc35c8326a7da0fbf7cc6fc00