### PR TITLE
Fix get item brand attribute

### DIFF
--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -1104,7 +1104,7 @@ def get_item_brand(item_code):
     data = frappe.db.get_value("Item", item_code, ["brand", "variant_of"], as_dict=True)
     if not data:
         return ""
-    brand = data.brand
-    if not brand and data.variant_of:
-        brand = frappe.db.get_value("Item", data.variant_of, "brand")
+    brand = data.get("brand")
+    if not brand and data.get("variant_of"):
+        brand = frappe.db.get_value("Item", data.get("variant_of"), "brand")
     return normalize_brand(brand) if brand else ""


### PR DESCRIPTION
In `posawesome/posawesome/api/items.py`, the `get_item_brand` function used direct attribute access (`data.brand`) to retrieve the brand of an item. This would cause an `AttributeError` if the database returned a dictionary-like object that did not contain the 'brand' or 'variant_of' keys.

This commit fixes the bug by switching to the `.get()` method, which safely returns `None` for missing keys, preventing the error.