### PR TITLE
Optimize POS item detail and offer refresh workflows

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -385,8 +385,10 @@ export default {
 			float_precision: 6, // Float precision for calculations
 			currency_precision: 6, // Currency precision for display
 			new_line: false, // Add new line for item
-			available_stock_cache: {},
-			brand_cache: {},
+                        available_stock_cache: {},
+                        item_detail_cache: {},
+                        item_stock_cache: {},
+                        brand_cache: {},
 			delivery_charges: [], // List of delivery charges
 			base_delivery_charges_rate: 0, // Delivery charge in company currency
 			delivery_charges_rate: 0, // Selected delivery charge rate

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -16,15 +16,175 @@ import { useDiscounts } from "../../composables/useDiscounts.js";
 import { useItemAddition } from "../../composables/useItemAddition.js";
 import { useStockUtils } from "../../composables/useStockUtils.js";
 
+const ITEM_DETAIL_CACHE_TTL = 5000;
+const STOCK_CACHE_TTL = 5000;
+
 const { setSerialNo, setBatchQty } = useBatchSerial();
 const { updateDiscountAmount, calcPrices, calcItemPrice } = useDiscounts();
 const { removeItem, addItem, getNewItem, clearInvoice } = useItemAddition();
 const { calcUom, calcStockQty } = useStockUtils();
 
 export default {
-	remove_item(item) {
-		return removeItem(item, this);
-	},
+        _ensureTaskBucket(rowId) {
+                if (!rowId) {
+                        return null;
+                }
+                if (!this._itemTaskCache) {
+                        this._itemTaskCache = new Map();
+                }
+                if (!this._itemTaskCache.has(rowId)) {
+                        this._itemTaskCache.set(rowId, {});
+                }
+                return this._itemTaskCache.get(rowId);
+        },
+        _getItemTaskPromise(rowId, taskName) {
+                if (!rowId || !this._itemTaskCache) {
+                        return null;
+                }
+                const bucket = this._itemTaskCache.get(rowId);
+                return bucket ? bucket[taskName] || null : null;
+        },
+        _setItemTaskPromise(rowId, taskName, promise) {
+                if (!rowId || !promise) {
+                        return promise;
+                }
+                const bucket = this._ensureTaskBucket(rowId);
+                const trackedPromise = Promise.resolve(promise).finally(() => {
+                        const activeBucket = this._itemTaskCache ? this._itemTaskCache.get(rowId) : null;
+                        if (activeBucket) {
+                                delete activeBucket[taskName];
+                                if (!Object.keys(activeBucket).length) {
+                                        this._itemTaskCache.delete(rowId);
+                                }
+                        }
+                });
+                bucket[taskName] = trackedPromise;
+                return trackedPromise;
+        },
+        resetItemTaskCache(rowId, taskName = null) {
+                if (!this._itemTaskCache) {
+                        return;
+                }
+                if (!rowId) {
+                        this._itemTaskCache = new Map();
+                        return;
+                }
+                if (taskName === null) {
+                        this._itemTaskCache.delete(rowId);
+                        return;
+                }
+                const bucket = this._itemTaskCache.get(rowId);
+                if (!bucket) {
+                        return;
+                }
+                delete bucket[taskName];
+                if (!Object.keys(bucket).length) {
+                        this._itemTaskCache.delete(rowId);
+                }
+        },
+        queueItemTask(itemOrRowId, taskName, taskFn, options = {}) {
+                const rowId = typeof itemOrRowId === "string" ? itemOrRowId : itemOrRowId?.posa_row_id;
+                const { force = false } = options;
+                const executeTask = () => Promise.resolve().then(() => taskFn());
+
+                if (!rowId) {
+                        return executeTask();
+                }
+
+                if (force) {
+                        this.resetItemTaskCache(rowId, taskName);
+                } else {
+                        const existing = this._getItemTaskPromise(rowId, taskName);
+                        if (existing) {
+                                return existing;
+                        }
+                }
+
+                const promise = executeTask();
+                return this._setItemTaskPromise(rowId, taskName, promise);
+        },
+        hasItemTaskPromise(rowId, taskName) {
+                return !!this._getItemTaskPromise(rowId, taskName);
+        },
+        getItemTaskPromise(rowId, taskName) {
+                return this._getItemTaskPromise(rowId, taskName);
+        },
+        _getItemDetailCacheKey(item) {
+                const code = item?.item_code;
+                const warehouse = item?.warehouse || this.pos_profile?.warehouse;
+                if (!code || !warehouse) {
+                        return null;
+                }
+                return `${code}::${warehouse}`;
+        },
+        _getCachedItemDetail(key) {
+                if (!key) {
+                        return null;
+                }
+                const cache = this.item_detail_cache || {};
+                const entry = cache[key];
+                if (!entry) {
+                        return null;
+                }
+                if (Date.now() - entry.ts > ITEM_DETAIL_CACHE_TTL) {
+                        delete cache[key];
+                        return null;
+                }
+                return entry.data;
+        },
+        _storeItemDetailCache(key, data) {
+                if (!key || !data) {
+                        return;
+                }
+                if (!this.item_detail_cache) {
+                        this.item_detail_cache = {};
+                }
+                this.item_detail_cache[key] = {
+                        ts: Date.now(),
+                        data: JSON.parse(JSON.stringify(data)),
+                };
+        },
+        clearItemDetailCache() {
+                this.item_detail_cache = {};
+        },
+        _getStockCacheKey(item) {
+                const code = item?.item_code;
+                const warehouse = item?.warehouse || this.pos_profile?.warehouse;
+                if (!code || !warehouse) {
+                        return null;
+                }
+                return `${code}::${warehouse}`;
+        },
+        _getCachedStockQty(key) {
+                if (!key) {
+                        return null;
+                }
+                const cache = this.item_stock_cache || {};
+                const entry = cache[key];
+                if (!entry) {
+                        return null;
+                }
+                if (Date.now() - entry.ts > STOCK_CACHE_TTL) {
+                        delete cache[key];
+                        return null;
+                }
+                return entry.qty;
+        },
+        _storeStockQty(key, qty) {
+                if (!key) {
+                        return;
+                }
+                if (!this.item_stock_cache) {
+                        this.item_stock_cache = {};
+                }
+                this.item_stock_cache[key] = { ts: Date.now(), qty };
+        },
+        clearItemStockCache() {
+                this.item_stock_cache = {};
+        },
+        remove_item(item) {
+                return removeItem(item, this);
+        },
 
         async add_item(item, options = {}) {
                 const res = await addItem(item, this);
@@ -1395,8 +1555,19 @@ export default {
 		}
 	},
 
+
+
         // Update details for a single item (fetch from backend)
         async update_item_detail(item, force_update = false) {
+                return this.queueItemTask(
+                        item,
+                        "update_item_detail",
+                        () => this._performItemDetailUpdate(item, force_update),
+                        { force: force_update },
+                );
+        },
+
+        async _performItemDetailUpdate(item, force_update = false) {
                 console.log("update_item_detail request", {
                         code: item ? item.item_code : undefined,
                         force_update,
@@ -1405,8 +1576,6 @@ export default {
                         return;
                 }
 
-                // If a manual rate was set (e.g. via explicit UOM pricing), don't
-                // overwrite it on expand unless explicitly forced.
                 if (item._manual_rate_set && !force_update) {
                         return;
                 }
@@ -1415,39 +1584,52 @@ export default {
                         item._detailSynced = false;
                 }
 
-                if (item._detailInFlight || (!force_update && item._detailSynced)) {
+                if (!force_update && item._detailSynced) {
+                        return;
+                }
+
+                const cacheKey = this._getItemDetailCacheKey(item);
+                if (!force_update) {
+                        const cachedPayload = this._getCachedItemDetail(cacheKey);
+                        if (cachedPayload) {
+                                this._applyItemDetailPayload(item, cachedPayload, { forceUpdate: force_update, fromCache: true });
+                                item._detailSynced = true;
+                                return;
+                        }
+                }
+
+                if (item._detailInFlight) {
                         return;
                 }
 
                 item._detailInFlight = true;
-                const vm = this;
 
                 try {
-                        const currentDoc = vm.get_invoice_doc();
+                        const currentDoc = this.get_invoice_doc();
                         const response = await frappe.call({
                                 method: "posawesome.posawesome.api.items.get_item_detail",
                                 args: {
-                                        warehouse: item.warehouse || vm.pos_profile.warehouse,
+                                        warehouse: item.warehouse || this.pos_profile.warehouse,
                                         doc: currentDoc,
-                                        price_list: vm.selected_price_list || vm.pos_profile.selling_price_list,
+                                        price_list: this.selected_price_list || this.pos_profile.selling_price_list,
                                         item: {
                                                 item_code: item.item_code,
-                                                customer: vm.customer,
+                                                customer: this.customer,
                                                 doctype: currentDoc.doctype,
                                                 name: currentDoc.name || `New ${currentDoc.doctype} 1`,
-                                                company: vm.pos_profile.company,
+                                                company: this.pos_profile.company,
                                                 conversion_rate: 1,
-                                                currency: vm.pos_profile.currency,
+                                                currency: this.pos_profile.currency,
                                                 qty: item.qty,
                                                 price_list_rate: item.base_price_list_rate ?? item.price_list_rate ?? 0,
                                                 child_docname: `New ${currentDoc.doctype} Item 1`,
-                                                cost_center: vm.pos_profile.cost_center,
-                                                pos_profile: vm.pos_profile.name,
+                                                cost_center: this.pos_profile.cost_center,
+                                                pos_profile: this.pos_profile.name,
                                                 uom: item.uom,
                                                 tax_category: "",
                                                 transaction_type: "selling",
-                                                update_stock: vm.pos_profile.update_stock,
-                                                price_list: vm.get_price_list(),
+                                                update_stock: this.pos_profile.update_stock,
+                                                price_list: this.get_price_list(),
                                                 has_batch_no: item.has_batch_no,
                                                 has_serial_no: item.has_serial_no,
                                                 serial_no: item.serial_no,
@@ -1462,150 +1644,15 @@ export default {
                                 return;
                         }
 
-                        if (!item.warehouse) {
-                                item.warehouse = vm.pos_profile.warehouse;
-                        }
-                        if (data.price_list_currency) {
-                                vm.price_list_currency = data.price_list_currency;
-                        }
-
-                        if (!item.original_currency) {
-                                item.original_currency =
-                                        data.price_list_currency || vm.price_list_currency || vm.selected_currency;
-                        }
-                        if (!item.original_rate) {
-                                item.original_rate = data.price_list_rate;
-                        }
-                        if (data.serial_no_data) {
-                                item.serial_no_data = data.serial_no_data;
-                        }
-                        if (data.batch_no_data) {
-                                item.batch_no_data = data.batch_no_data;
-                        }
-                        if (
-                                item.has_batch_no &&
-                                vm.pos_profile.posa_auto_set_batch &&
-                                !item.batch_no &&
-                                Array.isArray(data.batch_no_data) &&
-                                data.batch_no_data.length > 0
-                        ) {
-                                item.batch_no_data = data.batch_no_data;
-                                vm.set_batch_qty(item, null, false);
-                        }
-
-                        if (!item.locked_price) {
-                                if (force_update || !item.base_rate) {
-                                        if (data.price_list_rate !== 0 || !item.base_price_list_rate) {
-                                                item.base_price_list_rate = data.price_list_rate;
-                                                if (!item.posa_offer_applied) {
-                                                        item.base_rate = data.price_list_rate;
-                                                }
-                                        }
-                                }
-
-                                if (!item.posa_offer_applied) {
-                                        const companyCurrency = vm.pos_profile.currency;
-                                        const baseCurrency = companyCurrency;
-
-                                        if (vm.selected_currency === vm.price_list_currency && vm.selected_currency !== companyCurrency) {
-                                                const conv = vm.conversion_rate || 1;
-                                                item.price_list_rate = vm.flt(
-                                                        item.base_price_list_rate / conv,
-                                                        vm.currency_precision,
-                                                );
-
-                                                if (!item._manual_rate_set) {
-                                                        item.rate = vm.flt(item.base_rate / conv, vm.currency_precision);
-                                                }
-                                        } else if (vm.selected_currency !== baseCurrency) {
-                                                const exchange_rate = vm.exchange_rate || 1;
-                                                item.price_list_rate = vm.flt(
-                                                        item.base_price_list_rate * exchange_rate,
-                                                        vm.currency_precision,
-                                                );
-
-                                                item.rate = vm.flt(item.base_rate * exchange_rate, vm.currency_precision);
-                                        } else {
-                                                item.price_list_rate = item.base_price_list_rate;
-
-                                                if (!item._manual_rate_set) {
-                                                        item.rate = item.base_rate;
-                                                }
-                                        }
-                                } else {
-                                        const baseCurrency = vm.price_list_currency || vm.pos_profile.currency;
-                                        if (vm.selected_currency !== baseCurrency) {
-                                                item.price_list_rate = vm.flt(
-                                                        item.base_rate * vm.exchange_rate,
-                                                        vm.currency_precision,
-                                                );
-                                        } else {
-                                                item.price_list_rate = item.base_rate;
-                                        }
-                                }
-
-                                if (
-                                        !item.posa_offer_applied &&
-                                        vm.pos_profile.posa_apply_customer_discount &&
-                                        vm.customer_info.posa_discount > 0 &&
-                                        vm.customer_info.posa_discount <= 100 &&
-                                        item.posa_is_offer == 0 &&
-                                        !item.posa_is_replace
-                                ) {
-                                        const discount_percent =
-                                                item.max_discount > 0
-                                                        ? Math.min(item.max_discount, vm.customer_info.posa_discount)
-                                                        : vm.customer_info.posa_discount;
-
-                                        item.discount_percentage = discount_percent;
-
-                                        const discount_amount = vm.flt(
-                                                (item.price_list_rate * discount_percent) / 100,
-                                                vm.currency_precision,
-                                        );
-                                        item.discount_amount = discount_amount;
-
-                                        item.base_discount_amount = vm.flt(
-                                                (item.base_price_list_rate * discount_percent) / 100,
-                                                vm.currency_precision,
-                                        );
-
-                                        item.rate = vm.flt(item.price_list_rate - discount_amount, vm.currency_precision);
-                                        item.base_rate = vm.flt(
-                                                item.base_price_list_rate - item.base_discount_amount,
-                                                vm.currency_precision,
-                                        );
-                                }
-                        }
-
-                        item.last_purchase_rate = data.last_purchase_rate;
-                        item.projected_qty = data.projected_qty;
-                        item.reserved_qty = data.reserved_qty;
-                        item.conversion_factor = data.conversion_factor;
-                        item.stock_qty = data.stock_qty;
-                        item.actual_qty = data.actual_qty;
-                        item.stock_uom = data.stock_uom;
-                        item.has_serial_no = data.has_serial_no;
-                        item.has_batch_no = data.has_batch_no;
-
-                        item.amount = vm.flt(item.qty * item.rate, vm.currency_precision);
-                        item.base_amount = vm.flt(item.qty * item.base_rate, vm.currency_precision);
-
-                        console.log(`Updated rates for ${item.item_code} on expand:`, {
-                                base_rate: item.base_rate,
-                                rate: item.rate,
-                                base_price_list_rate: item.base_price_list_rate,
-                                price_list_rate: item.price_list_rate,
-                                exchange_rate: vm.exchange_rate,
-                                selected_currency: vm.selected_currency,
-                                default_currency: vm.pos_profile.currency,
-                        });
-
+                        this._applyItemDetailPayload(item, data, { forceUpdate: force_update, fromCache: false });
+                        this._storeItemDetailCache(cacheKey, data);
                         item._detailSynced = true;
-                        vm.$forceUpdate();
+                        if (typeof this.$forceUpdate === "function") {
+                                this.$forceUpdate();
+                        }
                 } catch (error) {
                         console.error("Error updating item detail:", error);
-                        vm.eventBus.emit("show_message", {
+                        this.eventBus.emit("show_message", {
                                 title: __("Error updating item details"),
                                 color: "error",
                         });
@@ -1614,6 +1661,200 @@ export default {
                 }
         },
 
+        _applyItemDetailPayload(item, data, options = {}) {
+                const { forceUpdate = false } = options;
+
+                if (!item.warehouse) {
+                        item.warehouse = this.pos_profile.warehouse;
+                }
+                if (data.price_list_currency) {
+                        this.price_list_currency = data.price_list_currency;
+                }
+
+                if (data.uom) {
+                        item.stock_uom = data.stock_uom;
+                        item.uom = data.uom;
+                }
+                if (data.conversion_factor) {
+                        item.conversion_factor = data.conversion_factor;
+                }
+
+                item.item_uoms = data.item_uoms || [];
+
+                if (Array.isArray(item.item_uoms) && item.item_uoms.length) {
+                        const existingIndex = item.item_uoms.findIndex((uom) => uom.uom === item.uom);
+                        if (existingIndex === -1) {
+                                item.item_uoms.push({
+                                        uom: item.uom,
+                                        conversion_factor: item.conversion_factor || 1,
+                                });
+                        }
+                }
+
+                if (data.uom) {
+                        item.uom = data.uom;
+                }
+
+                item.allow_change_warehouse = data.allow_change_warehouse;
+                item.locked_price = data.locked_price;
+                item.description = data.description;
+                item.item_tax_template = data.item_tax_template;
+                item.discount_percentage = data.discount_percentage;
+                item.warehouse = data.warehouse || item.warehouse;
+                item.has_batch_no = data.has_batch_no;
+                item.has_serial_no = data.has_serial_no;
+                item.serial_no = data.serial_no;
+                item.batch_no = data.batch_no;
+                item.is_stock_item = data.is_stock_item;
+                item.is_fixed_asset = data.is_fixed_asset;
+                item.allow_alternative_item = data.allow_alternative_item;
+                item.is_stock_item = data.is_stock_item;
+                item.warehouse = data.warehouse || item.warehouse;
+
+                item.actual_qty = data.actual_qty;
+                item.available_qty = data.actual_qty;
+
+                if (this.update_qty_limits) {
+                        this.update_qty_limits(item);
+                }
+
+                if (data.barcode) {
+                        item.barcode = data.barcode;
+                }
+                if (data.brand) {
+                        item.brand = data.brand;
+                }
+                if (data.batch_no) {
+                        item.batch_no = data.batch_no;
+                }
+                if (data.serial_no_data) {
+                        item.serial_no_data = data.serial_no_data;
+                }
+                if (data.batch_no_data) {
+                        item.batch_no_data = data.batch_no_data;
+                }
+                if (
+                        item.has_batch_no &&
+                        this.pos_profile.posa_auto_set_batch &&
+                        !item.batch_no &&
+                        Array.isArray(data.batch_no_data) &&
+                        data.batch_no_data.length > 0
+                ) {
+                        item.batch_no_data = data.batch_no_data;
+                        this.set_batch_qty(item, null, false);
+                }
+
+                if (!item.locked_price) {
+                        if (forceUpdate || !item.base_rate) {
+                                if (data.price_list_rate !== 0 || !item.base_price_list_rate) {
+                                        item.base_price_list_rate = data.price_list_rate;
+                                        if (!item.posa_offer_applied) {
+                                                item.base_rate = data.price_list_rate;
+                                        }
+                                }
+                        }
+
+                        if (!item.posa_offer_applied) {
+                                const companyCurrency = this.pos_profile.currency;
+                                const baseCurrency = companyCurrency;
+
+                                if (
+                                        this.selected_currency === this.price_list_currency &&
+                                        this.selected_currency !== companyCurrency
+                                ) {
+                                        const conv = this.conversion_rate || 1;
+                                        item.price_list_rate = this.flt(
+                                                item.base_price_list_rate / conv,
+                                                this.currency_precision,
+                                        );
+
+                                        if (!item._manual_rate_set) {
+                                                item.rate = this.flt(item.base_rate / conv, this.currency_precision);
+                                        }
+                                } else if (this.selected_currency !== baseCurrency) {
+                                        const exchange_rate = this.exchange_rate || 1;
+                                        item.price_list_rate = this.flt(
+                                                item.base_price_list_rate * exchange_rate,
+                                                this.currency_precision,
+                                        );
+
+                                        item.rate = this.flt(item.base_rate * exchange_rate, this.currency_precision);
+                                } else {
+                                        item.price_list_rate = item.base_price_list_rate;
+
+                                        if (!item._manual_rate_set) {
+                                                item.rate = item.base_rate;
+                                        }
+                                }
+                        } else {
+                                const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+                                if (this.selected_currency !== baseCurrency) {
+                                        item.price_list_rate = this.flt(
+                                                item.base_rate * this.exchange_rate,
+                                                this.currency_precision,
+                                        );
+                                } else {
+                                        item.price_list_rate = item.base_rate;
+                                }
+                        }
+
+                        if (
+                                !item.posa_offer_applied &&
+                                this.pos_profile.posa_apply_customer_discount &&
+                                this.customer_info.posa_discount > 0 &&
+                                this.customer_info.posa_discount <= 100 &&
+                                item.posa_is_offer == 0 &&
+                                !item.posa_is_replace
+                        ) {
+                                const discount_percent =
+                                        item.max_discount > 0
+                                                ? Math.min(item.max_discount, this.customer_info.posa_discount)
+                                                : this.customer_info.posa_discount;
+
+                                item.discount_percentage = discount_percent;
+
+                                const discount_amount = this.flt(
+                                        (item.price_list_rate * discount_percent) / 100,
+                                        this.currency_precision,
+                                );
+                                item.discount_amount = discount_amount;
+
+                                item.base_discount_amount = this.flt(
+                                        (item.base_price_list_rate * discount_percent) / 100,
+                                        this.currency_precision,
+                                );
+
+                                item.rate = this.flt(item.price_list_rate - discount_amount, this.currency_precision);
+                                item.base_rate = this.flt(
+                                        item.base_price_list_rate - item.base_discount_amount,
+                                        this.currency_precision,
+                                );
+                        }
+                }
+
+                item.last_purchase_rate = data.last_purchase_rate;
+                item.projected_qty = data.projected_qty;
+                item.reserved_qty = data.reserved_qty;
+                item.conversion_factor = data.conversion_factor;
+                item.stock_qty = data.stock_qty;
+                item.actual_qty = data.actual_qty;
+                item.stock_uom = data.stock_uom;
+                item.has_serial_no = data.has_serial_no;
+                item.has_batch_no = data.has_batch_no;
+
+                item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
+
+                console.log(`Updated rates for ${item.item_code} on expand:`, {
+                        base_rate: item.base_rate,
+                        rate: item.rate,
+                        base_price_list_rate: item.base_price_list_rate,
+                        price_list_rate: item.price_list_rate,
+                        exchange_rate: this.exchange_rate,
+                        selected_currency: this.selected_currency,
+                        default_currency: this.pos_profile.currency,
+                });
+        },
         // Fetch customer details (info, price list, etc)
 	async fetch_customer_details() {
 		var vm = this;
@@ -1801,9 +2042,12 @@ export default {
 	},
 
 	// Update UOM (unit of measure) for an item and recalculate prices
-	calc_uom(item, value) {
-		return calcUom(item, value, this);
-	},
+        calc_uom(item, value) {
+                if (!item) {
+                        return;
+                }
+                return this.queueItemTask(item, "calc_uom", () => calcUom(item, value, this));
+        },
 
 	// Calculate stock quantity for an item (simplified - validation handled centrally)
 	calc_stock_qty(item, value) {
@@ -1831,37 +2075,50 @@ export default {
 	},
 
 	// Fetch available stock for an item and cache it
-	async fetch_available_qty(item) {
-		if (!item || !item.item_code || !item.warehouse) return;
-		const key = `${item.item_code}:${item.warehouse}:${item.batch_no || ""}:${item.uom}`;
-		const cached = this.available_stock_cache[key];
-		const now = Date.now();
-		if (cached && now - cached.ts < 60000) {
-			item.available_qty = cached.qty;
-			this.update_qty_limits(item);
-			return;
-		}
-		try {
-			const r = await frappe.call({
-				method: "posawesome.posawesome.api.items.get_available_qty",
-				args: {
-					items: JSON.stringify([
-						{
-							item_code: item.item_code,
-							warehouse: item.warehouse,
-							batch_no: item.batch_no,
-						},
-					]),
-				},
-			});
-			const qty = r.message && r.message.length ? flt(r.message[0].available_qty) : 0;
-			this.available_stock_cache[key] = { qty, ts: now };
-			item.available_qty = qty;
-			this.update_qty_limits(item);
-		} catch (e) {
-			console.error("Failed to fetch available qty", e);
-		}
-	},
+        async fetch_available_qty(item) {
+                if (!item || !item.item_code || !item.warehouse) return;
+
+                const key = this._getStockCacheKey(item);
+                const cachedQty = this._getCachedStockQty(key);
+                if (cachedQty !== null && cachedQty !== undefined) {
+                        item.available_qty = cachedQty;
+                        this.update_qty_limits(item);
+                        return cachedQty;
+                }
+
+                const runner = async () => {
+                        try {
+                                const response = await frappe.call({
+                                        method: "posawesome.posawesome.api.items.get_available_qty",
+                                        args: {
+                                                items: JSON.stringify([
+                                                        {
+                                                                item_code: item.item_code,
+                                                                warehouse: item.warehouse,
+                                                                batch_no: item.batch_no,
+                                                        },
+                                                ]),
+                                        },
+                                });
+                                const qty =
+                                        response.message && response.message.length
+                                                ? flt(response.message[0].available_qty)
+                                                : 0;
+                                this._storeStockQty(key, qty);
+                                if (this.available_stock_cache) {
+                                        this.available_stock_cache[key] = { qty, ts: Date.now() };
+                                }
+                                item.available_qty = qty;
+                                this.update_qty_limits(item);
+                                return qty;
+                        } catch (error) {
+                                console.error("Failed to fetch available qty", error);
+                                throw error;
+                        }
+                };
+
+                return this.queueItemTask(item, "fetch_available_qty", runner);
+        },
 
 	// Set serial numbers for an item (and update qty)
 	set_serial_no(item) {

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -3,9 +3,18 @@ import { formatUtils } from "../../format.js";
 /* global __, frappe, flt */
 
 export default {
-        scheduleOfferRefresh() {
+        scheduleOfferRefresh(changedRowIds = []) {
                 if (this.isApplyingOffer) {
                         return;
+                }
+
+                this._pendingOfferRowIds = this._pendingOfferRowIds || new Set();
+                if (Array.isArray(changedRowIds)) {
+                        changedRowIds.forEach((rowId) => {
+                                if (rowId) {
+                                        this._pendingOfferRowIds.add(rowId);
+                                }
+                        });
                 }
 
                 if (this._offerRefreshPending) {
@@ -27,7 +36,12 @@ export default {
                                 return;
                         }
 
-                        this.handelOffers();
+                        const pendingRows = this._pendingOfferRowIds ? Array.from(this._pendingOfferRowIds) : [];
+                        this._pendingOfferRowIds = new Set();
+                        const removedRows = this._pendingRemovedRowInfo || {};
+                        this._pendingRemovedRowInfo = {};
+
+                        this.handelOffers(pendingRows, removedRows);
 
                         if (typeof this.$forceUpdate === "function") {
                                 this.$forceUpdate();
@@ -47,6 +61,8 @@ export default {
                 }
 
                 this._offerRefreshPending = false;
+                this._pendingOfferRowIds = new Set();
+                this._pendingRemovedRowInfo = {};
         },
         normalizeBrand(brand) {
                 return (brand || "").trim().toLowerCase();
@@ -93,33 +109,241 @@ export default {
 		return applied;
 	},
 
-        async handelOffers() {
+        async handelOffers(changedRowIds = [], removedRows = {}) {
                 try {
                         const sourceOffers = Array.isArray(this.posOffers) ? this.posOffers : [];
-                        const offerPromises = sourceOffers.map(async (offer) => {
-                                if (offer.apply_on === "Item Code") {
-                                        return this.getItemOffer(offer);
+                        if (!sourceOffers.length) {
+                                this.updatePosOffers([]);
+                                this._cachedOfferResults = new Map();
+                                return;
+                        }
+
+                        const allItems = [...(this.items || []), ...(this.packed_items || [])];
+                        const itemMap = new Map();
+                        allItems.forEach((item) => {
+                                if (item && item.posa_row_id) {
+                                        itemMap.set(item.posa_row_id, item);
                                 }
-                                if (offer.apply_on === "Item Group") {
-                                        return this.getGroupOffer(offer);
-                                }
-                                if (offer.apply_on === "Brand") {
-                                        return this.getBrandOffer(offer);
-                                }
-                                if (offer.apply_on === "Transaction") {
-                                        return this.getTransactionOffer(offer);
-                                }
-                                return null;
                         });
 
-                        const offerResults = await Promise.all(offerPromises);
-                        const offers = offerResults.filter((offer) => !!offer);
+                        const changedSet = new Set((Array.isArray(changedRowIds) ? changedRowIds : []).filter(Boolean));
+                        const removedInfo = removedRows || {};
+
+                        this._cachedOfferResults =
+                                this._cachedOfferResults instanceof Map ? this._cachedOfferResults : new Map();
+                        const cache = this._cachedOfferResults;
+
+                        const offerNames = new Set(sourceOffers.map((offer) => offer.name));
+                        for (const cachedName of Array.from(cache.keys())) {
+                                if (!offerNames.has(cachedName)) {
+                                        cache.delete(cachedName);
+                                }
+                        }
+
+                        const offersToRecompute =
+                                !changedSet.size && !Object.keys(removedInfo).length
+                                        ? sourceOffers
+                                        : sourceOffers.filter((offer) =>
+                                                  this.isOfferAffected(offer, changedSet, itemMap, removedInfo),
+                                          );
+
+                        let context = null;
+                        if (offersToRecompute.length) {
+                                context = await this.buildOfferEvaluationContext(allItems, offersToRecompute);
+                                context.itemMap = itemMap;
+                        } else {
+                                context = { itemMap };
+                        }
+
+                        for (const offer of offersToRecompute) {
+                                const evaluated = this.evaluateOffer(offer, context);
+                                if (evaluated) {
+                                        cache.set(offer.name, evaluated);
+                                } else {
+                                        cache.delete(offer.name);
+                                }
+                        }
+
+                        const offers = sourceOffers
+                                .map((offer) => cache.get(offer.name))
+                                .filter((entry) => !!entry);
 
                         this.setItemGiveOffer(offers);
                         this.updatePosOffers(offers);
                 } catch (error) {
                         console.error("Failed to process offers:", error);
                 }
+        },
+
+        isOfferAffected(offer, changedSet, itemMap, removedInfo = {}) {
+                if (!offer) {
+                        return false;
+                }
+
+                if (!changedSet || !changedSet.size) {
+                        return true;
+                }
+
+                const applyOn = offer.apply_on;
+                const normalizedBrand = applyOn === "Brand" ? this.normalizeBrand(offer.brand) : null;
+
+                for (const rowId of changedSet) {
+                        const item = itemMap.get(rowId);
+                        const fallback = removedInfo[rowId];
+                        const meta = item
+                                ? {
+                                          item_code: item.item_code,
+                                          item_group: item.item_group,
+                                          brand: this.normalizeBrand(
+                                                  item.brand || (this.brand_cache && this.brand_cache[item.item_code]) || "",
+                                          ),
+                                  }
+                                : fallback
+                                ? {
+                                          item_code: fallback.item_code,
+                                          item_group: fallback.item_group,
+                                          brand: this.normalizeBrand(
+                                                  fallback.brand || (this.brand_cache && this.brand_cache[fallback.item_code]) || "",
+                                          ),
+                                  }
+                                : null;
+
+                        if (!meta) {
+                                return true;
+                        }
+
+                        switch (applyOn) {
+                                case "Item Code":
+                                        if (meta.item_code === offer.item) {
+                                                return true;
+                                        }
+                                        break;
+                                case "Item Group":
+                                        if (meta.item_group === offer.item_group) {
+                                                return true;
+                                        }
+                                        break;
+                                case "Brand":
+                                        if (!normalizedBrand) {
+                                                return true;
+                                        }
+                                        if (!meta.brand) {
+                                                return true;
+                                        }
+                                        if (meta.brand === normalizedBrand) {
+                                                return true;
+                                        }
+                                        break;
+                                case "Transaction":
+                                        return true;
+                                default:
+                                        break;
+                        }
+                }
+
+                return false;
+        },
+
+        async buildOfferEvaluationContext(allItems, offers) {
+                const context = {
+                        itemMap: new Map(),
+                        itemCodeBuckets: new Map(),
+                        itemGroupBuckets: new Map(),
+                        brandBuckets: new Map(),
+                        transactionBucket: { items: [], qty: 0, amount: 0 },
+                };
+
+                const needItemCode = offers.some((offer) => offer.apply_on === "Item Code");
+                const needGroup = offers.some((offer) => offer.apply_on === "Item Group");
+                const needBrand = offers.some((offer) => offer.apply_on === "Brand");
+                const needTransaction = offers.some((offer) => offer.apply_on === "Transaction");
+
+                const brandCandidates = [];
+
+                (Array.isArray(allItems) ? allItems : []).forEach((item) => {
+                        if (!item) {
+                                return;
+                        }
+                        if (item.posa_row_id) {
+                                context.itemMap.set(item.posa_row_id, item);
+                        }
+
+                        const qty = item.stock_qty || 0;
+                        const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
+                        const amount = qty * rate;
+
+                        if (needItemCode && !item.posa_is_offer && item.item_code) {
+                                let bucket = context.itemCodeBuckets.get(item.item_code);
+                                if (!bucket) {
+                                        bucket = { items: [], qty: 0, amount: 0 };
+                                        context.itemCodeBuckets.set(item.item_code, bucket);
+                                }
+                                bucket.items.push(item);
+                                bucket.qty += qty;
+                                bucket.amount += amount;
+                        }
+
+                        if (needGroup && !item.posa_is_offer && item.item_group) {
+                                let bucket = context.itemGroupBuckets.get(item.item_group);
+                                if (!bucket) {
+                                        bucket = { items: [], qty: 0, amount: 0 };
+                                        context.itemGroupBuckets.set(item.item_group, bucket);
+                                }
+                                bucket.items.push(item);
+                                bucket.qty += qty;
+                                bucket.amount += amount;
+                        }
+
+                        if (needBrand && !item.posa_is_offer && item.item_code) {
+                                brandCandidates.push(item);
+                        }
+
+                        if (needTransaction && !item.posa_is_offer && !item.posa_is_replace) {
+                                context.transactionBucket.items.push(item);
+                                context.transactionBucket.qty += qty;
+                                context.transactionBucket.amount += amount;
+                        }
+                });
+
+                if (needBrand) {
+                        for (const item of brandCandidates) {
+                                const brand = await this.getItemBrand(item);
+                                if (!brand) {
+                                        continue;
+                                }
+                                let bucket = context.brandBuckets.get(brand);
+                                if (!bucket) {
+                                        bucket = { items: [], qty: 0, amount: 0 };
+                                        context.brandBuckets.set(brand, bucket);
+                                }
+                                bucket.items.push(item);
+                                bucket.qty += item.stock_qty || 0;
+                                const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
+                                bucket.amount += (item.stock_qty || 0) * rate;
+                        }
+                }
+
+                return context;
+        },
+
+        evaluateOffer(offer, context = {}) {
+                if (!offer) {
+                        return null;
+                }
+
+                if (offer.apply_on === "Item Code") {
+                        return this.getItemOffer({ ...offer }, context);
+                }
+                if (offer.apply_on === "Item Group") {
+                        return this.getGroupOffer({ ...offer }, context);
+                }
+                if (offer.apply_on === "Brand") {
+                        return this.getBrandOffer({ ...offer }, context);
+                }
+                if (offer.apply_on === "Transaction") {
+                        return this.getTransactionOffer({ ...offer }, context);
+                }
+                return null;
         },
 
 	setItemGiveOffer(offers) {
@@ -224,140 +448,179 @@ export default {
 		}
 	},
 
-	getItemOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Item Code") {
-			if (this.checkOfferCoupon(offer)) {
-				const combined = [...this.items, ...this.packed_items];
-				combined.forEach((item) => {
-					if (!item.posa_is_offer && item.item_code === offer.item) {
-						if (
-							offer.offer === "Item Price" &&
-							item.posa_offer_applied &&
-							!this.checkOfferIsAppley(item, offer)
-						) {
-							return;
-						}
-						const items = [];
-						const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-						const res = this.checkQtyAnountOffer(offer, item.stock_qty, item.stock_qty * rate);
-						if (res.apply) {
-							items.push(item.posa_row_id);
-							offer.items = items;
-							apply_offer = offer;
-						}
-					}
-				});
-			}
-		}
-		return apply_offer;
-	},
+        getItemOffer(offer, context = {}) {
+                if (!offer || offer.apply_on !== "Item Code") {
+                        return null;
+                }
 
-	getGroupOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Item Group") {
-			if (this.checkOfferCoupon(offer)) {
-				const items = [];
-				let total_count = 0;
-				let total_amount = 0;
-				const combined = [...this.items, ...this.packed_items];
-				combined.forEach((item) => {
-					if (!item.posa_is_offer && item.item_group === offer.item_group) {
-						if (
-							offer.offer === "Item Price" &&
-							item.posa_offer_applied &&
-							!this.checkOfferIsAppley(item, offer)
-						) {
-							return;
-						}
-						total_count += item.stock_qty;
-						const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-						total_amount += item.stock_qty * rate;
-						items.push(item.posa_row_id);
-					}
-				});
-				if (total_count || total_amount) {
-					const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
-					if (res.apply) {
-						offer.items = items;
-						apply_offer = offer;
-					}
-				}
-			}
-		}
-		return apply_offer;
-	},
+                if (!this.checkOfferCoupon(offer)) {
+                        return null;
+                }
 
-        async getBrandOffer(offer) {
-                let apply_offer = null;
-                if (offer.apply_on === "Brand") {
-                        if (this.checkOfferCoupon(offer)) {
-                                const items = [];
-                                let total_count = 0;
-                                let total_amount = 0;
-                                const offer_brand = this.normalizeBrand(offer.brand);
-                                const combined = [...this.items, ...this.packed_items];
-                                const brandedItems = await Promise.all(
-                                        combined.map(async (item) => ({
-                                                item,
-                                                brand: await this.getItemBrand(item),
-                                        })),
-                                );
+                const bucket = context.itemCodeBuckets ? context.itemCodeBuckets.get(offer.item) : null;
+                if (!bucket) {
+                        return null;
+                }
 
-                                brandedItems.forEach(({ item, brand }) => {
-                                        if (!item.posa_is_offer && brand && brand === offer_brand) {
-                                                if (
-                                                        offer.offer === "Item Price" &&
-                                                        item.posa_offer_applied &&
-                                                        !this.checkOfferIsAppley(item, offer)
-                                                ) {
-                                                        return;
-                                                }
-                                                total_count += item.stock_qty;
-                                                const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-                                                total_amount += item.stock_qty * rate;
-                                                items.push(item.posa_row_id);
-                                        }
-                                });
-                                if (total_count || total_amount) {
-                                        const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
-                                        if (res.apply) {
-                                                offer.items = items;
-                                                apply_offer = offer;
-					}
-				}
-			}
-		}
-		return apply_offer;
-	},
-	getTransactionOffer(offer) {
-		let apply_offer = null;
-		if (offer.apply_on === "Transaction") {
-			if (this.checkOfferCoupon(offer)) {
-				const combined = [...this.items, ...this.packed_items];
-				let total_qty = 0;
-				let total_amount = 0;
-				const items = [];
-				combined.forEach((item) => {
-					if (!item.posa_is_offer && !item.posa_is_replace) {
-						total_qty += item.stock_qty;
-						const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-						total_amount += item.stock_qty * rate;
-						items.push(item.posa_row_id);
-					}
-				});
-				const total_count = total_qty;
-				if (total_count || total_amount) {
-					const res = this.checkQtyAnountOffer(offer, total_count, total_amount);
-					if (res.apply) {
-						offer.items = items;
-						apply_offer = offer;
-					}
-				}
-			}
-		}
-		return apply_offer;
-	},
+                const items = [];
+                let totalQty = 0;
+                let totalAmount = 0;
+
+                bucket.items.forEach((item) => {
+                        if (!item || item.posa_is_offer) {
+                                return;
+                        }
+                        if (
+                                offer.offer === "Item Price" &&
+                                item.posa_offer_applied &&
+                                !this.checkOfferIsAppley(item, offer)
+                        ) {
+                                return;
+                        }
+                        const qty = item.stock_qty || 0;
+                        const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
+                        totalQty += qty;
+                        totalAmount += qty * rate;
+                        items.push(item.posa_row_id);
+                });
+
+                if (!totalQty && !totalAmount) {
+                        return null;
+                }
+
+                const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
+                if (!res.apply) {
+                        return null;
+                }
+
+                offer.items = items;
+                return offer;
+        },
+
+        getGroupOffer(offer, context = {}) {
+                if (!offer || offer.apply_on !== "Item Group") {
+                        return null;
+                }
+
+                if (!this.checkOfferCoupon(offer)) {
+                        return null;
+                }
+
+                const bucket = context.itemGroupBuckets ? context.itemGroupBuckets.get(offer.item_group) : null;
+                if (!bucket) {
+                        return null;
+                }
+
+                const items = [];
+                let totalQty = 0;
+                let totalAmount = 0;
+
+                bucket.items.forEach((item) => {
+                        if (!item || item.posa_is_offer) {
+                                return;
+                        }
+                        if (
+                                offer.offer === "Item Price" &&
+                                item.posa_offer_applied &&
+                                !this.checkOfferIsAppley(item, offer)
+                        ) {
+                                return;
+                        }
+                        const qty = item.stock_qty || 0;
+                        const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
+                        totalQty += qty;
+                        totalAmount += qty * rate;
+                        items.push(item.posa_row_id);
+                });
+
+                if (!totalQty && !totalAmount) {
+                        return null;
+                }
+
+                const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
+                if (!res.apply) {
+                        return null;
+                }
+
+                offer.items = items;
+                return offer;
+        },
+
+        getBrandOffer(offer, context = {}) {
+                if (!offer || offer.apply_on !== "Brand") {
+                        return null;
+                }
+
+                if (!this.checkOfferCoupon(offer)) {
+                        return null;
+                }
+
+                const normalizedBrand = this.normalizeBrand(offer.brand);
+                if (!normalizedBrand) {
+                        return null;
+                }
+
+                const bucket = context.brandBuckets ? context.brandBuckets.get(normalizedBrand) : null;
+                if (!bucket) {
+                        return null;
+                }
+
+                const items = [];
+                let totalQty = 0;
+                let totalAmount = 0;
+
+                bucket.items.forEach((item) => {
+                        if (!item || item.posa_is_offer) {
+                                return;
+                        }
+                        if (
+                                offer.offer === "Item Price" &&
+                                item.posa_offer_applied &&
+                                !this.checkOfferIsAppley(item, offer)
+                        ) {
+                                return;
+                        }
+                        const qty = item.stock_qty || 0;
+                        const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
+                        totalQty += qty;
+                        totalAmount += qty * rate;
+                        items.push(item.posa_row_id);
+                });
+
+                if (!totalQty && !totalAmount) {
+                        return null;
+                }
+
+                const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
+                if (!res.apply) {
+                        return null;
+                }
+
+                offer.items = items;
+                return offer;
+        },
+        getTransactionOffer(offer, context = {}) {
+                if (!offer || offer.apply_on !== "Transaction") {
+                        return null;
+                }
+
+                if (!this.checkOfferCoupon(offer)) {
+                        return null;
+                }
+
+                const bucket = context.transactionBucket || { items: [], qty: 0, amount: 0 };
+                if (!bucket.items.length && !bucket.qty && !bucket.amount) {
+                        return null;
+                }
+
+                const res = this.checkQtyAnountOffer(offer, bucket.qty, bucket.amount);
+                if (!res.apply) {
+                        return null;
+                }
+
+                offer.items = bucket.items.map((item) => item.posa_row_id);
+                return offer;
+        },
 
 	updatePosOffers(offers) {
 		this.eventBus.emit("update_pos_offers", offers);

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -6,6 +6,7 @@ const buildSnapshot = (items) => {
         const snapshot = {
                 order: [],
                 qty: {},
+                stockQty: {},
                 meta: {},
         };
 
@@ -16,10 +17,15 @@ const buildSnapshot = (items) => {
                 const rowId = item.posa_row_id;
                 snapshot.order.push(rowId);
                 snapshot.qty[rowId] = item.qty;
+                snapshot.stockQty[rowId] = item.stock_qty;
                 snapshot.meta[rowId] = {
                         item_code: item.item_code,
                         item_group: item.item_group,
                         brand: item.brand,
+                        uom: item.uom,
+                        conversion_factor: item.conversion_factor,
+                        price_list_rate: item.price_list_rate,
+                        stock_qty: item.stock_qty,
                         posa_is_offer: item.posa_is_offer,
                         posa_is_replace: item.posa_is_replace,
                 };
@@ -29,7 +35,7 @@ const buildSnapshot = (items) => {
 };
 
 const diffSnapshots = (previous, current) => {
-        const prevSnapshot = previous || { order: [], qty: {}, meta: {} };
+        const prevSnapshot = previous || { order: [], qty: {}, stockQty: {}, meta: {} };
         const changed = new Set();
         const removedInfo = {};
 
@@ -56,6 +62,17 @@ const diffSnapshots = (previous, current) => {
         currOrder.forEach((rowId) => {
                 const previousQty = prevSnapshot.qty ? prevSnapshot.qty[rowId] : undefined;
                 if (previousQty !== current.qty[rowId]) {
+                        changed.add(rowId);
+                }
+
+                const previousStockQty = prevSnapshot.stockQty ? prevSnapshot.stockQty[rowId] : undefined;
+                if (previousStockQty !== current.stockQty[rowId]) {
+                        changed.add(rowId);
+                }
+
+                const prevMeta = prevSnapshot.meta ? prevSnapshot.meta[rowId] : undefined;
+                const currMeta = current.meta ? current.meta[rowId] : undefined;
+                if (JSON.stringify(prevMeta) !== JSON.stringify(currMeta)) {
                         changed.add(rowId);
                 }
         });

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -2,6 +2,67 @@ import { clearPriceListCache } from "../../../offline/index.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 /* global frappe */
 
+const buildSnapshot = (items) => {
+        const snapshot = {
+                order: [],
+                qty: {},
+                meta: {},
+        };
+
+        (Array.isArray(items) ? items : []).forEach((item) => {
+                if (!item || !item.posa_row_id) {
+                        return;
+                }
+                const rowId = item.posa_row_id;
+                snapshot.order.push(rowId);
+                snapshot.qty[rowId] = item.qty;
+                snapshot.meta[rowId] = {
+                        item_code: item.item_code,
+                        item_group: item.item_group,
+                        brand: item.brand,
+                        posa_is_offer: item.posa_is_offer,
+                        posa_is_replace: item.posa_is_replace,
+                };
+        });
+
+        return snapshot;
+};
+
+const diffSnapshots = (previous, current) => {
+        const prevSnapshot = previous || { order: [], qty: {}, meta: {} };
+        const changed = new Set();
+        const removedInfo = {};
+
+        const prevOrder = Array.isArray(prevSnapshot.order) ? prevSnapshot.order : [];
+        const currOrder = Array.isArray(current.order) ? current.order : [];
+        const prevSet = new Set(prevOrder);
+        const currSet = new Set(currOrder);
+
+        currOrder.forEach((rowId) => {
+                if (!prevSet.has(rowId)) {
+                        changed.add(rowId);
+                }
+        });
+
+        prevOrder.forEach((rowId) => {
+                if (!currSet.has(rowId)) {
+                        changed.add(rowId);
+                        if (prevSnapshot.meta && prevSnapshot.meta[rowId]) {
+                                removedInfo[rowId] = { ...prevSnapshot.meta[rowId] };
+                        }
+                }
+        });
+
+        currOrder.forEach((rowId) => {
+                const previousQty = prevSnapshot.qty ? prevSnapshot.qty[rowId] : undefined;
+                if (previousQty !== current.qty[rowId]) {
+                        changed.add(rowId);
+                }
+        });
+
+        return { changed, removedInfo };
+};
+
 export default {
 	// Watch for customer change and update related data
         customer() {
@@ -33,17 +94,63 @@ export default {
 			value: this.discount_percentage_offer_name,
 		});
 	},
-	// Watch for items array changes (deep) and re-handle offers
+        // Watch for items array changes (deep) and re-handle offers
         items: {
                 deep: true,
-                handler() {
-                        this.scheduleOfferRefresh();
+                handler(newItems) {
+                        const snapshot = buildSnapshot(newItems);
+                        this._offerSnapshots = this._offerSnapshots || {};
+                        const previous = this._offerSnapshots.items;
+                        this._offerSnapshots.items = snapshot;
+
+                        const { changed, removedInfo } = diffSnapshots(previous, snapshot);
+
+                        if (removedInfo && Object.keys(removedInfo).length) {
+                                this._pendingRemovedRowInfo = {
+                                        ...(this._pendingRemovedRowInfo || {}),
+                                        ...removedInfo,
+                                };
+                        }
+
+                        if (!previous) {
+                                if (snapshot.order.length) {
+                                        this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                }
+                                return;
+                        }
+
+                        if (changed.size) {
+                                this.scheduleOfferRefresh(Array.from(changed));
+                        }
                 },
         },
         packed_items: {
                 deep: true,
-                handler() {
-                        this.scheduleOfferRefresh();
+                handler(newItems) {
+                        const snapshot = buildSnapshot(newItems);
+                        this._offerSnapshots = this._offerSnapshots || {};
+                        const previous = this._offerSnapshots.packed;
+                        this._offerSnapshots.packed = snapshot;
+
+                        const { changed, removedInfo } = diffSnapshots(previous, snapshot);
+
+                        if (removedInfo && Object.keys(removedInfo).length) {
+                                this._pendingRemovedRowInfo = {
+                                        ...(this._pendingRemovedRowInfo || {}),
+                                        ...removedInfo,
+                                };
+                        }
+
+                        if (!previous) {
+                                if (snapshot.order.length) {
+                                        this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                }
+                                return;
+                        }
+
+                        if (changed.size) {
+                                this.scheduleOfferRefresh(Array.from(changed));
+                        }
                 },
         },
 	// Watch for invoice type change and emit
@@ -111,6 +218,16 @@ export default {
                         this.packed_items.forEach((item) => {
                                 item._detailSynced = false;
                         });
+                }
+
+                if (typeof this.clearItemDetailCache === "function") {
+                        this.clearItemDetailCache();
+                }
+                if (typeof this.clearItemStockCache === "function") {
+                        this.clearItemStockCache();
+                }
+                if (this.available_stock_cache) {
+                        this.available_stock_cache = {};
                 }
         },
 

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -27,18 +27,33 @@ export function useItemAddition() {
                 });
         };
 
+        const scheduleItemTask = (context, item, taskName, task, contextLabel) => {
+                runAsyncTask(() => {
+                        if (item?.posa_row_id && typeof context?.getItemTaskPromise === "function") {
+                                const existing = context.getItemTaskPromise(item.posa_row_id, taskName);
+                                if (existing) {
+                                        return existing;
+                                }
+                        }
+                        return typeof task === "function" ? task() : null;
+                }, contextLabel);
+        };
+
         // Remove item from invoice
         const removeItem = (item, context) => {
                 const index = context.items.findIndex((el) => el.posa_row_id == item.posa_row_id);
                 if (index >= 0) {
                         context.items.splice(index, 1);
 		}
-		if (item.is_bundle) {
-			context.packed_items = context.packed_items.filter((it) => it.bundle_id !== item.bundle_id);
-		}
-		// Remove from expanded if present
-		context.expanded = context.expanded.filter((id) => id !== item.posa_row_id);
-	};
+                if (item.is_bundle) {
+                        context.packed_items = context.packed_items.filter((it) => it.bundle_id !== item.bundle_id);
+                }
+                // Remove from expanded if present
+                context.expanded = context.expanded.filter((id) => id !== item.posa_row_id);
+                if (item?.posa_row_id && typeof context?.resetItemTaskCache === "function") {
+                        context.resetItemTaskCache(item.posa_row_id);
+                }
+        };
 
 	const { getBundleComponents } = useBundles();
 
@@ -77,14 +92,26 @@ export function useItemAddition() {
 			};
 			context.packed_items.push(child);
                         if (context.update_item_detail) {
-                                runAsyncTask(() => context.update_item_detail(child, false), "update_item_detail:bundle_child");
+                                scheduleItemTask(
+                                        context,
+                                        child,
+                                        "update_item_detail",
+                                        () => context.update_item_detail(child, false),
+                                        "update_item_detail:bundle_child",
+                                );
                                 context.calc_stock_qty && context.calc_stock_qty(child, child.qty);
                         }
                         if (context.fetch_available_qty) {
-                                runAsyncTask(() => context.fetch_available_qty(child), "fetch_available_qty:bundle_child");
+                                scheduleItemTask(
+                                        context,
+                                        child,
+                                        "fetch_available_qty",
+                                        () => context.fetch_available_qty(child),
+                                        "fetch_available_qty:bundle_child",
+                                );
                         }
-		}
-	};
+                }
+        };
 
 	const moveItemToTop = (context, target) => {
 		if (!target) return;
@@ -155,7 +182,10 @@ export function useItemAddition() {
                                 new_item.uom &&
                                 (!new_item.stock_uom || new_item.uom !== new_item.stock_uom)
                         ) {
-                                runAsyncTask(
+                                scheduleItemTask(
+                                        context,
+                                        new_item,
+                                        "calc_uom",
                                         () => context.calc_uom(new_item, new_item.uom),
                                         "calc_uom:new_item",
                                 );
@@ -194,14 +224,20 @@ export function useItemAddition() {
                                 runAsyncTask(() => expandBundle(new_item, context), "expand_bundle");
                                 // Skip recalculation to preserve the manually set rate
                                 if (context.update_item_detail) {
-                                        runAsyncTask(
+                                        scheduleItemTask(
+                                                context,
+                                                new_item,
+                                                "update_item_detail",
                                                 () => context.update_item_detail(new_item, false),
                                                 "update_item_detail:new",
                                         );
                                 }
 
                                 if (context.fetch_available_qty) {
-                                        runAsyncTask(
+                                        scheduleItemTask(
+                                                context,
+                                                new_item,
+                                                "fetch_available_qty",
                                                 () => context.fetch_available_qty(new_item),
                                                 "fetch_available_qty:new",
                                         );
@@ -291,14 +327,20 @@ export function useItemAddition() {
                                         cur_item.uom &&
                                         (!cur_item.stock_uom || cur_item.uom !== cur_item.stock_uom)
                                 ) {
-                                        runAsyncTask(
+                                        scheduleItemTask(
+                                                context,
+                                                cur_item,
+                                                "calc_uom",
                                                 () => context.calc_uom(cur_item, cur_item.uom),
                                                 "calc_uom:merge_new_item",
                                         );
                                 }
 
                                 if (context.fetch_available_qty) {
-                                        runAsyncTask(
+                                        scheduleItemTask(
+                                                context,
+                                                cur_item,
+                                                "fetch_available_qty",
                                                 () => context.fetch_available_qty(cur_item),
                                                 "fetch_available_qty:merge_new",
                                         );
@@ -351,14 +393,20 @@ export function useItemAddition() {
                                 cur_item.uom &&
                                 (!cur_item.stock_uom || cur_item.uom !== cur_item.stock_uom)
                         ) {
-                                runAsyncTask(
+                                scheduleItemTask(
+                                        context,
+                                        cur_item,
+                                        "calc_uom",
                                         () => context.calc_uom(cur_item, cur_item.uom),
                                         "calc_uom:merge_existing",
                                 );
                         }
 
                         if (context.fetch_available_qty) {
-                                runAsyncTask(
+                                scheduleItemTask(
+                                        context,
+                                        cur_item,
+                                        "fetch_available_qty",
                                         () => context.fetch_available_qty(cur_item),
                                         "fetch_available_qty:existing",
                                 );
@@ -496,14 +544,27 @@ export function useItemAddition() {
 		// Always reset to default customer after invoice
 		context.customer = context.pos_profile.customer;
 
-		context.eventBus.emit("set_customer_readonly", false);
-		context.invoiceType = context.pos_profile.posa_default_sales_order ? "Order" : "Invoice";
-		context.invoiceTypes = ["Invoice", "Order", "Quotation"];
+                context.eventBus.emit("set_customer_readonly", false);
+                context.invoiceType = context.pos_profile.posa_default_sales_order ? "Order" : "Invoice";
+                context.invoiceTypes = ["Invoice", "Order", "Quotation"];
 
-		if (Object.prototype.hasOwnProperty.call(context, "itemSearch")) {
-			context.itemSearch = "";
-		}
-	};
+                if (Object.prototype.hasOwnProperty.call(context, "itemSearch")) {
+                        context.itemSearch = "";
+                }
+
+                if (typeof context.resetItemTaskCache === "function") {
+                        context.resetItemTaskCache(null);
+                }
+                if (typeof context.clearItemDetailCache === "function") {
+                        context.clearItemDetailCache();
+                }
+                if (typeof context.clearItemStockCache === "function") {
+                        context.clearItemStockCache();
+                }
+                if (context.available_stock_cache) {
+                        context.available_stock_cache = {};
+                }
+        };
 
 	// Add this utility for grouping logic, matching ItemsTable.vue
 	function groupAndAddItem(items, newItem) {


### PR DESCRIPTION
## Summary
- add per-row async throttling to item addition flows and clear caches when invoices reset
- introduce cached task queue utilities and short-lived item detail/stock caches for invoice item methods
- refine invoice watchers and offer handling to batch row changes, reuse cached data, and avoid redundant backend calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0fa1f4d8483268c758b2bd865a83a