### PR TITLE
Align POS additional discount calculations with backend base

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -194,9 +194,24 @@ export default {
                 }
 
                 const currencyPrecision = this.currency_precision ?? 2;
-                const base = getAdditionalDiscountBase(this);
+                const baseWithDiscount = flt(
+                        getAdditionalDiscountBase(this),
+                        currencyPrecision,
+                );
+                const currentDiscount = flt(
+                        this.additional_discount ??
+                                this.invoice_doc?.discount_amount ??
+                                0,
+                        currencyPrecision,
+                );
 
-                const baseMagnitude = Math.abs(flt(base, currencyPrecision));
+                let baseValue = baseWithDiscount - currentDiscount;
+
+                if (this.invoice_doc?.is_return) {
+                        baseValue = -Math.abs(baseValue);
+                }
+
+                const baseMagnitude = Math.abs(baseValue);
 
                 if (!baseMagnitude) {
                         this.additional_discount_percentage = 0;

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -175,8 +175,12 @@ export default {
 	invoiceType() {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);
 	},
-	// Watch for additional discount and update percentage accordingly
+        // Watch for additional discount and update percentage accordingly
         additional_discount() {
+                if (this._updatingAdditionalDiscountFromPercentage) {
+                        return;
+                }
+
                 const discount = flt(this.additional_discount);
 
                 if (!discount) {
@@ -189,14 +193,24 @@ export default {
                         return;
                 }
 
+                const currencyPrecision = this.currency_precision ?? 2;
                 const base = getAdditionalDiscountBase(this);
 
-                if (!base) {
+                const baseMagnitude = Math.abs(flt(base, currencyPrecision));
+
+                if (!baseMagnitude) {
                         this.additional_discount_percentage = 0;
                         return;
                 }
 
-                this.additional_discount_percentage = (discount / base) * 100;
+                const discountMagnitude = Math.abs(discount);
+                const sign = discount === 0 ? 0 : discount > 0 ? 1 : -1;
+                const percentage = flt(
+                        (discountMagnitude / baseMagnitude) * 100,
+                        this.float_precision ?? 3,
+                );
+
+                this.additional_discount_percentage = sign >= 0 ? percentage : -percentage;
         },
 	// Keep display date in sync with posting_date
 	posting_date: {

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -1,6 +1,7 @@
 import { clearPriceListCache } from "../../../offline/index.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
-/* global frappe */
+import { getAdditionalDiscountBase } from "../../composables/useDiscounts.js";
+/* global frappe, flt */
 
 const buildSnapshot = (items) => {
 	const snapshot = {
@@ -175,20 +176,28 @@ export default {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);
 	},
 	// Watch for additional discount and update percentage accordingly
-	additional_discount() {
-		if (!this.additional_discount || this.additional_discount == 0) {
-			this.additional_discount_percentage = 0;
-		} else if (this.pos_profile.posa_use_percentage_discount) {
-			// Prevent division by zero which causes NaN
-			if (this.Total && this.Total !== 0) {
-				this.additional_discount_percentage = (this.additional_discount / this.Total) * 100;
-			} else {
-				this.additional_discount_percentage = 0;
-			}
-		} else {
-			this.additional_discount_percentage = 0;
-		}
-	},
+        additional_discount() {
+                const discount = flt(this.additional_discount);
+
+                if (!discount) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                if (!this.pos_profile.posa_use_percentage_discount) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                const base = getAdditionalDiscountBase(this);
+
+                if (!base) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                this.additional_discount_percentage = (discount / base) * 100;
+        },
 	// Keep display date in sync with posting_date
 	posting_date: {
 		handler(newVal) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -62,21 +62,39 @@ export function useDiscounts() {
         // Update additional discount amount based on percentage
         const updateDiscountAmount = (context) => {
                 const value = flt(context.additional_discount_percentage);
+                const setAdditionalDiscount = (amount) => {
+                        context._updatingAdditionalDiscountFromPercentage = true;
+                        try {
+                                context.additional_discount = amount;
+                        } finally {
+                                context._updatingAdditionalDiscountFromPercentage = false;
+                        }
+                };
                 // If value is too large, reset to 0
                 if (value < -100 || value > 100) {
-			context.additional_discount_percentage = 0;
-			context.additional_discount = 0;
-			return;
-		}
-
-                const base = getAdditionalDiscountBase(context);
-
-                if (!base) {
-                        context.additional_discount = 0;
+                        context.additional_discount_percentage = 0;
+                        setAdditionalDiscount(0);
                         return;
                 }
 
-                context.additional_discount = (base * value) / 100;
+                const precision = context.currency_precision ?? 2;
+                const base = getAdditionalDiscountBase(context);
+
+                const baseMagnitude = Math.abs(flt(base, precision));
+
+                if (!baseMagnitude) {
+                        setAdditionalDiscount(0);
+                        return;
+                }
+
+                const percentageMagnitude = Math.abs(value);
+                const sign = value === 0 ? 0 : value > 0 ? 1 : -1;
+                const amount = flt(
+                        (baseMagnitude * percentageMagnitude) / 100,
+                        precision,
+                );
+
+                setAdditionalDiscount(sign >= 0 ? amount : -amount);
         };
 
 	// Calculate prices and discounts for an item based on field change

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -78,23 +78,28 @@ export function useDiscounts() {
                 }
 
                 const precision = context.currency_precision ?? 2;
-                const base = getAdditionalDiscountBase(context);
+                const baseWithDiscount = flt(getAdditionalDiscountBase(context), precision);
+                const currentDiscount = flt(
+                        context.additional_discount ??
+                                context.invoice_doc?.discount_amount ??
+                                0,
+                        precision,
+                );
 
-                const baseMagnitude = Math.abs(flt(base, precision));
+                let baseValue = baseWithDiscount - currentDiscount;
 
-                if (!baseMagnitude) {
+                if (context.invoice_doc?.is_return) {
+                        baseValue = -Math.abs(baseValue);
+                }
+
+                if (!baseValue) {
                         setAdditionalDiscount(0);
                         return;
                 }
 
-                const percentageMagnitude = Math.abs(value);
-                const sign = value === 0 ? 0 : value > 0 ? 1 : -1;
-                const amount = flt(
-                        (baseMagnitude * percentageMagnitude) / 100,
-                        precision,
-                );
+                const amount = flt((-baseValue * value) / 100, precision);
 
-                setAdditionalDiscount(sign >= 0 ? amount : -amount);
+                setAdditionalDiscount(amount);
         };
 
 	// Calculate prices and discounts for an item based on field change

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -1,23 +1,83 @@
 /* global __, flt */
 
+export const getAdditionalDiscountBase = (context) => {
+        if (!context) {
+                return 0;
+        }
+
+        const precision = context.currency_precision;
+        const doc = context.invoice_doc || {};
+        const discountAmount = flt(
+                context.additional_discount ?? doc.discount_amount ?? 0,
+                precision,
+        );
+
+        const applyOn =
+                doc.apply_discount_on ||
+                context.apply_discount_on ||
+                context.pos_profile?.apply_discount_on ||
+                null;
+
+        const hasValue = (value) => value !== undefined && value !== null;
+        const toCurrency = (value) => flt(value || 0, precision);
+
+        let base;
+
+        if (applyOn === "Net Total") {
+                if (hasValue(doc.net_total)) {
+                        base = toCurrency(doc.net_total) + discountAmount;
+                } else if (hasValue(context.net_total)) {
+                        base = toCurrency(context.net_total) + discountAmount;
+                }
+        } else if (applyOn === "Grand Total") {
+                if (hasValue(doc.grand_total)) {
+                        base = toCurrency(doc.grand_total) + discountAmount;
+                } else if (hasValue(doc.total)) {
+                        base = toCurrency(doc.total) + discountAmount;
+                } else if (hasValue(context.subtotal)) {
+                        base = toCurrency(context.subtotal) + discountAmount;
+                }
+        }
+
+        if (base === undefined) {
+                if (hasValue(context.Total)) {
+                        base = toCurrency(context.Total);
+                } else if (hasValue(doc.total)) {
+                        base = toCurrency(doc.total) + discountAmount;
+                } else if (hasValue(doc.grand_total)) {
+                        base = toCurrency(doc.grand_total) + discountAmount;
+                } else if (hasValue(doc.net_total)) {
+                        base = toCurrency(doc.net_total) + discountAmount;
+                } else if (hasValue(context.subtotal)) {
+                        base = toCurrency(context.subtotal) + discountAmount;
+                } else {
+                        base = 0;
+                }
+        }
+
+        return Number.isFinite(base) ? base : 0;
+};
+
 export function useDiscounts() {
-	// Update additional discount amount based on percentage
-	const updateDiscountAmount = (context) => {
-		const value = flt(context.additional_discount_percentage);
-		// If value is too large, reset to 0
-		if (value < -100 || value > 100) {
+        // Update additional discount amount based on percentage
+        const updateDiscountAmount = (context) => {
+                const value = flt(context.additional_discount_percentage);
+                // If value is too large, reset to 0
+                if (value < -100 || value > 100) {
 			context.additional_discount_percentage = 0;
 			context.additional_discount = 0;
 			return;
 		}
 
-		// Calculate discount amount based on percentage
-		if (context.Total && context.Total !== 0) {
-			context.additional_discount = (context.Total * value) / 100;
-		} else {
-			context.additional_discount = 0;
-		}
-	};
+                const base = getAdditionalDiscountBase(context);
+
+                if (!base) {
+                        context.additional_discount = 0;
+                        return;
+                }
+
+                context.additional_discount = (base * value) / 100;
+        };
 
 	// Calculate prices and discounts for an item based on field change
 	const calcPrices = (item, value, $event, context) => {


### PR DESCRIPTION
## Summary
- add a shared helper to derive the additional discount base using the same fields as the backend
- update discount amount calculations and watchers to respect the backend base and avoid overwriting percentage inputs

## Testing
- `node --input-type=module <<'NODE'
globalThis.flt = (value) => Number(value);
import { getAdditionalDiscountBase } from "./frontend/src/posapp/composables/useDiscounts.js";

const context = {
  currency_precision: 2,
  invoice_doc: {
    apply_discount_on: "Net Total",
    net_total: 90,
    discount_amount: 10,
  },
  additional_discount: 10,
};

console.log("base", getAdditionalDiscountBase(context));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68f1c7b93ffc83268a3b37a811167b37