### PR TITLE
Align additional discount calculations with backend

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -1,6 +1,9 @@
 import { clearPriceListCache } from "../../../offline/index.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
+import { useDiscounts } from "../../composables/useDiscounts.js";
 /* global frappe */
+
+const { getAdditionalDiscountBase } = useDiscounts();
 
 const buildSnapshot = (items) => {
 	const snapshot = {
@@ -175,20 +178,30 @@ export default {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);
 	},
 	// Watch for additional discount and update percentage accordingly
-	additional_discount() {
-		if (!this.additional_discount || this.additional_discount == 0) {
-			this.additional_discount_percentage = 0;
-		} else if (this.pos_profile.posa_use_percentage_discount) {
-			// Prevent division by zero which causes NaN
-			if (this.Total && this.Total !== 0) {
-				this.additional_discount_percentage = (this.additional_discount / this.Total) * 100;
-			} else {
-				this.additional_discount_percentage = 0;
-			}
-		} else {
-			this.additional_discount_percentage = 0;
-		}
-	},
+        additional_discount() {
+                const hasPercentageMode = Boolean(this.pos_profile.posa_use_percentage_discount);
+                const fltFn = typeof this.flt === "function" ? this.flt.bind(this) : null;
+                const discountAmount = fltFn ? fltFn(this.additional_discount) : Number(this.additional_discount) || 0;
+
+                if (!discountAmount) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                if (hasPercentageMode) {
+                        const baseAmount = getAdditionalDiscountBase(this);
+                        if (baseAmount) {
+                                const percent = (discountAmount / baseAmount) * 100;
+                                this.additional_discount_percentage = fltFn
+                                        ? fltFn(percent, this.float_precision)
+                                        : percent;
+                        } else {
+                                this.additional_discount_percentage = 0;
+                        }
+                } else {
+                        this.additional_discount_percentage = 0;
+                }
+        },
 	// Keep display date in sync with posting_date
 	posting_date: {
 		handler(newVal) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -1,23 +1,102 @@
 /* global __, flt */
 
 export function useDiscounts() {
-	// Update additional discount amount based on percentage
-	const updateDiscountAmount = (context) => {
-		const value = flt(context.additional_discount_percentage);
-		// If value is too large, reset to 0
-		if (value < -100 || value > 100) {
-			context.additional_discount_percentage = 0;
-			context.additional_discount = 0;
-			return;
-		}
+        const toNumber = (value) => {
+                if (value === null || value === undefined) {
+                        return null;
+                }
+                const number = flt(value);
+                return Number.isFinite(number) ? number : null;
+        };
 
-		// Calculate discount amount based on percentage
-		if (context.Total && context.Total !== 0) {
-			context.additional_discount = (context.Total * value) / 100;
-		} else {
-			context.additional_discount = 0;
-		}
-	};
+        const getAdditionalDiscountBase = (context) => {
+                if (!context) {
+                        return 0;
+                }
+
+                const doc = context.invoice_doc || {};
+                const discountAmount = flt(context.additional_discount);
+                const applyOn = doc.apply_discount_on || context.pos_profile?.apply_discount_on;
+
+                const addBackDiscount = (value) => {
+                        const numeric = toNumber(value);
+                        if (numeric === null) {
+                                return null;
+                        }
+                        return numeric + discountAmount;
+                };
+
+                const getTaxTotal = () => {
+                        if (doc && Array.isArray(doc.taxes) && doc.taxes.length) {
+                                return doc.taxes.reduce((sum, tax) => {
+                                        const amount =
+                                                toNumber(tax?.tax_amount_after_discount_amount) ??
+                                                toNumber(tax?.tax_amount);
+                                        return sum + (amount || 0);
+                                }, 0);
+                        }
+
+                        return (
+                                toNumber(doc?.total_taxes_and_charges) ?? toNumber(context.total_tax)
+                        );
+                };
+
+                let baseAmount = null;
+
+                if (applyOn === "Net Total") {
+                        baseAmount = addBackDiscount(doc?.net_total);
+                        if (baseAmount === null) {
+                                baseAmount = addBackDiscount(doc?.total);
+                        }
+                        if (baseAmount === null) {
+                                baseAmount = addBackDiscount(context.Total);
+                        }
+                } else if (applyOn === "Grand Total") {
+                        baseAmount = addBackDiscount(doc?.grand_total);
+                        if (baseAmount === null) {
+                                const net =
+                                        toNumber(doc?.net_total) ??
+                                        toNumber(doc?.total) ??
+                                        toNumber(context.Total);
+                                const taxes = getTaxTotal();
+                                if (net !== null || taxes !== null) {
+                                        baseAmount = (net || 0) + (taxes || 0) + discountAmount;
+                                }
+                        }
+                        if (baseAmount === null) {
+                                baseAmount = addBackDiscount(context.subtotal);
+                        }
+                }
+
+                if (baseAmount === null) {
+                        baseAmount = addBackDiscount(doc?.total);
+                }
+                if (baseAmount === null) {
+                        baseAmount = addBackDiscount(context.Total);
+                }
+
+                return baseAmount ?? 0;
+        };
+
+        // Update additional discount amount based on percentage
+        const updateDiscountAmount = (context) => {
+                const value = flt(context.additional_discount_percentage);
+                // If value is too large, reset to 0
+                if (value < -100 || value > 100) {
+                        context.additional_discount_percentage = 0;
+                        context.additional_discount = 0;
+                        return;
+                }
+
+                const baseAmount = getAdditionalDiscountBase(context);
+
+                // Calculate discount amount based on percentage
+                if (baseAmount) {
+                        context.additional_discount = (baseAmount * value) / 100;
+                } else {
+                        context.additional_discount = 0;
+                }
+        };
 
 	// Calculate prices and discounts for an item based on field change
 	const calcPrices = (item, value, $event, context) => {
@@ -252,9 +331,10 @@ export function useDiscounts() {
 		if (context.forceUpdate) context.forceUpdate();
 	};
 
-	return {
-		updateDiscountAmount,
-		calcPrices,
-		calcItemPrice,
-	};
+        return {
+                getAdditionalDiscountBase,
+                updateDiscountAmount,
+                calcPrices,
+                calcItemPrice,
+        };
 }


### PR DESCRIPTION
## Summary
- derive additional discount percentages from the same base values used by the server
- reuse the shared helper so watcher updates keep percentage inputs stable when the backend adjusts amounts

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f1c7b93ffc83268a3b37a811167b37