### PR TITLE
fix: support word-order agnostic item search

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3072,41 +3072,56 @@ export default {
 				return [];
 			}
 
-			const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
-			let filteredItems = [...this.items];
+                        const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
+                        let filteredItems = [...this.items];
 
-			// Apply search filter only for queries with at least three characters
-			if (searchTerm.length >= 3) {
-				filteredItems = filteredItems.filter((item) => {
-					const barcodeList = [];
-					if (Array.isArray(item.item_barcode)) {
-						barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
-					} else if (item.item_barcode) {
-						barcodeList.push(String(item.item_barcode));
-					}
-					if (Array.isArray(item.barcodes)) {
-						barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
-					}
+                        // Apply search filter only for queries with at least three characters
+                        if (searchTerm.length >= 3) {
+                                const searchTokens = Array.from(
+                                        new Set(
+                                                searchTerm
+                                                        .split(/\s+/)
+                                                        .map((token) => token.trim())
+                                                        .filter(Boolean),
+                                        ),
+                                );
 
-					const searchFields = [
-						item.item_code,
-						item.item_name,
-						item.barcode,
-						item.description,
-						...barcodeList,
-						...(this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)
-							? item.serial_no_data.map((s) => s.serial_no)
-							: []),
-						...(this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
-							? item.batch_no_data.map((b) => b.batch_no)
-							: []),
-					]
-						.filter(Boolean)
-						.map((field) => field.toLowerCase());
+                                filteredItems = filteredItems.filter((item) => {
+                                        const barcodeList = [];
+                                        if (Array.isArray(item.item_barcode)) {
+                                                barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
+                                        } else if (item.item_barcode) {
+                                                barcodeList.push(String(item.item_barcode));
+                                        }
+                                        if (Array.isArray(item.barcodes)) {
+                                                barcodeList.push(...item.barcodes.map((b) => String(b)).filter(Boolean));
+                                        }
 
-					return searchFields.some((field) => field.includes(searchTerm));
-				});
-			}
+                                        const searchFields = [
+                                                item.item_code,
+                                                item.item_name,
+                                                item.barcode,
+                                                item.description,
+                                                ...barcodeList,
+                                                ...(this.pos_profile?.posa_search_serial_no && Array.isArray(item.serial_no_data)
+                                                        ? item.serial_no_data.map((s) => s.serial_no)
+                                                        : []),
+                                                ...(this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
+                                                        ? item.batch_no_data.map((b) => b.batch_no)
+                                                        : []),
+                                        ]
+                                                .filter(Boolean)
+                                                .map((field) => field.toLowerCase());
+
+                                        if (!searchTokens.length) {
+                                                return searchFields.some((field) => field.includes(searchTerm));
+                                        }
+
+                                        return searchTokens.every((token) =>
+                                                searchFields.some((field) => field.includes(token)),
+                                        );
+                                });
+                        }
 
 			// Apply item group filter
 			if (this.item_group !== "ALL") {

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import json
+import re
 
 import frappe
 from erpnext.stock.doctype.batch.batch import (
@@ -212,10 +213,31 @@ def get_items(
         or_filters = []
         item_code_for_search = None
         data = {}
-        if search_value:
-            data = search_serial_or_batch_or_barcode_number(search_value, search_serial_no, search_batch_no)
+        normalized_search_value = " ".join(search_value.split()) if search_value else ""
+        search_tokens: list[str] = []
+        search_tokens_lower: list[str] = []
+
+        if normalized_search_value:
+            search_value = normalized_search_value
+            data = search_serial_or_batch_or_barcode_number(
+                search_value,
+                search_serial_no,
+                search_batch_no,
+            )
             item_code = data.get("item_code") if data.get("item_code") else search_value
             min_search_len = 2
+
+            raw_tokens = [tok.strip() for tok in re.split(r"\s+", search_value) if tok.strip()]
+            seen_tokens: set[str] = set()
+            for token in raw_tokens:
+                if use_limit_search and len(token) < min_search_len:
+                    continue
+                token_lower = token.lower()
+                if token_lower in seen_tokens:
+                    continue
+                seen_tokens.add(token_lower)
+                search_tokens.append(token)
+                search_tokens_lower.append(token_lower)
 
             if use_limit_search:
                 if len(search_value) >= min_search_len:
@@ -236,6 +258,21 @@ def get_items(
                     filters["item_code"] = item_code
             elif data.get("item_code"):
                 filters["item_code"] = data.get("item_code")
+
+            if search_tokens and not filters.get("item_code"):
+                like_fields = ["name", "item_name", "item_code"]
+                if include_description:
+                    like_fields.append("description")
+
+                existing = {tuple(cond) for cond in or_filters}
+                for token in search_tokens:
+                    escaped = frappe.db.escape_like(token)
+                    like_value = f"%{escaped}%"
+                    for field in like_fields:
+                        clause = (field, "like", like_value)
+                        if clause not in existing:
+                            or_filters.append(list(clause))
+                            existing.add(clause)
 
         if item_group and item_group.upper() != "ALL":
             filters["item_group"] = ["like", f"%{item_group}%"]
@@ -353,6 +390,38 @@ def get_items(
                         "item_attributes": item_attributes or "",
                     }
                 )
+
+                if search_tokens_lower and not filters.get("item_code"):
+                    searchable_strings = [
+                        cstr(row.get("item_code")),
+                        cstr(row.get("item_name")),
+                        cstr(row.get("name")),
+                        cstr(row.get("description")),
+                    ]
+
+                    barcode_values = []
+                    for barcode in row.get("item_barcode") or []:
+                        if isinstance(barcode, dict):
+                            barcode_values.append(cstr(barcode.get("barcode")))
+                        else:
+                            barcode_values.append(cstr(barcode))
+                    searchable_strings.extend(barcode_values)
+
+                    if search_serial_no:
+                        for serial in row.get("serial_no_data") or []:
+                            serial_value = serial.get("serial_no") if isinstance(serial, dict) else serial
+                            searchable_strings.append(cstr(serial_value))
+
+                    if search_batch_no:
+                        for batch in row.get("batch_no_data") or []:
+                            batch_value = batch.get("batch_no") if isinstance(batch, dict) else batch
+                            searchable_strings.append(cstr(batch_value))
+
+                    normalized_fields = [s.lower() for s in searchable_strings if s]
+
+                    if not all(any(token in field for field in normalized_fields) for token in search_tokens_lower):
+                        continue
+
                 result.append(row)
                 if limit_page_length and len(result) >= limit_page_length:
                     break

--- a/posawesome/posawesome/api/test_items_numeric_code.py
+++ b/posawesome/posawesome/api/test_items_numeric_code.py
@@ -13,6 +13,7 @@ class TestNumericItemCodes(FrappeTestCase):
             ("ALPHA-TEST", "Alpha"),
             ("BETA-TEST", "Beta"),
             ("002", "Gamma"),
+            ("LARGE-BLUE-WIDGET", "Large Blue Plastic Widget"),
         ]
         for code, name in items:
             if frappe.db.exists("Item", code):
@@ -43,3 +44,36 @@ class TestNumericItemCodes(FrappeTestCase):
             second_page = get_items(pos_profile, limit=2, start_after=last_name)
         codes = [i["item_code"] for i in second_page]
         self.assertIn("002", codes)
+
+    def test_word_order_insensitive_search_returns_item(self):
+        pos_profile = json.dumps(
+            {
+                "name": "TestProfileOrder",
+                "posa_use_limit_search": 1,
+                "posa_search_serial_no": 0,
+                "posa_search_batch_no": 0,
+            }
+        )
+
+        mock_detail = {
+            "item_code": "LARGE-BLUE-WIDGET",
+            "item_barcode": [],
+            "item_uoms": [],
+            "actual_qty": 0,
+            "has_batch_no": 0,
+            "has_serial_no": 0,
+            "batch_no_data": [],
+            "serial_no_data": [],
+            "rate": 0,
+            "price_list_rate": 0,
+            "currency": "INR",
+            "price_list_currency": "INR",
+            "plc_conversion_rate": 1,
+            "conversion_rate": 1,
+        }
+
+        with patch("posawesome.posawesome.api.items.get_items_details", return_value=[mock_detail]):
+            results = get_items(pos_profile, search_value="Blue Large", limit=20)
+
+        codes = [row["item_code"] for row in results]
+        self.assertIn("LARGE-BLUE-WIDGET", codes)


### PR DESCRIPTION
## Summary
- normalize server-side item search queries into unique tokens and expand database filters so all query words can match across item fields regardless of order
- ensure filtered results also validate token coverage using barcodes, serials, and batches for accurate matches
- add a regression test that confirms reversed word-order queries still return the intended item

## Testing
- `pytest posawesome/posawesome/api/test_items_numeric_code.py` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68dfea24f76883269c28a68f5a55e905