### PR TITLE
Fix percentage discount consistency

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -540,9 +540,12 @@ export default {
 		}
 		doc.is_pos = 1;
 		doc.ignore_pricing_rule = 1;
-		doc.company = doc.company || this.pos_profile.company;
-		doc.pos_profile = doc.pos_profile || this.pos_profile.name;
-		doc.posa_show_custom_name_marker_on_print = this.pos_profile.posa_show_custom_name_marker_on_print;
+                doc.company = doc.company || this.pos_profile.company;
+                doc.pos_profile = doc.pos_profile || this.pos_profile.name;
+                doc.posa_show_custom_name_marker_on_print = this.pos_profile.posa_show_custom_name_marker_on_print;
+                if (!doc.apply_discount_on && this.pos_profile?.apply_discount_on) {
+                        doc.apply_discount_on = this.pos_profile.apply_discount_on;
+                }
 
 		// Currency related fields
 		doc.currency = this.selected_currency || this.pos_profile.currency;

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -1,5 +1,6 @@
 import { clearPriceListCache } from "../../../offline/index.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
+import { getAdditionalDiscountBase } from "../../composables/useDiscounts.js";
 /* global frappe */
 
 const buildSnapshot = (items) => {
@@ -175,20 +176,25 @@ export default {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);
 	},
 	// Watch for additional discount and update percentage accordingly
-	additional_discount() {
-		if (!this.additional_discount || this.additional_discount == 0) {
-			this.additional_discount_percentage = 0;
-		} else if (this.pos_profile.posa_use_percentage_discount) {
-			// Prevent division by zero which causes NaN
-			if (this.Total && this.Total !== 0) {
-				this.additional_discount_percentage = (this.additional_discount / this.Total) * 100;
-			} else {
-				this.additional_discount_percentage = 0;
-			}
-		} else {
-			this.additional_discount_percentage = 0;
-		}
-	},
+        additional_discount() {
+                if (!this.additional_discount || this.additional_discount == 0) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                if (!this.pos_profile.posa_use_percentage_discount) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                const baseAmount = getAdditionalDiscountBase(this);
+
+                if (baseAmount && baseAmount !== 0) {
+                        this.additional_discount_percentage = (this.additional_discount / baseAmount) * 100;
+                } else {
+                        this.additional_discount_percentage = 0;
+                }
+        },
 	// Keep display date in sync with posting_date
 	posting_date: {
 		handler(newVal) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -1,23 +1,59 @@
 /* global __, flt */
 
-export function useDiscounts() {
-	// Update additional discount amount based on percentage
-	const updateDiscountAmount = (context) => {
-		const value = flt(context.additional_discount_percentage);
-		// If value is too large, reset to 0
-		if (value < -100 || value > 100) {
-			context.additional_discount_percentage = 0;
-			context.additional_discount = 0;
-			return;
-		}
+export const getAdditionalDiscountBase = (context) => {
+        if (!context) {
+                return 0;
+        }
 
-		// Calculate discount amount based on percentage
-		if (context.Total && context.Total !== 0) {
-			context.additional_discount = (context.Total * value) / 100;
-		} else {
-			context.additional_discount = 0;
-		}
-	};
+        const applyDiscountOn =
+                context?.invoice_doc?.apply_discount_on ||
+                context?.pos_profile?.apply_discount_on ||
+                "Net Total";
+
+        if (applyDiscountOn === "Grand Total") {
+                const subtotal = flt(context?.subtotal ?? 0);
+                const additionalDiscount = flt(context?.additional_discount ?? 0);
+
+                let totalTaxes = 0;
+                if (context?.invoice_doc) {
+                        if (context.invoice_doc.total_taxes_and_charges != null) {
+                                totalTaxes = flt(context.invoice_doc.total_taxes_and_charges);
+                        } else if (Array.isArray(context.invoice_doc.taxes)) {
+                                totalTaxes = context.invoice_doc.taxes.reduce((sum, tax) => {
+                                        return sum + flt(tax.tax_amount || 0);
+                                }, 0);
+                        }
+                }
+
+                // subtotal currently excludes the applied additional discount.
+                // Adding it back yields the amount before discount so we can apply the percentage.
+                const baseBeforeTaxes = subtotal + additionalDiscount;
+                return baseBeforeTaxes + totalTaxes;
+        }
+
+        return flt(context?.Total ?? 0);
+};
+
+export function useDiscounts() {
+        // Update additional discount amount based on percentage
+        const updateDiscountAmount = (context) => {
+                const value = flt(context.additional_discount_percentage);
+                // If value is too large, reset to 0
+                if (value < -100 || value > 100) {
+                        context.additional_discount_percentage = 0;
+                        context.additional_discount = 0;
+                        return;
+                }
+
+                const baseAmount = getAdditionalDiscountBase(context);
+
+                // Calculate discount amount based on percentage
+                if (baseAmount && baseAmount !== 0) {
+                        context.additional_discount = (baseAmount * value) / 100;
+                } else {
+                        context.additional_discount = 0;
+                }
+        };
 
 	// Calculate prices and discounts for an item based on field change
 	const calcPrices = (item, value, $event, context) => {


### PR DESCRIPTION
## Summary
- ensure POS invoices inherit the POS Profile apply_discount_on setting so the backend uses the same discount base
- reuse a shared helper to calculate the additional discount base and keep the percentage field in sync across invoice and payments views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0df541fc883268710c87184501439