### PR TITLE
Refactor sales person lookup helper

### DIFF
--- a/posawesome/posawesome/api/customers.py
+++ b/posawesome/posawesome/api/customers.py
@@ -11,7 +11,7 @@ from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
     get_loyalty_program_details_with_points,
 )
 from frappe.utils.caching import redis_cache
-from .utils import get_active_pos_profile
+from .utils import fetch_sales_person_names
 
 
 def get_customer_groups(pos_profile):
@@ -399,28 +399,4 @@ def make_address(args):
 
 @frappe.whitelist()
 def get_sales_person_names():
-    import json
-
-    print("Fetching sales persons...")
-    try:
-        profile = get_active_pos_profile()
-        allowed = []
-        if profile:
-            allowed = [
-                d.get("sales_person") for d in profile.get("posa_sales_persons", []) if d.get("sales_person")
-            ]
-        filters = {"enabled": 1}
-        if allowed:
-            filters["name"] = ["in", allowed]
-        sales_persons = frappe.get_list(
-            "Sales Person",
-            filters=filters,
-            fields=["name", "sales_person_name"],
-            limit_page_length=100000,
-        )
-        print(f"Found {len(sales_persons)} sales persons: {json.dumps(sales_persons)}")
-        return sales_persons
-    except Exception as e:
-        print(f"Error fetching sales persons: {str(e)}")
-        frappe.log_error(f"Error fetching sales persons: {str(e)}", "POS Sales Person Error")
-        return []
+    return fetch_sales_person_names()

--- a/posawesome/posawesome/api/utilities.py
+++ b/posawesome/posawesome/api/utilities.py
@@ -3,7 +3,7 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-import json
+
 import frappe
 from frappe.utils import cstr, add_to_date, get_datetime
 from typing import List, Dict
@@ -12,7 +12,7 @@ import os
 import psutil
 import functools
 
-from .utils import get_item_groups, get_active_pos_profile
+from .utils import get_item_groups, fetch_sales_person_names
 from posawesome.utils import get_build_version
 
 
@@ -169,31 +169,7 @@ def ensure_child_doctype(doc, table_field, child_doctype):
 
 @frappe.whitelist()
 def get_sales_person_names():
-    import json
-
-    print("Fetching sales persons...")
-    try:
-        profile = get_active_pos_profile()
-        allowed = []
-        if profile:
-            allowed = [
-                d.get("sales_person") for d in profile.get("posa_sales_persons", []) if d.get("sales_person")
-            ]
-        filters = {"enabled": 1}
-        if allowed:
-            filters["name"] = ["in", allowed]
-        sales_persons = frappe.get_list(
-            "Sales Person",
-            filters=filters,
-            fields=["name", "sales_person_name"],
-            limit_page_length=100000,
-        )
-        print(f"Found {len(sales_persons)} sales persons: {json.dumps(sales_persons)}")
-        return sales_persons
-    except Exception as e:
-        print(f"Error fetching sales persons: {str(e)}")
-        frappe.log_error(f"Error fetching sales persons: {str(e)}", "POS Sales Person Error")
-        return []
+    return fetch_sales_person_names()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- extract the shared sales person lookup logic into `posawesome/posawesome/api/utils.py` with centralized logging
- update the whitelisted endpoints in `utilities.py` and `customers.py` to delegate to the shared helper while keeping their responses unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e892d88f5083268632a67eaf83662f