### PR TITLE
Ensure invoice item rates refresh on customer price list change

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3578,9 +3578,14 @@ export default {
 			this.couponsCount = data.couponsCount;
 			this.appliedCouponsCount = data.appliedCouponsCount;
 		});
-		this.eventBus.on("update_customer_price_list", (data) => {
-			this.customer_price_list = data;
-		});
+                this.eventBus.on("update_customer_price_list", (data) => {
+                        const fallback = this.pos_profile?.selling_price_list || null;
+                        if (data === null || data === undefined) {
+                                this.customer_price_list = fallback;
+                                return;
+                        }
+                        this.customer_price_list = data;
+                });
 		this.eventBus.on("focus_item_search", () => {
 			this.focusItemSearch();
 		});

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -2256,39 +2256,37 @@ export default {
 		var vm = this;
 		if (!this.customer) return;
 
-		if (isOffline()) {
-			try {
-				const list = await getCustomerStorage();
-				const cached = (list || []).find(
-					(c) => c.name === vm.customer || c.customer_name === vm.customer,
-				);
-				if (cached) {
-					vm.customer_info = { ...cached };
-					if (
-						vm.pos_profile.posa_force_price_from_customer_price_list !== false &&
-						cached.customer_price_list
-					) {
-						vm.selected_price_list = cached.customer_price_list;
-						vm.eventBus.emit("update_customer_price_list", cached.customer_price_list);
-						vm.apply_cached_price_list(cached.customer_price_list);
-					}
-					return;
-				}
-				const queued = (getOfflineCustomers() || [])
-					.map((e) => e.args)
-					.find((c) => c.customer_name === vm.customer);
-				if (queued) {
-					vm.customer_info = { ...queued, name: queued.customer_name };
-					if (
-						vm.pos_profile.posa_force_price_from_customer_price_list !== false &&
-						queued.customer_price_list
-					) {
-						vm.selected_price_list = queued.customer_price_list;
-						vm.eventBus.emit("update_customer_price_list", queued.customer_price_list);
-						vm.apply_cached_price_list(queued.customer_price_list);
-					}
-					return;
-				}
+                if (isOffline()) {
+                        try {
+                                const list = await getCustomerStorage();
+                                const cached = (list || []).find(
+                                        (c) => c.name === vm.customer || c.customer_name === vm.customer,
+                                );
+                                if (cached) {
+                                        vm.customer_info = { ...cached };
+                                        if (vm.pos_profile.posa_force_price_from_customer_price_list !== false) {
+                                                const defaultPriceList = vm.pos_profile?.selling_price_list || null;
+                                                const resolvedPriceList = cached.customer_price_list || defaultPriceList;
+                                                vm.selected_price_list = resolvedPriceList;
+                                                vm.eventBus.emit("update_customer_price_list", resolvedPriceList);
+                                                vm.apply_cached_price_list(resolvedPriceList);
+                                        }
+                                        return;
+                                }
+                                const queued = (getOfflineCustomers() || [])
+                                        .map((e) => e.args)
+                                        .find((c) => c.customer_name === vm.customer);
+                                if (queued) {
+                                        vm.customer_info = { ...queued, name: queued.customer_name };
+                                        if (vm.pos_profile.posa_force_price_from_customer_price_list !== false) {
+                                                const defaultPriceList = vm.pos_profile?.selling_price_list || null;
+                                                const resolvedPriceList = queued.customer_price_list || defaultPriceList;
+                                                vm.selected_price_list = resolvedPriceList;
+                                                vm.eventBus.emit("update_customer_price_list", resolvedPriceList);
+                                                vm.apply_cached_price_list(resolvedPriceList);
+                                        }
+                                        return;
+                                }
 			} catch (error) {
 				console.error("Failed to fetch cached customer", error);
 			}
@@ -2310,18 +2308,17 @@ export default {
 			// When force reload is enabled, automatically switch to the
 			// customer's default price list so that item rates are fetched
 			// correctly from the server.
-			if (
-				vm.pos_profile.posa_force_price_from_customer_price_list !== false &&
-				message.customer_price_list
-			) {
-				vm.selected_price_list = message.customer_price_list;
-				vm.eventBus.emit("update_customer_price_list", message.customer_price_list);
-				vm.apply_cached_price_list(message.customer_price_list);
-			}
-		} catch (error) {
-			console.error("Failed to fetch customer details", error);
-		}
-	},
+                        if (vm.pos_profile.posa_force_price_from_customer_price_list !== false) {
+                                const defaultPriceList = vm.pos_profile?.selling_price_list || null;
+                                const resolvedPriceList = message.customer_price_list || defaultPriceList;
+                                vm.selected_price_list = resolvedPriceList;
+                                vm.eventBus.emit("update_customer_price_list", resolvedPriceList);
+                                vm.apply_cached_price_list(resolvedPriceList);
+                        }
+                } catch (error) {
+                        console.error("Failed to fetch customer details", error);
+                }
+        },
 
 	// Get price list for current customer
 	get_price_list() {
@@ -2331,15 +2328,16 @@ export default {
 	},
 
 	// Update price list for customer
-	update_price_list() {
-		// Only set the POS Profile price list if it has changed
-		const price_list = this.pos_profile.selling_price_list;
-		if (this.selected_price_list !== price_list) {
-			this.selected_price_list = price_list;
-			// Clear any customer specific price list to avoid reloading items
-			this.eventBus.emit("update_customer_price_list", null);
-		}
-	},
+        update_price_list() {
+                const price_list = this.pos_profile?.selling_price_list || null;
+                const hasChanged = this.selected_price_list !== price_list;
+                if (hasChanged) {
+                        this.selected_price_list = price_list;
+                } else if (this.selected_price_list === undefined) {
+                        this.selected_price_list = price_list;
+                }
+                this.eventBus.emit("update_customer_price_list", price_list);
+        },
 
 	_applyPriceListRate(item, newRate, priceCurrency) {
 		if (!item) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -2341,87 +2341,156 @@ export default {
 		}
 	},
 
-	// Apply cached price list rates to existing invoice items
-	async apply_cached_price_list(price_list) {
-		const cached = await getCachedPriceListItems(price_list);
-		if (!Array.isArray(cached) || !cached.length) {
+	_applyPriceListRate(item, newRate, priceCurrency) {
+		if (!item) {
 			return;
 		}
 
-		const map = {};
-		cached.forEach((ci) => {
-			map[ci.item_code] = ci;
-		});
+		const rate = Number.isFinite(Number(newRate)) ? Number(newRate) : 0;
+		const resolvedCurrency = priceCurrency || this.selected_currency;
+		const manualOverride = item._manual_rate_set === true;
+		const companyCurrency = this.pos_profile?.currency;
 
-		this.items.forEach((item) => {
-			const ci = map[item.item_code];
-			if (!ci) return;
+		if (!item.original_currency) {
+			item.original_currency = resolvedCurrency;
+		}
+		if (item.original_rate === undefined || item.original_rate === null) {
+			item.original_rate = rate;
+		}
 
-			const newRate = ci.rate || ci.price_list_rate;
-			const priceCurrency = ci.currency || this.selected_currency;
-
-			if (!item.original_currency) {
-				item.original_currency = priceCurrency;
-			}
-			if (!item.original_rate) {
-				item.original_rate = newRate;
-			}
-
-			if (priceCurrency === this.selected_currency) {
-				const companyCurrency = this.pos_profile.currency;
-				if (priceCurrency !== companyCurrency) {
-					const conv = this.conversion_rate || 1;
-					item.base_price_list_rate = newRate * conv;
-					if (!item._manual_rate_set) {
-						item.base_rate = newRate * conv;
-					}
-				} else {
-					item.base_price_list_rate = newRate;
-					if (!item._manual_rate_set) {
-						item.base_rate = newRate;
-					}
-				}
-				item.price_list_rate = newRate;
-				if (!item._manual_rate_set) {
-					item.rate = newRate;
+		if (resolvedCurrency === this.selected_currency) {
+			if (resolvedCurrency !== companyCurrency) {
+				const conv = this.conversion_rate || 1;
+				item.base_price_list_rate = rate * conv;
+				if (!manualOverride) {
+					item.base_rate = rate * conv;
 				}
 			} else {
-				// Rate in base currency
-				if (newRate !== 0 || !item.base_price_list_rate) {
-					item.base_price_list_rate = newRate;
-					if (!item._manual_rate_set) {
-						item.base_rate = newRate;
-					}
+				item.base_price_list_rate = rate;
+				if (!manualOverride) {
+					item.base_rate = rate;
 				}
-
-				const baseCurrency = this.pos_profile.currency;
-				if (this.selected_currency !== baseCurrency) {
-					const conv = this.exchange_rate || 1;
-					const convRate = this.flt(newRate * conv, this.currency_precision);
-					if (newRate !== 0 || !item.price_list_rate) {
-						item.price_list_rate = convRate;
-					}
-					if (!item._manual_rate_set && (newRate !== 0 || !item.rate)) {
-						item.rate = convRate;
-					}
-				} else {
-					if (newRate !== 0 || !item.price_list_rate) {
-						item.price_list_rate = newRate;
-					}
-					if (!item._manual_rate_set && (newRate !== 0 || !item.rate)) {
-						item.rate = newRate;
-					}
+			}
+			item.price_list_rate = rate;
+			if (!manualOverride) {
+				item.rate = rate;
+			}
+		} else {
+			if (rate !== 0 || !item.base_price_list_rate) {
+				item.base_price_list_rate = rate;
+				if (!manualOverride) {
+					item.base_rate = rate;
 				}
 			}
 
-			// Recalculate final amounts
-			item.amount = this.flt(item.qty * item.rate, this.currency_precision);
-			item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
-		});
+			if (this.selected_currency !== companyCurrency) {
+				const conv = this.exchange_rate || 1;
+				const converted = this.flt(rate * conv, this.currency_precision);
+				if (rate !== 0 || !item.price_list_rate) {
+					item.price_list_rate = converted;
+				}
+				if (!manualOverride && (rate !== 0 || !item.rate)) {
+					item.rate = converted;
+				}
+			} else {
+				if (rate !== 0 || !item.price_list_rate) {
+					item.price_list_rate = rate;
+				}
+				if (!manualOverride && (rate !== 0 || !item.rate)) {
+					item.rate = rate;
+				}
+			}
+		}
 
-		this.$forceUpdate();
+		if (typeof item.qty === "number" && typeof item.rate === "number") {
+			item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+		}
+		if (typeof item.qty === "number" && typeof item.base_rate === "number") {
+			item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
+		}
 	},
 
+	// Apply cached price list rates to existing invoice items
+	async apply_cached_price_list(price_list) {
+		const targetPriceList = price_list || this.pos_profile?.selling_price_list;
+		const cached = targetPriceList ? await getCachedPriceListItems(targetPriceList) : null;
+
+		const fallbackItems = [];
+
+		if (Array.isArray(this.items)) {
+			if (Array.isArray(cached) && cached.length) {
+				const priceMap = new Map();
+				cached.forEach((row) => {
+					if (row && row.item_code) {
+						priceMap.set(row.item_code, row);
+					}
+				});
+
+				this.items.forEach((item) => {
+					if (!item || !item.item_code) {
+						return;
+					}
+					const row = priceMap.get(item.item_code);
+					if (row) {
+						const rate = row.rate ?? row.price_list_rate ?? 0;
+						const currency = row.currency || this.selected_currency;
+						this._applyPriceListRate(item, rate, currency);
+					} else {
+						fallbackItems.push(item);
+					}
+				});
+			} else {
+				fallbackItems.push(...this.items);
+			}
+		}
+
+		if (fallbackItems.length && !isOffline() && targetPriceList) {
+			try {
+				const response = await frappe.call({
+					method: "posawesome.posawesome.api.items.get_items_details",
+					args: {
+						pos_profile: JSON.stringify(this.pos_profile),
+						items_data: JSON.stringify(fallbackItems),
+						price_list: targetPriceList,
+					},
+				});
+
+				const details = response?.message;
+				if (Array.isArray(details) && details.length) {
+					const detailMap = new Map();
+					details.forEach((detail) => {
+						if (!detail) {
+							return;
+						}
+						const key = detail.posa_row_id || detail.item_code;
+						if (key) {
+							detailMap.set(key, detail);
+						}
+					});
+
+					fallbackItems.forEach((item) => {
+						if (!item) {
+							return;
+						}
+						const key = item.posa_row_id || item.item_code;
+						const detail = detailMap.get(key);
+						if (!detail) {
+							return;
+						}
+						const rate = detail.price_list_rate ?? detail.rate ?? 0;
+						const currency = detail.currency || detail.price_list_currency || this.selected_currency;
+						this._applyPriceListRate(item, rate, currency);
+					});
+				}
+			} catch (error) {
+				console.error("Failed to refresh price list rates for invoice items", error);
+			}
+		}
+
+		if (typeof this.$forceUpdate === "function") {
+			this.$forceUpdate();
+		}
+	},
 	// Update additional discount amount based on percentage
 	update_discount_umount() {
 		return updateDiscountAmount(this);


### PR DESCRIPTION
## Summary
- add a reusable helper to apply price list rates without overwriting manually edited prices
- refresh existing invoice items from cached or server price lists when the customer changes
- keep the UI updated by forcing a refresh after rates are synchronized

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ef34ab3c608326b008806e490fe78a