### PR TITLE
Handle non-stock bundle items without stock errors

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -716,20 +716,56 @@ export default {
 			this.posting_date = date;
 			this.$forceUpdate();
 		},
-		// Override setFormatedFloat for qty field to handle stock limits and return mode
-		setFormatedQty(item, field_name, precision, no_negative, value) {
-			// Parse and set the value using the mixin's formatter
-			let parsedValue = this.setFormatedFloat(item, field_name, precision, no_negative, value);
+                shouldEnforceStockLimits(item) {
+                        if (!item) {
+                                return false;
+                        }
 
-			// Enforce available stock limits
-			if (item.max_qty !== undefined && this.flt(item[field_name]) > this.flt(item.max_qty)) {
-				const blockSale =
-					!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
-				if (blockSale) {
-					item[field_name] = item.max_qty;
-					parsedValue = item.max_qty;
-					this.eventBus.emit("show_message", {
-						title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
+                        if (item.is_stock_item === 0) {
+                                if (!item.is_bundle) {
+                                        return false;
+                                }
+
+                                const bundleChildren = this.packed_items.filter(
+                                        (ch) => ch.bundle_id === item.bundle_id,
+                                );
+                                return bundleChildren.some((ch) => ch.is_stock_item !== 0);
+                        }
+
+                        return true;
+                },
+                updateBundleChildrenQty(item) {
+                        if (!item || !item.is_bundle) {
+                                return;
+                        }
+
+                        const multiplier = item.qty || 0;
+                        this.packed_items
+                                .filter((it) => it.bundle_id === item.bundle_id)
+                                .forEach((ch) => {
+                                        ch.qty = multiplier * (ch.child_qty_per_bundle || 1);
+                                        this.calc_stock_qty(ch, ch.qty);
+                                });
+                },
+                // Override setFormatedFloat for qty field to handle stock limits and return mode
+                setFormatedQty(item, field_name, precision, no_negative, value) {
+                        // Parse and set the value using the mixin's formatter
+                        let parsedValue = this.setFormatedFloat(item, field_name, precision, no_negative, value);
+
+                        const enforceStockLimits = this.shouldEnforceStockLimits(item);
+                        // Enforce available stock limits
+                        if (
+                                enforceStockLimits &&
+                                item.max_qty !== undefined &&
+                                this.flt(item[field_name]) > this.flt(item.max_qty)
+                        ) {
+                                const blockSale =
+                                        !this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
+                                if (blockSale) {
+                                        item[field_name] = item.max_qty;
+                                        parsedValue = item.max_qty;
+                                        this.eventBus.emit("show_message", {
+                                                title: __(`Maximum available quantity is {0}. Quantity adjusted to match stock.`, [
 							this.formatFloat(item.max_qty),
 						]),
 						color: "error",
@@ -742,24 +778,19 @@ export default {
 				}
 			}
 
-			// Ensure negative value for return invoices
-			if (this.isReturnInvoice && parsedValue > 0) {
-				parsedValue = -Math.abs(parsedValue);
-				item[field_name] = parsedValue;
+                        // Ensure negative value for return invoices
+                        if (this.isReturnInvoice && parsedValue > 0) {
+                                parsedValue = -Math.abs(parsedValue);
+                                item[field_name] = parsedValue;
 			}
 
 			// Recalculate stock quantity with the adjusted value
-			this.calc_stock_qty(item, item[field_name]);
-			if (field_name === "qty" && item.is_bundle) {
-				this.packed_items
-					.filter((it) => it.bundle_id === item.bundle_id)
-					.forEach((ch) => {
-						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
-						this.calc_stock_qty(ch, ch.qty);
-					});
-			}
-			return parsedValue;
-		},
+                        this.calc_stock_qty(item, item[field_name]);
+                        if (field_name === "qty") {
+                                this.updateBundleChildrenQty(item);
+                        }
+                        return parsedValue;
+                },
 		async fetch_available_currencies() {
 			try {
 				console.log("Fetching available currencies...");
@@ -1147,20 +1178,23 @@ export default {
 		},
 
 		// Increase quantity of an item (handles return logic)
-		add_one(item) {
-			if (this.isReturnInvoice) {
-				// For returns, make quantity more negative
-				item.qty--;
-			} else {
-				const proposed = item.qty + 1;
-				const blockSale =
-					!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
-				const exceedsAvailable = item.max_qty !== undefined && proposed > item.max_qty;
-				if (blockSale && exceedsAvailable) {
-					item.qty = item.max_qty;
-					this.calc_stock_qty(item, item.qty);
-					this.eventBus.emit("show_message", {
-						title: __("Maximum available quantity is {0}. Quantity adjusted to match stock.", [
+                add_one(item) {
+                        const enforceStockLimits = this.shouldEnforceStockLimits(item);
+                        if (this.isReturnInvoice) {
+                                // For returns, make quantity more negative
+                                item.qty--;
+                        } else {
+                                const proposed = item.qty + 1;
+                                const blockSale =
+                                        enforceStockLimits &&
+                                        (!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty);
+                                const exceedsAvailable =
+                                        enforceStockLimits && item.max_qty !== undefined && proposed > item.max_qty;
+                                if (blockSale && exceedsAvailable) {
+                                        item.qty = item.max_qty;
+                                        this.calc_stock_qty(item, item.qty);
+                                        this.eventBus.emit("show_message", {
+                                                title: __("Maximum available quantity is {0}. Quantity adjusted to match stock.", [
 							this.formatFloat(item.max_qty),
 						]),
 						color: "error",
@@ -1175,46 +1209,32 @@ export default {
 						),
 						color: "warning",
 					});
-				}
-				item.qty = proposed;
-			}
-			if (item.qty == 0) {
-				this.remove_item(item);
-			}
-			this.calc_stock_qty(item, item.qty);
-			if (item.is_bundle) {
-				this.packed_items
-					.filter((it) => it.bundle_id === item.bundle_id)
-					.forEach((ch) => {
-						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
-						this.calc_stock_qty(ch, ch.qty);
-					});
-			}
-			this.$forceUpdate();
-		},
+                                }
+                                item.qty = proposed;
+                        }
+                        if (item.qty == 0) {
+                                this.remove_item(item);
+                        }
+                        this.calc_stock_qty(item, item.qty);
+                        this.updateBundleChildrenQty(item);
+                        this.$forceUpdate();
+                },
 
-		// Decrease quantity of an item (handles return logic)
-		subtract_one(item) {
+                // Decrease quantity of an item (handles return logic)
+                subtract_one(item) {
 			if (this.isReturnInvoice) {
 				// For returns, move quantity toward zero
 				item.qty++;
 			} else {
 				item.qty--;
-			}
-			if (item.qty == 0) {
-				this.remove_item(item);
-			}
-			this.calc_stock_qty(item, item.qty);
-			if (item.is_bundle) {
-				this.packed_items
-					.filter((it) => it.bundle_id === item.bundle_id)
-					.forEach((ch) => {
-						ch.qty = item.qty * (ch.child_qty_per_bundle || 1);
-						this.calc_stock_qty(ch, ch.qty);
-					});
-			}
-			this.$forceUpdate();
-		},
+                        }
+                        if (item.qty == 0) {
+                                this.remove_item(item);
+                        }
+                        this.calc_stock_qty(item, item.qty);
+                        this.updateBundleChildrenQty(item);
+                        this.$forceUpdate();
+                },
 
 		// Handle item reordering from drag and drop
 		handleItemReorder(reorderData) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -2464,20 +2464,26 @@ export default {
 	},
 
 	// Update quantity limits based on available stock (simplified - validation handled centrally)
-	update_qty_limits(item) {
-		if (item && item.available_qty !== undefined) {
-			item.max_qty = flt(item.available_qty / (item.conversion_factor || 1));
+        update_qty_limits(item) {
+                if (item && item.is_stock_item === 0) {
+                        item.max_qty = undefined;
+                        item.disable_increment = false;
+                        return;
+                }
 
-			// Set increment disable flag based on stock limits
-			item.disable_increment =
-				(!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty) &&
-				item.qty >= item.max_qty;
-		}
-	},
+                if (item && item.available_qty !== undefined) {
+                        item.max_qty = flt(item.available_qty / (item.conversion_factor || 1));
 
-	// Fetch available stock for an item and cache it
-	async fetch_available_qty(item) {
-		if (!item || !item.item_code || !item.warehouse) return;
+                        // Set increment disable flag based on stock limits
+                        item.disable_increment =
+                                (!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty) &&
+                                item.qty >= item.max_qty;
+                }
+        },
+
+        // Fetch available stock for an item and cache it
+        async fetch_available_qty(item) {
+                if (!item || !item.item_code || !item.warehouse || item.is_stock_item === 0) return;
 
 		const key = this._getStockCacheKey(item);
 		const cachedQty = this._getCachedStockQty(key);

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -67,43 +67,44 @@ export function useItemAddition() {
 		parent.bundle_id = context.makeid ? context.makeid(10) : Math.random().toString(36).substr(2, 10);
 		// Force reactivity so the bundle badge appears immediately
 		context.items = [...context.items];
-		for (const comp of components) {
-			const child = {
-				parent_item: parent.item_code,
-				bundle_id: parent.bundle_id,
-				item_code: comp.item_code,
-				item_name: comp.item_name || comp.item_code,
-				qty: (parent.qty || 1) * comp.qty,
-				stock_qty: (parent.qty || 1) * comp.qty,
-				uom: comp.uom,
-				rate: 0,
-				child_qty_per_bundle: comp.qty,
-				warehouse: context.pos_profile.warehouse,
-				is_stock_item: 1,
-				has_batch_no: comp.is_batch,
-				has_serial_no: comp.is_serial,
-				posa_row_id: context.makeid ? context.makeid(20) : Math.random().toString(36).substr(2, 20),
-				posa_offers: JSON.stringify([]),
-				posa_offer_applied: 0,
+                for (const comp of components) {
+                        const isStockItem = comp.is_stock_item ?? 1;
+                        const child = {
+                                parent_item: parent.item_code,
+                                bundle_id: parent.bundle_id,
+                                item_code: comp.item_code,
+                                item_name: comp.item_name || comp.item_code,
+                                qty: (parent.qty || 1) * comp.qty,
+                                stock_qty: (parent.qty || 1) * comp.qty,
+                                uom: comp.uom,
+                                rate: 0,
+                                child_qty_per_bundle: comp.qty,
+                                warehouse: context.pos_profile.warehouse,
+                                is_stock_item: isStockItem ? 1 : 0,
+                                has_batch_no: comp.is_batch,
+                                has_serial_no: comp.is_serial,
+                                posa_row_id: context.makeid ? context.makeid(20) : Math.random().toString(36).substr(2, 20),
+                                posa_offers: JSON.stringify([]),
+                                posa_offer_applied: 0,
 				posa_is_offer: 0,
 			};
 			context.packed_items.push(child);
-			if (context.update_item_detail) {
-				scheduleItemTask(
-					context,
-					child,
-					"update_item_detail",
-					() => context.update_item_detail(child, false),
-					"update_item_detail:bundle_child",
-				);
-				context.calc_stock_qty && context.calc_stock_qty(child, child.qty);
-			}
-			if (context.fetch_available_qty) {
-				scheduleItemTask(
-					context,
-					child,
-					"fetch_available_qty",
-					() => context.fetch_available_qty(child),
+                        if (context.update_item_detail) {
+                                scheduleItemTask(
+                                        context,
+                                        child,
+                                        "update_item_detail",
+                                        () => context.update_item_detail(child, false),
+                                        "update_item_detail:bundle_child",
+                                );
+                                context.calc_stock_qty && context.calc_stock_qty(child, child.qty);
+                        }
+                        if (context.fetch_available_qty && isStockItem) {
+                                scheduleItemTask(
+                                        context,
+                                        child,
+                                        "fetch_available_qty",
+                                        () => context.fetch_available_qty(child),
 					"fetch_available_qty:bundle_child",
 				);
 			}

--- a/posawesome/posawesome/api/bundles.py
+++ b/posawesome/posawesome/api/bundles.py
@@ -30,7 +30,7 @@ def get_bundle_components(bundles):
             item = frappe.db.get_value(
                 "Item",
                 row.item_code,
-                ["has_batch_no", "has_serial_no", "stock_uom"],
+                ["has_batch_no", "has_serial_no", "stock_uom", "is_stock_item"],
                 as_dict=True,
             )
             uom = row.uom or (item.stock_uom if item else None)
@@ -41,6 +41,7 @@ def get_bundle_components(bundles):
                     "uom": uom,
                     "is_batch": item.has_batch_no if item else 0,
                     "is_serial": item.has_serial_no if item else 0,
+                    "is_stock_item": item.is_stock_item if item else 0,
                 }
             )
         result[code] = components


### PR DESCRIPTION
## Summary
- add a reusable helper to sync bundle child quantities and centralize stock limit enforcement for quantity changes
- skip stock availability checks for non-stock bundle children so bundle adjustments no longer raise stock errors
- return each component's stock flag from the bundle API so the front-end can distinguish stock-tracked items

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9da58fb988326a6189a6db042ec2a