### PR TITLE
Refactor POS async data flows

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -631,25 +631,29 @@ export default {
 			this.expanded = Array.isArray(ids) ? ids.slice(-1) : [];
 		},
 
-		print_draft_invoice() {
-			if (!this.pos_profile.posa_allow_print_draft_invoices) {
-				this.eventBus.emit("show_message", {
-					title: __(`You are not allowed to print draft invoices`),
-					color: "error",
-				});
-				return;
-			}
-			let invoice_name = this.invoice_doc.name;
-			frappe.run_serially([
-				() => {
-					const invoice_doc = this.save_and_clear_invoice();
-					invoice_name = invoice_doc.name ? invoice_doc.name : invoice_name;
-				},
-				() => {
-					this.load_print_page(invoice_name);
-				},
-			]);
-		},
+                async print_draft_invoice() {
+                        if (!this.pos_profile.posa_allow_print_draft_invoices) {
+                                this.eventBus.emit("show_message", {
+                                        title: __(`You are not allowed to print draft invoices`),
+                                        color: "error",
+                                });
+                                return;
+                        }
+                        let invoice_name = this.invoice_doc.name;
+                        try {
+                                const invoice_doc = await this.save_and_clear_invoice();
+                                if (invoice_doc?.name) {
+                                        invoice_name = invoice_doc.name;
+                                }
+                                this.load_print_page(invoice_name);
+                        } catch (error) {
+                                console.error("Failed to print draft invoice:", error);
+                                this.eventBus.emit("show_message", {
+                                        title: __("Unable to print draft invoice"),
+                                        color: "error",
+                                });
+                        }
+                },
 		async set_delivery_charges() {
 			var vm = this;
 			if (!this.pos_profile || !this.customer || !this.pos_profile.posa_use_delivery_charges) {

--- a/frontend/src/posapp/components/pos/Mpesa-Payments.vue
+++ b/frontend/src/posapp/components/pos/Mpesa-Payments.vue
@@ -25,13 +25,26 @@
 							density="compact"
 							clearable
 						></v-text-field>
-						<v-btn variant="text" class="ml-2" color="primary" theme="dark" @click="search">{{
-							__("Search")
-						}}</v-btn>
-					</v-row>
-					<v-row>
-						<v-col cols="12" class="pa-1" v-if="dialog_data">
-							<v-data-table
+                                                <v-btn
+                                                        variant="text"
+                                                        class="ml-2"
+                                                        color="primary"
+                                                        theme="dark"
+                                                        :loading="isLoading"
+                                                        :disabled="isLoading || isSubmitting"
+                                                        @click="search"
+                                                >{{ __("Search") }}</v-btn>
+                                        </v-row>
+                                        <v-row v-if="errorMessage">
+                                                <v-col cols="12" class="pt-0">
+                                                        <v-alert type="error" dense border="start" class="mx-4">
+                                                                {{ errorMessage }}
+                                                        </v-alert>
+                                                </v-col>
+                                        </v-row>
+                                        <v-row>
+                                                <v-col cols="12" class="pa-1" v-if="dialog_data">
+                                                        <v-data-table
 								:headers="headers"
 								:items="dialog_data"
 								item-key="name"
@@ -53,11 +66,18 @@
 				</v-container>
 				<v-card-actions class="mt-4">
 					<v-spacer></v-spacer>
-					<v-btn color="error mx-2" theme="dark" @click="close_dialog">Close</v-btn>
-					<v-btn v-if="selected.length" color="success" theme="dark" @click="submit_dialog">{{
-						__("Submit")
-					}}</v-btn>
-				</v-card-actions>
+                                        <v-btn color="error mx-2" theme="dark" @click="close_dialog">Close</v-btn>
+                                        <v-btn
+                                                v-if="selected.length"
+                                                color="success"
+                                                theme="dark"
+                                                :loading="isSubmitting"
+                                                :disabled="isSubmitting"
+                                                @click="submit_dialog"
+                                        >{{
+                                                __("Submit")
+                                        }}</v-btn>
+                                </v-card-actions>
 			</v-card>
 		</v-dialog>
 	</v-row>
@@ -70,13 +90,16 @@ export default {
 		dialog: false,
 		singleSelect: true,
 		selected: [],
-		dialog_data: "",
-		company: "",
-		customer: "",
-		mode_of_payment: "",
-		full_name: "",
-		mobile_no: "",
-		headers: [
+                dialog_data: "",
+                company: "",
+                customer: "",
+                mode_of_payment: "",
+                full_name: "",
+                mobile_no: "",
+                isLoading: false,
+                isSubmitting: false,
+                errorMessage: "",
+                headers: [
 			{
 				title: __("Full Name"),
 				value: "full_name",
@@ -114,59 +137,78 @@ export default {
 				this.search();
 			}
 		},
-		search() {
-			const vm = this;
-			frappe.call({
-				method: "posawesome.posawesome.api.m_pesa.get_mpesa_draft_payments",
-				args: {
-					company: this.company,
-					mode_of_payment: this.mode_of_payment,
-					mobile_no: this.mobile_no,
-					full_name: this.full_name,
-				},
-				async: false,
-				callback: function (r) {
-					if (!r.exc) {
-						vm.dialog_data = r.message;
-					}
-				},
-			});
-		},
-		submit_dialog() {
-			var vm = this;
-			if (this.selected.length > 0) {
-				const selected_payment = this.selected[0].name;
-				frappe.call({
-					method: "posawesome.posawesome.api.m_pesa.submit_mpesa_payment",
-					args: {
-						mpesa_payment: selected_payment,
-						customer: this.customer,
-					},
-					async: false,
-					callback: function (r) {
-						if (!r.exc) {
-							vm.eventBus.emit("set_mpesa_payment", r.message);
-							vm.dialog = false;
-						}
-					},
-				});
-			}
-		},
+                async search() {
+                        if (this.isLoading || this.isSubmitting) {
+                                return;
+                        }
+
+                        this.errorMessage = "";
+                        this.isLoading = true;
+
+                        try {
+                                const { message } = await frappe.call({
+                                        method: "posawesome.posawesome.api.m_pesa.get_mpesa_draft_payments",
+                                        args: {
+                                                company: this.company,
+                                                mode_of_payment: this.mode_of_payment,
+                                                mobile_no: this.mobile_no,
+                                                full_name: this.full_name,
+                                        },
+                                });
+
+                                this.dialog_data = message;
+                        } catch (error) {
+                                console.error("Failed to search M-Pesa payments:", error);
+                                this.errorMessage = __("Unable to fetch M-Pesa payments");
+                        } finally {
+                                this.isLoading = false;
+                        }
+                },
+                async submit_dialog() {
+                        if (this.isSubmitting || this.selected.length === 0) {
+                                return;
+                        }
+
+                        this.errorMessage = "";
+                        this.isSubmitting = true;
+
+                        try {
+                                const selected_payment = this.selected[0].name;
+                                const { message } = await frappe.call({
+                                        method: "posawesome.posawesome.api.m_pesa.submit_mpesa_payment",
+                                        args: {
+                                                mpesa_payment: selected_payment,
+                                                customer: this.customer,
+                                        },
+                                });
+
+                                this.eventBus.emit("set_mpesa_payment", message);
+                                this.dialog = false;
+                        } catch (error) {
+                                console.error("Failed to submit M-Pesa payment:", error);
+                                this.errorMessage = __("Unable to submit the selected payment");
+                        } finally {
+                                this.isSubmitting = false;
+                        }
+                },
 		formatCurrency(value) {
 			return this.$options.mixins[0].methods.formatCurrency.call(this, value, 2);
 		},
 	},
 	created: function () {
-		this.eventBus.on("open_mpesa_payments", (data) => {
-			this.dialog = true;
-			this.full_name = "";
-			this.mobile_no = "";
-			this.company = data.company;
-			this.customer = data.customer;
-			this.mode_of_payment = data.mode_of_payment;
-			this.dialog_data = "";
-			this.selected = [];
-		});
+                this.eventBus.on("open_mpesa_payments", (data) => {
+                        this.dialog = true;
+                        this.full_name = "";
+                        this.mobile_no = "";
+                        this.company = data.company;
+                        this.customer = data.customer;
+                        this.mode_of_payment = data.mode_of_payment;
+                        this.dialog_data = "";
+                        this.selected = [];
+                        this.errorMessage = "";
+                        this.isLoading = false;
+                        this.isSubmitting = false;
+                });
 	},
 	beforeUnmount() {
 		this.eventBus.off("open_mpesa_payments");

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1799,94 +1799,118 @@ export default {
 			});
 		},
 		// Request payment for phone type
-		request_payment() {
-			this.phone_dialog = false;
-			const vm = this;
-			if (!this.invoice_doc.contact_mobile) {
-				this.eventBus.emit("show_message", {
-					title: __("Please set the customer's mobile number"),
-					color: "error",
-				});
-				this.eventBus.emit("open_edit_customer");
-				this.back_to_invoice();
-				return;
-			}
-			this.eventBus.emit("freeze", { title: __("Waiting for payment...") });
-			this.invoice_doc.payments.forEach((payment) => {
-				payment.amount = this.flt(payment.amount);
-			});
-			let formData = { ...this.invoice_doc };
-			formData["total_change"] = !this.invoice_doc.is_return ? -this.diff_payment : 0;
-			formData["paid_change"] = !this.invoice_doc.is_return ? this.paid_change : 0;
-			formData["credit_change"] = -this.credit_change;
-			formData["redeemed_customer_credit"] = this.redeemed_customer_credit;
-			formData["customer_credit_dict"] = this.customer_credit_dict;
-			formData["is_cashback"] = this.is_cashback;
-			frappe
-				.call({
-					method: "posawesome.posawesome.api.invoices.update_invoice",
-					args: { data: formData },
-					async: false,
-					callback: function (r) {
-						if (r.message) {
-							vm.invoice_doc = r.message;
-						}
-					},
-				})
-				.then(() => {
-					frappe
-						.call({
-							method: "posawesome.posawesome.api.payments.create_payment_request",
-							args: { doc: vm.invoice_doc },
-						})
-						.fail(() => {
-							vm.eventBus.emit("unfreeze");
-							vm.eventBus.emit("show_message", {
-								title: __("Payment request failed"),
-								color: "error",
-							});
-						})
-						.then(({ message }) => {
-							const payment_request_name = message.name;
-							setTimeout(() => {
-								frappe.db
-									.get_value("Payment Request", payment_request_name, [
-										"status",
-										"grand_total",
-									])
-									.then(({ message }) => {
-										if (message.status !== "Paid") {
-											vm.eventBus.emit("unfreeze");
-											vm.eventBus.emit("show_message", {
-												title: __(
-													"Payment Request took too long to respond. Please try requesting for payment again",
-												),
-												color: "error",
-											});
-										} else {
-											vm.eventBus.emit("unfreeze");
-											vm.eventBus.emit("show_message", {
-												title: __("Payment of {0} received successfully.", [
-													vm.formatCurrency(
-														message.grand_total,
-														vm.invoice_doc.currency,
-														0,
-													),
-												]),
-												color: "success",
-											});
-											frappe.db
-												.get_doc(vm.invoice_doc.doctype, vm.invoice_doc.name)
-												.then((doc) => {
-													vm.invoice_doc = doc;
-													vm.submit(null, true);
-												});
-										}
-									});
-							}, 30000);
-						});
-				});
-		},
+                async request_payment() {
+                        this.phone_dialog = false;
+                        if (!this.invoice_doc.contact_mobile) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Please set the customer's mobile number"),
+                                        color: "error",
+                                });
+                                this.eventBus.emit("open_edit_customer");
+                                this.back_to_invoice();
+                                return;
+                        }
+
+                        this.eventBus.emit("freeze", { title: __("Waiting for payment...") });
+
+                        try {
+                                this.invoice_doc.payments.forEach((payment) => {
+                                        payment.amount = this.flt(payment.amount);
+                                });
+
+                                const formData = {
+                                        ...this.invoice_doc,
+                                        total_change: !this.invoice_doc.is_return ? -this.diff_payment : 0,
+                                        paid_change: !this.invoice_doc.is_return ? this.paid_change : 0,
+                                        credit_change: -this.credit_change,
+                                        redeemed_customer_credit: this.redeemed_customer_credit,
+                                        customer_credit_dict: this.customer_credit_dict,
+                                        is_cashback: this.is_cashback,
+                                };
+
+                                const updateResponse = await frappe.call({
+                                        method: "posawesome.posawesome.api.invoices.update_invoice",
+                                        args: { data: formData },
+                                });
+
+                                if (updateResponse?.message) {
+                                        this.invoice_doc = updateResponse.message;
+                                }
+
+                                const paymentResponse = await frappe.call({
+                                        method: "posawesome.posawesome.api.payments.create_payment_request",
+                                        args: { doc: this.invoice_doc },
+                                });
+
+                                const payment_request_name = paymentResponse?.message?.name;
+                                if (!payment_request_name) {
+                                        throw new Error("Payment request failed");
+                                }
+
+                                await new Promise((resolve, reject) => {
+                                        setTimeout(async () => {
+                                                try {
+                                                        const { message } = await frappe.db.get_value(
+                                                                "Payment Request",
+                                                                payment_request_name,
+                                                                ["status", "grand_total"],
+                                                        );
+
+                                                        if (!message) {
+                                                                this.eventBus.emit("show_message", {
+                                                                        title: __(
+                                                                                "Payment request status could not be retrieved. Please try again",
+                                                                        ),
+                                                                        color: "error",
+                                                                });
+                                                                resolve();
+                                                                return;
+                                                        }
+
+                                                        if (message.status !== "Paid") {
+                                                                this.eventBus.emit("show_message", {
+                                                                        title: __(
+                                                                                "Payment Request took too long to respond. Please try requesting for payment again",
+                                                                        ),
+                                                                        color: "error",
+                                                                });
+                                                                resolve();
+                                                                return;
+                                                        }
+
+                                                        this.eventBus.emit("show_message", {
+                                                                title: __("Payment of {0} received successfully.", [
+                                                                        this.formatCurrency(
+                                                                                message.grand_total,
+                                                                                this.invoice_doc.currency,
+                                                                                0,
+                                                                        ),
+                                                                ]),
+                                                                color: "success",
+                                                        });
+
+                                                        const doc = await frappe.db.get_doc(
+                                                                this.invoice_doc.doctype,
+                                                                this.invoice_doc.name,
+                                                        );
+                                                        this.invoice_doc = doc;
+                                                        this.submit(null, true);
+                                                        resolve();
+                                                } catch (error) {
+                                                        reject(error);
+                                                }
+                                        }, 30000);
+                                });
+                        } catch (error) {
+                                console.error("Payment request error:", error);
+                                this.eventBus.emit("show_message", {
+                                        title: __(error.message || "Payment request failed"),
+                                        color: "error",
+                                });
+                        } finally {
+                                this.eventBus.emit("unfreeze");
+                        }
+                },
 		// Get M-Pesa payment modes from backend
 		get_mpesa_modes() {
 			const vm = this;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -256,32 +256,36 @@ export default {
 	},
 
 	// Save and clear the current invoice (draft logic)
-	save_and_clear_invoice() {
-		let old_invoice = null;
-		const doc = this.get_invoice_doc();
-		if (doc.name) {
-			old_invoice = this.update_invoice(doc);
-		} else {
-			if (doc.items.length) {
-				old_invoice = this.update_invoice(doc);
-			} else {
-				this.eventBus.emit("show_message", {
-					title: `Nothing to save`,
-					color: "error",
-				});
-			}
-		}
-		if (!old_invoice) {
-			this.eventBus.emit("show_message", {
-				title: `Error saving the current invoice`,
-				color: "error",
-			});
-		} else {
-			this.clear_invoice();
-			this.eventBus.emit("focus_item_search");
-			return old_invoice;
-		}
-	},
+        async save_and_clear_invoice() {
+                let old_invoice = null;
+                const doc = this.get_invoice_doc();
+
+                try {
+                        if (doc.name) {
+                                old_invoice = await this.update_invoice(doc);
+                        } else if (doc.items.length) {
+                                old_invoice = await this.update_invoice(doc);
+                        } else {
+                                this.eventBus.emit("show_message", {
+                                        title: `Nothing to save`,
+                                        color: "error",
+                                });
+                        }
+                } catch (error) {
+                        console.error("Error saving and clearing invoice:", error);
+                }
+
+                if (!old_invoice) {
+                        this.eventBus.emit("show_message", {
+                                title: `Error saving the current invoice`,
+                                color: "error",
+                        });
+                } else {
+                        this.clear_invoice();
+                        this.eventBus.emit("focus_item_search");
+                        return old_invoice;
+                }
+        },
 
 	// Start a new order (or return order) with provided data
 	async new_order(data = {}) {
@@ -852,97 +856,109 @@ export default {
 	},
 
 	// Update invoice in backend
-	update_invoice(doc) {
-		var vm = this;
-		if (isOffline()) {
-			// When offline, simply merge the passed doc with the current invoice_doc
-			// to allow offline invoice creation without server calls
-			vm.invoice_doc = Object.assign({}, vm.invoice_doc || {}, doc);
-			return vm.invoice_doc;
-		}
-		frappe.call({
-			method:
-				doc.doctype === "Sales Order" && this.pos_profile.posa_create_only_sales_order
-					? "posawesome.posawesome.api.sales_orders.update_sales_order"
-					: doc.doctype === "Quotation"
-						? "posawesome.posawesome.api.quotations.update_quotation"
-						: "posawesome.posawesome.api.invoices.update_invoice",
-			args: {
-				data: doc,
-			},
-			async: false,
-			callback: function (r) {
-				if (r.message) {
-					vm.invoice_doc = r.message;
-					if (r.message.exchange_rate_date) {
-						vm.exchange_rate_date = r.message.exchange_rate_date;
-						const posting_backend = vm.formatDateForBackend(vm.posting_date_display);
-						if (posting_backend !== vm.exchange_rate_date) {
-							vm.eventBus.emit("show_message", {
-								title: __(
-									"Exchange rate date " +
-										vm.exchange_rate_date +
-										" differs from posting date " +
-										posting_backend,
-								),
-								color: "warning",
-							});
-						}
-					}
-				}
-			},
-		});
-		return this.invoice_doc;
-	},
+        async update_invoice(doc) {
+                if (isOffline()) {
+                        // When offline, simply merge the passed doc with the current invoice_doc
+                        // to allow offline invoice creation without server calls
+                        this.invoice_doc = Object.assign({}, this.invoice_doc || {}, doc);
+                        return this.invoice_doc;
+                }
 
-	// Update invoice from order in backend
-	update_invoice_from_order(doc) {
-		var vm = this;
-		if (isOffline()) {
-			// Offline mode - merge doc locally without server update
-			vm.invoice_doc = Object.assign({}, vm.invoice_doc || {}, doc);
-			return vm.invoice_doc;
-		}
-		frappe.call({
-			method: "posawesome.posawesome.api.invoices.update_invoice_from_order",
-			args: {
-				data: doc,
-			},
-			async: false,
-			callback: function (r) {
-				if (r.message) {
-					vm.invoice_doc = r.message;
-					if (r.message.exchange_rate_date) {
-						vm.exchange_rate_date = r.message.exchange_rate_date;
-						const posting_backend = vm.formatDateForBackend(vm.posting_date_display);
-						if (posting_backend !== vm.exchange_rate_date) {
-							vm.eventBus.emit("show_message", {
-								title: __(
-									"Exchange rate date " +
-										vm.exchange_rate_date +
-										" differs from posting date " +
-										posting_backend,
-								),
-								color: "warning",
-							});
-						}
-					}
-				}
-			},
-		});
-		return this.invoice_doc;
-	},
+                const method =
+                        doc.doctype === "Sales Order" && this.pos_profile.posa_create_only_sales_order
+                                ? "posawesome.posawesome.api.sales_orders.update_sales_order"
+                                : doc.doctype === "Quotation"
+                                        ? "posawesome.posawesome.api.quotations.update_quotation"
+                                        : "posawesome.posawesome.api.invoices.update_invoice";
 
-	// Process and save invoice (handles update or create)
-	process_invoice() {
-		const doc = this.get_invoice_doc();
-		try {
-			const updated_doc = this.update_invoice(doc);
-			if (updated_doc && updated_doc.posting_date) {
-				this.posting_date = this.formatDateForBackend(updated_doc.posting_date);
-			}
-			return updated_doc;
-		} catch (error) {
+                try {
+                        const response = await frappe.call({
+                                method,
+                                args: {
+                                        data: doc,
+                                },
+                        });
+
+                        const message = response?.message;
+                        if (message) {
+                                this.invoice_doc = message;
+                                if (message.exchange_rate_date) {
+                                        this.exchange_rate_date = message.exchange_rate_date;
+                                        const posting_backend = this.formatDateForBackend(this.posting_date_display);
+                                        if (posting_backend !== this.exchange_rate_date) {
+                                                this.eventBus.emit("show_message", {
+                                                        title: __(
+                                                                "Exchange rate date " +
+                                                                        this.exchange_rate_date +
+                                                                        " differs from posting date " +
+                                                                        posting_backend,
+                                                        ),
+                                                        color: "warning",
+                                                });
+                                        }
+                                }
+                        }
+
+                        return this.invoice_doc;
+                } catch (error) {
+                        console.error("Error updating invoice:", error);
+                        throw error;
+                }
+        },
+
+        // Update invoice from order in backend
+        async update_invoice_from_order(doc) {
+                if (isOffline()) {
+                        // Offline mode - merge doc locally without server update
+                        this.invoice_doc = Object.assign({}, this.invoice_doc || {}, doc);
+                        return this.invoice_doc;
+                }
+
+                try {
+                        const response = await frappe.call({
+                                method: "posawesome.posawesome.api.invoices.update_invoice_from_order",
+                                args: {
+                                        data: doc,
+                                },
+                        });
+
+                        const message = response?.message;
+                        if (message) {
+                                this.invoice_doc = message;
+                                if (message.exchange_rate_date) {
+                                        this.exchange_rate_date = message.exchange_rate_date;
+                                        const posting_backend = this.formatDateForBackend(this.posting_date_display);
+                                        if (posting_backend !== this.exchange_rate_date) {
+                                                this.eventBus.emit("show_message", {
+                                                        title: __(
+                                                                "Exchange rate date " +
+                                                                        this.exchange_rate_date +
+                                                                        " differs from posting date " +
+                                                                        posting_backend,
+                                                        ),
+                                                        color: "warning",
+                                                });
+                                        }
+                                }
+                        }
+
+                        return this.invoice_doc;
+                } catch (error) {
+                        console.error("Error updating invoice from order:", error);
+                        throw error;
+                }
+        },
+
+        // Process and save invoice (handles update or create)
+        async process_invoice() {
+                const doc = this.get_invoice_doc();
+                try {
+                        const updated_doc = await this.update_invoice(doc);
+                        if (updated_doc && updated_doc.posting_date) {
+                                this.posting_date = this.formatDateForBackend(updated_doc.posting_date);
+                        }
+                        return updated_doc;
+                } catch (error) {
 			console.error("Error in process_invoice:", error);
 			this.eventBus.emit("show_message", {
 				title: __(error.message || "Error processing invoice"),
@@ -953,16 +969,10 @@ export default {
 	},
 
 	// Process and save invoice from order
-	async process_invoice_from_order() {
-		const doc = await this.get_invoice_from_order_doc();
-		var up_invoice;
-		if (doc.name) {
-			up_invoice = await this.update_invoice_from_order(doc);
-			return up_invoice;
-		} else {
-			return this.update_invoice_from_order(doc);
-		}
-	},
+        async process_invoice_from_order() {
+                const doc = await this.get_invoice_from_order_doc();
+                return this.update_invoice_from_order(doc);
+        },
 
 	// Show payment dialog after validation and processing
 	async show_payment() {
@@ -1009,19 +1019,19 @@ export default {
                                 !this.new_delivery_date &&
                                 !(this.invoice_doc && this.invoice_doc.posa_delivery_date)
                         ) {
-				console.log("Building local Sales Order doc for payment");
-				invoice_doc = this.get_invoice_doc();
+                                console.log("Building local Sales Order doc for payment");
+                                invoice_doc = this.get_invoice_doc();
                         } else if (
                                 this.invoice_doc &&
                                 this.invoice_doc.doctype === "Sales Order" &&
                                 this.invoiceType === "Invoice"
                         ) {
-				console.log("Processing Sales Order payment");
-				invoice_doc = await this.process_invoice_from_order();
-			} else {
-				console.log("Processing regular invoice");
-				invoice_doc = this.process_invoice();
-			}
+                                console.log("Processing Sales Order payment");
+                                invoice_doc = await this.process_invoice_from_order();
+                        } else {
+                                console.log("Processing regular invoice");
+                                invoice_doc = await this.process_invoice();
+                        }
 
 			if (!invoice_doc) {
 				console.log("Failed to process invoice");
@@ -1270,43 +1280,51 @@ export default {
 		return true;
 	},
 
-	// Get draft invoices from backend
-	get_draft_invoices() {
-		var vm = this;
-		frappe.call({
-			method: "posawesome.posawesome.api.invoices.get_draft_invoices",
-			args: {
-				pos_opening_shift: this.pos_opening_shift.name,
-				doctype: this.pos_profile.create_pos_invoice_instead_of_sales_invoice
-					? "POS Invoice"
-					: "Sales Invoice",
-			},
-			async: false,
-			callback: function (r) {
-				if (r.message) {
-					vm.eventBus.emit("open_drafts", r.message);
-				}
-			},
-		});
-	},
+        // Get draft invoices from backend
+        async get_draft_invoices() {
+                try {
+                        const { message } = await frappe.call({
+                                method: "posawesome.posawesome.api.invoices.get_draft_invoices",
+                                args: {
+                                        pos_opening_shift: this.pos_opening_shift.name,
+                                        doctype: this.pos_profile.create_pos_invoice_instead_of_sales_invoice
+                                                ? "POS Invoice"
+                                                : "Sales Invoice",
+                                },
+                        });
+                        if (message) {
+                                this.eventBus.emit("open_drafts", message);
+                        }
+                } catch (error) {
+                        console.error("Error fetching draft invoices:", error);
+                        this.eventBus.emit("show_message", {
+                                title: __("Unable to fetch draft invoices"),
+                                color: "error",
+                        });
+                }
+        },
 
-	// Get draft orders from backend
-	get_draft_orders() {
-		var vm = this;
-		frappe.call({
-			method: "posawesome.posawesome.api.sales_orders.search_orders",
-			args: {
-				company: this.pos_profile.company,
-				currency: this.pos_profile.currency,
-			},
-			async: false,
-			callback: function (r) {
-				if (r.message) {
-					vm.eventBus.emit("open_orders", r.message);
-				}
-			},
-		});
-	},
+        // Get draft orders from backend
+        async get_draft_orders() {
+                try {
+                        const { message } = await frappe.call({
+                                method: "posawesome.posawesome.api.sales_orders.search_orders",
+                                args: {
+                                        company: this.pos_profile.company,
+                                        currency: this.pos_profile.currency,
+                                },
+                        });
+                        if (message) {
+                                this.eventBus.emit("open_orders", message);
+                        }
+                } catch (error) {
+                        console.error("Error fetching draft orders:", error);
+                        this.eventBus.emit("show_message", {
+                                title: __("Unable to fetch draft orders"),
+                                color: "error",
+                        });
+                }
+        },
 
 	// Open returns dialog
 	open_returns() {

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -51,29 +51,35 @@ export default {
         normalizeBrand(brand) {
                 return (brand || "").trim().toLowerCase();
         },
-	getItemBrand(item) {
-		let brand = this.normalizeBrand(item.brand);
-		if (brand) {
-			item.brand = brand;
-			return brand;
-		}
-		if (this.brand_cache && this.brand_cache[item.item_code]) {
-			brand = this.brand_cache[item.item_code];
-		} else {
-			frappe.call({
-				method: "posawesome.posawesome.api.items.get_item_brand",
-				args: { item_code: item.item_code },
-				async: false,
-				callback: (r) => {
-					brand = this.normalizeBrand(r.message);
-				},
-			});
-			this.brand_cache = this.brand_cache || {};
-			this.brand_cache[item.item_code] = brand;
-		}
-		item.brand = brand;
-		return brand;
-	},
+        async getItemBrand(item) {
+                let brand = this.normalizeBrand(item.brand);
+                if (brand) {
+                        item.brand = brand;
+                        return brand;
+                }
+
+                this.brand_cache = this.brand_cache || {};
+
+                if (this.brand_cache[item.item_code]) {
+                        brand = this.brand_cache[item.item_code];
+                } else {
+                        try {
+                                const { message } = await frappe.call({
+                                        method: "posawesome.posawesome.api.items.get_item_brand",
+                                        args: { item_code: item.item_code },
+                                });
+                                brand = this.normalizeBrand(message);
+                        } catch (error) {
+                                console.error("Failed to fetch item brand:", error);
+                                brand = "";
+                        }
+
+                        this.brand_cache[item.item_code] = brand;
+                }
+
+                item.brand = brand;
+                return brand;
+        },
 	checkOfferIsAppley(item, offer) {
 		let applied = false;
 		const item_offers = JSON.parse(item.posa_offers);
@@ -87,35 +93,34 @@ export default {
 		return applied;
 	},
 
-	handelOffers() {
-		const offers = [];
-		this.posOffers.forEach((offer) => {
-			if (offer.apply_on === "Item Code") {
-				const itemOffer = this.getItemOffer(offer);
-				if (itemOffer) {
-					offers.push(itemOffer);
-				}
-			} else if (offer.apply_on === "Item Group") {
-				const groupOffer = this.getGroupOffer(offer);
-				if (groupOffer) {
-					offers.push(groupOffer);
-				}
-			} else if (offer.apply_on === "Brand") {
-				const brandOffer = this.getBrandOffer(offer);
-				if (brandOffer) {
-					offers.push(brandOffer);
-				}
-			} else if (offer.apply_on === "Transaction") {
-				const transactionOffer = this.getTransactionOffer(offer);
-				if (transactionOffer) {
-					offers.push(transactionOffer);
-				}
-			}
-		});
+        async handelOffers() {
+                try {
+                        const sourceOffers = Array.isArray(this.posOffers) ? this.posOffers : [];
+                        const offerPromises = sourceOffers.map(async (offer) => {
+                                if (offer.apply_on === "Item Code") {
+                                        return this.getItemOffer(offer);
+                                }
+                                if (offer.apply_on === "Item Group") {
+                                        return this.getGroupOffer(offer);
+                                }
+                                if (offer.apply_on === "Brand") {
+                                        return this.getBrandOffer(offer);
+                                }
+                                if (offer.apply_on === "Transaction") {
+                                        return this.getTransactionOffer(offer);
+                                }
+                                return null;
+                        });
 
-		this.setItemGiveOffer(offers);
-		this.updatePosOffers(offers);
-	},
+                        const offerResults = await Promise.all(offerPromises);
+                        const offers = offerResults.filter((offer) => !!offer);
+
+                        this.setItemGiveOffer(offers);
+                        this.updatePosOffers(offers);
+                } catch (error) {
+                        console.error("Failed to process offers:", error);
+                }
+        },
 
 	setItemGiveOffer(offers) {
 		// Set item give offer for replace
@@ -283,36 +288,42 @@ export default {
 		return apply_offer;
 	},
 
-	getBrandOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Brand") {
-			if (this.checkOfferCoupon(offer)) {
-				const items = [];
-				let total_count = 0;
-				let total_amount = 0;
-				const offer_brand = this.normalizeBrand(offer.brand);
-				const combined = [...this.items, ...this.packed_items];
-				combined.forEach((item) => {
-					const item_brand = this.getItemBrand(item);
-					if (!item.posa_is_offer && item_brand && item_brand === offer_brand) {
-						if (
-							offer.offer === "Item Price" &&
-							item.posa_offer_applied &&
-							!this.checkOfferIsAppley(item, offer)
-						) {
-							return;
-						}
-						total_count += item.stock_qty;
-						const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-						total_amount += item.stock_qty * rate;
-						items.push(item.posa_row_id);
-					}
-				});
-				if (total_count || total_amount) {
-					const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
-					if (res.apply) {
-						offer.items = items;
-						apply_offer = offer;
+        async getBrandOffer(offer) {
+                let apply_offer = null;
+                if (offer.apply_on === "Brand") {
+                        if (this.checkOfferCoupon(offer)) {
+                                const items = [];
+                                let total_count = 0;
+                                let total_amount = 0;
+                                const offer_brand = this.normalizeBrand(offer.brand);
+                                const combined = [...this.items, ...this.packed_items];
+                                const brandedItems = await Promise.all(
+                                        combined.map(async (item) => ({
+                                                item,
+                                                brand: await this.getItemBrand(item),
+                                        })),
+                                );
+
+                                brandedItems.forEach(({ item, brand }) => {
+                                        if (!item.posa_is_offer && brand && brand === offer_brand) {
+                                                if (
+                                                        offer.offer === "Item Price" &&
+                                                        item.posa_offer_applied &&
+                                                        !this.checkOfferIsAppley(item, offer)
+                                                ) {
+                                                        return;
+                                                }
+                                                total_count += item.stock_qty;
+                                                const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
+                                                total_amount += item.stock_qty * rate;
+                                                items.push(item.posa_row_id);
+                                        }
+                                });
+                                if (total_count || total_amount) {
+                                        const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
+                                        if (res.apply) {
+                                                offer.items = items;
+                                                apply_offer = offer;
 					}
 				}
 			}

--- a/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.js
+++ b/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.js
@@ -49,20 +49,20 @@ frappe.ui.form.on("POS Closing Shift", {
                         });
 	},
 
-	get_pos_invoices(frm) {
-		frappe.call({
-			method: "posawesome.posawesome.doctype.pos_closing_shift.pos_closing_shift.get_pos_invoices",
-			args: {
-				pos_opening_shift: frm.doc.pos_opening_shift,
-			},
-			callback: (r) => {
-				let pos_docs = r.message;
-				set_form_data(pos_docs, frm);
-				refresh_fields(frm);
-				set_html_data(frm);
-			},
-		});
-	},
+        get_pos_invoices(frm) {
+                frappe.call({
+                        method: "posawesome.posawesome.doctype.pos_closing_shift.pos_closing_shift.get_pos_invoices",
+                        args: {
+                                pos_opening_shift: frm.doc.pos_opening_shift,
+                        },
+                        callback: async (r) => {
+                                const pos_docs = r.message;
+                                await set_form_data(pos_docs, frm);
+                                refresh_fields(frm);
+                                set_html_data(frm);
+                        },
+                });
+        },
 
 	get_pos_payments(frm) {
 		frappe.call({
@@ -87,16 +87,20 @@ frappe.ui.form.on("POS Closing Shift Detail", {
 	},
 });
 
-function set_form_data(data, frm) {
-        data.forEach((d) => {
+async function set_form_data(data, frm) {
+        if (!Array.isArray(data)) {
+                return;
+        }
+
+        for (const d of data) {
                 add_to_pos_transaction(d, frm);
                 const conversion_rate = get_conversion_rate(d);
                 frm.doc.grand_total += get_base_value(d, "grand_total", "base_grand_total", conversion_rate);
                 frm.doc.net_total += get_base_value(d, "net_total", "base_net_total", conversion_rate);
                 frm.doc.total_quantity += flt(d.total_qty);
-                add_to_payments(d, frm, conversion_rate);
+                await add_to_payments(d, frm, conversion_rate);
                 add_to_taxes(d, frm, conversion_rate);
-        });
+        }
 }
 
 function set_form_payments_data(data, frm) {
@@ -133,22 +137,18 @@ function add_to_pos_payments(d, frm) {
 	});
 }
 
-function add_to_payments(d, frm, conversion_rate) {
-        d.payments.forEach((p) => {
+async function add_to_payments(d, frm, conversion_rate) {
+        const payments = Array.isArray(d.payments) ? d.payments : [];
+        const cash_mode_of_payment = await get_cash_mode_of_payment(frm);
+
+        payments.forEach((p) => {
                 const payment = frm.doc.payment_reconciliation.find(
                         (pay) => pay.mode_of_payment === p.mode_of_payment,
                 );
                 if (payment) {
                         let amount = get_base_value(p, "amount", "base_amount", conversion_rate);
-                        let cash_mode_of_payment = get_value(
-                                "POS Profile",
-                                frm.doc.pos_profile,
-                                "posa_cash_mode_of_payment",
-                        );
-                        if (!cash_mode_of_payment) {
-                                cash_mode_of_payment = "Cash";
-                        }
-                        if (payment.mode_of_payment == cash_mode_of_payment) {
+
+                        if (payment.mode_of_payment === cash_mode_of_payment) {
                                 amount -= get_base_value(d, "change_amount", "base_change_amount", conversion_rate);
                         }
                         payment.expected_amount += flt(amount);
@@ -228,23 +228,32 @@ function set_html_data(frm) {
 	});
 }
 
-const get_value = (doctype, name, field) => {
-        let value;
-        frappe.call({
-                method: "frappe.client.get_value",
-                args: {
-			doctype: doctype,
-			filters: { name: name },
-			fieldname: field,
-		},
-		async: false,
-		callback: function (r) {
-			if (!r.exc) {
-				value = r.message[field];
-			}
-		},
-        });
-        return value;
+const get_value = async (doctype, name, field) => {
+        if (!doctype || !name || !field) {
+                        return undefined;
+        }
+
+        try {
+                const { message } = await frappe.db.get_value(doctype, name, field);
+                return message ? message[field] : undefined;
+        } catch (error) {
+                console.error("Failed to fetch value:", error);
+                return undefined;
+        }
+};
+
+const get_cash_mode_of_payment = async (frm) => {
+        const profile = frm.doc.pos_profile;
+
+        if (!frm.__cashModeCache || frm.__cashModeCache.profile !== profile) {
+                const value = await get_value("POS Profile", profile, "posa_cash_mode_of_payment");
+                frm.__cashModeCache = {
+                        profile,
+                        value: value || "Cash",
+                };
+        }
+
+        return frm.__cashModeCache.value;
 };
 
 const get_conversion_rate = (doc) =>


### PR DESCRIPTION
## Summary
- refactor invoice save/update helpers to await frappe calls and propagate results to payment flows
- update phone payment, M-Pesa, and sales order dialogs to use async/await with loading and error handling
- modernize offer brand lookups and POS closing shift helpers to use cached asynchronous database access

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0ec4673d88326a62a8fdc4e6149cf