### PR TITLE
Allow applying credit notes during POS payments

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -565,10 +565,20 @@
 						redeem_customer_credit
 					"
 				>
-					<v-row v-for="(row, idx) in customer_credit_dict" :key="idx">
-						<v-col cols="4">
-							<div class="pa-2 py-3">{{ row.credit_origin }}</div>
-						</v-col>
+                                        <v-row v-for="(row, idx) in customer_credit_dict" :key="idx">
+                                                <v-col cols="4">
+                                                        <div class="pa-2 py-3">
+                                                                <div class="text-body-2 font-weight-medium">
+                                                                        {{ row.credit_origin }}
+                                                                </div>
+                                                                <div
+                                                                        v-if="creditSourceLabel(row)"
+                                                                        class="text-caption text-medium-emphasis"
+                                                                >
+                                                                        {{ creditSourceLabel(row) }}
+                                                                </div>
+                                                        </div>
+                                                </v-col>
 						<v-col cols="4">
 							<v-text-field
 								density="compact"
@@ -1150,29 +1160,55 @@ export default {
 				this.eventBus.emit("focus_item_search");
 			});
 		},
-		// Highlight and focus the submit button when payment screen opens
-		handleShowPayment(data) {
-			if (data === "true") {
-				this.$nextTick(() => {
-					setTimeout(() => {
-						const btn = this.$refs.submitButton;
-						const el = btn && btn.$el ? btn.$el : btn;
-						if (el) {
-							el.scrollIntoView({ behavior: "smooth", block: "center" });
-							el.focus();
-							this.highlightSubmit = true;
-						}
-					}, 100);
-				});
-			} else {
-				this.highlightSubmit = false;
-			}
-		},
-		// Reset all cash payments to zero
-		reset_cash_payments() {
-			this.invoice_doc.payments.forEach((payment) => {
-				if (payment.mode_of_payment.toLowerCase() === "cash") {
-					payment.amount = 0;
+                // Highlight and focus the submit button when payment screen opens
+                handleShowPayment(data) {
+                        if (data === "true") {
+                                this.$nextTick(() => {
+                                        setTimeout(() => {
+                                                const btn = this.$refs.submitButton;
+                                                const el = btn && btn.$el ? btn.$el : btn;
+                                                if (el) {
+                                                        el.scrollIntoView({ behavior: "smooth", block: "center" });
+                                                        el.focus();
+                                                        this.highlightSubmit = true;
+                                                }
+                                        }, 100);
+                                });
+                        } else {
+                                this.highlightSubmit = false;
+                        }
+                },
+                // Build a readable label for credit sources (advance, overpayment, credit note)
+                creditSourceLabel(row) {
+                        if (!row) {
+                                return "";
+                        }
+
+                        const parts = [];
+
+                        if (row.type) {
+                                if (row.type === "Advance") {
+                                        parts.push(__("Advance Payment"));
+                                } else if (row.type === "Invoice") {
+                                        parts.push(__("Invoice Credit"));
+                                } else if (row.type === "Credit Note") {
+                                        parts.push(__("Credit Note"));
+                                } else {
+                                        parts.push(row.type);
+                                }
+                        }
+
+                        if (row.return_against) {
+                                parts.push(row.return_against);
+                        }
+
+                        return parts.join(" • ");
+                },
+                // Reset all cash payments to zero
+                reset_cash_payments() {
+                        this.invoice_doc.payments.forEach((payment) => {
+                                if (payment.mode_of_payment.toLowerCase() === "cash") {
+                                        payment.amount = 0;
 				}
 			});
 		},

--- a/posawesome/posawesome/api/payments.py
+++ b/posawesome/posawesome/api/payments.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import json
 import frappe
-from frappe.utils import nowdate
+from frappe.utils import nowdate, flt
 from frappe import _
 from erpnext.accounts.party import get_party_bank_account
 from erpnext.accounts.doctype.payment_request.payment_request import (
@@ -217,7 +217,7 @@ def redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, c
         if not cost_center:
             frappe.throw(_("Cost Center is not set in pos profile {}").format(invoice_doc.pos_profile))
         for row in data.get("customer_credit_dict"):
-            if row["type"] == "Invoice" and row["credit_to_redeem"]:
+            if row["type"] in ("Invoice", "Credit Note") and row["credit_to_redeem"]:
                 outstanding_invoice = frappe.get_doc("Sales Invoice", row["credit_origin"])
 
                 jv_doc = frappe.get_doc(
@@ -322,10 +322,38 @@ def get_available_credit(customer, company):
     )
 
     for row in outstanding_invoices:
-        outstanding_amount = -(row.outstanding_amount)
+        outstanding_amount = abs(flt(row.outstanding_amount))
+        if not outstanding_amount:
+            continue
         row = {
             "type": "Invoice",
             "credit_origin": row.name,
+            "total_credit": outstanding_amount,
+            "credit_to_redeem": 0,
+        }
+
+        total_credit.append(row)
+
+    credit_notes = frappe.get_all(
+        "Sales Invoice",
+        {
+            "outstanding_amount": ["<", 0],
+            "docstatus": 1,
+            "is_return": 1,
+            "customer": customer,
+            "company": company,
+        },
+        ["name", "outstanding_amount", "return_against"],
+    )
+
+    for row in credit_notes:
+        outstanding_amount = abs(flt(row.outstanding_amount))
+        if not outstanding_amount:
+            continue
+        row = {
+            "type": "Credit Note",
+            "credit_origin": row.name,
+            "return_against": row.return_against,
             "total_credit": outstanding_amount,
             "credit_to_redeem": 0,
         }


### PR DESCRIPTION
## Summary
- include customer credit notes when fetching redeemable balances for POS
- allow redeeming credit notes alongside advances/overpayments with clearer labeling in the payment screen

## Testing
- ⚠️ `yarn --cwd frontend lint` *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e749bec1a08326904adeec9175df13