### PR TITLE
Avoid flashing server connecting indicator during healthy checks

### DIFF
--- a/frontend/src/posapp/composables/useNetwork.js
+++ b/frontend/src/posapp/composables/useNetwork.js
@@ -44,22 +44,27 @@ export function manualNetworkRetry(vm) {
 
 // Enhanced periodic check with exponential backoff
 function scheduleNextCheck(vm) {
-	setTimeout(async () => {
-		if (isManualOffline()) {
-			vm.serverConnecting = false;
-			vm.networkOnline = false;
-			vm.serverOnline = false;
-			window.serverOnline = false;
-			persistStatus(false, false);
-			vm.$forceUpdate();
-			scheduleNextCheck(vm);
-			return;
-		}
-		vm.serverConnecting = true;
-		vm.$forceUpdate();
-		await vm.checkNetworkConnectivity();
-		vm.serverConnecting = false;
-		vm.$forceUpdate();
+        setTimeout(async () => {
+                if (isManualOffline()) {
+                        vm.serverConnecting = false;
+                        vm.networkOnline = false;
+                        vm.serverOnline = false;
+                        window.serverOnline = false;
+                        persistStatus(false, false);
+                        vm.$forceUpdate();
+                        scheduleNextCheck(vm);
+                        return;
+                }
+                const shouldShowConnecting = !vm.serverOnline || !vm.networkOnline;
+                if (shouldShowConnecting) {
+                        vm.serverConnecting = true;
+                        vm.$forceUpdate();
+                }
+                await vm.checkNetworkConnectivity();
+                if (shouldShowConnecting) {
+                        vm.serverConnecting = false;
+                        vm.$forceUpdate();
+                }
 		// If failed, increase interval (up to max)
 		if (!vm.serverOnline) {
 			checkInterval = Math.min(checkInterval * 2, MAX_INTERVAL);


### PR DESCRIPTION
## Summary
- avoid toggling the server connecting indicator during routine health checks
- only show the connecting state when the network or server is actually offline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f72cccef108326bf5c9e79521803ea