### PR TITLE
Handle missing POS offer items by fetching details lazily

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1455,8 +1455,8 @@ export default {
                 handleSetOffers(data) {
                         this.posOffers = data;
                 },
-                handleUpdateInvoiceOffers(data) {
-                        this.updateInvoiceOffers(data);
+                async handleUpdateInvoiceOffers(data) {
+                        await this.updateInvoiceOffers(data);
                 },
                 handleUpdateInvoiceCoupons(data) {
                         this.posa_coupons = data;


### PR DESCRIPTION
## Summary
- fetch offer item details on demand when they are missing from the cached POS item list to prevent "Offer item unavailable" failures
- refactor offer application logic to await asynchronous give-item resolution and keep invoice offer state consistent
- await invoice-offer updates from the main Invoice component so UI state reflects asynchronous offer changes

## Testing
- `yarn --cwd frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68faf46d94288326a8e9c58e2f3d2085