### PR TITLE
Fix SQL query construction in offers API

### DIFF
--- a/posawesome/posawesome/api/offers.py
+++ b/posawesome/posawesome/api/offers.py
@@ -51,8 +51,7 @@ def get_offers(profile):
         "valid_from": date,
         "valid_upto": date,
     }
-    data = (
-        frappe.db.sql(
+    data = frappe.db.sql(
             """
         SELECT *
         FROM `tabPOS Offer`


### PR DESCRIPTION
## Summary
- correct the get_offers SQL query definition so the module imports without syntax errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4bdafe2b48326a45933eb74589b85