### PR TITLE
Ensure lazy offer items populate their names

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1455,8 +1455,8 @@ export default {
                 handleSetOffers(data) {
                         this.posOffers = data;
                 },
-                handleUpdateInvoiceOffers(data) {
-                        this.updateInvoiceOffers(data);
+                async handleUpdateInvoiceOffers(data) {
+                        await this.updateInvoiceOffers(data);
                 },
                 handleUpdateInvoiceCoupons(data) {
                         this.posa_coupons = data;

--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -167,7 +167,7 @@ def _fetch_item_meta(item_codes: Tuple[str, ...]):
         return []
     return frappe.get_all(
         "Item",
-        fields=["name", "has_batch_no", "has_serial_no", "stock_uom"],
+        fields=["name", "item_name", "has_batch_no", "has_serial_no", "stock_uom"],
         filters={"name": ["in", item_codes]},
     )
 
@@ -351,6 +351,8 @@ def merge_item_row(
             "conversion_rate": exchange_rate,
         }
     )
+    if not row.get("item_name") and meta.get("item_name"):
+        row["item_name"] = meta.get("item_name")
     return row
 
 


### PR DESCRIPTION
## Summary
- include `item_name` when fetching item metadata for POS offer lookups
- populate missing item names on lazily fetched offer items so the invoice table shows them correctly

## Testing
- `yarn --cwd frontend build`


------
https://chatgpt.com/codex/tasks/task_e_68faf46d94288326a8e9c58e2f3d2085