### PR TITLE
feat: improve item search matching across word order

### DIFF
--- a/frontend/src/offline.js
+++ b/frontend/src/offline.js
@@ -992,29 +992,147 @@ export async function getStoredItems() {
 }
 
 export async function searchStoredItems({ search = "", itemGroup = "", limit = 100, offset = 0 } = {}) {
-	try {
-		await checkDbHealth();
-		if (!db.isOpen()) await db.open();
-		let collection = db.table("items");
-		if (itemGroup && itemGroup.toLowerCase() !== "all") {
-			collection = collection.where("item_group").equalsIgnoreCase(itemGroup);
-		}
-		if (search) {
-			const term = search.toLowerCase();
-			collection = collection.filter((it) => {
-				const nameMatch = it.item_name && it.item_name.toLowerCase().includes(term);
-				const codeMatch = it.item_code && it.item_code.toLowerCase().includes(term);
-				const barcodeMatch = Array.isArray(it.item_barcode)
-					? it.item_barcode.some((b) => b.barcode && b.barcode.toLowerCase() === term)
-					: it.item_barcode && String(it.item_barcode).toLowerCase().includes(term);
-				return nameMatch || codeMatch || barcodeMatch;
-			});
-		}
-		return await collection.offset(offset).limit(limit).toArray();
-	} catch (e) {
-		console.error("Failed to query stored items", e);
-		return [];
-	}
+        try {
+                await checkDbHealth();
+                if (!db.isOpen()) await db.open();
+
+                const normalizedSearch = String(search || "").toLowerCase().trim();
+                const words = Array.from(new Set(normalizedSearch.split(/\s+/).filter(Boolean)));
+                const primaryWord = words.reduce(
+                        (longest, word) => (word.length > longest.length ? word : longest),
+                        words[0] || "",
+                );
+
+                const matchesAllWords = (item) => {
+                        if (!words.length) {
+                                return true;
+                        }
+
+                        const searchable = [];
+                        const pushValue = (value) => {
+                                if (value === undefined || value === null) {
+                                        return;
+                                }
+                                const text = String(value).trim().toLowerCase();
+                                if (text) {
+                                        searchable.push(text);
+                                }
+                        };
+
+                        pushValue(item.item_code);
+                        pushValue(item.item_name);
+                        pushValue(item.name);
+                        pushValue(item.description);
+                        pushValue(item.barcode);
+                        pushValue(item.brand);
+                        pushValue(item.item_group);
+                        pushValue(item.attributes);
+
+                        const handleArray = (source, extractor) => {
+                                if (!Array.isArray(source)) {
+                                        return;
+                                }
+                                source.forEach((entry) => {
+                                        if (extractor) {
+                                                pushValue(extractor(entry));
+                                        } else {
+                                                pushValue(entry);
+                                        }
+                                });
+                        };
+
+                        if (Array.isArray(item.item_barcode)) {
+                                item.item_barcode.forEach((barcode) => pushValue(barcode && barcode.barcode));
+                        } else {
+                                pushValue(item.item_barcode);
+                        }
+
+                        handleArray(item.barcodes);
+                        handleArray(item.serial_no_data, (serial) => serial && serial.serial_no);
+                        handleArray(item.serials);
+                        handleArray(item.batch_no_data, (batch) => batch && batch.batch_no);
+                        handleArray(item.batches);
+
+                        const attributes = item.item_attributes;
+                        if (Array.isArray(attributes)) {
+                                attributes.forEach((attr) => {
+                                        if (attr && typeof attr === "object") {
+                                                pushValue(attr.attribute);
+                                                pushValue(attr.attribute_value);
+                                        } else {
+                                                pushValue(attr);
+                                        }
+                                });
+                        } else {
+                                pushValue(attributes);
+                        }
+
+                        if (!searchable.length) {
+                                return false;
+                        }
+
+                        return words.every((word) => searchable.some((field) => field.includes(word)));
+                };
+
+                const applyItemGroupFilter = (collection) => {
+                        if (itemGroup && itemGroup.toLowerCase() !== "all") {
+                                const group = itemGroup.toLowerCase();
+                                return collection.filter((it) => it.item_group && it.item_group.toLowerCase() === group);
+                        }
+                        return collection;
+                };
+
+                if (primaryWord) {
+                        let collection = db
+                                .table("items")
+                                .where("item_code")
+                                .startsWithIgnoreCase(primaryWord)
+                                .or("item_name")
+                                .startsWithIgnoreCase(primaryWord)
+                                .or("barcodes")
+                                .equalsIgnoreCase(primaryWord)
+                                .or("name_keywords")
+                                .startsWithIgnoreCase(primaryWord)
+                                .or("serials")
+                                .equalsIgnoreCase(primaryWord)
+                                .or("batches")
+                                .equalsIgnoreCase(primaryWord);
+
+                        collection = applyItemGroupFilter(collection);
+
+                        let results = await collection.toArray();
+                        results = results.filter(matchesAllWords);
+
+                        if (!results.length) {
+                                let fallback = applyItemGroupFilter(db.table("items"));
+                                results = await fallback.filter(matchesAllWords).toArray();
+                        }
+
+                        if (!results.length) {
+                                return [];
+                        }
+
+                        const map = new Map();
+                        results.forEach((item) => {
+                                if (!map.has(item.item_code)) {
+                                        map.set(item.item_code, item);
+                                }
+                        });
+
+                        const unique = Array.from(map.values());
+                        return unique.slice(offset, offset + limit);
+                }
+
+                let collection = applyItemGroupFilter(db.table("items"));
+                if (words.length) {
+                        collection = collection.filter(matchesAllWords);
+                }
+                const res = await collection.offset(offset).limit(limit).toArray();
+                return res;
+        } catch (e) {
+                console.error("Failed to query stored items", e);
+                return [];
+        }
 }
 
 export async function saveItems(items) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -783,8 +783,9 @@ export default {
 
 	methods: {
 		// Performance optimization: Memoized search function
-		memoizedSearch(searchTerm, itemGroup) {
-			const cacheKey = `${searchTerm || ""}_${itemGroup || "ALL"}`;
+               memoizedSearch(searchTerm, itemGroup) {
+                       const normalizedSearch = this.normalizeSearchTerm(searchTerm);
+                       const cacheKey = `${normalizedSearch || ""}_${itemGroup || "ALL"}`;
 
 			// Check if we have a cached result
 			if (this.searchCache && this.searchCache.has(cacheKey)) {
@@ -793,7 +794,7 @@ export default {
 			}
 
 			// Perform the search
-			const result = this.performSearch(searchTerm, itemGroup);
+                       const result = this.performSearch(normalizedSearch, itemGroup);
 
 			// Cache the result
 			if (this.searchCache) {
@@ -803,12 +804,33 @@ export default {
 			return result;
 		},
 
-		performSearch(searchTerm, itemGroup) {
-			if (!this.items || !this.items.length) {
-				return [];
-			}
+               normalizeSearchTerm(searchTerm) {
+                       if (!searchTerm || !String(searchTerm).trim()) {
+                               return "";
+                       }
 
-			let filtered = this.items;
+                       const words = String(searchTerm)
+                               .toLowerCase()
+                               .trim()
+                               .split(/\s+/)
+                               .filter(Boolean);
+
+                       if (!words.length) {
+                               return "";
+                       }
+
+                       // Sort to make cache keys consistent regardless of order and remove duplicates
+                       const uniqueWords = [...new Set(words)].sort();
+
+                       return uniqueWords.join(" ");
+               },
+
+               performSearch(searchTerm, itemGroup) {
+                       if (!this.items || !this.items.length) {
+                               return [];
+                       }
+
+                       let filtered = this.items;
 
 			// Filter by item group
 			if (itemGroup !== "ALL") {
@@ -819,25 +841,48 @@ export default {
 			}
 
 			// Filter by search term only if it exists and is long enough
-			if (searchTerm && searchTerm.trim() && searchTerm.trim().length >= 3) {
-				const term = searchTerm.toLowerCase();
-				filtered = filtered.filter((item) => {
-					const barcodeMatch =
-						(Array.isArray(item.item_barcode) &&
-							item.item_barcode.some(
-								(b) => b.barcode && b.barcode.toLowerCase().includes(term),
-							)) ||
-						(Array.isArray(item.barcodes) &&
-							item.barcodes.some((bc) => String(bc).toLowerCase().includes(term))) ||
-						(item.barcode && String(item.barcode).toLowerCase().includes(term));
+                       if (searchTerm && searchTerm.trim() && searchTerm.trim().length >= 3) {
+                               const searchWords = searchTerm
+                                       .toLowerCase()
+                                       .split(/\s+/)
+                                       .filter(Boolean);
 
-					return (
-						item.item_code.toLowerCase().includes(term) ||
-						item.item_name.toLowerCase().includes(term) ||
-						barcodeMatch
-					);
-				});
-			}
+                               filtered = filtered.filter((item) => {
+                                       if (!searchWords.length) {
+                                               return true;
+                                       }
+
+                                       const name = (item.item_name || "").toLowerCase();
+                                       const code = (item.item_code || "").toLowerCase();
+
+                                       const barcodeValues = [];
+                                       if (Array.isArray(item.item_barcode)) {
+                                               item.item_barcode.forEach((b) => {
+                                                       if (b?.barcode) {
+                                                               barcodeValues.push(String(b.barcode).toLowerCase());
+                                                       }
+                                               });
+                                       }
+                                       if (Array.isArray(item.barcodes)) {
+                                               item.barcodes.forEach((bc) => {
+                                                       if (bc) {
+                                                               barcodeValues.push(String(bc).toLowerCase());
+                                                       }
+                                               });
+                                       }
+                                       if (item.barcode) {
+                                               barcodeValues.push(String(item.barcode).toLowerCase());
+                                       }
+
+                                       return searchWords.every((word) => {
+                                               return (
+                                                       code.includes(word) ||
+                                                       name.includes(word) ||
+                                                       barcodeValues.some((barcode) => barcode.includes(word))
+                                               );
+                                       });
+                               });
+                       }
 
 			return filtered;
 		},
@@ -3073,16 +3118,19 @@ export default {
 				return [];
 			}
 
-			const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
-			let filteredItems = [...this.items];
+                       const rawSearchTerm = this.get_search(this.first_search).trim();
+                       const searchTerm = this.normalizeSearchTerm(rawSearchTerm);
+                       let filteredItems = [...this.items];
 
-			// Apply search filter only for queries with at least three characters
-			if (searchTerm.length >= 3) {
-				filteredItems = filteredItems.filter((item) => {
-					const barcodeList = [];
-					if (Array.isArray(item.item_barcode)) {
-						barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
-					} else if (item.item_barcode) {
+                        // Apply search filter only for queries with at least three characters
+                       if (searchTerm.length >= 3) {
+                               const searchWords = searchTerm.split(/\s+/).filter(Boolean);
+
+                               filteredItems = filteredItems.filter((item) => {
+                                        const barcodeList = [];
+                                        if (Array.isArray(item.item_barcode)) {
+                                                barcodeList.push(...item.item_barcode.map((b) => b.barcode).filter(Boolean));
+                                        } else if (item.item_barcode) {
 						barcodeList.push(String(item.item_barcode));
 					}
 					if (Array.isArray(item.barcodes)) {
@@ -3101,13 +3149,19 @@ export default {
 						...(this.pos_profile?.posa_search_batch_no && Array.isArray(item.batch_no_data)
 							? item.batch_no_data.map((b) => b.batch_no)
 							: []),
-					]
-						.filter(Boolean)
-						.map((field) => field.toLowerCase());
+                                        ]
+                                                .filter(Boolean)
+                                                .map((field) => String(field).toLowerCase());
 
-					return searchFields.some((field) => field.includes(searchTerm));
-				});
-			}
+                                        if (!searchWords.length) {
+                                                return true;
+                                        }
+
+                                        return searchWords.every((word) =>
+                                                searchFields.some((field) => field.includes(word)),
+                                        );
+                                });
+                        }
 
 			// Apply item group filter
 			if (this.item_group !== "ALL") {


### PR DESCRIPTION
## Summary
- normalize search queries into individual words before filtering cached results
- update item filtering to require every search word to match item codes, names, or barcodes
- reuse the normalized search logic in both memoized and computed item filtering paths

## Testing
- `yarn lint` *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bbaa5d708326a412daee26037eda