### PR TITLE
Prevent offline print fallback while online

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -363,7 +363,7 @@ export default {
 				"&no_letterhead=" +
 				letter_head;
 
-                        const printOptions = {};
+                        const printOptions = { allowOfflineFallback: isOffline() };
                         if (this.posProfile.posa_silent_print) {
                                 silentPrint(url, printOptions);
                         } else {

--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -1100,7 +1100,7 @@ export default {
 
 			console.log("Opening printing URL:", url);
 
-                        const printOptions = {};
+                        const printOptions = { allowOfflineFallback: isOffline() };
                         if (this.pos_profile?.posa_silent_print) {
                                 silentPrint(url, printOptions);
                         } else {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1635,7 +1635,10 @@ export default {
 				print_format +
 				"&no_letterhead=" +
 				letter_head;
-                        const printOptions = { invoiceDoc: this.invoice_doc };
+                        const printOptions = {
+                                invoiceDoc: this.invoice_doc,
+                                allowOfflineFallback: isOffline(),
+                        };
                         if (this.pos_profile.posa_silent_print) {
                                 silentPrint(url, printOptions);
                         } else {

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1,4 +1,5 @@
 import { silentPrint } from "../../plugins/print.js";
+import { isOffline } from "../../../offline/index.js";
 import { formatUtils } from "../../format.js";
 /* global __, frappe, flt */
 
@@ -1355,9 +1356,9 @@ export default {
 			"&no_letterhead=" +
 			letter_head;
 
-		if (this.pos_profile.posa_silent_print) {
-			silentPrint(url);
-		} else {
+                if (this.pos_profile.posa_silent_print) {
+                        silentPrint(url, { allowOfflineFallback: isOffline() });
+                } else {
 			const printWindow = window.open(url, "Print");
 			printWindow.addEventListener(
 				"load",

--- a/frontend/src/posapp/plugins/print.js
+++ b/frontend/src/posapp/plugins/print.js
@@ -156,6 +156,7 @@ async function ensureReadyAndPrint(targetWindow, options = {}) {
                 selectors = DEFAULT_READY_SELECTORS,
                 timeout = DEFAULT_TIMEOUT,
                 invoiceDoc = null,
+                allowOfflineFallback = true,
         } = options;
 
         const readySelectors = Array.isArray(selectors)
@@ -168,7 +169,10 @@ async function ensureReadyAndPrint(targetWindow, options = {}) {
                 targetWindow.print();
         } catch (err) {
                 console.warn("Print readiness check failed", err);
-                const usedFallback = await fallbackToOfflinePrint(invoiceDoc, targetWindow);
+                let usedFallback = false;
+                if (allowOfflineFallback && invoiceDoc) {
+                        usedFallback = await fallbackToOfflinePrint(invoiceDoc, targetWindow);
+                }
                 if (!usedFallback) {
                         try {
                                 targetWindow.focus();


### PR DESCRIPTION
## Summary
- gate the offline print fallback behind an explicit option in the POS print helper
- mark POS print entry points to only allow the fallback when the client is offline
- reuse the online print preview when available instead of rewriting the window with the offline template

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f61eeae87083269d57238f3f994020