### PR TITLE
Exclude expired gift coupons from automatic fetch

### DIFF
--- a/posawesome/posawesome/api/offers.py
+++ b/posawesome/posawesome/api/offers.py
@@ -22,14 +22,17 @@ def get_pos_coupon(coupon, customer, company):
 @frappe.whitelist()
 def get_active_gift_coupons(customer, company):
     coupons = []
+    today = nowdate()
     coupons_data = frappe.get_all(
         "POS Coupon",
-        filters={
-            "company": company,
-            "coupon_type": "Gift Card",
-            "customer": customer,
-            "used": 0,
-        },
+        filters=[
+            ["company", "=", company],
+            ["coupon_type", "=", "Gift Card"],
+            ["customer", "=", customer],
+            ["used", "=", 0],
+            ["or", ["valid_from", "is", "not set"], ["valid_from", "<=", today]],
+            ["or", ["valid_upto", "is", "not set"], ["valid_upto", ">=", today]],
+        ],
         fields=["coupon_code"],
     )
     if len(coupons_data):


### PR DESCRIPTION
## Summary
- ensure get_active_gift_coupons only returns gift coupons that are currently valid for the customer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902ea9d016c832686312a8eb20c5d56