### PR TITLE
Fix invoice stock validation for non-stock items

### DIFF
--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -70,11 +70,30 @@ def _get_available_stock(item):
     return get_stock_availability(item_code, warehouse)
 
 
+def _is_stock_item(item):
+    """Return True when the provided row represents a stock item."""
+
+    if item is None:
+        return False
+
+    flag = item.get("is_stock_item")
+    if flag is not None:
+        return bool(cint(flag))
+
+    item_code = item.get("item_code")
+    if not item_code:
+        return False
+
+    return bool(cint(frappe.get_cached_value("Item", item_code, "is_stock_item") or 0))
+
+
 def _collect_stock_errors(items):
     """Return list of items exceeding available stock."""
     errors = []
     for d in items:
         if flt(d.get("qty")) < 0:
+            continue
+        if not _is_stock_item(d):
             continue
         available = _get_available_stock(d)
         requested = flt(d.get("stock_qty") or (flt(d.get("qty")) * flt(d.get("conversion_factor") or 1)))


### PR DESCRIPTION
## Summary
- add a helper to determine when an invoice row represents a stock item
- skip stock validation for non-stock rows so services and bundles can be invoiced

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef2acd53608326add9ab8d87fb2c5b