### PR TITLE
Sync selector availability with cart reservations

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -470,10 +470,10 @@ export default {
 		...shortcutMethods,
 		...offerMethods,
 		...invoiceItemMethods,
-		initializeItemsHeaders() {
-			// Define all available columns
-			this.available_columns = [
-				{ title: __("Name"), align: "start", sortable: true, key: "item_name", required: true },
+                initializeItemsHeaders() {
+                        // Define all available columns
+                        this.available_columns = [
+                                { title: __("Name"), align: "start", sortable: true, key: "item_name", required: true },
 				{ title: __("QTY"), key: "qty", align: "center", required: true },
 				{ title: __("UOM"), key: "uom", align: "center", required: false },
 				{
@@ -507,14 +507,57 @@ export default {
 					.map((col) => col.key);
 			}
 
-			// Generate headers based on selected columns
-			this.updateHeadersFromSelection();
-		},
-		// Handle item dropped from ItemsSelector to ItemsTable
-		handleItemDrop(item) {
-			console.log("Item dropped:", item);
+                        // Generate headers based on selected columns
+                        this.updateHeadersFromSelection();
+                },
+                emitCartQuantities() {
+                        const totals = {};
+                        const normalizeNumber = (value) => {
+                                const num = Number(value);
+                                return Number.isFinite(num) ? num : null;
+                        };
+                        const accumulate = (line) => {
+                                if (!line || !line.item_code) {
+                                        return;
+                                }
 
-			// Use the existing add_item method to add the dropped item
+                                const code = String(line.item_code).trim();
+                                if (!code) {
+                                        return;
+                                }
+
+                                let stockQty = normalizeNumber(line.stock_qty);
+                                if (stockQty === null) {
+                                        const qty = normalizeNumber(line.qty);
+                                        if (qty !== null) {
+                                                const conversion = normalizeNumber(line.conversion_factor);
+                                                const factor = conversion !== null && conversion !== 0 ? conversion : 1;
+                                                stockQty = qty * factor;
+                                        }
+                                }
+
+                                if (stockQty === null) {
+                                        return;
+                                }
+
+                                const positiveQty = Math.max(0, stockQty);
+                                if (!positiveQty) {
+                                        return;
+                                }
+
+                                totals[code] = (totals[code] || 0) + positiveQty;
+                        };
+
+                        (Array.isArray(this.items) ? this.items : []).forEach(accumulate);
+                        (Array.isArray(this.packed_items) ? this.packed_items : []).forEach(accumulate);
+
+                        this.eventBus.emit("cart_quantities_updated", totals);
+                },
+                // Handle item dropped from ItemsSelector to ItemsTable
+                handleItemDrop(item) {
+                        console.log("Item dropped:", item);
+
+                        // Use the existing add_item method to add the dropped item
 			this.add_item(item);
 		},
 
@@ -1414,6 +1457,8 @@ export default {
                 if (this.pos_profile.posa_allow_multi_currency) {
                         this.fetch_available_currencies();
                 }
+
+                this.emitCartQuantities();
         },
         // Cleanup event listeners before component is destroyed
         beforeUnmount() {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -644,9 +644,10 @@ export default {
 		temp_force_server_items: false,
 		// Performance optimizations
 		searchCache: new Map(),
-		barcodeIndex: new Map(),
-		itemCache: new Map(),
-		virtualScrollEnabled: true,
+                barcodeIndex: new Map(),
+                itemCache: new Map(),
+                cartQuantities: {},
+                virtualScrollEnabled: true,
 		virtualScrollBuffer: 200,
 		renderBuffer: 10,
 		lastScrollTop: 0,
@@ -2062,24 +2063,151 @@ export default {
 			const item_code_len = first_search.length - prefix_len - 6;
 			return first_search.substr(0, prefix_len + item_code_len);
 		},
-		esc_event() {
-			this.search = null;
-			this.first_search = null;
-			this.search_backup = null;
-			this.qty = 1;
-			this.focusItemSearch();
-		},
-		async update_items_details(items) {
-			const vm = this;
-			if (!items || !items.length) return;
+                esc_event() {
+                        this.search = null;
+                        this.first_search = null;
+                        this.search_backup = null;
+                        this.qty = 1;
+                        this.focusItemSearch();
+                },
+                captureBaseAvailability(item, explicitActualQty = undefined) {
+                        if (!item) {
+                                return;
+                        }
 
-			// reset any pending retry timer
+                        if (typeof item.available_qty === "number" && !Number.isNaN(item.available_qty)) {
+                                item._base_available_qty = item.available_qty;
+                        }
+
+                        const hasExplicit = typeof explicitActualQty === "number" && !Number.isNaN(explicitActualQty);
+                        if (hasExplicit) {
+                                item._base_actual_qty = explicitActualQty;
+                                return;
+                        }
+
+                        if (typeof item.actual_qty === "number" && !Number.isNaN(item.actual_qty)) {
+                                item._base_actual_qty = item.actual_qty;
+                        }
+                },
+                getBaseActualQty(item) {
+                        if (!item) {
+                                return null;
+                        }
+
+                        if (typeof item._base_actual_qty === "number" && !Number.isNaN(item._base_actual_qty)) {
+                                return item._base_actual_qty;
+                        }
+
+                        if (typeof item.actual_qty === "number" && !Number.isNaN(item.actual_qty)) {
+                                item._base_actual_qty = item.actual_qty;
+                                return item.actual_qty;
+                        }
+
+                        if (typeof item.available_qty === "number" && !Number.isNaN(item.available_qty)) {
+                                item._base_available_qty = item.available_qty;
+                                item._base_actual_qty = item.available_qty;
+                                return item.available_qty;
+                        }
+
+                        return null;
+                },
+                applyReservationToItem(item) {
+                        if (!item || !item.item_code) {
+                                return;
+                        }
+
+                        const codeKey = String(item.item_code).trim();
+                        const baseActual = this.getBaseActualQty(item);
+                        if (baseActual === null) {
+                                return;
+                        }
+
+                        const reserved = Number(this.cartQuantities?.[codeKey]) || 0;
+                        const adjustedActual = Math.max(0, baseActual - reserved);
+                        if (item.actual_qty !== adjustedActual) {
+                                item.actual_qty = adjustedActual;
+                        }
+
+                        if (typeof item._base_available_qty === "number" && !Number.isNaN(item._base_available_qty)) {
+                                const adjustedAvailable = Math.max(0, item._base_available_qty - reserved);
+                                if (item.available_qty !== adjustedAvailable) {
+                                        item.available_qty = adjustedAvailable;
+                                }
+                        }
+                },
+                recomputeAvailabilityForCodes(codes = []) {
+                        if (!Array.isArray(codes) || !codes.length) {
+                                return;
+                        }
+
+                        const normalizedCodes = codes
+                                .filter((code) => code !== undefined && code !== null && String(code).trim())
+                                .map((code) => String(code).trim());
+                        if (!normalizedCodes.length) {
+                                return;
+                        }
+
+                        const targetCodes = new Set(normalizedCodes);
+                        const applyIfAffected = (item) => {
+                                if (!item || !item.item_code) {
+                                        return;
+                                }
+                                const code = String(item.item_code).trim();
+                                if (code && targetCodes.has(code)) {
+                                        this.applyReservationToItem(item);
+                                }
+                        };
+
+                        if (Array.isArray(this.items)) {
+                                this.items.forEach(applyIfAffected);
+                        }
+
+                        if (Array.isArray(this.displayedItems)) {
+                                this.displayedItems.forEach(applyIfAffected);
+                        }
+
+                        targetCodes.forEach((code) => {
+                                const indexedItem = this.lookupItemByBarcode(code);
+                                if (indexedItem) {
+                                        this.applyReservationToItem(indexedItem);
+                                }
+                        });
+
+                        this.$forceUpdate();
+                },
+                handleCartQuantitiesUpdated(totals = {}) {
+                        const normalizedTotals = {};
+                        if (totals && typeof totals === "object") {
+                                Object.entries(totals).forEach(([code, qty]) => {
+                                        const normalizedCode = String(code).trim();
+                                        const numericQty = Number(qty);
+                                        if (normalizedCode && Number.isFinite(numericQty) && numericQty > 0) {
+                                                normalizedTotals[normalizedCode] = numericQty;
+                                        }
+                                });
+                        }
+
+                        const previousCodes = Object.keys(this.cartQuantities || {});
+                        this.cartQuantities = normalizedTotals;
+                        const affected = new Set([...previousCodes, ...Object.keys(normalizedTotals)]);
+                        if (affected.size) {
+                                this.recomputeAvailabilityForCodes(Array.from(affected));
+                        }
+                },
+                async update_items_details(items) {
+                        const vm = this;
+                        if (!items || !items.length) return;
+
+                        // reset any pending retry timer
 			if (vm.itemDetailsRetryTimeout) {
 				clearTimeout(vm.itemDetailsRetryTimeout);
 				vm.itemDetailsRetryTimeout = null;
 			}
 
-			const itemCodes = items.map((it) => it.item_code);
+                        const itemCodes = items.map((it) => it.item_code);
+                        const affectedCodes = Array.from(
+                                new Set(itemCodes.filter((code) => code !== undefined && code !== null)),
+                        );
 			const cacheResult = await getCachedItemDetails(
 				vm.pos_profile.name,
 				vm.active_price_list,
@@ -2105,14 +2233,15 @@ export default {
 							item.price_list_rate = price;
 						}
 					}
-					if (det.currency) {
-						item.currency = det.currency;
-					}
+                                        if (det.currency) {
+                                                item.currency = det.currency;
+                                        }
 
-					if (!item.original_rate) {
-						item.original_rate = item.rate;
-						item.original_currency = item.currency || vm.pos_profile.currency;
-					}
+                                        vm.captureBaseAvailability(item, det.actual_qty);
+                                        if (!item.original_rate) {
+                                                item.original_rate = item.rate;
+                                                item.original_currency = item.currency || vm.pos_profile.currency;
+                                        }
 
 					vm.indexItem(item);
 					vm.applyCurrencyConversionToItem(item);
@@ -2121,12 +2250,13 @@ export default {
 
 			let allCached = cacheResult.missing.length === 0;
 			items.forEach((item) => {
-				const localQty = getLocalStock(item.item_code);
-				if (localQty !== null) {
-					item.actual_qty = localQty;
-				} else {
-					allCached = false;
-				}
+                                const localQty = getLocalStock(item.item_code);
+                                if (localQty !== null) {
+                                        item.actual_qty = localQty;
+                                        vm.captureBaseAvailability(item, localQty);
+                                } else {
+                                        allCached = false;
+                                }
 
 				if (!item.item_uoms || item.item_uoms.length === 0) {
 					const cachedUoms = getItemUOMs(item.item_code);
@@ -2141,19 +2271,21 @@ export default {
 			});
 
 			// When offline or everything is cached, skip server call
-			if (isOffline() || allCached) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                        if (isOffline() || allCached) {
+                                vm.itemDetailsRetryCount = 0;
+                                vm.recomputeAvailabilityForCodes(affectedCodes);
+                                return;
+                        }
 
 			const itemsToFetch = items.filter(
 				(it) => cacheResult.missing.includes(it.item_code) && !it.has_variants,
 			);
 
-			if (itemsToFetch.length === 0) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                        if (itemsToFetch.length === 0) {
+                                vm.itemDetailsRetryCount = 0;
+                                vm.recomputeAvailabilityForCodes(affectedCodes);
+                                return;
+                        }
 
 			try {
 				const details = await vm.fetchItemDetails(itemsToFetch);
@@ -2204,11 +2336,12 @@ export default {
 						}
 					});
 
-					updatedItems.forEach(({ item, updates }) => {
-						Object.assign(item, updates);
-						vm.indexItem(item);
-						vm.applyCurrencyConversionToItem(item);
-					});
+                                        updatedItems.forEach(({ item, updates }) => {
+                                                Object.assign(item, updates);
+                                                vm.captureBaseAvailability(item, updates.actual_qty);
+                                                vm.indexItem(item);
+                                                vm.applyCurrencyConversionToItem(item);
+                                        });
 
 					updateLocalStockCache(details);
 					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
@@ -2234,14 +2367,15 @@ export default {
 			} catch (err) {
 				if (err.name !== "AbortError") {
 					console.error("Error fetching item details:", err);
-					items.forEach((item) => {
-						const localQty = getLocalStock(item.item_code);
-						if (localQty !== null) {
-							item.actual_qty = localQty;
-						}
-						if (!item.item_uoms || item.item_uoms.length === 0) {
-							const cached = getItemUOMs(item.item_code);
-							if (cached.length > 0) {
+                                        items.forEach((item) => {
+                                                const localQty = getLocalStock(item.item_code);
+                                                if (localQty !== null) {
+                                                        item.actual_qty = localQty;
+                                                        vm.captureBaseAvailability(item, localQty);
+                                                }
+                                                if (!item.item_uoms || item.item_uoms.length === 0) {
+                                                        const cached = getItemUOMs(item.item_code);
+                                                        if (cached.length > 0) {
 								item.item_uoms = cached;
 							}
 						}
@@ -2258,12 +2392,14 @@ export default {
 			}
 
 			// Cleanup on component destroy
-			this.cleanupBeforeDestroy = () => {
-				if (vm.abortController) {
-					vm.abortController.abort();
-				}
-			};
-		},
+                        this.cleanupBeforeDestroy = () => {
+                                if (vm.abortController) {
+                                        vm.abortController.abort();
+                                }
+                        };
+
+                        vm.recomputeAvailabilityForCodes(affectedCodes);
+                },
 		update_cur_items_details() {
 			if (this.displayedItems && this.displayedItems.length > 0) {
 				this.update_items_details(this.displayedItems);
@@ -3574,10 +3710,11 @@ export default {
 			this.offersCount = data.offersCount;
 			this.appliedOffersCount = data.appliedOffersCount;
 		});
-		this.eventBus.on("update_coupons_counters", (data) => {
-			this.couponsCount = data.couponsCount;
-			this.appliedCouponsCount = data.appliedCouponsCount;
-		});
+                this.eventBus.on("update_coupons_counters", (data) => {
+                        this.couponsCount = data.couponsCount;
+                        this.appliedCouponsCount = data.appliedCouponsCount;
+                });
+                this.eventBus.on("cart_quantities_updated", this.handleCartQuantitiesUpdated);
                 this.eventBus.on("update_customer_price_list", (data) => {
                         const fallback = this.pos_profile?.selling_price_list || null;
                         if (data === null || data === undefined) {
@@ -3761,13 +3898,14 @@ export default {
 			this.scanAudioContext = null;
 		}
 
-		this.eventBus.off("update_currency");
-		this.eventBus.off("server-online");
-		this.eventBus.off("register_pos_profile");
-		this.eventBus.off("update_cur_items_details");
-		this.eventBus.off("update_offers_counters");
-		this.eventBus.off("update_coupons_counters");
-		this.eventBus.off("update_customer_price_list");
+                this.eventBus.off("update_currency");
+                this.eventBus.off("server-online");
+                this.eventBus.off("register_pos_profile");
+                this.eventBus.off("update_cur_items_details");
+                this.eventBus.off("update_offers_counters");
+                this.eventBus.off("update_coupons_counters");
+                this.eventBus.off("cart_quantities_updated", this.handleCartQuantitiesUpdated);
+                this.eventBus.off("update_customer_price_list");
 		this.eventBus.off("force_reload_items");
 		this.eventBus.off("focus_item_search");
 		window.removeEventListener("resize", this.checkItemContainerOverflow);

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2194,6 +2194,101 @@ export default {
                                 this.recomputeAvailabilityForCodes(Array.from(affected));
                         }
                 },
+                handleInvoiceStockUpdated(payload = {}) {
+                        try {
+                                const collectedCodes = [];
+                                const pushCode = (value) => {
+                                        if (value === undefined || value === null) {
+                                                return;
+                                        }
+                                        const normalized = String(value).trim();
+                                        if (!normalized) {
+                                                return;
+                                        }
+                                        collectedCodes.push(normalized);
+                                };
+
+                                if (Array.isArray(payload)) {
+                                        payload.forEach(pushCode);
+                                } else if (payload && typeof payload === "object") {
+                                        if (Array.isArray(payload.item_codes)) {
+                                                payload.item_codes.forEach(pushCode);
+                                        }
+                                        if (Array.isArray(payload.items)) {
+                                                payload.items.forEach((entry) => pushCode(entry?.item_code));
+                                        }
+                                        if (payload.invoice && Array.isArray(payload.invoice.items)) {
+                                                payload.invoice.items.forEach((entry) => pushCode(entry?.item_code));
+                                        }
+                                }
+
+                                const uniqueCodes = Array.from(new Set(collectedCodes));
+                                if (!uniqueCodes.length) {
+                                        return;
+                                }
+
+                                const codesSet = new Set(uniqueCodes);
+                                const itemsByCode = new Map();
+                                const captureFromList = (list) => {
+                                        if (!Array.isArray(list)) {
+                                                return;
+                                        }
+                                        list.forEach((item) => {
+                                                if (!item || item.item_code === undefined || item.item_code === null) {
+                                                        return;
+                                                }
+                                                const code = String(item.item_code).trim();
+                                                if (!code || !codesSet.has(code) || itemsByCode.has(code)) {
+                                                        return;
+                                                }
+                                                itemsByCode.set(code, item);
+                                        });
+                                };
+
+                                captureFromList(this.items);
+                                captureFromList(this.displayedItems);
+
+                                uniqueCodes.forEach((code) => {
+                                        if (!itemsByCode.has(code)) {
+                                                const indexed = this.lookupItemByBarcode(code);
+                                                if (indexed) {
+                                                        itemsByCode.set(code, indexed);
+                                                }
+                                        }
+                                });
+
+                                if (!itemsByCode.size) {
+                                        return;
+                                }
+
+                                const targets = Array.from(itemsByCode.values());
+                                const immediateCodes = new Set();
+                                targets.forEach((item) => {
+                                        try {
+                                                const localQtyRaw = getLocalStock(item.item_code);
+                                                const localQty = Number(localQtyRaw);
+                                                if (!Number.isFinite(localQty)) {
+                                                        return;
+                                                }
+                                                this.captureBaseAvailability(item, localQty);
+                                                item.actual_qty = localQty;
+                                                immediateCodes.add(String(item.item_code).trim());
+                                        } catch (err) {
+                                                console.warn("Failed to apply local stock for", item?.item_code, err);
+                                        }
+                                });
+
+                                if (immediateCodes.size) {
+                                        this.recomputeAvailabilityForCodes(Array.from(immediateCodes));
+                                }
+
+                                this.update_items_details(targets).catch((error) => {
+                                        console.error("Failed to refresh item details after invoice submission", error);
+                                });
+                        } catch (error) {
+                                console.error("Failed to process invoice stock update", error);
+                        }
+                },
                 async update_items_details(items) {
                         const vm = this;
                         if (!items || !items.length) return;
@@ -3715,6 +3810,7 @@ export default {
                         this.appliedCouponsCount = data.appliedCouponsCount;
                 });
                 this.eventBus.on("cart_quantities_updated", this.handleCartQuantitiesUpdated);
+                this.eventBus.on("invoice_stock_updated", this.handleInvoiceStockUpdated);
                 this.eventBus.on("update_customer_price_list", (data) => {
                         const fallback = this.pos_profile?.selling_price_list || null;
                         if (data === null || data === undefined) {
@@ -3905,9 +4001,10 @@ export default {
                 this.eventBus.off("update_offers_counters");
                 this.eventBus.off("update_coupons_counters");
                 this.eventBus.off("cart_quantities_updated", this.handleCartQuantitiesUpdated);
+                this.eventBus.off("invoice_stock_updated", this.handleInvoiceStockUpdated);
                 this.eventBus.off("update_customer_price_list");
-		this.eventBus.off("force_reload_items");
-		this.eventBus.off("focus_item_search");
+                this.eventBus.off("force_reload_items");
+                this.eventBus.off("focus_item_search");
 		window.removeEventListener("resize", this.checkItemContainerOverflow);
 		if (this.metricsRaf) {
 			cancelAnimationFrame(this.metricsRaf);

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1428,14 +1428,53 @@ export default {
 				customer_credit_dict: this.customer_credit_dict,
 				is_cashback: this.is_cashback,
 			};
-			const vm = this;
+                        const vm = this;
+                        const notifyStockUpdate = (items = []) => {
+                                const safeItems = Array.isArray(items) ? items : [];
+                                const sanitizedItems = [];
+                                const uniqueCodes = [];
+                                const seenCodes = new Set();
 
-			if (isOffline()) {
-				try {
-					saveOfflineInvoice({ data: data, invoice: this.invoice_doc });
-					this.eventBus.emit("pending_invoices_changed", getPendingOfflineInvoiceCount());
-					vm.eventBus.emit("show_message", {
-						title: __("Invoice saved offline"),
+                                safeItems.forEach((entry) => {
+                                        if (!entry) {
+                                                return;
+                                        }
+
+                                        const code = entry.item_code !== undefined && entry.item_code !== null
+                                                ? String(entry.item_code).trim()
+                                                : "";
+
+                                        if (!code) {
+                                                return;
+                                        }
+
+                                        sanitizedItems.push({ item_code: code });
+                                        if (!seenCodes.has(code)) {
+                                                seenCodes.add(code);
+                                                uniqueCodes.push(code);
+                                        }
+                                });
+
+                                if (!uniqueCodes.length) {
+                                        return;
+                                }
+
+                                vm.eventBus.emit("invoice_stock_updated", {
+                                        item_codes: uniqueCodes,
+                                        items: sanitizedItems,
+                                });
+                        };
+
+                        if (isOffline()) {
+                                try {
+                                        const soldItems = Array.isArray(vm.invoice_doc?.items) ? vm.invoice_doc.items : [];
+                                        updateLocalStock(soldItems);
+                                        notifyStockUpdate(soldItems);
+
+                                        saveOfflineInvoice({ data: data, invoice: this.invoice_doc });
+                                        this.eventBus.emit("pending_invoices_changed", getPendingOfflineInvoiceCount());
+                                        vm.eventBus.emit("show_message", {
+                                                title: __("Invoice saved offline"),
 						color: "warning",
 					});
 					if (print) {
@@ -1511,29 +1550,31 @@ export default {
 					}
 					if (print) {
 						vm.load_print_page();
-					}
-					vm.customer_credit_dict = [];
-					vm.redeem_customer_credit = false;
-					vm.is_cashback = true;
-					vm.is_credit_return = false;
+                                        }
+                                        vm.customer_credit_dict = [];
+                                        vm.redeem_customer_credit = false;
+                                        vm.is_cashback = true;
+                                        vm.is_credit_return = false;
 					vm.sales_person = "";
 					vm.eventBus.emit("set_last_invoice", vm.invoice_doc.name);
-					vm.eventBus.emit("show_message", {
-						title:
-							vm.invoiceType === "Order" && vm.pos_profile.posa_create_only_sales_order
-								? __("Sales Order {0} is Submitted", [r.message.name])
-								: vm.invoiceType === "Quotation"
-									? __("Quotation {0} is Submitted", [r.message.name])
-									: __("Invoice {0} is Submitted", [r.message.name]),
-						color: "success",
-					});
-					frappe.utils.play_sound("submit");
-					// Update local stock quantities immediately after successful
-					// invoice submission so item availability reflects changes
-					updateLocalStock(vm.invoice_doc.items || []);
-					vm.addresses = [];
-					vm.eventBus.emit("clear_invoice");
-					vm.eventBus.emit("focus_item_search");
+                                        vm.eventBus.emit("show_message", {
+                                                title:
+                                                        vm.invoiceType === "Order" && vm.pos_profile.posa_create_only_sales_order
+                                                                ? __("Sales Order {0} is Submitted", [r.message.name])
+                                                                : vm.invoiceType === "Quotation"
+                                                                        ? __("Quotation {0} is Submitted", [r.message.name])
+                                                                        : __("Invoice {0} is Submitted", [r.message.name]),
+                                                color: "success",
+                                        });
+                                        frappe.utils.play_sound("submit");
+                                        // Update local stock quantities immediately after successful
+                                        // invoice submission so item availability reflects changes
+                                        const soldItems = Array.isArray(vm.invoice_doc?.items) ? vm.invoice_doc.items : [];
+                                        updateLocalStock(soldItems);
+                                        notifyStockUpdate(soldItems);
+                                        vm.addresses = [];
+                                        vm.eventBus.emit("clear_invoice");
+                                        vm.eventBus.emit("focus_item_search");
 					vm.eventBus.emit("reset_posting_date");
 					vm.back_to_invoice();
 					vm.loading = false;

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -120,58 +120,60 @@ export default {
 			const snapshot = buildSnapshot(newItems);
 			this._offerSnapshots = this._offerSnapshots || {};
 			const previous = this._offerSnapshots.items;
-			this._offerSnapshots.items = snapshot;
+                        this._offerSnapshots.items = snapshot;
 
-			const { changed, removedInfo } = diffSnapshots(previous, snapshot);
+                        const { changed, removedInfo } = diffSnapshots(previous, snapshot);
 
-			if (removedInfo && Object.keys(removedInfo).length) {
+                        if (removedInfo && Object.keys(removedInfo).length) {
 				this._pendingRemovedRowInfo = {
 					...(this._pendingRemovedRowInfo || {}),
 					...removedInfo,
-				};
-			}
+                                };
+                        }
 
-			if (!previous) {
-				if (snapshot.order.length) {
-					this.scheduleOfferRefresh([...new Set(snapshot.order)]);
-				}
-				return;
-			}
+                        if (!previous) {
+                                if (snapshot.order.length) {
+                                        this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                }
+                        } else if (changed.size) {
+                                this.scheduleOfferRefresh(Array.from(changed));
+                        }
 
-			if (changed.size) {
-				this.scheduleOfferRefresh(Array.from(changed));
-			}
-		},
-	},
-	packed_items: {
-		deep: true,
-		handler(newItems) {
+                        if (typeof this.emitCartQuantities === "function") {
+                                this.emitCartQuantities();
+                        }
+                },
+        },
+        packed_items: {
+                deep: true,
+                handler(newItems) {
 			const snapshot = buildSnapshot(newItems);
 			this._offerSnapshots = this._offerSnapshots || {};
 			const previous = this._offerSnapshots.packed;
-			this._offerSnapshots.packed = snapshot;
+                        this._offerSnapshots.packed = snapshot;
 
-			const { changed, removedInfo } = diffSnapshots(previous, snapshot);
+                        const { changed, removedInfo } = diffSnapshots(previous, snapshot);
 
-			if (removedInfo && Object.keys(removedInfo).length) {
+                        if (removedInfo && Object.keys(removedInfo).length) {
 				this._pendingRemovedRowInfo = {
 					...(this._pendingRemovedRowInfo || {}),
 					...removedInfo,
-				};
-			}
+                                };
+                        }
 
-			if (!previous) {
-				if (snapshot.order.length) {
-					this.scheduleOfferRefresh([...new Set(snapshot.order)]);
-				}
-				return;
-			}
+                        if (!previous) {
+                                if (snapshot.order.length) {
+                                        this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                }
+                        } else if (changed.size) {
+                                this.scheduleOfferRefresh(Array.from(changed));
+                        }
 
-			if (changed.size) {
-				this.scheduleOfferRefresh(Array.from(changed));
-			}
-		},
-	},
+                        if (typeof this.emitCartQuantities === "function") {
+                                this.emitCartQuantities();
+                        }
+                },
+        },
 	// Watch for invoice type change and emit
 	invoiceType() {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);


### PR DESCRIPTION
## Summary
- emit cart quantity totals from the invoice and trigger updates during initialization and item changes
- listen for cart quantity updates in the item selector and adjust displayed stock against reserved quantities
- ensure selectors recompute availability after item detail refreshes and when cart contents change

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5efda2f948326ae85d21a8d5dacde