### PR TITLE
Fix POS additional discount calculations to respect net totals

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -345,6 +345,7 @@ import { useInvoiceStore } from "../../stores/invoiceStore.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
 import stockCoordinator from "../../utils/stockCoordinator.js";
+import { applyAdditionalDiscountFromDoc } from "../../composables/useDiscounts.js";
 
 export default {
 	name: "POSInvoice",
@@ -1468,8 +1469,7 @@ export default {
                         }
                         if (data.return_doc) {
                                 console.log("Return against existing invoice:", data.return_doc.name);
-                                this.discount_amount = data.return_doc.discount_amount || 0;
-                                this.additional_discount = data.return_doc.discount_amount || 0;
+                                applyAdditionalDiscountFromDoc(this, data.return_doc, { isReturn: true });
                                 this.return_doc = data.return_doc;
                                 this.invoice_doc.return_against = data.return_doc.name;
                         } else {

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -298,14 +298,15 @@
 			</div>
 		</v-card>
 		<!-- Payment Section -->
-		<InvoiceSummary
-			:pos_profile="pos_profile"
-			:total_qty="total_qty"
-			:additional_discount="additional_discount"
-			:additional_discount_percentage="additional_discount_percentage"
-			:total_items_discount_amount="total_items_discount_amount"
-			:subtotal="subtotal"
-			:displayCurrency="displayCurrency"
+                <InvoiceSummary
+                        :pos_profile="pos_profile"
+                        :total_qty="total_qty"
+                        :additional_discount="additional_discount"
+                        :additional_discount_percentage="additional_discount_percentage"
+                        :total_items_discount_amount="total_items_discount_amount"
+                        :subtotal="subtotal"
+                        :invoice_doc="invoice_doc"
+                        :displayCurrency="displayCurrency"
 			:formatFloat="formatFloat"
 			:formatCurrency="formatCurrency"
 			:currencySymbol="currencySymbol"
@@ -829,16 +830,20 @@ export default {
 			}
 			this.update_delivery_charges_rate();
 		},
-		update_delivery_charges_rate() {
-			if (this.base_delivery_charges_rate) {
-				this.delivery_charges_rate = this.flt(
-					this.base_delivery_charges_rate / (this.conversion_rate || 1),
-					this.currency_precision,
-				);
-			} else {
-				this.delivery_charges_rate = 0;
-			}
-		},
+                update_delivery_charges_rate() {
+                        if (this.base_delivery_charges_rate) {
+                                this.delivery_charges_rate = this.flt(
+                                        this.base_delivery_charges_rate / (this.conversion_rate || 1),
+                                        this.currency_precision,
+                                );
+                        } else {
+                                this.delivery_charges_rate = 0;
+                        }
+
+                        if (typeof this.syncInvoiceDocTotals === "function") {
+                                this.syncInvoiceDocTotals();
+                        }
+                },
 		updatePostingDate(date) {
 			if (!date) return;
 			this.posting_date = date;

--- a/frontend/src/posapp/components/pos/InvoiceSummary.vue
+++ b/frontend/src/posapp/components/pos/InvoiceSummary.vue
@@ -58,35 +58,65 @@
 						/>
 					</v-col>
 
-					<!-- Items Discount -->
-					<v-col cols="6">
-						<v-text-field
-							:model-value="formatCurrency(total_items_discount_amount)"
-							:prefix="currencySymbol(displayCurrency)"
-							:label="frappe._('Items Discounts')"
-							prepend-inner-icon="mdi-tag-minus"
-							variant="solo"
-							density="compact"
-							color="warning"
-							readonly
-							class="summary-field"
-						/>
-					</v-col>
+                                        <!-- Items Discount -->
+                                        <v-col cols="6">
+                                                <v-text-field
+                                                        :model-value="formatCurrency(total_items_discount_amount)"
+                                                        :prefix="currencySymbol(displayCurrency)"
+                                                        :label="frappe._('Items Discounts')"
+                                                        prepend-inner-icon="mdi-tag-minus"
+                                                        variant="solo"
+                                                        density="compact"
+                                                        color="warning"
+                                                        readonly
+                                                        class="summary-field"
+                                                />
+                                        </v-col>
 
-					<!-- Total (moved to maintain row alignment) -->
+                                        <!-- Net Total -->
+                                        <v-col cols="6">
+                                                <v-text-field
+                                                        :model-value="formatCurrency(resolvedNetTotal)"
+                                                        :prefix="currencySymbol(displayCurrency)"
+                                                        :label="frappe._('Net Total')"
+                                                        prepend-inner-icon="mdi-scale-balance"
+                                                        variant="solo"
+                                                        density="compact"
+                                                        readonly
+                                                        color="primary"
+                                                        class="summary-field"
+                                                />
+                                        </v-col>
+
+                                        <!-- Tax and Charges -->
+                                        <v-col cols="6">
+                                                <v-text-field
+                                                        :model-value="formatCurrency(resolvedTaxes)"
+                                                        :prefix="currencySymbol(displayCurrency)"
+                                                        :label="frappe._('Tax and Charges')"
+                                                        prepend-inner-icon="mdi-receipt"
+                                                        variant="solo"
+                                                        density="compact"
+                                                        readonly
+                                                        color="primary"
+                                                        class="summary-field"
+                                                />
+                                        </v-col>
+
+                                        <!-- Grand Total -->
                                         <v-col cols="6">
                                                 <v-text-field
                                                         :model-value="formatCurrency(resolvedSubtotal)"
-							:prefix="currencySymbol(displayCurrency)"
-							:label="frappe._('Total')"
-							prepend-inner-icon="mdi-cash"
-							variant="solo"
-							density="compact"
-							readonly
-							color="success"
-							class="summary-field"
-						/>
-					</v-col>
+                                                        :prefix="currencySymbol(displayCurrency)"
+                                                        :label="frappe._('Grand Total')"
+                                                        prepend-inner-icon="mdi-cash"
+                                                        variant="solo"
+                                                        density="compact"
+                                                        readonly
+                                                        color="success"
+                                                        class="summary-field"
+                                                />
+                                        </v-col>
 				</v-row>
 			</v-col>
 
@@ -260,45 +290,88 @@ export default {
                         }
                         return false;
                 },
-                resolvedSubtotal() {
-                        const parseNumber = (value) => {
-                                if (value === null || value === undefined || value === "") {
-                                        return null;
-                                }
-                                if (typeof value === "number") {
-                                        return Number.isFinite(value) ? value : null;
-                                }
-                                const parsed = Number.parseFloat(value);
-                                return Number.isFinite(parsed) ? parsed : null;
-                        };
-
+                resolvedNetTotal() {
                         const doc = this.invoice_doc || {};
                         const candidates = [
-                                parseNumber(doc.rounded_total),
-                                parseNumber(doc.grand_total),
-                                parseNumber(doc.total),
-                                parseNumber(this.subtotal),
+                                this.parseNumber(doc.net_total),
+                                this.parseNumber(doc.base_net_total),
+                                this.parseNumber(doc.total),
+                                this.parseNumber(doc.base_total),
+                                this.parseNumber(this.subtotal),
+                        ];
+                        let net = candidates.find((value) => value !== null && value !== undefined);
+                        if (net === undefined) {
+                                net = 0;
+                        }
+
+                        if (this.isReturnDocument(doc)) {
+                                net = Math.abs(net);
+                        }
+
+                        return net;
+                },
+                resolvedTaxes() {
+                        const doc = this.invoice_doc || {};
+                        const candidates = [
+                                this.parseNumber(doc.total_taxes_and_charges),
+                                this.parseNumber(doc.base_total_taxes_and_charges),
+                        ];
+                        let taxes = candidates.find((value) => value !== null && value !== undefined);
+                        if (taxes === undefined) {
+                                taxes = 0;
+                        }
+
+                        if (this.isReturnDocument(doc)) {
+                                taxes = Math.abs(taxes);
+                        }
+
+                        return taxes;
+                },
+                resolvedSubtotal() {
+                        const doc = this.invoice_doc || {};
+                        const candidates = [
+                                this.parseNumber(doc.rounded_total),
+                                this.parseNumber(doc.base_rounded_total),
+                                this.parseNumber(doc.grand_total),
+                                this.parseNumber(doc.base_grand_total),
+                                this.parseNumber(doc.total),
+                                this.parseNumber(this.subtotal),
                         ];
                         let total = candidates.find((value) => value !== null && value !== undefined);
                         if (total === undefined) {
                                 total = 0;
                         }
 
-                        const flag = doc && Object.prototype.hasOwnProperty.call(doc, "is_return") ? doc.is_return : null;
-                        const isReturn = typeof flag === "string" ? ["1", "true", "yes"].includes(flag.toLowerCase()) : Boolean(flag);
-
-                        if (isReturn) {
+                        if (this.isReturnDocument(doc)) {
                                 total = Math.abs(total);
                         }
 
                         return total;
                 },
         },
-	methods: {
-		// Debounced handlers for better performance
-		handleAdditionalDiscountUpdate(value) {
-			this.$emit("update:additional_discount", value);
-		},
+        methods: {
+                parseNumber(value) {
+                        if (value === null || value === undefined || value === "") {
+                                return null;
+                        }
+                        if (typeof value === "number") {
+                                return Number.isFinite(value) ? value : null;
+                        }
+                        const parsed = Number.parseFloat(value);
+                        return Number.isFinite(parsed) ? parsed : null;
+                },
+                isReturnDocument(doc = this.invoice_doc || {}) {
+                        const flag =
+                                doc && Object.prototype.hasOwnProperty.call(doc, "is_return") ? doc.is_return : null;
+                        if (typeof flag === "string") {
+                                return ["1", "true", "yes"].includes(flag.toLowerCase());
+                        }
+                        return Boolean(flag);
+                },
+                // Debounced handlers for better performance
+                handleAdditionalDiscountUpdate(value) {
+                        this.$emit("update:additional_discount", value);
+                },
 
 		handleAdditionalDiscountPercentageUpdate(value) {
 			this.$emit("update:additional_discount_percentage", value);

--- a/frontend/src/posapp/components/pos/InvoiceSummary.vue
+++ b/frontend/src/posapp/components/pos/InvoiceSummary.vue
@@ -74,9 +74,9 @@
 					</v-col>
 
 					<!-- Total (moved to maintain row alignment) -->
-					<v-col cols="6">
-						<v-text-field
-							:model-value="formatCurrency(subtotal)"
+                                        <v-col cols="6">
+                                                <v-text-field
+                                                        :model-value="formatCurrency(resolvedSubtotal)"
 							:prefix="currencySymbol(displayCurrency)"
 							:label="frappe._('Total')"
 							prepend-inner-icon="mdi-cash"
@@ -206,18 +206,19 @@
 
 <script>
 export default {
-	props: {
-		pos_profile: Object,
-		total_qty: [Number, String],
-		additional_discount: Number,
-		additional_discount_percentage: Number,
-		total_items_discount_amount: Number,
-		subtotal: Number,
-		displayCurrency: String,
-		formatFloat: Function,
-		formatCurrency: Function,
-		currencySymbol: Function,
-		discount_percentage_offer_name: [String, Number],
+        props: {
+                pos_profile: Object,
+                total_qty: [Number, String],
+                additional_discount: Number,
+                additional_discount_percentage: Number,
+                total_items_discount_amount: Number,
+                subtotal: Number,
+                invoice_doc: Object,
+                displayCurrency: String,
+                formatFloat: Function,
+                formatCurrency: Function,
+                currencySymbol: Function,
+                discount_percentage_offer_name: [String, Number],
 		isNumber: Function,
 	},
 	data() {
@@ -246,20 +247,53 @@ export default {
 		"apply-offers",
 		"show-payment",
 	],
-	computed: {
-		hide_qty_decimals() {
-			try {
-				const saved = localStorage.getItem("posawesome_item_selector_settings");
-				if (saved) {
-					const opts = JSON.parse(saved);
-					return !!opts.hide_qty_decimals;
-				}
-			} catch (e) {
-				console.error("Failed to load item selector settings:", e);
-			}
-			return false;
-		},
-	},
+        computed: {
+                hide_qty_decimals() {
+                        try {
+                                const saved = localStorage.getItem("posawesome_item_selector_settings");
+                                if (saved) {
+                                        const opts = JSON.parse(saved);
+                                        return !!opts.hide_qty_decimals;
+                                }
+                        } catch (e) {
+                                console.error("Failed to load item selector settings:", e);
+                        }
+                        return false;
+                },
+                resolvedSubtotal() {
+                        const parseNumber = (value) => {
+                                if (value === null || value === undefined || value === "") {
+                                        return null;
+                                }
+                                if (typeof value === "number") {
+                                        return Number.isFinite(value) ? value : null;
+                                }
+                                const parsed = Number.parseFloat(value);
+                                return Number.isFinite(parsed) ? parsed : null;
+                        };
+
+                        const doc = this.invoice_doc || {};
+                        const candidates = [
+                                parseNumber(doc.rounded_total),
+                                parseNumber(doc.grand_total),
+                                parseNumber(doc.total),
+                                parseNumber(this.subtotal),
+                        ];
+                        let total = candidates.find((value) => value !== null && value !== undefined);
+                        if (total === undefined) {
+                                total = 0;
+                        }
+
+                        const flag = doc && Object.prototype.hasOwnProperty.call(doc, "is_return") ? doc.is_return : null;
+                        const isReturn = typeof flag === "string" ? ["1", "true", "yes"].includes(flag.toLowerCase()) : Boolean(flag);
+
+                        if (isReturn) {
+                                total = Math.abs(total);
+                        }
+
+                        return total;
+                },
+        },
 	methods: {
 		// Debounced handlers for better performance
 		handleAdditionalDiscountUpdate(value) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1,13 +1,13 @@
 /* global __, frappe, flt */
 import {
-	isOffline,
-	saveCustomerBalance,
-	getCachedCustomerBalance,
-	getCachedPriceListItems,
-	getCustomerStorage,
-	getOfflineCustomers,
-	getTaxTemplate,
-	getTaxInclusiveSetting,
+        isOffline,
+        saveCustomerBalance,
+        getCachedCustomerBalance,
+        getCachedPriceListItems,
+        getCustomerStorage,
+        getOfflineCustomers,
+        getTaxTemplate,
+        getTaxInclusiveSetting,
 } from "../../../offline/index.js";
 
 // Import composables
@@ -19,6 +19,37 @@ import stockCoordinator from "../../utils/stockCoordinator.js";
 
 const ITEM_DETAIL_CACHE_TTL = 5000;
 const STOCK_CACHE_TTL = 5000;
+
+const truthyFlag = (value) => {
+        if (typeof value === "boolean") {
+                return value;
+        }
+        if (typeof value === "number") {
+                return value !== 0;
+        }
+        if (typeof value === "string") {
+                const normalized = value.trim().toLowerCase();
+                if (!normalized.length) {
+                        return false;
+                }
+                return !["0", "false", "no", "off"].includes(normalized);
+        }
+        return Boolean(value);
+};
+
+const toNumber = (value) => {
+        if (value === null || value === undefined || value === "") {
+                return 0;
+        }
+        if (typeof value === "number") {
+                return Number.isFinite(value) ? value : 0;
+        }
+        if (typeof value === "string") {
+                const parsed = Number.parseFloat(value);
+                return Number.isFinite(parsed) ? parsed : 0;
+        }
+        return 0;
+};
 
 const { setSerialNo, setBatchQty } = useBatchSerial();
 const { updateDiscountAmount, calcPrices, calcItemPrice } = useDiscounts();
@@ -180,12 +211,156 @@ export default {
 		}
 		this.item_stock_cache[key] = { ts: Date.now(), qty };
 	},
-	clearItemStockCache() {
-		this.item_stock_cache = {};
-	},
-	remove_item(item) {
-		return removeItem(item, this);
-	},
+        clearItemStockCache() {
+                this.item_stock_cache = {};
+        },
+
+        resolveInvoiceTaxesTemplate() {
+                const doc = this.invoice_doc;
+                if (doc && Array.isArray(doc.taxes) && doc.taxes.length) {
+                        return {
+                                rows: doc.taxes.map((tax) => ({ ...tax })),
+                                inclusiveFallback: null,
+                        };
+                }
+
+                if (isOffline()) {
+                        const template = getTaxTemplate(this.pos_profile?.taxes_and_charges);
+                        if (template && Array.isArray(template.taxes) && template.taxes.length) {
+                                return {
+                                        rows: template.taxes.map((tax) => ({ ...tax })),
+                                        inclusiveFallback: truthyFlag(getTaxInclusiveSetting()),
+                                };
+                        }
+                }
+
+                return { rows: [], inclusiveFallback: null };
+        },
+
+        computeInvoiceTaxSnapshot({
+                baseNet = 0,
+                subtotalBeforeTaxes = 0,
+                templateRows = [],
+                inclusiveFallback = null,
+        } = {}) {
+                const precision = Number.isInteger(this.currency_precision) ? this.currency_precision : 2;
+                const exchangeRate = this.exchange_rate || 1;
+                const doc = this.invoice_doc || {};
+                const baseNetAbs = Math.max(toNumber(baseNet), 0);
+                const subtotalAbs = Math.max(toNumber(subtotalBeforeTaxes), 0);
+
+                if (!Array.isArray(templateRows) || !templateRows.length) {
+                        const netTotal = flt(baseNetAbs, precision);
+                        const grandTotal = flt(subtotalAbs, precision);
+                        return {
+                                rows: [],
+                                totalTaxes: 0,
+                                inclusiveTaxes: 0,
+                                netTotal,
+                                grandTotal,
+                        };
+                }
+
+                const originalNet = Math.abs(
+                        toNumber(doc.net_total || doc.base_net_total || doc.total || doc.base_total || baseNetAbs),
+                );
+                const ratio = originalNet ? baseNetAbs / originalNet : null;
+
+                let runningTotal = subtotalAbs;
+                let totalTaxes = 0;
+                let inclusiveTaxes = 0;
+                let inclusiveBase = baseNetAbs;
+                const computedRows = [];
+
+                templateRows.forEach((templateRow, index) => {
+                        if (!templateRow) {
+                                return;
+                        }
+
+                        const chargeType = templateRow.charge_type || "On Net Total";
+                        const rateValue = Number.parseFloat(templateRow.rate);
+                        const rate = Number.isFinite(rateValue) ? rateValue : null;
+                        const originalAmount = Math.abs(toNumber(templateRow.tax_amount));
+                        const previous = computedRows[index - 1] || null;
+
+                        const included =
+                                chargeType === "Actual"
+                                        ? false
+                                        : templateRow.hasOwnProperty("included_in_print_rate")
+                                                ? truthyFlag(templateRow.included_in_print_rate)
+                                                : truthyFlag(inclusiveFallback);
+
+                        let taxAmount = 0;
+
+                        if (chargeType === "Actual") {
+                                taxAmount = originalAmount;
+                        } else if (included && rate !== null) {
+                                const baseForInclusive = Math.max(inclusiveBase, 0);
+                                taxAmount = (baseForInclusive * rate) / (100 + rate);
+                        } else if (chargeType === "On Net Total" && rate !== null) {
+                                taxAmount = (baseNetAbs * rate) / 100;
+                        } else if (chargeType === "On Previous Row Amount" && rate !== null) {
+                                const baseAmount = previous ? previous.tax_amount : originalAmount;
+                                taxAmount = (baseAmount * rate) / 100;
+                        } else if (chargeType === "On Previous Row Total" && rate !== null) {
+                                const baseAmount = previous ? previous.total_after_tax : runningTotal;
+                                taxAmount = (baseAmount * rate) / 100;
+                        } else if (rate !== null) {
+                                taxAmount = (baseNetAbs * rate) / 100;
+                        } else if (ratio !== null && originalAmount) {
+                                taxAmount = originalAmount * ratio;
+                        } else {
+                                taxAmount = originalAmount;
+                        }
+
+                        if (!Number.isFinite(taxAmount)) {
+                                taxAmount = 0;
+                        }
+
+                        const roundedAmount = flt(taxAmount, precision);
+                        const totalAfterTax = included ? runningTotal : flt(runningTotal + roundedAmount, precision);
+
+                        computedRows.push({
+                                template: templateRow,
+                                tax_amount: roundedAmount,
+                                total_after_tax: totalAfterTax,
+                                included,
+                        });
+
+                        runningTotal = totalAfterTax;
+                        totalTaxes += roundedAmount;
+                        if (included) {
+                                inclusiveTaxes += roundedAmount;
+                                inclusiveBase = Math.max(inclusiveBase - roundedAmount, 0);
+                        }
+                });
+
+                const rows = computedRows.map(({ template, tax_amount, total_after_tax, included }) => {
+                        const clone = { ...template };
+                        clone.charge_type = template.charge_type || "On Net Total";
+                        clone.included_in_print_rate = included ? 1 : 0;
+                        clone.tax_amount = flt(tax_amount, precision);
+                        clone.total = flt(total_after_tax, precision);
+                        clone.base_tax_amount = flt(clone.tax_amount * exchangeRate, precision);
+                        clone.base_total = flt(clone.total * exchangeRate, precision);
+                        return clone;
+                });
+
+                const netTotal = flt(Math.max(baseNetAbs - inclusiveTaxes, 0), precision);
+                const grandTotal = flt(Math.max(runningTotal, 0), precision);
+
+                return {
+                        rows,
+                        totalTaxes: flt(totalTaxes, precision),
+                        inclusiveTaxes: flt(inclusiveTaxes, precision),
+                        netTotal,
+                        grandTotal,
+                };
+        },
+
+        remove_item(item) {
+                return removeItem(item, this);
+        },
 
 	async add_item(item, options = {}) {
 		const res = await addItem(item, this);
@@ -590,10 +765,8 @@ export default {
 		let total = this.Total;
 		if (isReturn && total > 0) total = -Math.abs(total);
 
-		doc.total = total;
-		doc.net_total = total; // Will adjust later if taxes are inclusive
-		doc.base_total = total * (this.exchange_rate || 1);
-		doc.base_net_total = total * (this.exchange_rate || 1);
+                doc.total = total;
+                doc.base_total = total * (this.exchange_rate || 1);
 
 		// Apply discounts with correct sign for returns
 		let discountAmount = flt(this.additional_discount);
@@ -607,77 +780,51 @@ export default {
 
 		doc.additional_discount_percentage = discountPercentage;
 
-		// Calculate grand total with correct sign for returns
-		let grandTotal = this.subtotal;
+                // Prepare taxes array using current cart values
+                const discountAbs = Math.abs(discountAmount);
+                const totalAbs = Math.abs(this.Total);
+                const baseNetAbs = Math.max(totalAbs - discountAbs, 0);
+                const subtotalBeforeTaxesAbs = Math.max(Math.abs(this.subtotal), 0);
+                const taxTemplateSource = this.resolveInvoiceTaxesTemplate();
+                const taxSnapshot = this.computeInvoiceTaxSnapshot({
+                        baseNet: baseNetAbs,
+                        subtotalBeforeTaxes: subtotalBeforeTaxesAbs,
+                        templateRows: taxTemplateSource.rows,
+                        inclusiveFallback: taxTemplateSource.inclusiveFallback,
+                });
 
-		// Prepare taxes array
-		doc.taxes = [];
-		if (this.invoice_doc && this.invoice_doc.taxes) {
-			let totalTax = 0;
-			this.invoice_doc.taxes.forEach((tax) => {
-				if (tax.tax_amount) {
-					grandTotal += flt(tax.tax_amount);
-					totalTax += flt(tax.tax_amount);
-				}
-				doc.taxes.push({
-					account_head: tax.account_head,
-					charge_type: tax.charge_type || "On Net Total",
-					description: tax.description,
-					rate: tax.rate,
-					included_in_print_rate: tax.included_in_print_rate || 0,
-					tax_amount: tax.tax_amount,
-					total: tax.total,
-					base_tax_amount: tax.tax_amount * (this.exchange_rate || 1),
-					base_total: tax.total * (this.exchange_rate || 1),
-				});
-			});
-			doc.total_taxes_and_charges = totalTax;
-		} else if (isOffline()) {
-			const tmpl = getTaxTemplate(this.pos_profile.taxes_and_charges);
-			if (tmpl && Array.isArray(tmpl.taxes)) {
-				const inclusive = getTaxInclusiveSetting();
-				let runningTotal = grandTotal;
-				let totalTax = 0;
-				tmpl.taxes.forEach((row) => {
-					let tax_amount = 0;
-					if (row.charge_type === "Actual") {
-						tax_amount = flt(row.tax_amount || 0);
-					} else if (inclusive) {
-						tax_amount = flt((doc.total * flt(row.rate)) / 100);
-					} else {
-						tax_amount = flt((doc.net_total * flt(row.rate)) / 100);
-					}
-					if (!inclusive) {
-						runningTotal += tax_amount;
-					}
-					totalTax += tax_amount;
-					doc.taxes.push({
-						account_head: row.account_head,
-						charge_type: row.charge_type || "On Net Total",
-						description: row.description,
-						rate: row.rate,
-						included_in_print_rate: row.charge_type === "Actual" ? 0 : inclusive ? 1 : 0,
-						tax_amount: tax_amount,
-						total: runningTotal,
-						base_tax_amount: tax_amount * (this.exchange_rate || 1),
-						base_total: runningTotal * (this.exchange_rate || 1),
-					});
-				});
-				if (inclusive) {
-					doc.net_total = doc.total - totalTax;
-					doc.base_net_total = doc.net_total * (this.exchange_rate || 1);
-					grandTotal = doc.total;
-				} else {
-					grandTotal = runningTotal;
-				}
-				doc.total_taxes_and_charges = totalTax;
-			}
-		}
+                const signMultiplier = isReturn ? -1 : 1;
 
-		if (isReturn && grandTotal > 0) grandTotal = -Math.abs(grandTotal);
+                doc.taxes = taxSnapshot.rows.map((row) => {
+                        const normalized = { ...row };
+                        normalized.tax_amount = normalized.tax_amount * signMultiplier;
+                        normalized.base_tax_amount = normalized.base_tax_amount * signMultiplier;
+                        normalized.total = normalized.total * signMultiplier;
+                        normalized.base_total = normalized.base_total * signMultiplier;
+                        return normalized;
+                });
 
-		doc.grand_total = grandTotal;
-		doc.base_grand_total = grandTotal * (this.exchange_rate || 1);
+                const totalTaxesSigned = taxSnapshot.totalTaxes * signMultiplier;
+                doc.total_taxes_and_charges = totalTaxesSigned;
+                doc.base_total_taxes_and_charges = flt(
+                        totalTaxesSigned * (this.exchange_rate || 1),
+                        this.currency_precision,
+                );
+
+                const netTotalSigned = taxSnapshot.netTotal * signMultiplier;
+                doc.net_total = netTotalSigned;
+                doc.base_net_total = flt(netTotalSigned * (this.exchange_rate || 1), this.currency_precision);
+
+                let grandTotalAbs = taxSnapshot.grandTotal;
+                if (!Number.isFinite(grandTotalAbs)) {
+                        grandTotalAbs = subtotalBeforeTaxesAbs;
+                }
+                let grandTotal = grandTotalAbs * signMultiplier;
+
+                if (isReturn && grandTotal > 0) grandTotal = -Math.abs(grandTotal);
+
+                doc.grand_total = grandTotal;
+                doc.base_grand_total = grandTotal * (this.exchange_rate || 1);
 
 		// Apply rounding to get rounded total unless disabled in POS Profile
 		if (this.pos_profile.disable_rounded_total) {
@@ -816,6 +963,7 @@ export default {
                 assignIfDefined(patch, "base_discount_amount", snapshot.base_discount_amount);
                 assignIfDefined(patch, "additional_discount_percentage", snapshot.additional_discount_percentage);
                 assignIfDefined(patch, "total_taxes_and_charges", snapshot.total_taxes_and_charges);
+                assignIfDefined(patch, "base_total_taxes_and_charges", snapshot.base_total_taxes_and_charges);
                 assignIfDefined(patch, "grand_total", snapshot.grand_total);
                 assignIfDefined(patch, "base_grand_total", snapshot.base_grand_total);
                 assignIfDefined(patch, "rounded_total", snapshot.rounded_total);

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -12,7 +12,7 @@ import {
 
 // Import composables
 import { useBatchSerial } from "../../composables/useBatchSerial.js";
-import { useDiscounts } from "../../composables/useDiscounts.js";
+import { useDiscounts, applyAdditionalDiscountFromDoc } from "../../composables/useDiscounts.js";
 import { useItemAddition } from "../../composables/useItemAddition.js";
 import { useStockUtils } from "../../composables/useStockUtils.js";
 import stockCoordinator from "../../utils/stockCoordinator.js";
@@ -393,9 +393,7 @@ export default {
 
 		this.customer = data.customer;
 		this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
-		this.discount_amount = data.discount_amount;
-		this.additional_discount_percentage = data.additional_discount_percentage;
-		this.additional_discount = data.discount_amount;
+                applyAdditionalDiscountFromDoc(this, data);
 
 		if (this.items.length > 0) {
 			this.items.forEach((item) => {
@@ -502,8 +500,7 @@ export default {
 			});
 			this.customer = data.customer;
 			this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
-			this.discount_amount = data.discount_amount;
-			this.additional_discount_percentage = data.additional_discount_percentage;
+                        applyAdditionalDiscountFromDoc(this, data);
 			this.items.forEach((item) => {
 				if (item.serial_no) {
 					item.serial_no_selected = [];

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -226,9 +226,13 @@ export default {
 	},
 
 	// Reset all invoice fields to default/empty values
-	clear_invoice() {
-		return clearInvoice(this);
-	},
+        clear_invoice() {
+                const result = clearInvoice(this);
+                if (typeof this.syncInvoiceDocTotals === "function") {
+                        this.syncInvoiceDocTotals();
+                }
+                return result;
+        },
 
 	// Fetch customer balance from backend or cache
 	async fetch_customer_balance() {
@@ -416,13 +420,17 @@ export default {
 			this.eventBus.emit("set_pos_coupons", data.posa_coupons);
 		}
 
-		console.log("load_invoice completed, invoice state:", {
-			invoiceType: this.invoiceType,
-			is_return: this.invoice_doc.is_return,
-			items: this.items.length,
-			customer: this.customer,
-		});
-	},
+                console.log("load_invoice completed, invoice state:", {
+                        invoiceType: this.invoiceType,
+                        is_return: this.invoice_doc.is_return,
+                        items: this.items.length,
+                        customer: this.customer,
+                });
+
+                if (typeof this.syncInvoiceDocTotals === "function") {
+                        this.syncInvoiceDocTotals();
+                }
+        },
 
 	// Save and clear the current invoice (draft logic)
 	async save_and_clear_invoice() {
@@ -769,8 +777,70 @@ export default {
 			});
 		}
 
-		return doc;
-	},
+                return doc;
+        },
+
+        syncInvoiceDocTotals(options = {}) {
+                if (!this.invoiceStore || typeof this.invoiceStore.mergeInvoiceDoc !== "function") {
+                        return null;
+                }
+
+                let snapshot;
+                try {
+                        snapshot = this.get_invoice_doc();
+                } catch (error) {
+                        console.error("Failed to build invoice snapshot while syncing totals", error);
+                        return null;
+                }
+
+                const assignIfDefined = (target, key, value, includeNull = true) => {
+                        if (value === undefined) {
+                                return;
+                        }
+                        if (value === null && !includeNull) {
+                                return;
+                        }
+                        target[key] = value;
+                };
+
+                const patch = {};
+
+                assignIfDefined(patch, "currency", snapshot.currency, false);
+                assignIfDefined(patch, "conversion_rate", snapshot.conversion_rate, false);
+                assignIfDefined(patch, "plc_conversion_rate", snapshot.plc_conversion_rate, false);
+                assignIfDefined(patch, "total", snapshot.total);
+                assignIfDefined(patch, "base_total", snapshot.base_total);
+                assignIfDefined(patch, "net_total", snapshot.net_total);
+                assignIfDefined(patch, "base_net_total", snapshot.base_net_total);
+                assignIfDefined(patch, "discount_amount", snapshot.discount_amount);
+                assignIfDefined(patch, "base_discount_amount", snapshot.base_discount_amount);
+                assignIfDefined(patch, "additional_discount_percentage", snapshot.additional_discount_percentage);
+                assignIfDefined(patch, "total_taxes_and_charges", snapshot.total_taxes_and_charges);
+                assignIfDefined(patch, "grand_total", snapshot.grand_total);
+                assignIfDefined(patch, "base_grand_total", snapshot.base_grand_total);
+                assignIfDefined(patch, "rounded_total", snapshot.rounded_total);
+                assignIfDefined(patch, "base_rounded_total", snapshot.base_rounded_total);
+                assignIfDefined(patch, "posa_delivery_charges_rate", snapshot.posa_delivery_charges_rate);
+                assignIfDefined(patch, "posa_delivery_charges", snapshot.posa_delivery_charges);
+                assignIfDefined(patch, "is_return", snapshot.is_return);
+
+                if (Array.isArray(snapshot.taxes)) {
+                        patch.taxes = snapshot.taxes.map((tax) => ({ ...tax }));
+                }
+
+                if (options && typeof options.mergeExtras === "object") {
+                        Object.assign(patch, options.mergeExtras);
+                }
+
+                try {
+                        this.invoiceStore.mergeInvoiceDoc(patch);
+                } catch (error) {
+                        console.error("Failed to merge invoice totals into store", error, { patch });
+                        return null;
+                }
+
+                return patch;
+        },
 
 	// Get invoice doc from order doc (for sales order to invoice conversion)
 	async get_invoice_from_order_doc() {
@@ -2610,9 +2680,13 @@ export default {
 		}
 	},
 	// Update additional discount amount based on percentage
-	update_discount_umount() {
-		return updateDiscountAmount(this);
-	},
+        update_discount_umount() {
+                const result = updateDiscountAmount(this);
+                if (typeof this.syncInvoiceDocTotals === "function") {
+                        this.syncInvoiceDocTotals();
+                }
+                return result;
+        },
 
 	// Calculate prices and discounts for an item based on field change
 	calc_prices(item, value, $event) {

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -1,6 +1,7 @@
 import { clearPriceListCache } from "../../../offline/index.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
-/* global frappe */
+import { resolveAdditionalDiscountBase } from "../../composables/useDiscounts.js";
+/* global frappe, flt */
 
 const buildSnapshot = (items) => {
 	const snapshot = {
@@ -179,20 +180,36 @@ export default {
 		this.eventBus.emit("update_invoice_type", this.invoiceType);
 	},
 	// Watch for additional discount and update percentage accordingly
-	additional_discount() {
-		if (!this.additional_discount || this.additional_discount == 0) {
-			this.additional_discount_percentage = 0;
-		} else if (this.pos_profile.posa_use_percentage_discount) {
-			// Prevent division by zero which causes NaN
-			if (this.Total && this.Total !== 0) {
-				this.additional_discount_percentage = (this.additional_discount / this.Total) * 100;
-			} else {
-				this.additional_discount_percentage = 0;
-			}
-		} else {
-			this.additional_discount_percentage = 0;
-		}
-	},
+        additional_discount() {
+                const normalize = (value, precision) => {
+                        if (typeof this.flt === "function") {
+                                return precision !== undefined ? this.flt(value, precision) : this.flt(value);
+                        }
+                        if (typeof flt === "function") {
+                                return precision !== undefined ? flt(value, precision) : flt(value);
+                        }
+                        const parsed = parseFloat(value);
+                        return Number.isFinite(parsed) ? parsed : 0;
+                };
+
+                const amount = normalize(this.additional_discount, this.currency_precision);
+                if (!amount) {
+                        this.additional_discount_percentage = 0;
+                        return;
+                }
+
+                if (this.pos_profile.posa_use_percentage_discount) {
+                        const base = resolveAdditionalDiscountBase(this);
+                        if (Number.isFinite(base) && base !== 0) {
+                                const percentage = (amount / base) * 100;
+                                this.additional_discount_percentage = normalize(percentage, this.float_precision);
+                        } else {
+                                this.additional_discount_percentage = 0;
+                        }
+                } else {
+                        this.additional_discount_percentage = 0;
+                }
+        },
 	// Keep display date in sync with posting_date
 	posting_date: {
 		handler(newVal) {

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -143,6 +143,10 @@ export default {
                         if (typeof this.emitCartQuantities === "function") {
                                 this.emitCartQuantities();
                         }
+
+                        if (typeof this.syncInvoiceDocTotals === "function") {
+                                this.syncInvoiceDocTotals();
+                        }
                 },
         },
         packed_items: {
@@ -195,6 +199,9 @@ export default {
                 const amount = normalize(this.additional_discount, this.currency_precision);
                 if (!amount) {
                         this.additional_discount_percentage = 0;
+                        if (typeof this.syncInvoiceDocTotals === "function") {
+                                this.syncInvoiceDocTotals();
+                        }
                         return;
                 }
 
@@ -209,9 +216,18 @@ export default {
                 } else {
                         this.additional_discount_percentage = 0;
                 }
+
+                if (typeof this.syncInvoiceDocTotals === "function") {
+                        this.syncInvoiceDocTotals();
+                }
         },
-	// Keep display date in sync with posting_date
-	posting_date: {
+        delivery_charges_rate() {
+                if (typeof this.syncInvoiceDocTotals === "function") {
+                        this.syncInvoiceDocTotals();
+                }
+        },
+        // Keep display date in sync with posting_date
+        posting_date: {
 		handler(newVal) {
 			this.posting_date_display = this.formatDateForDisplay(newVal);
 		},

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -1,23 +1,255 @@
 /* global __, flt */
 
-export function useDiscounts() {
-	// Update additional discount amount based on percentage
-	const updateDiscountAmount = (context) => {
-		const value = flt(context.additional_discount_percentage);
-		// If value is too large, reset to 0
-		if (value < -100 || value > 100) {
-			context.additional_discount_percentage = 0;
-			context.additional_discount = 0;
-			return;
-		}
+const truthyFlag = (value) => {
+        if (typeof value === "boolean") {
+                return value;
+        }
+        if (typeof value === "number") {
+                return value !== 0;
+        }
+        if (typeof value === "string") {
+                const normalized = value.trim().toLowerCase();
+                if (!normalized.length) {
+                        return false;
+                }
+                return !["0", "false", "no"].includes(normalized);
+        }
+        return Boolean(value);
+};
 
-		// Calculate discount amount based on percentage
-		if (context.Total && context.Total !== 0) {
-			context.additional_discount = (context.Total * value) / 100;
-		} else {
-			context.additional_discount = 0;
-		}
-	};
+const readMaybeFunction = (value) => {
+        if (typeof value === "function") {
+                try {
+                        return value();
+                } catch (error) {
+                        console.warn("Failed to evaluate function-based value while resolving discounts", error);
+                        return undefined;
+                }
+        }
+        return value;
+};
+
+const resolveFlt = (context) => {
+        if (context && typeof context.flt === "function") {
+                return context.flt.bind(context);
+        }
+        if (typeof flt === "function") {
+                return flt;
+        }
+        return (value) => {
+                const parsed = parseFloat(value);
+                return Number.isFinite(parsed) ? parsed : 0;
+        };
+};
+
+const toNumber = (context, value) => {
+        if (value === null || value === undefined || value === "") {
+                return null;
+        }
+        if (typeof value === "number") {
+                return Number.isFinite(value) ? value : null;
+        }
+        if (typeof value === "string") {
+                const fltFn = resolveFlt(context);
+                const parsed = fltFn(value);
+                return Number.isFinite(parsed) ? parsed : null;
+        }
+        return null;
+};
+
+const adjustReturnSign = (value, isReturn) => {
+        if (!Number.isFinite(value) || value === 0) {
+                return value;
+        }
+        if (isReturn && value > 0) {
+                return -value;
+        }
+        return value;
+};
+
+const resolveIsReturn = (context, overrides, doc) => {
+        if (overrides && Object.prototype.hasOwnProperty.call(overrides, "isReturn")) {
+                return Boolean(overrides.isReturn);
+        }
+        if (doc && Object.prototype.hasOwnProperty.call(doc, "is_return")) {
+                return truthyFlag(doc.is_return);
+        }
+        if (context && context.invoice_doc && Object.prototype.hasOwnProperty.call(context.invoice_doc, "is_return")) {
+                return truthyFlag(context.invoice_doc.is_return);
+        }
+        if (context && typeof context.isReturnInvoice === "boolean") {
+                return context.isReturnInvoice;
+        }
+        if (context && typeof context.isReturnInvoice === "function") {
+                try {
+                        return Boolean(context.isReturnInvoice());
+                } catch (error) {
+                        console.warn("Failed to evaluate isReturnInvoice while resolving discounts", error);
+                }
+        }
+        if (context && context.invoiceType === "Return") {
+                return true;
+        }
+        return false;
+};
+
+export function resolveAdditionalDiscountBase(context, overrides = {}) {
+        if (!context) {
+                return 0;
+        }
+
+        const doc = overrides.invoiceDoc ?? context.invoice_doc ?? null;
+        const isReturn = resolveIsReturn(context, overrides, doc);
+
+        const candidateNetSources = [];
+
+        if (Object.prototype.hasOwnProperty.call(overrides, "netTotal")) {
+                candidateNetSources.push(toNumber(context, overrides.netTotal));
+        }
+
+        if (doc && Object.prototype.hasOwnProperty.call(doc, "net_total")) {
+                candidateNetSources.push(toNumber(context, doc.net_total));
+        }
+
+        if (context && Object.prototype.hasOwnProperty.call(context, "net_total")) {
+                candidateNetSources.push(toNumber(context, context.net_total));
+        }
+
+        const netCandidate = candidateNetSources.find((val) => val !== null && val !== undefined);
+        if (netCandidate !== undefined) {
+                return adjustReturnSign(netCandidate, isReturn);
+        }
+
+        const grossCandidates = [];
+
+        if (Object.prototype.hasOwnProperty.call(overrides, "total")) {
+                grossCandidates.push(toNumber(context, readMaybeFunction(overrides.total)));
+        }
+
+        if (doc && Object.prototype.hasOwnProperty.call(doc, "total")) {
+                grossCandidates.push(toNumber(context, doc.total));
+        }
+
+        if (doc && Object.prototype.hasOwnProperty.call(doc, "grand_total")) {
+                grossCandidates.push(toNumber(context, doc.grand_total));
+        }
+
+        const contextTotal = readMaybeFunction(context?.Total);
+        if (contextTotal !== undefined) {
+                grossCandidates.push(toNumber(context, contextTotal));
+        }
+
+        if (context && Object.prototype.hasOwnProperty.call(context, "subtotal")) {
+                grossCandidates.push(toNumber(context, readMaybeFunction(context.subtotal)));
+        }
+
+        let gross = grossCandidates.find((val) => val !== null && val !== undefined);
+        if (gross === undefined) {
+                gross = 0;
+        }
+
+        const taxesSource =
+                overrides.taxes ??
+                (doc && Array.isArray(doc.taxes) ? doc.taxes : undefined) ??
+                (Array.isArray(context?.taxes) ? context.taxes : undefined);
+
+        if (Array.isArray(taxesSource) && taxesSource.length && Number.isFinite(gross) && gross !== 0) {
+                let inclusiveTaxTotal = 0;
+                taxesSource.forEach((tax) => {
+                        if (!tax) {
+                                return;
+                        }
+                        if (!truthyFlag(tax.included_in_print_rate)) {
+                                return;
+                        }
+                        const taxAmount = toNumber(context, tax.tax_amount);
+                        if (taxAmount !== null && taxAmount !== undefined) {
+                                inclusiveTaxTotal += taxAmount;
+                        }
+                });
+
+                if (inclusiveTaxTotal) {
+                        const netFromTaxes = gross - inclusiveTaxTotal;
+                        if (Number.isFinite(netFromTaxes)) {
+                                return adjustReturnSign(netFromTaxes, isReturn);
+                        }
+                }
+        }
+
+        return adjustReturnSign(Number.isFinite(gross) ? gross : 0, isReturn);
+}
+
+export function applyAdditionalDiscountFromDoc(target, doc, overrides = {}) {
+        if (!target || !doc) {
+                        return;
+        }
+
+        const fltFn = resolveFlt(target);
+        const currencyPrecision = overrides.currencyPrecision ?? target?.currency_precision;
+        const percentPrecision = overrides.percentPrecision ?? target?.float_precision;
+
+        const overrideContext = { ...overrides, invoiceDoc: doc };
+        if (!Object.prototype.hasOwnProperty.call(overrideContext, "total")) {
+                overrideContext.total = doc.total ?? doc.grand_total ?? overrideContext.total;
+        }
+        if (!Object.prototype.hasOwnProperty.call(overrideContext, "netTotal") && Object.prototype.hasOwnProperty.call(doc, "net_total")) {
+                overrideContext.netTotal = doc.net_total;
+        }
+        if (!Object.prototype.hasOwnProperty.call(overrideContext, "taxes") && Array.isArray(doc.taxes)) {
+                overrideContext.taxes = doc.taxes;
+        }
+
+        let amount = toNumber(target, doc.discount_amount ?? doc.additional_discount ?? 0);
+        if (amount === null || amount === undefined) {
+                amount = 0;
+        }
+        amount = currencyPrecision !== undefined ? fltFn(amount, currencyPrecision) : fltFn(amount);
+
+        const base = resolveAdditionalDiscountBase(target, overrideContext);
+
+        let percentage = toNumber(target, doc.additional_discount_percentage);
+        if ((percentage === null || percentage === undefined) && Number.isFinite(base) && base !== 0 && amount) {
+                percentage = (amount / base) * 100;
+        }
+        if (percentage === null || percentage === undefined) {
+                percentage = 0;
+        }
+        percentage = percentPrecision !== undefined ? fltFn(percentage, percentPrecision) : fltFn(percentage);
+
+        if (Number.isFinite(base) && base !== 0) {
+                const recomputedAmount = (base * percentage) / 100;
+                amount = currencyPrecision !== undefined ? fltFn(recomputedAmount, currencyPrecision) : fltFn(recomputedAmount);
+        }
+
+        target.additional_discount = amount;
+        if (Object.prototype.hasOwnProperty.call(target, "discount_amount")) {
+                target.discount_amount = amount;
+        }
+        target.additional_discount_percentage = percentage;
+}
+
+export function useDiscounts() {
+        // Update additional discount amount based on percentage
+        const updateDiscountAmount = (context) => {
+                const fltFn = resolveFlt(context);
+                const value = fltFn(context.additional_discount_percentage);
+                // If value is too large, reset to 0
+                if (value < -100 || value > 100) {
+                        context.additional_discount_percentage = 0;
+                        context.additional_discount = 0;
+                        return;
+                }
+
+                const base = resolveAdditionalDiscountBase(context);
+                if (!Number.isFinite(base) || base === 0) {
+                        context.additional_discount = 0;
+                        return;
+                }
+
+                const amount = (base * value) / 100;
+                const precision = context?.currency_precision;
+                context.additional_discount = precision !== undefined ? fltFn(amount, precision) : fltFn(amount);
+        };
 
 	// Calculate prices and discounts for an item based on field change
 	const calcPrices = (item, value, $event, context) => {


### PR DESCRIPTION
## Summary
- add reusable helpers that resolve the correct additional discount base and sync discount fields from documents
- update discount recalculation paths to use the net-based helper, including invoice watchers and return invoice hydration
- keep return invoices aligned with their source documents by reusing the helper when loading saved returns

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f65c1252cc83269bbd91b5bc0c6476