### PR TITLE
Disable low stock warnings during manual item addition

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -565,7 +565,6 @@ import { useCartValidation } from "../../composables/useCartValidation.js";
 import { useItemsIntegration } from "../../composables/useItemsIntegration.js";
 import {
   parseBooleanSetting,
-  formatNegativeStockWarning,
   formatStockShortageError,
 } from "../../utils/stock.js";
 import placeholderImage from "./placeholder-image.png";
@@ -1921,16 +1920,9 @@ export default {
 						return;
 					}
 
-					this.eventBus.emit("show_message", {
-						title: formatNegativeStockWarning(
-							new_item.item_name || new_item.item_code || scannedCodeForDisplay,
-							availableQty,
-							requestedQty
-						),
-						color: "warning",
-					});
-					}
-				}
+                                        // Low stock warnings are suppressed to avoid distracting notifications
+                                        }
+                                }
 
 				if (fromScanner) {
 					this.awaitingScanResult = true;
@@ -3047,17 +3039,8 @@ export default {
 					return;
 				}
 
-				if (negativeStockEnabled) {
-					this.eventBus.emit("show_message", {
-						title: formatNegativeStockWarning(
-							newItem.item_name || newItem.item_code || scannedCode,
-							availableQty,
-							requestedQty
-						),
-						color: "warning",
-					});
-				}
-			}
+                                // Suppress low stock notifications when negative stock is allowed
+                        }
 
 			this.awaitingScanResult = true;
 

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -28,7 +28,11 @@ export default {
 
         async add_item(item, options = {}) {
                 const res = await addItem(item, this);
-                if (!options?.skipNotification && this.eventBus?.emit) {
+
+                const shouldNotify =
+                        options?.notifyOnSuccess === true && !options?.skipNotification && this.eventBus?.emit;
+
+                if (shouldNotify) {
                         const rawQty = typeof item?.qty === "number" ? item.qty : parseFloat(item?.qty);
                         const shouldAnnounce = Number.isFinite(rawQty) ? rawQty > 0 : true;
 

--- a/frontend/src/posapp/composables/useCartValidation.js
+++ b/frontend/src/posapp/composables/useCartValidation.js
@@ -11,7 +11,6 @@ import { ref } from 'vue';
 
 import {
     parseBooleanSetting,
-    formatNegativeStockWarning,
     formatStockShortageError,
 } from '../utils/stock.js';
 export function useCartValidation() {
@@ -62,7 +61,7 @@ export function useCartValidation() {
                 if (eventBus) {
                     eventBus.emit("show_message", {
                         title: `No stock available for ${item.item_name}`,
-                        color: "warning",
+                        color: "error",
                     });
                 }
                 return false;
@@ -105,18 +104,6 @@ export function useCartValidation() {
                 }
                 return false;
             }
-
-            if (allowNegativeStock && exceedsAvailable && eventBus && showNegativeStockWarning) {
-                eventBus.emit("show_message", {
-                    title: formatNegativeStockWarning(
-                        item.item_name || item.item_code,
-                        item.actual_qty,
-                        requestedQty
-                    ),
-                    color: "warning",
-                });
-            }
-
             return true;
 
         } catch (error) {
@@ -241,17 +228,6 @@ export function useCartValidation() {
                 });
             }
             return false;
-        }
-
-        if (allowNegativeStock && exceedsAvailable && eventBus && showNegativeStockWarning) {
-            eventBus.emit("show_message", {
-                title: formatNegativeStockWarning(
-                    item.item_name || item.item_code,
-                    item.actual_qty,
-                    requestedQty
-                ),
-                color: "warning",
-            });
         }
 
         return true;


### PR DESCRIPTION
## Summary
- change zero-stock validation feedback to use error styling and remove non-blocking low stock notifications during cart validation and item selection
- stop emitting success notifications when adding invoice items unless explicitly requested, keeping manual additions quiet

## Testing
- yarn lint *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f268d620832684d7cf9ad62056b0