### PR TITLE
Respect net totals when computing additional discounts

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -345,6 +345,7 @@ import { useInvoiceStore } from "../../stores/invoiceStore.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
 import stockCoordinator from "../../utils/stockCoordinator.js";
+import { computeAdditionalDiscountPercentage } from "../../composables/useDiscounts.js";
 
 export default {
 	name: "POSInvoice",
@@ -1468,8 +1469,11 @@ export default {
                         }
                         if (data.return_doc) {
                                 console.log("Return against existing invoice:", data.return_doc.name);
-                                this.discount_amount = data.return_doc.discount_amount || 0;
-                                this.additional_discount = data.return_doc.discount_amount || 0;
+                                const returnDiscount = data.return_doc.discount_amount || 0;
+                                this.discount_amount = returnDiscount;
+                                this.additional_discount = returnDiscount;
+                                const recalculated = computeAdditionalDiscountPercentage(this, this.additional_discount);
+                                this.additional_discount_percentage = Number.isFinite(recalculated) ? recalculated : 0;
                                 this.return_doc = data.return_doc;
                                 this.invoice_doc.return_against = data.return_doc.name;
                         } else {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -21,7 +21,12 @@ const ITEM_DETAIL_CACHE_TTL = 5000;
 const STOCK_CACHE_TTL = 5000;
 
 const { setSerialNo, setBatchQty } = useBatchSerial();
-const { updateDiscountAmount, calcPrices, calcItemPrice } = useDiscounts();
+const {
+        updateDiscountAmount,
+        calcPrices,
+        calcItemPrice,
+        computeAdditionalDiscountPercentage,
+} = useDiscounts();
 const { removeItem, addItem, getNewItem, clearInvoice } = useItemAddition();
 const { calcUom, calcStockQty } = useStockUtils();
 
@@ -393,9 +398,15 @@ export default {
 
 		this.customer = data.customer;
 		this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
-		this.discount_amount = data.discount_amount;
-		this.additional_discount_percentage = data.additional_discount_percentage;
-		this.additional_discount = data.discount_amount;
+                const discountAmount = data.discount_amount || 0;
+                this.discount_amount = discountAmount;
+                this.additional_discount = discountAmount;
+                const derivedPercentage = computeAdditionalDiscountPercentage(this, discountAmount);
+                if (Number.isFinite(derivedPercentage)) {
+                        this.additional_discount_percentage = derivedPercentage;
+                } else {
+                        this.additional_discount_percentage = data.additional_discount_percentage || 0;
+                }
 
 		if (this.items.length > 0) {
 			this.items.forEach((item) => {
@@ -467,12 +478,13 @@ export default {
 		this.eventBus.emit("set_pos_coupons", []);
 		this.posa_coupons = [];
 		this.return_doc = "";
-		if (!data.name && !data.is_return) {
-			this.items = [];
-			this.customer = this.pos_profile.customer;
-			this.invoice_doc = "";
-			this.discount_amount = 0;
-			this.additional_discount_percentage = 0;
+                if (!data.name && !data.is_return) {
+                        this.items = [];
+                        this.customer = this.pos_profile.customer;
+                        this.invoice_doc = "";
+                        this.discount_amount = 0;
+                        this.additional_discount = 0;
+                        this.additional_discount_percentage = 0;
 			this.invoiceType = "Invoice";
 			this.invoiceTypes = ["Invoice", "Order", "Quotation"];
 		} else {
@@ -500,10 +512,17 @@ export default {
 					this.set_batch_qty(item, item.batch_no);
 				}
 			});
-			this.customer = data.customer;
-			this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
-			this.discount_amount = data.discount_amount;
-			this.additional_discount_percentage = data.additional_discount_percentage;
+                        this.customer = data.customer;
+                        this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
+                        const discountAmount = data.discount_amount || 0;
+                        this.discount_amount = discountAmount;
+                        this.additional_discount = discountAmount;
+                        const derivedPercentage = computeAdditionalDiscountPercentage(this, discountAmount);
+                        if (Number.isFinite(derivedPercentage)) {
+                                this.additional_discount_percentage = derivedPercentage;
+                        } else {
+                                this.additional_discount_percentage = data.additional_discount_percentage || 0;
+                        }
 			this.items.forEach((item) => {
 				if (item.serial_no) {
 					item.serial_no_selected = [];

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1,5 +1,9 @@
 import { silentPrint } from "../../plugins/print.js";
 import { formatUtils } from "../../format.js";
+import {
+        computeAdditionalDiscountAmount,
+        computeAdditionalDiscountPercentage,
+} from "../../composables/useDiscounts.js";
 /* global __, frappe, flt */
 
 export default {
@@ -1220,27 +1224,24 @@ export default {
 			// Discount already applied, do not recalculate when items change
 			return;
 		}
-		if (
-			(!this.discount_percentage_offer_name || this.discount_percentage_offer_name == offer.name) &&
-			offer.discount_percentage > 0 &&
-			offer.discount_percentage <= 100
-		) {
-			this.discount_amount = this.flt(
-				(flt(this.Total) * flt(offer.discount_percentage)) / 100,
-				this.currency_precision,
-			);
-			this.discount_percentage_offer_name = offer.name;
+                if (
+                        (!this.discount_percentage_offer_name || this.discount_percentage_offer_name == offer.name) &&
+                        offer.discount_percentage > 0 &&
+                        offer.discount_percentage <= 100
+                ) {
+                        const calculatedAmount = computeAdditionalDiscountAmount(this, offer.discount_percentage);
+                        this.discount_amount = this.flt
+                                ? this.flt(calculatedAmount, this.currency_precision)
+                                : calculatedAmount;
+                        this.discount_percentage_offer_name = offer.name;
 
-			// Update invoice level discount fields so the value
-			// is reflected in the UI and saved correctly
-			this.additional_discount = this.discount_amount;
-			if (this.Total && this.Total !== 0) {
-				this.additional_discount_percentage = (this.discount_amount / this.Total) * 100;
-			} else {
-				this.additional_discount_percentage = 0;
-			}
-		}
-	},
+                        // Update invoice level discount fields so the value
+                        // is reflected in the UI and saved correctly
+                        this.additional_discount = this.discount_amount;
+                        const percentage = computeAdditionalDiscountPercentage(this, this.additional_discount);
+                        this.additional_discount_percentage = Number.isFinite(percentage) ? percentage : 0;
+                }
+        },
 
 	RemoveOnTotal(offer) {
 		if (this.discount_percentage_offer_name && this.discount_percentage_offer_name == offer.offer_name) {

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -1,5 +1,6 @@
 import { clearPriceListCache } from "../../../offline/index.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
+import { computeAdditionalDiscountPercentage } from "../../composables/useDiscounts.js";
 /* global frappe */
 
 const buildSnapshot = (items) => {
@@ -179,20 +180,20 @@ export default {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);
 	},
 	// Watch for additional discount and update percentage accordingly
-	additional_discount() {
-		if (!this.additional_discount || this.additional_discount == 0) {
-			this.additional_discount_percentage = 0;
-		} else if (this.pos_profile.posa_use_percentage_discount) {
-			// Prevent division by zero which causes NaN
-			if (this.Total && this.Total !== 0) {
-				this.additional_discount_percentage = (this.additional_discount / this.Total) * 100;
-			} else {
-				this.additional_discount_percentage = 0;
-			}
-		} else {
-			this.additional_discount_percentage = 0;
-		}
-	},
+        additional_discount() {
+                if (!this.additional_discount || this.additional_discount == 0) {
+                        this.additional_discount_percentage = 0;
+                } else if (this.pos_profile?.posa_use_percentage_discount) {
+                        const percentage = computeAdditionalDiscountPercentage(this, this.additional_discount);
+                        if (Number.isFinite(percentage)) {
+                                this.additional_discount_percentage = percentage;
+                        } else {
+                                this.additional_discount_percentage = 0;
+                        }
+                } else {
+                        this.additional_discount_percentage = 0;
+                }
+        },
 	// Keep display date in sync with posting_date
 	posting_date: {
 		handler(newVal) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -1,23 +1,271 @@
 /* global __, flt */
 
-export function useDiscounts() {
-	// Update additional discount amount based on percentage
-	const updateDiscountAmount = (context) => {
-		const value = flt(context.additional_discount_percentage);
-		// If value is too large, reset to 0
-		if (value < -100 || value > 100) {
-			context.additional_discount_percentage = 0;
-			context.additional_discount = 0;
-			return;
-		}
+const unwrap = (input) => {
+        if (input === null || input === undefined) {
+                return input;
+        }
 
-		// Calculate discount amount based on percentage
-		if (context.Total && context.Total !== 0) {
-			context.additional_discount = (context.Total * value) / 100;
-		} else {
-			context.additional_discount = 0;
-		}
-	};
+        if (typeof input === "function") {
+                try {
+                        return unwrap(input());
+                } catch (error) {
+                        console.warn("Failed to unwrap function value for discount base", error);
+                        return null;
+                }
+        }
+
+        if (typeof input === "object" && "value" in input) {
+                return unwrap(input.value);
+        }
+
+        return input;
+};
+
+const toFiniteNumber = (value) => {
+        const unwrapped = unwrap(value);
+        if (unwrapped === null || unwrapped === undefined || unwrapped === "") {
+                return null;
+        }
+
+        if (typeof unwrapped === "number") {
+                        return Number.isFinite(unwrapped) ? unwrapped : null;
+        }
+
+        const parsed = Number.parseFloat(unwrapped);
+        return Number.isFinite(parsed) ? parsed : null;
+};
+
+const isReturnInvoiceContext = (context) => {
+        if (!context) return false;
+
+        try {
+                if (typeof context.isReturnInvoice === "function" && context.isReturnInvoice()) {
+                        return true;
+                }
+        } catch (error) {
+                console.warn("Error evaluating isReturnInvoice", error);
+        }
+
+        if (context.invoiceType === "Return") {
+                return true;
+        }
+
+        const doc = context.invoice_doc;
+        if (!doc) {
+                return false;
+        }
+
+        const isReturnRaw = unwrap(doc.is_return);
+        if (typeof isReturnRaw === "string") {
+                return ["1", "true", "yes"].includes(isReturnRaw.trim().toLowerCase());
+        }
+
+        return Boolean(isReturnRaw);
+};
+
+const pickFirstNumber = (candidates, makePositive) => {
+        for (const candidate of candidates) {
+                const number = toFiniteNumber(candidate);
+                if (number === null) {
+                        continue;
+                }
+
+                return {
+                        value: makePositive ? Math.abs(number) : number,
+                        found: true,
+                };
+        }
+
+        return {
+                value: 0,
+                found: false,
+        };
+};
+
+const normalizePrecision = (context, value, precision) => {
+        if (!Number.isFinite(value)) {
+                return 0;
+        }
+
+        if (typeof context?.flt === "function") {
+                return context.flt(value, precision);
+        }
+
+        if (typeof flt === "function") {
+                return flt(value, precision);
+        }
+
+        if (typeof precision === "number" && Number.isFinite(precision)) {
+                const factor = 10 ** precision;
+                return Math.round(value * factor) / factor;
+        }
+
+        return value;
+};
+
+const computeNetFromTaxes = (context, grossBase, makePositive) => {
+        if (!context?.invoice_doc?.taxes?.length) {
+                return null;
+        }
+
+        let inclusiveSum = 0;
+        let foundInclusive = false;
+
+        context.invoice_doc.taxes.forEach((tax) => {
+                const includedRaw = unwrap(tax?.included_in_print_rate);
+                let isIncluded = false;
+
+                if (typeof includedRaw === "string") {
+                        const normalized = includedRaw.trim().toLowerCase();
+                        isIncluded = ["1", "true", "yes"].includes(normalized);
+                } else {
+                        isIncluded = Boolean(includedRaw);
+                }
+
+                if (!isIncluded) {
+                        return;
+                }
+
+                const amount = toFiniteNumber(tax?.tax_amount);
+                if (amount === null) {
+                        return;
+                }
+
+                inclusiveSum += makePositive ? Math.abs(amount) : amount;
+                foundInclusive = true;
+        });
+
+        if (!foundInclusive) {
+                return null;
+        }
+
+        const candidate = makePositive ? Math.abs(grossBase - inclusiveSum) : grossBase - inclusiveSum;
+        return Number.isFinite(candidate) ? candidate : null;
+};
+
+const computeNetFromItems = (context, makePositive) => {
+        const items = context?.items || context?.invoice_doc?.items;
+        if (!Array.isArray(items) || !items.length) {
+                return null;
+        }
+
+        let sum = 0;
+        let found = false;
+
+        items.forEach((item) => {
+                if (!item) return;
+
+                const netAmount = toFiniteNumber(item.net_amount);
+                if (netAmount !== null) {
+                        sum += makePositive ? Math.abs(netAmount) : netAmount;
+                        found = true;
+                        return;
+                }
+
+                const amount = toFiniteNumber(item.amount);
+                if (amount !== null) {
+                        sum += makePositive ? Math.abs(amount) : amount;
+                        found = true;
+                }
+        });
+
+        if (!found) {
+                        return null;
+        }
+
+        return sum;
+};
+
+export const getDiscountBaseAmount = (context) => {
+        const doc = context?.invoice_doc || {};
+        const preferenceRaw = unwrap(doc.apply_discount_on) || unwrap(context?.pos_profile?.apply_discount_on) || "";
+        const preference = typeof preferenceRaw === "string" ? preferenceRaw.trim().toLowerCase() : "";
+        const preferNet = preference === "net total";
+
+        const makePositive = isReturnInvoiceContext(context);
+
+        const grossResult = pickFirstNumber(
+                [
+                        context?.Total,
+                        doc.total,
+                        doc.grand_total,
+                        doc.base_total && context?.exchange_rate
+                                ? doc.base_total / context.exchange_rate
+                                : null,
+                ],
+                makePositive,
+        );
+
+        const grossBase = grossResult.value;
+
+        if (!preferNet) {
+                return grossBase;
+        }
+
+        const netResult = pickFirstNumber(
+                [
+                        doc.net_total,
+                        doc.base_net_total && context?.exchange_rate
+                                ? doc.base_net_total / context.exchange_rate
+                                : null,
+                ],
+                makePositive,
+        );
+
+        if (netResult.found) {
+                return netResult.value;
+        }
+
+        const netFromItems = computeNetFromItems(context, makePositive);
+        if (Number.isFinite(netFromItems)) {
+                return netFromItems;
+        }
+
+        const derivedNet = computeNetFromTaxes(context, grossBase, makePositive);
+        if (Number.isFinite(derivedNet)) {
+                return derivedNet;
+        }
+
+        return grossBase;
+};
+
+export const computeAdditionalDiscountAmount = (context, percentage) => {
+        const base = getDiscountBaseAmount(context);
+        const percentNumber = toFiniteNumber(percentage) ?? 0;
+
+        if (!Number.isFinite(base) || Math.abs(base) < Number.EPSILON) {
+                return 0;
+        }
+
+        const amount = (base * percentNumber) / 100;
+        return normalizePrecision(context, amount, context?.currency_precision);
+};
+
+export const computeAdditionalDiscountPercentage = (context, amount) => {
+        const base = getDiscountBaseAmount(context);
+
+        if (!Number.isFinite(base) || Math.abs(base) < Number.EPSILON) {
+                return 0;
+        }
+
+        const discount = toFiniteNumber(amount) ?? 0;
+        const percentage = (discount / base) * 100;
+        return normalizePrecision(context, percentage, context?.float_precision);
+};
+
+export function useDiscounts() {
+        // Update additional discount amount based on percentage
+        const updateDiscountAmount = (context) => {
+                const value = flt(context.additional_discount_percentage);
+                // If value is too large, reset to 0
+                if (value < -100 || value > 100) {
+                        context.additional_discount_percentage = 0;
+                        context.additional_discount = 0;
+                        return;
+                }
+
+                context.additional_discount = computeAdditionalDiscountAmount(context, value);
+        };
 
 	// Calculate prices and discounts for an item based on field change
 	const calcPrices = (item, value, $event, context) => {
@@ -252,9 +500,12 @@ export function useDiscounts() {
 		if (context.forceUpdate) context.forceUpdate();
 	};
 
-	return {
-		updateDiscountAmount,
-		calcPrices,
-		calcItemPrice,
-	};
+        return {
+                updateDiscountAmount,
+                calcPrices,
+                calcItemPrice,
+                getDiscountBaseAmount,
+                computeAdditionalDiscountAmount,
+                computeAdditionalDiscountPercentage,
+        };
 }


### PR DESCRIPTION
## Summary
- add shared helpers to resolve the appropriate discount base and convert between amounts and percentages
- reuse the new helpers across invoice watchers, offer application, and invoice hydration so return discounts stay consistent
- update return invoice handling to recompute the additional discount percentage from the stored amount

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68f65c1252cc83269bbd91b5bc0c6476