### PR TITLE
Align shift dialog action buttons

### DIFF
--- a/frontend/src/posapp/components/pos/ClosingDialog.vue
+++ b/frontend/src/posapp/components/pos/ClosingDialog.vue
@@ -80,29 +80,29 @@
 				</v-card-text>
 
 				<v-divider></v-divider>
-				<v-card-actions class="dialog-actions-container">
-					<v-btn
-						theme="dark"
-						@click="submit_dialog"
-						class="pos-action-btn submit-action-btn"
-						size="large"
-						elevation="2"
-					>
-						<v-icon start>mdi-check-circle-outline</v-icon>
-						<span>{{ __("Submit") }}</span>
-					</v-btn>
-					<v-spacer></v-spacer>
-					<v-btn
-						theme="dark"
-						@click="close_dialog"
-						class="pos-action-btn cancel-action-btn"
-						size="large"
-						elevation="2"
-					>
-						<v-icon start>mdi-close-circle-outline</v-icon>
-						<span>{{ __("Close") }}</span>
-					</v-btn>
-				</v-card-actions>
+                                <v-card-actions class="dialog-actions-container">
+                                        <v-spacer></v-spacer>
+                                        <v-btn
+                                                theme="dark"
+                                                @click="close_dialog"
+                                                class="pos-action-btn cancel-action-btn"
+                                                size="large"
+                                                elevation="2"
+                                        >
+                                                <v-icon start>mdi-close-circle-outline</v-icon>
+                                                <span>{{ __("Close") }}</span>
+                                        </v-btn>
+                                        <v-btn
+                                                theme="dark"
+                                                @click="submit_dialog"
+                                                class="pos-action-btn submit-action-btn"
+                                                size="large"
+                                                elevation="2"
+                                        >
+                                                <v-icon start>mdi-check-circle-outline</v-icon>
+                                                <span>{{ __("Submit") }}</span>
+                                        </v-btn>
+                                </v-card-actions>
 			</v-card>
 		</v-dialog>
 	</v-row>

--- a/frontend/src/posapp/components/pos/OpeningDialog.vue
+++ b/frontend/src/posapp/components/pos/OpeningDialog.vue
@@ -92,31 +92,31 @@
 				</v-card-text>
 
 				<!-- Actions Section -->
-				<v-card-actions class="dialog-actions-container">
-					<v-btn
-						theme="dark"
-						@click="go_desk"
-						class="pos-action-btn cancel-action-btn"
-						size="large"
-						elevation="2"
-					>
-						<v-icon start>mdi-close-circle-outline</v-icon>
-						<span>{{ __("Cancel") }}</span>
-					</v-btn>
-					<v-spacer />
-					<v-btn
-						theme="dark"
-						:disabled="is_loading"
-						:loading="is_loading"
-						@click="submit_dialog"
-						class="pos-action-btn submit-action-btn"
-						size="large"
-						elevation="2"
-					>
-						<v-icon start>mdi-check-circle-outline</v-icon>
-						<span>{{ __("Submit") }}</span>
-					</v-btn>
-				</v-card-actions>
+                                <v-card-actions class="dialog-actions-container">
+                                        <v-spacer />
+                                        <v-btn
+                                                theme="dark"
+                                                @click="go_desk"
+                                                class="pos-action-btn cancel-action-btn"
+                                                size="large"
+                                                elevation="2"
+                                        >
+                                                <v-icon start>mdi-close-circle-outline</v-icon>
+                                                <span>{{ __("Close") }}</span>
+                                        </v-btn>
+                                        <v-btn
+                                                theme="dark"
+                                                :disabled="is_loading"
+                                                :loading="is_loading"
+                                                @click="submit_dialog"
+                                                class="pos-action-btn submit-action-btn"
+                                                size="large"
+                                                elevation="2"
+                                        >
+                                                <v-icon start>mdi-check-circle-outline</v-icon>
+                                                <span>{{ __("Submit") }}</span>
+                                        </v-btn>
+                                </v-card-actions>
 			</v-card>
 		</v-dialog>
 	</v-row>


### PR DESCRIPTION
## Summary
- align the action buttons in the opening shift dialog to the right with Close preceding Submit
- match the closing shift dialog layout so Close and Submit sit together on the right side

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f73348ea0c83269b568a3dd7ea758c