### PR TITLE
Fix additional discount base for inclusive taxes

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -61,27 +61,112 @@ export default {
 		bucket[taskName] = trackedPromise;
 		return trackedPromise;
 	},
-	resetItemTaskCache(rowId, taskName = null) {
-		if (!this._itemTaskCache) {
-			return;
-		}
-		if (!rowId) {
-			this._itemTaskCache = new Map();
-			return;
-		}
-		if (taskName === null) {
-			this._itemTaskCache.delete(rowId);
-			return;
-		}
-		const bucket = this._itemTaskCache.get(rowId);
-		if (!bucket) {
-			return;
-		}
-		delete bucket[taskName];
-		if (!Object.keys(bucket).length) {
-			this._itemTaskCache.delete(rowId);
-		}
-	},
+        resetItemTaskCache(rowId, taskName = null) {
+                if (!this._itemTaskCache) {
+                        return;
+                }
+                if (!rowId) {
+                        this._itemTaskCache = new Map();
+                        return;
+                }
+                if (taskName === null) {
+                        this._itemTaskCache.delete(rowId);
+                        return;
+                }
+                const bucket = this._itemTaskCache.get(rowId);
+                if (!bucket) {
+                        return;
+                }
+                delete bucket[taskName];
+                if (!Object.keys(bucket).length) {
+                        this._itemTaskCache.delete(rowId);
+                }
+        },
+        getDiscountBaseAmount() {
+                const total = flt(this.Total || 0);
+                if (!total) {
+                        return 0;
+                }
+
+                const baseTotal = this.isReturnInvoice ? Math.abs(total) : total;
+
+                const applyDiscountOn =
+                        (this.invoice_doc && this.invoice_doc.apply_discount_on) ||
+                        (this.pos_profile && this.pos_profile.apply_discount_on) ||
+                        "Net Total";
+
+                const applyOnNet =
+                        typeof applyDiscountOn === "string" && applyDiscountOn.toLowerCase().includes("net");
+
+                if (!applyOnNet) {
+                        return baseTotal;
+                }
+
+                const docNet = this.invoice_doc && this.invoice_doc.net_total;
+                if (docNet) {
+                        const normalizedNet = this.isReturnInvoice ? Math.abs(flt(docNet)) : flt(docNet);
+                        if (normalizedNet) {
+                                return normalizedNet;
+                        }
+                }
+
+                let includedTax = 0;
+                const taxes = this.invoice_doc && Array.isArray(this.invoice_doc.taxes) ? this.invoice_doc.taxes : [];
+                if (taxes.length) {
+                        taxes.forEach((tax) => {
+                                if (!tax) {
+                                        return;
+                                }
+                                const included =
+                                        tax.included_in_print_rate ||
+                                        (!!(this.pos_profile && this.pos_profile.posa_tax_inclusive) &&
+                                                tax.charge_type !== "Actual");
+                                if (!included) {
+                                        return;
+                                }
+                                const taxAmount = flt(tax.tax_amount || 0);
+                                if (taxAmount) {
+                                        includedTax += Math.abs(taxAmount);
+                                }
+                        });
+                }
+
+                if (
+                        !includedTax &&
+                        ((this.pos_profile && this.pos_profile.posa_tax_inclusive) || getTaxInclusiveSetting())
+                ) {
+                        const templateName = this.pos_profile && this.pos_profile.taxes_and_charges;
+                        if (templateName) {
+                                const template = getTaxTemplate(templateName);
+                                if (template && Array.isArray(template.taxes)) {
+                                        let cumulativeRate = 0;
+                                        template.taxes.forEach((row) => {
+                                                if (!row) {
+                                                        return;
+                                                }
+                                                const chargeType = row.charge_type || "On Net Total";
+                                                if (chargeType === "Actual") {
+                                                        return;
+                                                }
+                                                const rate = flt(row.rate ?? row.tax_rate ?? 0);
+                                                if (rate) {
+                                                        cumulativeRate += rate;
+                                                }
+                                        });
+                                        if (cumulativeRate) {
+                                                includedTax = (baseTotal * cumulativeRate) / (100 + cumulativeRate);
+                                        }
+                                }
+                        }
+                }
+
+                const base = baseTotal - includedTax;
+                if (base > 0) {
+                        return flt(base, this.currency_precision || 2);
+                }
+
+                return baseTotal;
+        },
 	queueItemTask(itemOrRowId, taskName, taskFn, options = {}) {
 		const rowId = typeof itemOrRowId === "string" ? itemOrRowId : itemOrRowId?.posa_row_id;
 		const { force = false } = options;
@@ -593,13 +678,31 @@ export default {
 		let discountAmount = flt(this.additional_discount);
 		if (isReturn && discountAmount > 0) discountAmount = -Math.abs(discountAmount);
 
-		doc.discount_amount = discountAmount;
-		doc.base_discount_amount = discountAmount * (this.exchange_rate || 1);
+                doc.discount_amount = discountAmount;
+                doc.base_discount_amount = discountAmount * (this.exchange_rate || 1);
 
-		let discountPercentage = flt(this.additional_discount_percentage);
-		if (isReturn && discountPercentage > 0) discountPercentage = -Math.abs(discountPercentage);
+                const baseForDiscount =
+                        typeof this.getDiscountBaseAmount === "function"
+                                ? this.getDiscountBaseAmount()
+                                : this.Total;
+                let discountPercentage = 0;
+                const normalizedBase = Math.abs(flt(baseForDiscount));
+                const normalizedAmount = Math.abs(discountAmount);
+                if (normalizedBase) {
+                        discountPercentage = (normalizedAmount / normalizedBase) * 100;
+                }
+                if (isReturn && discountPercentage > 0) {
+                        discountPercentage = -Math.abs(discountPercentage);
+                }
 
-		doc.additional_discount_percentage = discountPercentage;
+                doc.additional_discount_percentage = discountPercentage;
+
+                const applyDiscountOn =
+                        (this.invoice_doc && this.invoice_doc.apply_discount_on) ||
+                        (this.pos_profile && this.pos_profile.apply_discount_on);
+                if (applyDiscountOn) {
+                        doc.apply_discount_on = applyDiscountOn;
+                }
 
 		// Calculate grand total with correct sign for returns
 		let grandTotal = this.subtotal;

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1225,20 +1225,26 @@ export default {
 			offer.discount_percentage > 0 &&
 			offer.discount_percentage <= 100
 		) {
-			this.discount_amount = this.flt(
-				(flt(this.Total) * flt(offer.discount_percentage)) / 100,
-				this.currency_precision,
-			);
+                        const baseForDiscount =
+                                typeof this.getDiscountBaseAmount === "function"
+                                        ? this.getDiscountBaseAmount()
+                                        : this.Total;
+                        this.discount_amount = this.flt(
+                                (flt(baseForDiscount) * flt(offer.discount_percentage)) / 100,
+                                this.currency_precision,
+                        );
 			this.discount_percentage_offer_name = offer.name;
 
 			// Update invoice level discount fields so the value
 			// is reflected in the UI and saved correctly
 			this.additional_discount = this.discount_amount;
-			if (this.Total && this.Total !== 0) {
-				this.additional_discount_percentage = (this.discount_amount / this.Total) * 100;
-			} else {
-				this.additional_discount_percentage = 0;
-			}
+                        const normalizedBase = Math.abs(baseForDiscount || 0);
+                        if (normalizedBase) {
+                                this.additional_discount_percentage =
+                                        (this.discount_amount / normalizedBase) * 100;
+                        } else {
+                                this.additional_discount_percentage = 0;
+                        }
 		}
 	},
 

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -175,20 +175,34 @@ export default {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);
 	},
 	// Watch for additional discount and update percentage accordingly
-	additional_discount() {
-		if (!this.additional_discount || this.additional_discount == 0) {
-			this.additional_discount_percentage = 0;
-		} else if (this.pos_profile.posa_use_percentage_discount) {
-			// Prevent division by zero which causes NaN
-			if (this.Total && this.Total !== 0) {
-				this.additional_discount_percentage = (this.additional_discount / this.Total) * 100;
-			} else {
-				this.additional_discount_percentage = 0;
-			}
-		} else {
-			this.additional_discount_percentage = 0;
-		}
-	},
+        additional_discount() {
+                const discountValue = this.flt ? this.flt(this.additional_discount) : Number(this.additional_discount || 0);
+
+                if (!discountValue) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                if (!this.pos_profile.posa_use_percentage_discount) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                const baseForDiscount =
+                        typeof this.getDiscountBaseAmount === "function"
+                                ? this.getDiscountBaseAmount()
+                                : this.Total;
+
+                const normalizedBase = Math.abs(baseForDiscount || 0);
+
+                if (!normalizedBase) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                const normalizedDiscount = Math.abs(discountValue);
+                this.additional_discount_percentage = (normalizedDiscount / normalizedBase) * 100;
+        },
 	// Keep display date in sync with posting_date
 	posting_date: {
 		handler(newVal) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -12,11 +12,18 @@ export function useDiscounts() {
 		}
 
 		// Calculate discount amount based on percentage
-		if (context.Total && context.Total !== 0) {
-			context.additional_discount = (context.Total * value) / 100;
-		} else {
-			context.additional_discount = 0;
-		}
+                const baseForDiscount =
+                        typeof context.getDiscountBaseAmount === "function"
+                                ? context.getDiscountBaseAmount()
+                                : context.Total;
+                const normalizedBase = flt(baseForDiscount);
+
+                if (normalizedBase && normalizedBase !== 0) {
+                        context.additional_discount =
+                                (normalizedBase * value) / 100;
+                } else {
+                        context.additional_discount = 0;
+                }
 	};
 
 	// Calculate prices and discounts for an item based on field change


### PR DESCRIPTION
## Summary
- compute a reusable base amount for additional discounts that respects net total and inclusive tax settings
- update discount watcher, offer application, and percentage-to-amount conversions to use the shared base logic
- ensure invoice submission uses the recalculated percentage and propagates the configured discount target

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ef4bb661648326ab41cbfc6ef3faed