### PR TITLE
Force item selector stock refresh after invoice submission

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -344,6 +344,7 @@ import shortcutMethods from "./invoiceShortcuts";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
+import stockCoordinator from "../../utils/stockCoordinator.js";
 
 export default {
 	name: "POSInvoice",
@@ -386,10 +387,11 @@ export default {
 			float_precision: 6, // Float precision for calculations
 			currency_precision: 6, // Currency precision for display
 			new_line: false, // Add new line for item
-			available_stock_cache: {},
-			item_detail_cache: {},
-			item_stock_cache: {},
-			brand_cache: {},
+                        available_stock_cache: {},
+                        item_detail_cache: {},
+                        item_stock_cache: {},
+                        brand_cache: {},
+                        stockUnsubscribe: null,
 			delivery_charges: [], // List of delivery charges
 			base_delivery_charges_rate: 0, // Delivery charge in company currency
 			delivery_charges_rate: 0, // Selected delivery charge rate
@@ -551,6 +553,13 @@ export default {
                         (Array.isArray(this.items) ? this.items : []).forEach(accumulate);
                         (Array.isArray(this.packed_items) ? this.packed_items : []).forEach(accumulate);
 
+                        const impacted = stockCoordinator.updateReservations(totals, {
+                                source: "invoice",
+                        });
+                        if (impacted.length) {
+                                this.applyStockStateToInvoiceItems(impacted);
+                        }
+
                         this.eventBus.emit("cart_quantities_updated", totals);
                 },
                 // Handle item dropped from ItemsSelector to ItemsTable
@@ -558,13 +567,80 @@ export default {
                         console.log("Item dropped:", item);
 
                         // Use the existing add_item method to add the dropped item
-			this.add_item(item);
-		},
+                        this.add_item(item);
+                },
 
-		// Show visual feedback when item is being dragged over drop zone
-		showDropFeedback(isDragging) {
-			// Add visual feedback class to the items table
-			const itemsTable = this.$el.querySelector(".modern-items-table");
+                applyStockStateToInvoiceItems(codes = null) {
+                        const collections = [];
+                        if (Array.isArray(this.items)) {
+                                collections.push(this.items);
+                        }
+                        if (Array.isArray(this.packed_items)) {
+                                collections.push(this.packed_items);
+                        }
+                        if (!collections.length) {
+                                return;
+                        }
+                        const codesSet = (() => {
+                                if (codes === null) {
+                                        return null;
+                                }
+                                const iterable = Array.isArray(codes)
+                                        ? codes
+                                        : codes instanceof Set || (codes && typeof codes[Symbol.iterator] === "function")
+                                        ? Array.from(codes)
+                                        : [codes];
+                                return new Set(
+                                        iterable
+                                                .map((code) =>
+                                                        code !== undefined && code !== null
+                                                                ? String(code).trim()
+                                                                : "",
+                                                )
+                                                .filter(Boolean),
+                                );
+                        })();
+
+                        collections.forEach((items) => {
+                                stockCoordinator.applyAvailabilityToCollection(items, codesSet, {
+                                        updateBaseAvailable: false,
+                                });
+                        });
+
+                        this.$forceUpdate();
+                },
+                primeInvoiceStockState(source = "invoice") {
+                        const baseItems = [];
+                        if (Array.isArray(this.items)) {
+                                baseItems.push(...this.items);
+                        }
+                        if (Array.isArray(this.packed_items)) {
+                                baseItems.push(...this.packed_items);
+                        }
+                        if (!baseItems.length) {
+                                return;
+                        }
+
+                        stockCoordinator.primeFromItems(baseItems, { silent: true, source });
+                        const codes = baseItems
+                                .map((item) =>
+                                        item && item.item_code !== undefined ? String(item.item_code).trim() : null,
+                                )
+                                .filter(Boolean);
+                        this.applyStockStateToInvoiceItems(codes);
+                },
+                handleStockCoordinatorUpdate(event = {}) {
+                        const codes = Array.isArray(event.codes) ? event.codes : [];
+                        if (!codes.length) {
+                                return;
+                        }
+                        this.applyStockStateToInvoiceItems(codes);
+                },
+
+                // Show visual feedback when item is being dragged over drop zone
+                showDropFeedback(isDragging) {
+                        // Add visual feedback class to the items table
+                        const itemsTable = this.$el.querySelector(".modern-items-table");
 			if (itemsTable) {
 				if (isDragging) {
 					itemsTable.classList.add("drag-over");
@@ -1376,6 +1452,7 @@ export default {
                                         this.update_item_detail(item);
                                 }
                         });
+                        this.primeInvoiceStockState();
                 },
                 handleLoadReturnInvoice(data) {
                         console.log("Invoice component received load_return_invoice event with data:", data);
@@ -1454,14 +1531,24 @@ export default {
                         this.eventBus.on(eventName, handler);
                 });
 
+                this.stockUnsubscribe = stockCoordinator.subscribe(this.handleStockCoordinatorUpdate);
+
                 if (this.pos_profile.posa_allow_multi_currency) {
                         this.fetch_available_currencies();
                 }
 
                 this.emitCartQuantities();
+                this.$nextTick(() => {
+                        this.primeInvoiceStockState();
+                });
         },
         // Cleanup event listeners before component is destroyed
         beforeUnmount() {
+                if (typeof this.stockUnsubscribe === "function") {
+                        this.stockUnsubscribe();
+                        this.stockUnsubscribe = null;
+                }
+
                 Object.entries(this._busHandlers || {}).forEach(([eventName, handler]) => {
                         this.eventBus.off(eventName, handler);
                 });

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -470,10 +470,10 @@ export default {
 		...shortcutMethods,
 		...offerMethods,
 		...invoiceItemMethods,
-		initializeItemsHeaders() {
-			// Define all available columns
-			this.available_columns = [
-				{ title: __("Name"), align: "start", sortable: true, key: "item_name", required: true },
+                initializeItemsHeaders() {
+                        // Define all available columns
+                        this.available_columns = [
+                                { title: __("Name"), align: "start", sortable: true, key: "item_name", required: true },
 				{ title: __("QTY"), key: "qty", align: "center", required: true },
 				{ title: __("UOM"), key: "uom", align: "center", required: false },
 				{
@@ -507,14 +507,57 @@ export default {
 					.map((col) => col.key);
 			}
 
-			// Generate headers based on selected columns
-			this.updateHeadersFromSelection();
-		},
-		// Handle item dropped from ItemsSelector to ItemsTable
-		handleItemDrop(item) {
-			console.log("Item dropped:", item);
+                        // Generate headers based on selected columns
+                        this.updateHeadersFromSelection();
+                },
+                emitCartQuantities() {
+                        const totals = {};
+                        const normalizeNumber = (value) => {
+                                const num = Number(value);
+                                return Number.isFinite(num) ? num : null;
+                        };
+                        const accumulate = (line) => {
+                                if (!line || !line.item_code) {
+                                        return;
+                                }
 
-			// Use the existing add_item method to add the dropped item
+                                const code = String(line.item_code).trim();
+                                if (!code) {
+                                        return;
+                                }
+
+                                let stockQty = normalizeNumber(line.stock_qty);
+                                if (stockQty === null) {
+                                        const qty = normalizeNumber(line.qty);
+                                        if (qty !== null) {
+                                                const conversion = normalizeNumber(line.conversion_factor);
+                                                const factor = conversion !== null && conversion !== 0 ? conversion : 1;
+                                                stockQty = qty * factor;
+                                        }
+                                }
+
+                                if (stockQty === null) {
+                                        return;
+                                }
+
+                                const positiveQty = Math.max(0, stockQty);
+                                if (!positiveQty) {
+                                        return;
+                                }
+
+                                totals[code] = (totals[code] || 0) + positiveQty;
+                        };
+
+                        (Array.isArray(this.items) ? this.items : []).forEach(accumulate);
+                        (Array.isArray(this.packed_items) ? this.packed_items : []).forEach(accumulate);
+
+                        this.eventBus.emit("cart_quantities_updated", totals);
+                },
+                // Handle item dropped from ItemsSelector to ItemsTable
+                handleItemDrop(item) {
+                        console.log("Item dropped:", item);
+
+                        // Use the existing add_item method to add the dropped item
 			this.add_item(item);
 		},
 
@@ -1414,6 +1457,8 @@ export default {
                 if (this.pos_profile.posa_allow_multi_currency) {
                         this.fetch_available_currencies();
                 }
+
+                this.emitCartQuantities();
         },
         // Cleanup event listeners before component is destroyed
         beforeUnmount() {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -529,33 +529,34 @@ import { ensurePosProfile } from "../../../utils/pos_profile.js";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 import { RecycleScroller } from "vue-virtual-scroller";
 import {
-	saveItemUOMs,
-	getItemUOMs,
-	getLocalStock,
-	isOffline,
-	getStoredItemsCount,
-	initializeStockCache,
-	saveItemsBulk,
-	saveItems,
-	clearStoredItems,
-	getLocalStockCache,
-	setLocalStockCache,
-	initPromise,
-	memoryInitPromise,
-	checkDbHealth,
-	getCachedPriceListItems,
-	savePriceListItems,
-	clearPriceListCache,
-	updateLocalStockCache,
-	isStockCacheReady,
-	getCachedItemDetails,
-	saveItemDetailsCache,
-	saveItemGroups,
-	getCachedItemGroups,
-	getItemsLastSync,
-	setItemsLastSync,
-	forceClearAllCache,
+        saveItemUOMs,
+        getItemUOMs,
+        getLocalStock,
+        isOffline,
+        getStoredItemsCount,
+        initializeStockCache,
+        saveItemsBulk,
+        saveItems,
+        clearStoredItems,
+        getLocalStockCache,
+        setLocalStockCache,
+        initPromise,
+        memoryInitPromise,
+        checkDbHealth,
+        getCachedPriceListItems,
+        savePriceListItems,
+        clearPriceListCache,
+        updateLocalStockCache,
+        isStockCacheReady,
+        getCachedItemDetails,
+        saveItemDetailsCache,
+        saveItemGroups,
+        getCachedItemGroups,
+        getItemsLastSync,
+        setItemsLastSync,
+        forceClearAllCache,
 } from "../../../offline/index.js";
+import stockCoordinator from "../../utils/stockCoordinator.js";
 import { useResponsive } from "../../composables/useResponsive.js";
 import { useRtl } from "../../composables/useRtl.js";
 import { useFlyAnimation } from "../../composables/useFlyAnimation.js";
@@ -623,10 +624,11 @@ export default {
 		selected_currency: "",
 		exchange_rate: 1,
 		prePopulateInProgress: false,
-		itemWorker: null,
-		flyConfig: { speed: 0.6, easing: "ease-in-out" },
-		storageAvailable: true,
-		localStorageAvailable: true,
+                itemWorker: null,
+                flyConfig: { speed: 0.6, easing: "ease-in-out" },
+                storageAvailable: true,
+                localStorageAvailable: true,
+                stockUnsubscribe: null,
 		items_request_token: 0,
 		pendingGetItems: null,
 		lastGetItemsKey: "",
@@ -646,7 +648,6 @@ export default {
 		searchCache: new Map(),
                 barcodeIndex: new Map(),
                 itemCache: new Map(),
-                cartQuantities: {},
                 virtualScrollEnabled: true,
 		virtualScrollBuffer: 200,
 		renderBuffer: 10,
@@ -1405,11 +1406,11 @@ export default {
 		show_coupons() {
 			this.eventBus.emit("show_coupons", "true");
 		},
-		async initializeItems() {
-			await this.ensureStorageHealth();
-			if (
-				this.pos_profile &&
-				this.pos_profile.posa_local_storage &&
+                async initializeItems() {
+                        await this.ensureStorageHealth();
+                        if (
+                                this.pos_profile &&
+                                this.pos_profile.posa_local_storage &&
 				this.storageAvailable &&
 				!this.usesLimitSearch
 			) {
@@ -1422,15 +1423,19 @@ export default {
 			}
 			await this.get_items(true);
 
-			if (
-				this.pos_profile &&
-				this.pos_profile.posa_local_storage &&
-				this.storageAvailable &&
-				!this.usesLimitSearch
-			) {
-				await this.verifyServerItemCount();
-			}
-		},
+                        if (
+                                this.pos_profile &&
+                                this.pos_profile.posa_local_storage &&
+                                this.storageAvailable &&
+                                !this.usesLimitSearch
+                        ) {
+                                await this.verifyServerItemCount();
+                        }
+
+                        this.$nextTick(() => {
+                                this.primeStockState();
+                        });
+                },
 		async forceReloadItems() {
 			console.log("[ItemsSelector] forceReloadItems called");
 			// Clear cached price list items so the reload always
@@ -2070,23 +2075,101 @@ export default {
                         this.qty = 1;
                         this.focusItemSearch();
                 },
+                syncItemsWithStockState(codes = null, options = {}) {
+                        const collections = [];
+                        if (Array.isArray(this.items)) {
+                                collections.push(this.items);
+                        }
+                        if (Array.isArray(this.displayedItems)) {
+                                collections.push(this.displayedItems);
+                        }
+                        if (Array.isArray(this.filteredItems)) {
+                                collections.push(this.filteredItems);
+                        }
+                        const codesSet = (() => {
+                                if (codes === null) {
+                                        return null;
+                                }
+                                const iterable = Array.isArray(codes)
+                                        ? codes
+                                        : codes instanceof Set || typeof codes[Symbol.iterator] === "function"
+                                        ? Array.from(codes)
+                                        : [codes];
+                                return new Set(
+                                        iterable
+                                                .map((code) =>
+                                                        code !== undefined && code !== null
+                                                                ? String(code).trim()
+                                                                : "",
+                                                )
+                                                .filter(Boolean),
+                                );
+                        })();
+                        collections.forEach((items) => {
+                                stockCoordinator.applyAvailabilityToCollection(items, codesSet, options);
+                        });
+                        if (collections.length) {
+                                this.$forceUpdate();
+                        }
+                },
+                primeStockState(source = "items-selector") {
+                        const allItems = Array.isArray(this.items) ? [...this.items] : [];
+                        const extra = Array.isArray(this.displayedItems) ? this.displayedItems : [];
+                        extra.forEach((item) => {
+                                if (allItems.includes(item)) {
+                                        return;
+                                }
+                                allItems.push(item);
+                        });
+                        if (!allItems.length) {
+                                return;
+                        }
+                        stockCoordinator.primeFromItems(allItems, { silent: true, source });
+                        this.syncItemsWithStockState(
+                                allItems
+                                        .map((item) => (item && item.item_code !== undefined ? String(item.item_code).trim() : null))
+                                        .filter(Boolean),
+                                { updateBaseAvailable: false },
+                        );
+                },
+                handleStockSnapshotUpdate(event = {}) {
+                        const codes = Array.isArray(event.codes) ? event.codes : [];
+                        if (!codes.length) {
+                                return;
+                        }
+                        this.syncItemsWithStockState(codes, { updateBaseAvailable: false });
+                },
                 captureBaseAvailability(item, explicitActualQty = undefined) {
                         if (!item) {
                                 return;
                         }
 
+                        let resolvedBase = null;
+
                         if (typeof item.available_qty === "number" && !Number.isNaN(item.available_qty)) {
                                 item._base_available_qty = item.available_qty;
+                                resolvedBase = item.available_qty;
                         }
 
                         const hasExplicit = typeof explicitActualQty === "number" && !Number.isNaN(explicitActualQty);
                         if (hasExplicit) {
                                 item._base_actual_qty = explicitActualQty;
-                                return;
+                                resolvedBase = explicitActualQty;
+                        } else if (typeof item.actual_qty === "number" && !Number.isNaN(item.actual_qty)) {
+                                item._base_actual_qty = item.actual_qty;
+                                resolvedBase = item.actual_qty;
                         }
 
-                        if (typeof item.actual_qty === "number" && !Number.isNaN(item.actual_qty)) {
-                                item._base_actual_qty = item.actual_qty;
+                        if (resolvedBase !== null && item.item_code) {
+                                stockCoordinator.updateBaseQuantities(
+                                        [
+                                                {
+                                                        item_code: item.item_code,
+                                                        actual_qty: resolvedBase,
+                                                },
+                                        ],
+                                        { silent: true, source: "items-selector" },
+                                );
                         }
                 },
                 getBaseActualQty(item) {
@@ -2117,23 +2200,23 @@ export default {
                         }
 
                         const codeKey = String(item.item_code).trim();
-                        const baseActual = this.getBaseActualQty(item);
-                        if (baseActual === null) {
+                        if (!codeKey) {
                                 return;
                         }
 
-                        const reserved = Number(this.cartQuantities?.[codeKey]) || 0;
-                        const adjustedActual = Math.max(0, baseActual - reserved);
-                        if (item.actual_qty !== adjustedActual) {
-                                item.actual_qty = adjustedActual;
+                        if (this.getBaseActualQty(item) !== null) {
+                                stockCoordinator.updateBaseQuantities(
+                                        [
+                                                {
+                                                        item_code: codeKey,
+                                                        actual_qty: item._base_actual_qty,
+                                                },
+                                        ],
+                                        { silent: true, source: "items-selector" },
+                                );
                         }
 
-                        if (typeof item._base_available_qty === "number" && !Number.isNaN(item._base_available_qty)) {
-                                const adjustedAvailable = Math.max(0, item._base_available_qty - reserved);
-                                if (item.available_qty !== adjustedAvailable) {
-                                        item.available_qty = adjustedAvailable;
-                                }
-                        }
+                        stockCoordinator.applyAvailabilityToItem(item, { updateBaseAvailable: false });
                 },
                 recomputeAvailabilityForCodes(codes = []) {
                         if (!Array.isArray(codes) || !codes.length) {
@@ -2148,50 +2231,20 @@ export default {
                         }
 
                         const targetCodes = new Set(normalizedCodes);
-                        const applyIfAffected = (item) => {
-                                if (!item || !item.item_code) {
-                                        return;
-                                }
-                                const code = String(item.item_code).trim();
-                                if (code && targetCodes.has(code)) {
-                                        this.applyReservationToItem(item);
-                                }
-                        };
-
-                        if (Array.isArray(this.items)) {
-                                this.items.forEach(applyIfAffected);
-                        }
-
-                        if (Array.isArray(this.displayedItems)) {
-                                this.displayedItems.forEach(applyIfAffected);
-                        }
-
+                        this.syncItemsWithStockState(targetCodes, { updateBaseAvailable: false });
                         targetCodes.forEach((code) => {
                                 const indexedItem = this.lookupItemByBarcode(code);
                                 if (indexedItem) {
                                         this.applyReservationToItem(indexedItem);
                                 }
                         });
-
-                        this.$forceUpdate();
                 },
                 handleCartQuantitiesUpdated(totals = {}) {
-                        const normalizedTotals = {};
-                        if (totals && typeof totals === "object") {
-                                Object.entries(totals).forEach(([code, qty]) => {
-                                        const normalizedCode = String(code).trim();
-                                        const numericQty = Number(qty);
-                                        if (normalizedCode && Number.isFinite(numericQty) && numericQty > 0) {
-                                                normalizedTotals[normalizedCode] = numericQty;
-                                        }
-                                });
-                        }
-
-                        const previousCodes = Object.keys(this.cartQuantities || {});
-                        this.cartQuantities = normalizedTotals;
-                        const affected = new Set([...previousCodes, ...Object.keys(normalizedTotals)]);
-                        if (affected.size) {
-                                this.recomputeAvailabilityForCodes(Array.from(affected));
+                        const impacted = stockCoordinator.updateReservations(totals, {
+                                source: "items-selector",
+                        });
+                        if (impacted.length) {
+                                this.recomputeAvailabilityForCodes(impacted);
                         }
                 },
                 async handleInvoiceStockAdjusted(payload = {}) {
@@ -2299,6 +2352,18 @@ export default {
                         const affectedCodes = Array.from(
                                 new Set(itemCodes.filter((code) => code !== undefined && code !== null)),
                         );
+                        const baseRecords = new Map();
+                        const flushBaseRecords = () => {
+                                if (!baseRecords.size) {
+                                        return;
+                                }
+                                const baseEntries = Array.from(baseRecords.entries()).map(([code, qty]) => ({
+                                        item_code: code,
+                                        actual_qty: qty,
+                                }));
+                                stockCoordinator.updateBaseQuantities(baseEntries, { source: "items-selector" });
+                                baseRecords.clear();
+                        };
                         const cacheResult = await getCachedItemDetails(
                                 vm.pos_profile.name,
                                 vm.active_price_list,
@@ -2330,6 +2395,9 @@ export default {
                                         }
 
                                         vm.captureBaseAvailability(item, det.actual_qty);
+                                        if (det.actual_qty !== undefined && det.actual_qty !== null) {
+                                                baseRecords.set(item.item_code, det.actual_qty);
+                                        }
                                         if (!item.original_rate) {
                                                 item.original_rate = item.rate;
                                                 item.original_currency = item.currency || vm.pos_profile.currency;
@@ -2341,11 +2409,12 @@ export default {
 			});
 
 			let allCached = cacheResult.missing.length === 0;
-			items.forEach((item) => {
+                        items.forEach((item) => {
                                 const localQty = getLocalStock(item.item_code);
                                 if (localQty !== null) {
                                         item.actual_qty = localQty;
                                         vm.captureBaseAvailability(item, localQty);
+                                        baseRecords.set(item.item_code, localQty);
                                 } else {
                                         allCached = false;
                                 }
@@ -2362,9 +2431,10 @@ export default {
 				}
 			});
 
-			// When offline or everything is cached, skip server call
+                        // When offline or everything is cached, skip server call
                         if (isOffline() || allCached) {
                                 vm.itemDetailsRetryCount = 0;
+                                flushBaseRecords();
                                 vm.recomputeAvailabilityForCodes(affectedCodes);
                                 return;
                         }
@@ -2375,6 +2445,7 @@ export default {
 
                         if (itemsToFetch.length === 0) {
                                 vm.itemDetailsRetryCount = 0;
+                                flushBaseRecords();
                                 vm.recomputeAvailabilityForCodes(affectedCodes);
                                 return;
                         }
@@ -2431,6 +2502,9 @@ export default {
                                         updatedItems.forEach(({ item, updates }) => {
                                                 Object.assign(item, updates);
                                                 vm.captureBaseAvailability(item, updates.actual_qty);
+                                                if (updates.actual_qty !== undefined && updates.actual_qty !== null) {
+                                                        baseRecords.set(item.item_code, updates.actual_qty);
+                                                }
                                                 vm.indexItem(item);
                                                 vm.applyCurrencyConversionToItem(item);
                                         });
@@ -2464,11 +2538,12 @@ export default {
                                                 if (localQty !== null) {
                                                         item.actual_qty = localQty;
                                                         vm.captureBaseAvailability(item, localQty);
+                                                        baseRecords.set(item.item_code, localQty);
                                                 }
                                                 if (!item.item_uoms || item.item_uoms.length === 0) {
                                                         const cached = getItemUOMs(item.item_code);
                                                         if (cached.length > 0) {
-								item.item_uoms = cached;
+                                                                item.item_uoms = cached;
 							}
 						}
 					});
@@ -2490,6 +2565,7 @@ export default {
                                 }
                         };
 
+                        flushBaseRecords();
                         vm.recomputeAvailabilityForCodes(affectedCodes);
                 },
 		update_cur_items_details() {
@@ -3724,12 +3800,14 @@ export default {
 		},
 	},
 
-	async created() {
-		console.log("ItemsSelector created - starting initialization with Pinia store");
+        async created() {
+                console.log("ItemsSelector created - starting initialization with Pinia store");
 
-		// Initialize the Pinia store with existing POS profile data
-		if (this.pos_profile && this.pos_profile.name) {
-			await this.initializeStore(this.pos_profile, this.customer, this.customer_price_list);
+                this.stockUnsubscribe = stockCoordinator.subscribe(this.handleStockSnapshotUpdate);
+
+                // Initialize the Pinia store with existing POS profile data
+                if (this.pos_profile && this.pos_profile.name) {
+                        await this.initializeStore(this.pos_profile, this.customer, this.customer_price_list);
 			console.log("Pinia store initialized successfully");
 		} else {
 			console.warn("No POS Profile available for store initialization");
@@ -3952,15 +4030,20 @@ export default {
 		});
 	},
 
-	beforeUnmount() {
-		// Clear interval when component is destroyed
-		if (this.refresh_interval) {
-			clearInterval(this.refresh_interval);
-		}
+        beforeUnmount() {
+                // Clear interval when component is destroyed
+                if (this.refresh_interval) {
+                        clearInterval(this.refresh_interval);
+                }
 
-		if (this.itemDetailsRetryTimeout) {
-			clearTimeout(this.itemDetailsRetryTimeout);
-		}
+                if (typeof this.stockUnsubscribe === "function") {
+                        this.stockUnsubscribe();
+                        this.stockUnsubscribe = null;
+                }
+
+                if (this.itemDetailsRetryTimeout) {
+                        clearTimeout(this.itemDetailsRetryTimeout);
+                }
 		this.itemDetailsRetryCount = 0;
 
 		// Call cleanup function for abort controller

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -644,9 +644,10 @@ export default {
 		temp_force_server_items: false,
 		// Performance optimizations
 		searchCache: new Map(),
-		barcodeIndex: new Map(),
-		itemCache: new Map(),
-		virtualScrollEnabled: true,
+                barcodeIndex: new Map(),
+                itemCache: new Map(),
+                cartQuantities: {},
+                virtualScrollEnabled: true,
 		virtualScrollBuffer: 200,
 		renderBuffer: 10,
 		lastScrollTop: 0,
@@ -2062,29 +2063,248 @@ export default {
 			const item_code_len = first_search.length - prefix_len - 6;
 			return first_search.substr(0, prefix_len + item_code_len);
 		},
-		esc_event() {
-			this.search = null;
-			this.first_search = null;
-			this.search_backup = null;
-			this.qty = 1;
-			this.focusItemSearch();
-		},
-		async update_items_details(items) {
-			const vm = this;
-			if (!items || !items.length) return;
+                esc_event() {
+                        this.search = null;
+                        this.first_search = null;
+                        this.search_backup = null;
+                        this.qty = 1;
+                        this.focusItemSearch();
+                },
+                captureBaseAvailability(item, explicitActualQty = undefined) {
+                        if (!item) {
+                                return;
+                        }
 
-			// reset any pending retry timer
-			if (vm.itemDetailsRetryTimeout) {
+                        if (typeof item.available_qty === "number" && !Number.isNaN(item.available_qty)) {
+                                item._base_available_qty = item.available_qty;
+                        }
+
+                        const hasExplicit = typeof explicitActualQty === "number" && !Number.isNaN(explicitActualQty);
+                        if (hasExplicit) {
+                                item._base_actual_qty = explicitActualQty;
+                                return;
+                        }
+
+                        if (typeof item.actual_qty === "number" && !Number.isNaN(item.actual_qty)) {
+                                item._base_actual_qty = item.actual_qty;
+                        }
+                },
+                getBaseActualQty(item) {
+                        if (!item) {
+                                return null;
+                        }
+
+                        if (typeof item._base_actual_qty === "number" && !Number.isNaN(item._base_actual_qty)) {
+                                return item._base_actual_qty;
+                        }
+
+                        if (typeof item.actual_qty === "number" && !Number.isNaN(item.actual_qty)) {
+                                item._base_actual_qty = item.actual_qty;
+                                return item.actual_qty;
+                        }
+
+                        if (typeof item.available_qty === "number" && !Number.isNaN(item.available_qty)) {
+                                item._base_available_qty = item.available_qty;
+                                item._base_actual_qty = item.available_qty;
+                                return item.available_qty;
+                        }
+
+                        return null;
+                },
+                applyReservationToItem(item) {
+                        if (!item || !item.item_code) {
+                                return;
+                        }
+
+                        const codeKey = String(item.item_code).trim();
+                        const baseActual = this.getBaseActualQty(item);
+                        if (baseActual === null) {
+                                return;
+                        }
+
+                        const reserved = Number(this.cartQuantities?.[codeKey]) || 0;
+                        const adjustedActual = Math.max(0, baseActual - reserved);
+                        if (item.actual_qty !== adjustedActual) {
+                                item.actual_qty = adjustedActual;
+                        }
+
+                        if (typeof item._base_available_qty === "number" && !Number.isNaN(item._base_available_qty)) {
+                                const adjustedAvailable = Math.max(0, item._base_available_qty - reserved);
+                                if (item.available_qty !== adjustedAvailable) {
+                                        item.available_qty = adjustedAvailable;
+                                }
+                        }
+                },
+                recomputeAvailabilityForCodes(codes = []) {
+                        if (!Array.isArray(codes) || !codes.length) {
+                                return;
+                        }
+
+                        const normalizedCodes = codes
+                                .filter((code) => code !== undefined && code !== null && String(code).trim())
+                                .map((code) => String(code).trim());
+                        if (!normalizedCodes.length) {
+                                return;
+                        }
+
+                        const targetCodes = new Set(normalizedCodes);
+                        const applyIfAffected = (item) => {
+                                if (!item || !item.item_code) {
+                                        return;
+                                }
+                                const code = String(item.item_code).trim();
+                                if (code && targetCodes.has(code)) {
+                                        this.applyReservationToItem(item);
+                                }
+                        };
+
+                        if (Array.isArray(this.items)) {
+                                this.items.forEach(applyIfAffected);
+                        }
+
+                        if (Array.isArray(this.displayedItems)) {
+                                this.displayedItems.forEach(applyIfAffected);
+                        }
+
+                        targetCodes.forEach((code) => {
+                                const indexedItem = this.lookupItemByBarcode(code);
+                                if (indexedItem) {
+                                        this.applyReservationToItem(indexedItem);
+                                }
+                        });
+
+                        this.$forceUpdate();
+                },
+                handleCartQuantitiesUpdated(totals = {}) {
+                        const normalizedTotals = {};
+                        if (totals && typeof totals === "object") {
+                                Object.entries(totals).forEach(([code, qty]) => {
+                                        const normalizedCode = String(code).trim();
+                                        const numericQty = Number(qty);
+                                        if (normalizedCode && Number.isFinite(numericQty) && numericQty > 0) {
+                                                normalizedTotals[normalizedCode] = numericQty;
+                                        }
+                                });
+                        }
+
+                        const previousCodes = Object.keys(this.cartQuantities || {});
+                        this.cartQuantities = normalizedTotals;
+                        const affected = new Set([...previousCodes, ...Object.keys(normalizedTotals)]);
+                        if (affected.size) {
+                                this.recomputeAvailabilityForCodes(Array.from(affected));
+                        }
+                },
+                async handleInvoiceStockAdjusted(payload = {}) {
+                        const collectedCodes = new Set();
+
+                        const collectCode = (code) => {
+                                if (code === undefined || code === null) {
+                                        return;
+                                }
+                                const normalized = String(code).trim();
+                                if (normalized) {
+                                        collectedCodes.add(normalized);
+                                }
+                        };
+
+                        const collectFromItems = (items) => {
+                                if (!Array.isArray(items)) {
+                                        return;
+                                }
+                                items.forEach((entry) => {
+                                        if (!entry) {
+                                                return;
+                                        }
+                                        if (typeof entry === "string" || typeof entry === "number") {
+                                                collectCode(entry);
+                                        } else if (entry.item_code !== undefined) {
+                                                collectCode(entry.item_code);
+                                        }
+                                });
+                        };
+
+                        if (Array.isArray(payload)) {
+                                collectFromItems(payload);
+                        } else if (payload && typeof payload === "object") {
+                                collectFromItems(payload.items);
+                                collectFromItems(payload.item_codes);
+                                if (payload.item_code !== undefined) {
+                                        collectCode(payload.item_code);
+                                }
+                        } else {
+                                collectCode(payload);
+                        }
+
+                        if (!collectedCodes.size) {
+                                return;
+                        }
+
+                        const codes = Array.from(collectedCodes);
+                        const targetCodes = new Set(codes);
+                        const seenItems = new Set();
+                        const candidates = [];
+
+                        const considerItem = (item) => {
+                                if (!item || !item.item_code) {
+                                        return;
+                                }
+                                const code = String(item.item_code).trim();
+                                if (!code || !targetCodes.has(code)) {
+                                        return;
+                                }
+                                if (seenItems.has(item)) {
+                                        return;
+                                }
+                                seenItems.add(item);
+                                candidates.push(item);
+                        };
+
+                        if (Array.isArray(this.items)) {
+                                this.items.forEach(considerItem);
+                        }
+
+                        if (Array.isArray(this.displayedItems)) {
+                                this.displayedItems.forEach(considerItem);
+                        }
+
+                        targetCodes.forEach((code) => {
+                                const indexed = this.lookupItemByBarcode(code);
+                                if (indexed) {
+                                        considerItem(indexed);
+                                }
+                        });
+
+                        try {
+                                if (candidates.length) {
+                                        await this.update_items_details(candidates, { forceRefresh: true });
+                                }
+                        } catch (error) {
+                                console.error("Failed to refresh item details after invoice submission", error);
+                        } finally {
+                                this.recomputeAvailabilityForCodes(codes);
+                        }
+                },
+                async update_items_details(items, options = {}) {
+                        const { forceRefresh = false } = options;
+                        const vm = this;
+                        if (!items || !items.length) return;
+
+                        // reset any pending retry timer
+                        if (vm.itemDetailsRetryTimeout) {
 				clearTimeout(vm.itemDetailsRetryTimeout);
 				vm.itemDetailsRetryTimeout = null;
 			}
 
-			const itemCodes = items.map((it) => it.item_code);
-			const cacheResult = await getCachedItemDetails(
-				vm.pos_profile.name,
-				vm.active_price_list,
-				itemCodes,
-			);
+                        const itemCodes = items.map((it) => it.item_code);
+                        const affectedCodes = Array.from(
+                                new Set(itemCodes.filter((code) => code !== undefined && code !== null)),
+                        );
+                        const cacheResult = await getCachedItemDetails(
+                                vm.pos_profile.name,
+                                vm.active_price_list,
+                                itemCodes,
+                                forceRefresh ? 0 : undefined,
+                        );
 			cacheResult.cached.forEach((det) => {
 				const item = items.find((it) => it.item_code === det.item_code);
 				if (item) {
@@ -2105,14 +2325,15 @@ export default {
 							item.price_list_rate = price;
 						}
 					}
-					if (det.currency) {
-						item.currency = det.currency;
-					}
+                                        if (det.currency) {
+                                                item.currency = det.currency;
+                                        }
 
-					if (!item.original_rate) {
-						item.original_rate = item.rate;
-						item.original_currency = item.currency || vm.pos_profile.currency;
-					}
+                                        vm.captureBaseAvailability(item, det.actual_qty);
+                                        if (!item.original_rate) {
+                                                item.original_rate = item.rate;
+                                                item.original_currency = item.currency || vm.pos_profile.currency;
+                                        }
 
 					vm.indexItem(item);
 					vm.applyCurrencyConversionToItem(item);
@@ -2121,12 +2342,13 @@ export default {
 
 			let allCached = cacheResult.missing.length === 0;
 			items.forEach((item) => {
-				const localQty = getLocalStock(item.item_code);
-				if (localQty !== null) {
-					item.actual_qty = localQty;
-				} else {
-					allCached = false;
-				}
+                                const localQty = getLocalStock(item.item_code);
+                                if (localQty !== null) {
+                                        item.actual_qty = localQty;
+                                        vm.captureBaseAvailability(item, localQty);
+                                } else {
+                                        allCached = false;
+                                }
 
 				if (!item.item_uoms || item.item_uoms.length === 0) {
 					const cachedUoms = getItemUOMs(item.item_code);
@@ -2141,19 +2363,21 @@ export default {
 			});
 
 			// When offline or everything is cached, skip server call
-			if (isOffline() || allCached) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                        if (isOffline() || allCached) {
+                                vm.itemDetailsRetryCount = 0;
+                                vm.recomputeAvailabilityForCodes(affectedCodes);
+                                return;
+                        }
 
 			const itemsToFetch = items.filter(
 				(it) => cacheResult.missing.includes(it.item_code) && !it.has_variants,
 			);
 
-			if (itemsToFetch.length === 0) {
-				vm.itemDetailsRetryCount = 0;
-				return;
-			}
+                        if (itemsToFetch.length === 0) {
+                                vm.itemDetailsRetryCount = 0;
+                                vm.recomputeAvailabilityForCodes(affectedCodes);
+                                return;
+                        }
 
 			try {
 				const details = await vm.fetchItemDetails(itemsToFetch);
@@ -2204,11 +2428,12 @@ export default {
 						}
 					});
 
-					updatedItems.forEach(({ item, updates }) => {
-						Object.assign(item, updates);
-						vm.indexItem(item);
-						vm.applyCurrencyConversionToItem(item);
-					});
+                                        updatedItems.forEach(({ item, updates }) => {
+                                                Object.assign(item, updates);
+                                                vm.captureBaseAvailability(item, updates.actual_qty);
+                                                vm.indexItem(item);
+                                                vm.applyCurrencyConversionToItem(item);
+                                        });
 
 					updateLocalStockCache(details);
 					saveItemDetailsCache(vm.pos_profile.name, vm.active_price_list, details);
@@ -2234,14 +2459,15 @@ export default {
 			} catch (err) {
 				if (err.name !== "AbortError") {
 					console.error("Error fetching item details:", err);
-					items.forEach((item) => {
-						const localQty = getLocalStock(item.item_code);
-						if (localQty !== null) {
-							item.actual_qty = localQty;
-						}
-						if (!item.item_uoms || item.item_uoms.length === 0) {
-							const cached = getItemUOMs(item.item_code);
-							if (cached.length > 0) {
+                                        items.forEach((item) => {
+                                                const localQty = getLocalStock(item.item_code);
+                                                if (localQty !== null) {
+                                                        item.actual_qty = localQty;
+                                                        vm.captureBaseAvailability(item, localQty);
+                                                }
+                                                if (!item.item_uoms || item.item_uoms.length === 0) {
+                                                        const cached = getItemUOMs(item.item_code);
+                                                        if (cached.length > 0) {
 								item.item_uoms = cached;
 							}
 						}
@@ -2258,12 +2484,14 @@ export default {
 			}
 
 			// Cleanup on component destroy
-			this.cleanupBeforeDestroy = () => {
-				if (vm.abortController) {
-					vm.abortController.abort();
-				}
-			};
-		},
+                        this.cleanupBeforeDestroy = () => {
+                                if (vm.abortController) {
+                                        vm.abortController.abort();
+                                }
+                        };
+
+                        vm.recomputeAvailabilityForCodes(affectedCodes);
+                },
 		update_cur_items_details() {
 			if (this.displayedItems && this.displayedItems.length > 0) {
 				this.update_items_details(this.displayedItems);
@@ -3574,10 +3802,12 @@ export default {
 			this.offersCount = data.offersCount;
 			this.appliedOffersCount = data.appliedOffersCount;
 		});
-		this.eventBus.on("update_coupons_counters", (data) => {
-			this.couponsCount = data.couponsCount;
-			this.appliedCouponsCount = data.appliedCouponsCount;
-		});
+                this.eventBus.on("update_coupons_counters", (data) => {
+                        this.couponsCount = data.couponsCount;
+                        this.appliedCouponsCount = data.appliedCouponsCount;
+                });
+                this.eventBus.on("cart_quantities_updated", this.handleCartQuantitiesUpdated);
+                this.eventBus.on("invoice_stock_adjusted", this.handleInvoiceStockAdjusted);
                 this.eventBus.on("update_customer_price_list", (data) => {
                         const fallback = this.pos_profile?.selling_price_list || null;
                         if (data === null || data === undefined) {
@@ -3761,13 +3991,15 @@ export default {
 			this.scanAudioContext = null;
 		}
 
-		this.eventBus.off("update_currency");
-		this.eventBus.off("server-online");
-		this.eventBus.off("register_pos_profile");
-		this.eventBus.off("update_cur_items_details");
-		this.eventBus.off("update_offers_counters");
-		this.eventBus.off("update_coupons_counters");
-		this.eventBus.off("update_customer_price_list");
+                this.eventBus.off("update_currency");
+                this.eventBus.off("server-online");
+                this.eventBus.off("register_pos_profile");
+                this.eventBus.off("update_cur_items_details");
+                this.eventBus.off("update_offers_counters");
+                this.eventBus.off("update_coupons_counters");
+                this.eventBus.off("cart_quantities_updated", this.handleCartQuantitiesUpdated);
+                this.eventBus.off("invoice_stock_adjusted", this.handleInvoiceStockAdjusted);
+                this.eventBus.off("update_customer_price_list");
 		this.eventBus.off("force_reload_items");
 		this.eventBus.off("focus_item_search");
 		window.removeEventListener("resize", this.checkItemContainerOverflow);

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -766,6 +766,7 @@ import { silentPrint, watchPrintWindow } from "../../plugins/print.js";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
+import stockCoordinator from "../../utils/stockCoordinator.js";
 
 export default {
 	// Using format mixin for shared formatting methods
@@ -1530,10 +1531,13 @@ export default {
                                         frappe.utils.play_sound("submit");
                                         // Update local stock quantities immediately after successful
                                         // invoice submission so item availability reflects changes
-                                        updateLocalStock(vm.invoice_doc.items || []);
                                         const submittedItems = Array.isArray(vm.invoice_doc.items)
                                                 ? vm.invoice_doc.items
                                                 : [];
+                                        updateLocalStock(submittedItems);
+                                        stockCoordinator.applyInvoiceConsumption(submittedItems, {
+                                                source: "invoice",
+                                        });
                                         const submittedCodes = submittedItems
                                                 .map((item) => (item ? item.item_code : null))
                                                 .filter((code) => code !== undefined && code !== null);

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1518,24 +1518,35 @@ export default {
 					vm.is_credit_return = false;
 					vm.sales_person = "";
 					vm.eventBus.emit("set_last_invoice", vm.invoice_doc.name);
-					vm.eventBus.emit("show_message", {
-						title:
-							vm.invoiceType === "Order" && vm.pos_profile.posa_create_only_sales_order
-								? __("Sales Order {0} is Submitted", [r.message.name])
-								: vm.invoiceType === "Quotation"
-									? __("Quotation {0} is Submitted", [r.message.name])
-									: __("Invoice {0} is Submitted", [r.message.name]),
-						color: "success",
-					});
-					frappe.utils.play_sound("submit");
-					// Update local stock quantities immediately after successful
-					// invoice submission so item availability reflects changes
-					updateLocalStock(vm.invoice_doc.items || []);
-					vm.addresses = [];
-					vm.eventBus.emit("clear_invoice");
-					vm.eventBus.emit("focus_item_search");
-					vm.eventBus.emit("reset_posting_date");
-					vm.back_to_invoice();
+                                        vm.eventBus.emit("show_message", {
+                                                title:
+                                                        vm.invoiceType === "Order" && vm.pos_profile.posa_create_only_sales_order
+                                                                ? __("Sales Order {0} is Submitted", [r.message.name])
+                                                                : vm.invoiceType === "Quotation"
+                                                                        ? __("Quotation {0} is Submitted", [r.message.name])
+                                                                        : __("Invoice {0} is Submitted", [r.message.name]),
+                                                color: "success",
+                                        });
+                                        frappe.utils.play_sound("submit");
+                                        // Update local stock quantities immediately after successful
+                                        // invoice submission so item availability reflects changes
+                                        updateLocalStock(vm.invoice_doc.items || []);
+                                        const submittedItems = Array.isArray(vm.invoice_doc.items)
+                                                ? vm.invoice_doc.items
+                                                : [];
+                                        const submittedCodes = submittedItems
+                                                .map((item) => (item ? item.item_code : null))
+                                                .filter((code) => code !== undefined && code !== null);
+                                        vm.eventBus.emit("invoice_stock_adjusted", {
+                                                items: submittedItems,
+                                                item_codes: submittedCodes,
+                                                timestamp: Date.now(),
+                                        });
+                                        vm.addresses = [];
+                                        vm.eventBus.emit("clear_invoice");
+                                        vm.eventBus.emit("focus_item_search");
+                                        vm.eventBus.emit("reset_posting_date");
+                                        vm.back_to_invoice();
 					vm.loading = false;
 				},
 			});

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -120,58 +120,60 @@ export default {
 			const snapshot = buildSnapshot(newItems);
 			this._offerSnapshots = this._offerSnapshots || {};
 			const previous = this._offerSnapshots.items;
-			this._offerSnapshots.items = snapshot;
+                        this._offerSnapshots.items = snapshot;
 
-			const { changed, removedInfo } = diffSnapshots(previous, snapshot);
+                        const { changed, removedInfo } = diffSnapshots(previous, snapshot);
 
-			if (removedInfo && Object.keys(removedInfo).length) {
+                        if (removedInfo && Object.keys(removedInfo).length) {
 				this._pendingRemovedRowInfo = {
 					...(this._pendingRemovedRowInfo || {}),
 					...removedInfo,
-				};
-			}
+                                };
+                        }
 
-			if (!previous) {
-				if (snapshot.order.length) {
-					this.scheduleOfferRefresh([...new Set(snapshot.order)]);
-				}
-				return;
-			}
+                        if (!previous) {
+                                if (snapshot.order.length) {
+                                        this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                }
+                        } else if (changed.size) {
+                                this.scheduleOfferRefresh(Array.from(changed));
+                        }
 
-			if (changed.size) {
-				this.scheduleOfferRefresh(Array.from(changed));
-			}
-		},
-	},
-	packed_items: {
-		deep: true,
-		handler(newItems) {
+                        if (typeof this.emitCartQuantities === "function") {
+                                this.emitCartQuantities();
+                        }
+                },
+        },
+        packed_items: {
+                deep: true,
+                handler(newItems) {
 			const snapshot = buildSnapshot(newItems);
 			this._offerSnapshots = this._offerSnapshots || {};
 			const previous = this._offerSnapshots.packed;
-			this._offerSnapshots.packed = snapshot;
+                        this._offerSnapshots.packed = snapshot;
 
-			const { changed, removedInfo } = diffSnapshots(previous, snapshot);
+                        const { changed, removedInfo } = diffSnapshots(previous, snapshot);
 
-			if (removedInfo && Object.keys(removedInfo).length) {
+                        if (removedInfo && Object.keys(removedInfo).length) {
 				this._pendingRemovedRowInfo = {
 					...(this._pendingRemovedRowInfo || {}),
 					...removedInfo,
-				};
-			}
+                                };
+                        }
 
-			if (!previous) {
-				if (snapshot.order.length) {
-					this.scheduleOfferRefresh([...new Set(snapshot.order)]);
-				}
-				return;
-			}
+                        if (!previous) {
+                                if (snapshot.order.length) {
+                                        this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                }
+                        } else if (changed.size) {
+                                this.scheduleOfferRefresh(Array.from(changed));
+                        }
 
-			if (changed.size) {
-				this.scheduleOfferRefresh(Array.from(changed));
-			}
-		},
-	},
+                        if (typeof this.emitCartQuantities === "function") {
+                                this.emitCartQuantities();
+                        }
+                },
+        },
 	// Watch for invoice type change and emit
 	invoiceType() {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);

--- a/frontend/src/posapp/utils/stockCoordinator.js
+++ b/frontend/src/posapp/utils/stockCoordinator.js
@@ -1,0 +1,390 @@
+const listeners = new Set();
+const baseQuantities = new Map();
+const reservedQuantities = new Map();
+const availabilityMap = new Map();
+
+const normalizeCode = (code) => {
+        if (code === undefined || code === null) {
+                return null;
+        }
+        const normalized = String(code).trim();
+        return normalized ? normalized : null;
+};
+
+const toNumber = (value) => {
+        if (value === undefined || value === null) {
+                return null;
+        }
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+                return null;
+        }
+        return num;
+};
+
+const computeAvailability = (code) => {
+        if (!code) {
+                return null;
+        }
+        if (!baseQuantities.has(code)) {
+                availabilityMap.delete(code);
+                return null;
+        }
+        const base = baseQuantities.get(code);
+        const reserved = reservedQuantities.get(code) || 0;
+        const available = Math.max(0, base - reserved);
+        availabilityMap.set(code, available);
+        return available;
+};
+
+const buildSnapshot = (codes) => {
+        const snapshot = {};
+        codes.forEach((code) => {
+                const normalized = normalizeCode(code);
+                if (!normalized) {
+                        return;
+                }
+                const base = baseQuantities.has(normalized) ? baseQuantities.get(normalized) : null;
+                const reserved = reservedQuantities.get(normalized) || 0;
+                const available = availabilityMap.has(normalized)
+                        ? availabilityMap.get(normalized)
+                        : computeAvailability(normalized);
+                snapshot[normalized] = {
+                        baseActual: base,
+                        reserved,
+                        available,
+                };
+        });
+        return snapshot;
+};
+
+const notifyListeners = (type, codes, meta = {}) => {
+        if (!Array.isArray(codes) || !codes.length) {
+                return;
+        }
+        const snapshot = buildSnapshot(codes);
+        listeners.forEach((listener) => {
+                try {
+                        listener({ type, codes, snapshot, meta });
+                } catch (error) {
+                        // eslint-disable-next-line no-console
+                        console.error("Stock listener failed", error);
+                }
+        });
+};
+
+const updateBaseQuantities = (entries = [], options = {}) => {
+        const { silent = false, pruneMissing = false } = options;
+        const changed = new Set();
+        const seen = new Set();
+
+        entries.forEach((entry) => {
+                if (!entry) {
+                        return;
+                }
+                const code = normalizeCode(entry.item_code ?? entry.code ?? entry.name);
+                if (!code) {
+                        return;
+                }
+                seen.add(code);
+                const baseCandidate =
+                        toNumber(
+                                entry.actual_qty ??
+                                        entry.available_qty ??
+                                        entry.base_actual_qty ??
+                                        entry.base_available_qty ??
+                                        entry.base_qty ??
+                                        entry.qty ??
+                                        entry.stock_qty,
+                        );
+                if (baseCandidate === null) {
+                        return;
+                }
+                const current = baseQuantities.get(code);
+                if (current === undefined || current !== baseCandidate) {
+                        baseQuantities.set(code, baseCandidate);
+                        changed.add(code);
+                }
+        });
+
+        if (pruneMissing) {
+                Array.from(baseQuantities.keys()).forEach((code) => {
+                        if (!seen.has(code)) {
+                                baseQuantities.delete(code);
+                                changed.add(code);
+                        }
+                });
+        }
+
+        const affected = Array.from(changed);
+        affected.forEach((code) => computeAvailability(code));
+
+        if (!silent && affected.length) {
+                        notifyListeners("base", affected, { source: options.source });
+        }
+
+        return affected;
+};
+
+const updateReservations = (totals = {}, options = {}) => {
+        const { silent = false } = options;
+        const incoming = new Map();
+        if (totals && typeof totals === "object") {
+                Object.entries(totals).forEach(([codeValue, qtyValue]) => {
+                        const code = normalizeCode(codeValue);
+                        const qty = toNumber(qtyValue);
+                        if (!code || qty === null) {
+                                return;
+                        }
+                        const positive = qty > 0 ? qty : 0;
+                        if (positive > 0) {
+                                incoming.set(code, positive);
+                        }
+                });
+        }
+
+        const changed = new Set();
+        const processed = new Set();
+
+        incoming.forEach((qty, code) => {
+                processed.add(code);
+                const previous = reservedQuantities.get(code) || 0;
+                if (previous !== qty) {
+                        reservedQuantities.set(code, qty);
+                        changed.add(code);
+                }
+        });
+
+        Array.from(reservedQuantities.keys()).forEach((code) => {
+                if (!processed.has(code)) {
+                        const previous = reservedQuantities.get(code) || 0;
+                        if (previous !== 0) {
+                                changed.add(code);
+                        }
+                        reservedQuantities.delete(code);
+                }
+        });
+
+        const affected = Array.from(changed);
+        affected.forEach((code) => computeAvailability(code));
+
+        if (!silent && affected.length) {
+                notifyListeners("reservation", affected, { source: options.source });
+        }
+
+        return affected;
+};
+
+const clearAll = () => {
+        const affected = Array.from(
+                new Set([
+                        ...baseQuantities.keys(),
+                        ...reservedQuantities.keys(),
+                        ...availabilityMap.keys(),
+                ]),
+        );
+        baseQuantities.clear();
+        reservedQuantities.clear();
+        availabilityMap.clear();
+        if (affected.length) {
+                notifyListeners("reset", affected, {});
+        }
+        return affected;
+};
+
+const getAvailability = (code) => {
+        const normalized = normalizeCode(code);
+        if (!normalized) {
+                return null;
+        }
+        if (availabilityMap.has(normalized)) {
+                return availabilityMap.get(normalized);
+        }
+        return computeAvailability(normalized);
+};
+
+const getReserved = (code) => {
+        const normalized = normalizeCode(code);
+        if (!normalized) {
+                return 0;
+        }
+        return reservedQuantities.get(normalized) || 0;
+};
+
+const getBase = (code) => {
+        const normalized = normalizeCode(code);
+        if (!normalized) {
+                return null;
+        }
+        return baseQuantities.has(normalized) ? baseQuantities.get(normalized) : null;
+};
+
+const getSnapshot = (codes) => {
+        if (!codes) {
+                return buildSnapshot([
+                        ...new Set([
+                                ...baseQuantities.keys(),
+                                ...reservedQuantities.keys(),
+                                ...availabilityMap.keys(),
+                        ]),
+                ]);
+        }
+        return buildSnapshot(Array.isArray(codes) ? codes : [codes]);
+};
+
+const applyAvailabilityToItem = (item, options = {}) => {
+        if (!item || item.item_code === undefined || item.item_code === null) {
+                return;
+        }
+        const code = normalizeCode(item.item_code);
+        if (!code) {
+                return;
+        }
+
+        if (!baseQuantities.has(code)) {
+                const fallbackBase = toNumber(
+                        item._base_actual_qty ??
+                                item._base_available_qty ??
+                                item.actual_qty ??
+                                item.available_qty ??
+                                item.stock_qty,
+                );
+                if (fallbackBase !== null) {
+                        baseQuantities.set(code, fallbackBase);
+                }
+        }
+
+        const base = baseQuantities.has(code) ? baseQuantities.get(code) : null;
+        if (base !== null && options.updateBase !== false) {
+                item._base_actual_qty = base;
+                if (options.updateBaseAvailable !== false) {
+                        item._base_available_qty = base;
+                }
+        }
+
+        const available = getAvailability(code);
+        if (available !== null) {
+                if (options.updateActual !== false) {
+                        item.actual_qty = available;
+                }
+                if (options.updateAvailable !== false && item.available_qty !== undefined) {
+                        item.available_qty = available;
+                }
+        } else if (base !== null && options.updateActual !== false) {
+                item.actual_qty = base;
+        }
+};
+
+const applyAvailabilityToCollection = (items, codesSet = null, options = {}) => {
+        if (!Array.isArray(items) || !items.length) {
+                return;
+        }
+        items.forEach((item) => {
+                if (!item || item.item_code === undefined || item.item_code === null) {
+                        return;
+                }
+                const code = normalizeCode(item.item_code);
+                if (!code) {
+                        return;
+                }
+                if (codesSet && !codesSet.has(code)) {
+                        return;
+                }
+                applyAvailabilityToItem(item, options);
+        });
+};
+
+const primeFromItems = (items = [], options = {}) => {
+        const entries = [];
+        items.forEach((item) => {
+                if (!item || item.item_code === undefined || item.item_code === null) {
+                        return;
+                }
+                const code = normalizeCode(item.item_code);
+                if (!code) {
+                        return;
+                }
+                const baseCandidate = toNumber(
+                        item._base_actual_qty ??
+                                item._base_available_qty ??
+                                item.actual_qty ??
+                                item.available_qty ??
+                                item.stock_qty,
+                );
+                if (baseCandidate === null) {
+                        return;
+                }
+                entries.push({ item_code: code, actual_qty: baseCandidate });
+        });
+        if (!entries.length) {
+                return [];
+        }
+        return updateBaseQuantities(entries, { silent: options.silent !== false, source: options.source });
+};
+
+const applyInvoiceConsumption = (items = [], options = {}) => {
+        const { silent = false } = options;
+        const changed = new Set();
+        items.forEach((entry) => {
+                if (!entry) {
+                        return;
+                }
+                const code = normalizeCode(entry.item_code);
+                if (!code) {
+                        return;
+                }
+                if (!baseQuantities.has(code)) {
+                        return;
+                }
+                const stockQty = toNumber(entry.stock_qty);
+                let consumption = stockQty;
+                if (consumption === null) {
+                        const qty = toNumber(entry.qty);
+                        const factor = toNumber(entry.conversion_factor);
+                        if (qty !== null) {
+                                const multiplier = factor !== null && factor !== 0 ? factor : 1;
+                                consumption = qty * multiplier;
+                        }
+                }
+                if (consumption === null) {
+                        return;
+                }
+                const current = baseQuantities.get(code);
+                const next = Math.max(0, current - consumption);
+                if (next !== current) {
+                        baseQuantities.set(code, next);
+                        changed.add(code);
+                }
+        });
+        const affected = Array.from(changed);
+        affected.forEach((code) => computeAvailability(code));
+        if (!silent && affected.length) {
+                notifyListeners("base", affected, { source: options.source || "invoice" });
+        }
+        return affected;
+};
+
+const subscribe = (listener) => {
+        if (typeof listener !== "function") {
+                return () => {};
+        }
+        listeners.add(listener);
+        return () => {
+                listeners.delete(listener);
+        };
+};
+
+export default {
+        updateBaseQuantities,
+        updateReservations,
+        clearAll,
+        getAvailability,
+        getReserved,
+        getBase,
+        getSnapshot,
+        applyAvailabilityToItem,
+        applyAvailabilityToCollection,
+        primeFromItems,
+        applyInvoiceConsumption,
+        subscribe,
+};

--- a/frontend/src/posapp/utils/stockCoordinator.js
+++ b/frontend/src/posapp/utils/stockCoordinator.js
@@ -32,7 +32,7 @@ const computeAvailability = (code) => {
         }
         const base = baseQuantities.get(code);
         const reserved = reservedQuantities.get(code) || 0;
-        const available = Math.max(0, base - reserved);
+        const available = base - reserved;
         availabilityMap.set(code, available);
         return available;
 };
@@ -350,7 +350,7 @@ const applyInvoiceConsumption = (items = [], options = {}) => {
                         return;
                 }
                 const current = baseQuantities.get(code);
-                const next = Math.max(0, current - consumption);
+                const next = current - consumption;
                 if (next !== current) {
                         baseQuantities.set(code, next);
                         changed.add(code);


### PR DESCRIPTION
## Summary
- emit an invoice_stock_adjusted event after submission so other components can react to stock changes
- let the item selector force-refresh affected item details and recompute availability when stock adjustments occur
- support bypassing cached item details when a refresh is requested to pull the latest quantities

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5efda2f948326ae85d21a8d5dacde