### PR TITLE
Ensure quotation reload keeps correct doctype

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1619,11 +1619,19 @@ export default {
 		},
 		// Open print page for invoice
 		load_print_page() {
-			const print_format = this.pos_profile.print_format_for_online || this.pos_profile.print_format;
-			const letter_head = this.pos_profile.letter_head || 0;
-			const doctype = this.pos_profile.create_pos_invoice_instead_of_sales_invoice
-				? "POS Invoice"
-				: "Sales Invoice";
+                        const print_format = this.pos_profile.print_format_for_online || this.pos_profile.print_format;
+                        const letter_head = this.pos_profile.letter_head || 0;
+                        let doctype;
+
+                        if (this.invoiceType === "Quotation") {
+                                doctype = "Quotation";
+                        } else if (this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order) {
+                                doctype = "Sales Order";
+                        } else if (this.pos_profile.create_pos_invoice_instead_of_sales_invoice) {
+                                doctype = "POS Invoice";
+                        } else {
+                                doctype = "Sales Invoice";
+                        }
 			const url =
 				frappe.urllib.get_base_url() +
 				"/printview?doctype=" +

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -640,37 +640,55 @@ export default {
 		}
 
 		// Always set these fields first
-		if (this.invoiceType === "Quotation") {
-			doc.doctype = "Quotation";
-		} else if (this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order) {
-			doc.doctype = "Sales Order";
-		} else if (this.pos_profile.create_pos_invoice_instead_of_sales_invoice) {
-			doc.doctype = "POS Invoice";
-		} else {
-			doc.doctype = "Sales Invoice";
-		}
-		doc.is_pos = 1;
-		doc.ignore_pricing_rule = 1;
-		doc.company = doc.company || this.pos_profile.company;
-		doc.pos_profile = doc.pos_profile || this.pos_profile.name;
-		doc.posa_show_custom_name_marker_on_print = this.pos_profile.posa_show_custom_name_marker_on_print;
+                if (this.invoiceType === "Quotation") {
+                        doc.doctype = "Quotation";
+                } else if (this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order) {
+                        doc.doctype = "Sales Order";
+                } else if (this.pos_profile.create_pos_invoice_instead_of_sales_invoice) {
+                        doc.doctype = "POS Invoice";
+                } else {
+                        doc.doctype = "Sales Invoice";
+                }
+                doc.is_pos = 1;
+                doc.ignore_pricing_rule = 1;
+                doc.company = doc.company || this.pos_profile.company;
+                doc.pos_profile = doc.pos_profile || this.pos_profile.name;
+                doc.posa_show_custom_name_marker_on_print = this.pos_profile.posa_show_custom_name_marker_on_print;
 
-		// Currency related fields
-		doc.currency = this.selected_currency || this.pos_profile.currency;
-		doc.conversion_rate = (sourceDoc && sourceDoc.conversion_rate) || this.conversion_rate || 1;
+                // Currency related fields
+                doc.currency = this.selected_currency || this.pos_profile.currency;
+                doc.conversion_rate = (sourceDoc && sourceDoc.conversion_rate) || this.conversion_rate || 1;
 
-		// Use actual price list currency if available
-		doc.price_list_currency = this.price_list_currency || doc.currency;
+                // Use actual price list currency if available
+                doc.price_list_currency = this.price_list_currency || doc.currency;
 
-		doc.plc_conversion_rate =
-			(sourceDoc && sourceDoc.plc_conversion_rate) ||
-			(doc.price_list_currency === doc.currency ? 1 : this.exchange_rate);
+                doc.plc_conversion_rate =
+                        (sourceDoc && sourceDoc.plc_conversion_rate) ||
+                        (doc.price_list_currency === doc.currency ? 1 : this.exchange_rate);
 
-		// Other fields
-		doc.campaign = doc.campaign || this.pos_profile.campaign;
-		doc.selling_price_list = this.pos_profile.selling_price_list;
-		doc.naming_series = doc.naming_series || this.pos_profile.naming_series;
-		doc.customer = this.customer;
+                // Other fields
+                doc.campaign = doc.campaign || this.pos_profile.campaign;
+                doc.selling_price_list = this.pos_profile.selling_price_list;
+                doc.naming_series = doc.naming_series || this.pos_profile.naming_series;
+                const customerDetails =
+                        this.customer_info && typeof this.customer_info === "object"
+                                ? this.customer_info
+                                : {};
+                const resolvedCustomer =
+                        this.customer ||
+                        customerDetails.customer ||
+                        doc.customer ||
+                        null;
+                doc.customer = resolvedCustomer;
+                if (!doc.customer_name && customerDetails.customer_name) {
+                        doc.customer_name = customerDetails.customer_name;
+                }
+                if (doc.doctype === "Quotation") {
+                        doc.quotation_to = doc.quotation_to || "Customer";
+                        if (resolvedCustomer) {
+                                doc.party_name = resolvedCustomer;
+                        }
+                }
 
 		// Determine if this is a return invoice
 		const isReturn = this.isReturnInvoice;
@@ -1311,17 +1329,28 @@ export default {
                                 return null;
                         }
 
-			const current = this.invoice_doc || {};
-			const name = current.name;
-			const doctype =
-				current.doctype ||
-				(this.pos_profile?.create_pos_invoice_instead_of_sales_invoice
-					? "POS Invoice"
-					: "Sales Invoice");
+                        const current = this.invoice_doc || {};
+                        const name = current.name;
+                        let doctype = current.doctype;
 
-			if (!name || !doctype) {
-				return null;
-			}
+                        if (!doctype) {
+                                if (this.invoiceType === "Quotation") {
+                                        doctype = "Quotation";
+                                } else if (
+                                        this.invoiceType === "Order" &&
+                                        this.pos_profile?.posa_create_only_sales_order
+                                ) {
+                                        doctype = "Sales Order";
+                                } else if (this.pos_profile?.create_pos_invoice_instead_of_sales_invoice) {
+                                        doctype = "POS Invoice";
+                                } else {
+                                        doctype = "Sales Invoice";
+                                }
+                        }
+
+                        if (!name || !doctype) {
+                                return null;
+                        }
 
 			const manualOverrides = this._collectManualRateOverrides(this.items);
 
@@ -1330,11 +1359,14 @@ export default {
 				args: { doctype, name },
 			});
 
-			const doc = r?.message;
-			if (doc) {
-				if (manualOverrides.length) {
-					this._applyManualRateOverridesToDoc(doc, manualOverrides);
-				}
+                        const doc = r?.message;
+                        if (doc) {
+                                if (!doc.doctype && doctype) {
+                                        doc.doctype = doctype;
+                                }
+                                if (manualOverrides.length) {
+                                        this._applyManualRateOverridesToDoc(doc, manualOverrides);
+                                }
                                 await this.load_invoice(doc, {
                                         preserveAdditionalDiscountPercentage: true,
                                 });
@@ -2655,6 +2687,20 @@ export default {
                                 updatedDoc[field] = customerDetails[field];
                         }
                 });
+
+                if (!updatedDoc.customer_name && resolvedCustomerName) {
+                        updatedDoc.customer_name = resolvedCustomerName;
+                }
+
+                const currentDoctype = updatedDoc.doctype || existingDoc.doctype || null;
+                if (currentDoctype === "Quotation") {
+                        updatedDoc.quotation_to = updatedDoc.quotation_to || "Customer";
+                        if (resolvedCustomer) {
+                                updatedDoc.party_name = resolvedCustomer;
+                        } else if (hasCustomerChanged) {
+                                updatedDoc.party_name = null;
+                        }
+                }
 
                 const addressFields = {
                         customer_address:


### PR DESCRIPTION
## Summary
- ensure invoice reloads fall back to the active invoice type so quotations fetch quotation docs
- retain the resolved doctype on refreshed documents to keep quotation context intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901fce046e08326b83a33908820139c