### PR TITLE
Prompt to handle POS overpayments from non-default payments

### DIFF
--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -817,13 +817,18 @@ export default {
 			// get payment methods from pos profile
 			if (!this.pos_profile.posa_allow_make_new_payments) return;
 			this.payment_methods = [];
-			this.pos_profile.payments.forEach((method) => {
-				this.payment_methods.push({
-					mode_of_payment: method.mode_of_payment,
-					amount: 0,
-					row_id: method.name,
-				});
-			});
+                        this.pos_profile.payments.forEach((method) => {
+                                this.payment_methods.push({
+                                        mode_of_payment: method.mode_of_payment,
+                                        amount: 0,
+                                        row_id: method.name,
+                                        is_default:
+                                                method.default === 1 ||
+                                                method.default === "1" ||
+                                                method.default === true,
+                                        account: method.account || method.default_account || "",
+                                });
+                        });
 		},
 		clear_all(with_customer_info = true) {
 			this.customer_name = "";
@@ -841,219 +846,339 @@ export default {
 			this.selected_mpesa_payments = [];
 			this.set_payment_methods();
 		},
-		submit() {
-			if (this.isSubmitting) return;
-			this.isSubmitting = true;
-			const customer = this.customer_name;
-			const vm = this;
+                async submit() {
+                        if (this.isSubmitting) return;
+                        this.isSubmitting = true;
+                        const customer = this.customer_name;
+                        const vm = this;
 
-			if (!customer) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please select a customer"));
-				return;
-			}
+                        let payload;
+                        try {
+                                payload = await this.preparePaymentPayload(customer);
+                        } catch (error) {
+                                vm.isSubmitting = false;
+                                throw error;
+                        }
 
-			// Check if we have selected invoices
-			if (this.selected_invoices.length == 0) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please select an invoice"));
-				return;
-			}
+                        if (!payload) {
+                                vm.isSubmitting = false;
+                                return;
+                        }
 
-			// Calculate payment values
-			let total_payments =
-				this.total_selected_payments +
-				this.total_selected_mpesa_payments +
-				this.total_payment_methods;
+                        if (isOffline()) {
+                                try {
+                                        saveOfflinePayment({ args: { payload } });
+                                        vm.eventBus.emit("show_message", {
+                                                title: __("Payment saved offline"),
+                                                color: "warning",
+                                        });
+                                        vm.clear_all(false);
+                                        vm.customer_name = customer;
+                                        vm.get_outstanding_invoices();
+                                        vm.get_unallocated_payments();
+                                        vm.set_mpesa_search_params();
+                                        vm.get_draft_mpesa_payments_register();
+                                } catch (error) {
+                                        frappe.msgprint(
+                                                __("Cannot Save Offline Payment: ") + (error.message || __("Unknown error")),
+                                        );
+                                }
+                                vm.isSubmitting = false;
+                                return;
+                        }
 
-			if (total_payments <= 0) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please make a payment or select an payment"));
-				return;
-			}
+                        frappe.call({
+                                method: "posawesome.posawesome.api.payment_entry.process_pos_payment",
+                                args: { payload },
+                                freeze: true,
+                                freeze_message: __("Processing Payment"),
+                                callback: function (r) {
+                                        vm.isSubmitting = false;
+                                        if (r.message) {
+                                                frappe.utils.play_sound("submit");
+                                                vm.clear_all(false);
+                                                vm.customer_name = customer;
+                                                vm.get_outstanding_invoices();
+                                                vm.get_unallocated_payments();
+                                                vm.set_mpesa_search_params();
+                                                vm.get_draft_mpesa_payments_register();
+                                        }
+                                },
+                                error: function () {
+                                        vm.isSubmitting = false;
+                                },
+                        });
+                },
+                async submit_and_print() {
+                        if (this.isSubmitting) return;
+                        this.isSubmitting = true;
+                        const customer = this.customer_name;
+                        const vm = this;
 
-			this.payment_methods.forEach((payment) => {
-				payment.amount = flt(payment.amount);
-			});
+                        let payload;
+                        try {
+                                payload = await this.preparePaymentPayload(customer);
+                        } catch (error) {
+                                vm.isSubmitting = false;
+                                throw error;
+                        }
 
-			const payload = {};
-			payload.customer = customer;
-			payload.company = this.company;
-			payload.currency = this.pos_profile.currency;
-			payload.pos_opening_shift_name = this.pos_opening_shift.name;
-			payload.pos_profile_name = this.pos_profile.name;
-			payload.pos_profile = this.pos_profile;
-			payload.payment_methods = this.payment_methods;
-			payload.selected_invoices = this.selected_invoices;
-			payload.selected_payments = this.selected_payments;
-			payload.total_selected_invoices = flt(this.total_selected_invoices);
-			payload.selected_mpesa_payments = this.selected_mpesa_payments;
-			payload.total_selected_payments = flt(this.total_selected_payments);
-			payload.total_payment_methods = flt(this.total_payment_methods);
-			payload.total_selected_mpesa_payments = flt(this.total_selected_mpesa_payments);
+                        if (!payload) {
+                                vm.isSubmitting = false;
+                                return;
+                        }
 
-			if (isOffline()) {
-				try {
-					saveOfflinePayment({ args: { payload } });
-					vm.eventBus.emit("show_message", {
-						title: __("Payment saved offline"),
-						color: "warning",
-					});
-					vm.clear_all(false);
-					vm.customer_name = customer;
-					vm.get_outstanding_invoices();
-					vm.get_unallocated_payments();
-					vm.set_mpesa_search_params();
-					vm.get_draft_mpesa_payments_register();
-				} catch (error) {
-					frappe.msgprint(
-						__("Cannot Save Offline Payment: ") + (error.message || __("Unknown error")),
-					);
-				}
-				vm.isSubmitting = false;
-				return;
-			}
+                        if (isOffline()) {
+                                try {
+                                        saveOfflinePayment({ args: { payload } });
+                                        vm.eventBus.emit("show_message", {
+                                                title: __("Payment saved offline"),
+                                                color: "warning",
+                                        });
+                                        vm.clear_all(false);
+                                        vm.customer_name = customer;
+                                        vm.get_outstanding_invoices();
+                                        vm.get_unallocated_payments();
+                                        vm.set_mpesa_search_params();
+                                        vm.get_draft_mpesa_payments_register();
+                                } catch (error) {
+                                        frappe.msgprint(
+                                                __("Cannot Save Offline Payment: ") + (error.message || __("Unknown error")),
+                                        );
+                                }
+                                vm.isSubmitting = false;
+                                return;
+                        }
 
-			frappe.call({
-				method: "posawesome.posawesome.api.payment_entry.process_pos_payment",
-				args: { payload },
-				freeze: true,
-				freeze_message: __("Processing Payment"),
-				callback: function (r) {
-					vm.isSubmitting = false;
-					if (r.message) {
-						frappe.utils.play_sound("submit");
-						vm.clear_all(false);
-						vm.customer_name = customer;
-						vm.get_outstanding_invoices();
-						vm.get_unallocated_payments();
-						vm.set_mpesa_search_params();
-						vm.get_draft_mpesa_payments_register();
-					}
-				},
-				error: function () {
-					vm.isSubmitting = false;
-				},
-			});
-		},
-		submit_and_print() {
-			if (this.isSubmitting) return;
-			this.isSubmitting = true;
-			const customer = this.customer_name;
-			const vm = this;
-			if (!customer) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please select a customer"));
-				return;
-			}
+                        frappe.call({
+                                method: "posawesome.posawesome.api.payment_entry.process_pos_payment",
+                                args: { payload },
+                                freeze: true,
+                                freeze_message: __("Processing Payment"),
+                                callback: function (r) {
+                                        vm.isSubmitting = false;
+                                        if (r.message) {
+                                                console.log("Server response:", JSON.stringify(r.message));
+                                                frappe.utils.play_sound("submit");
 
-			// Check if we have selected invoices
-			if (this.selected_invoices.length == 0) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please select an invoice"));
-				return;
-			}
+                                                const payment_name =
+                                                        r.message.new_payments_entry && r.message.new_payments_entry.length > 0
+                                                                ? r.message.new_payments_entry[0].name
+                                                                : null;
 
-			// Calculate payment values
-			let total_payments =
-				this.total_selected_payments +
-				this.total_selected_mpesa_payments +
-				this.total_payment_methods;
+                                                if (payment_name) {
+                                                        console.log("Opening print view with payment name:", payment_name);
+                                                        vm.load_print_page(payment_name);
+                                                } else {
+                                                        console.log("No payment_name found in response");
+                                                        frappe.msgprint(
+                                                                __(
+                                                                        "Payment submitted but print function could not be executed. Payment name not found.",
+                                                                ),
+                                                        );
+                                                }
+                                                vm.clear_all(false);
+                                                vm.customer_name = customer;
+                                                vm.get_outstanding_invoices();
+                                                vm.get_unallocated_payments();
+                                                vm.set_mpesa_search_params();
+                                                vm.get_draft_mpesa_payments_register();
+                                        }
+                                },
+                                error: function () {
+                                        vm.isSubmitting = false;
+                                },
+                        });
+                },
+                async preparePaymentPayload(customer) {
+                        if (!customer) {
+                                frappe.throw(__("Please select a customer"));
+                        }
 
-			if (total_payments <= 0) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please make a payment or select an payment"));
-				return;
-			}
+                        if (this.selected_invoices.length === 0) {
+                                frappe.throw(__("Please select an invoice"));
+                        }
 
-			this.payment_methods.forEach((payment) => {
-				payment.amount = flt(payment.amount);
-			});
+                        const total_payments =
+                                this.total_selected_payments +
+                                this.total_selected_mpesa_payments +
+                                this.total_payment_methods;
 
-			const payload = {};
-			payload.customer = customer;
-			payload.company = this.company;
-			payload.currency = this.pos_profile.currency;
-			payload.pos_opening_shift_name = this.pos_opening_shift.name;
-			payload.pos_profile_name = this.pos_profile.name;
-			payload.pos_profile = this.pos_profile;
-			payload.payment_methods = this.payment_methods;
-			payload.selected_invoices = this.selected_invoices;
-			payload.selected_payments = this.selected_payments;
-			payload.total_selected_invoices = flt(this.total_selected_invoices);
-			payload.selected_mpesa_payments = this.selected_mpesa_payments;
-			payload.total_selected_payments = flt(this.total_selected_payments);
-			payload.total_payment_methods = flt(this.total_payment_methods);
-			payload.total_selected_mpesa_payments = flt(this.total_selected_mpesa_payments);
+                        if (total_payments <= 0) {
+                                frappe.throw(__("Please make a payment or select an payment"));
+                        }
 
-			if (isOffline()) {
-				try {
-					saveOfflinePayment({ args: { payload } });
-					vm.eventBus.emit("show_message", {
-						title: __("Payment saved offline"),
-						color: "warning",
-					});
-					vm.clear_all(false);
-					vm.customer_name = customer;
-					vm.get_outstanding_invoices();
-					vm.get_unallocated_payments();
-					vm.set_mpesa_search_params();
-					vm.get_draft_mpesa_payments_register();
-				} catch (error) {
-					frappe.msgprint(
-						__("Cannot Save Offline Payment: ") + (error.message || __("Unknown error")),
-					);
-				}
-				vm.isSubmitting = false;
-				return;
-			}
+                        this.payment_methods.forEach((payment) => {
+                                payment.amount = flt(payment.amount);
+                        });
 
-			frappe.call({
-				method: "posawesome.posawesome.api.payment_entry.process_pos_payment",
-				args: { payload },
-				freeze: true,
-				freeze_message: __("Processing Payment"),
-				callback: function (r) {
-					vm.isSubmitting = false;
-					if (r.message) {
-						console.log("Server response:", JSON.stringify(r.message));
-						frappe.utils.play_sound("submit");
+                        const payload = {};
+                        payload.customer = customer;
+                        payload.company = this.company;
+                        payload.currency = this.pos_profile.currency;
+                        payload.pos_opening_shift_name = this.pos_opening_shift.name;
+                        payload.pos_profile_name = this.pos_profile.name;
+                        payload.pos_profile = this.pos_profile;
+                        payload.payment_methods = this.payment_methods;
+                        payload.selected_invoices = this.selected_invoices;
+                        payload.selected_payments = this.selected_payments;
+                        payload.total_selected_invoices = flt(this.total_selected_invoices);
+                        payload.selected_mpesa_payments = this.selected_mpesa_payments;
+                        payload.total_selected_payments = flt(this.total_selected_payments);
+                        payload.total_payment_methods = flt(this.total_payment_methods);
+                        payload.total_selected_mpesa_payments = flt(this.total_selected_mpesa_payments);
 
-						// Extract payment name from server response
-						const payment_name =
-							r.message.new_payments_entry && r.message.new_payments_entry.length > 0
-								? r.message.new_payments_entry[0].name
-								: null;
+                        const overpaymentPayload = await this.resolveOverpayment(total_payments);
+                        if (overpaymentPayload === false) {
+                                return null;
+                        }
+                        if (overpaymentPayload) {
+                                Object.assign(payload, overpaymentPayload);
+                        }
 
-						if (payment_name) {
-							console.log("Opening print view with payment name:", payment_name);
-							vm.load_print_page(payment_name);
-						} else {
-							console.log("No payment_name found in response");
-							frappe.msgprint(
-								__(
-									"Payment submitted but print function could not be executed. Payment name not found.",
-								),
-							);
-						}
-						vm.clear_all(false);
-						vm.customer_name = customer;
-						vm.get_outstanding_invoices();
-						vm.get_unallocated_payments();
-						vm.set_mpesa_search_params();
-						vm.get_draft_mpesa_payments_register();
-					}
-				},
-				error: function () {
-					vm.isSubmitting = false;
-				},
-			});
-		},
-		selectSingleInvoice(item) {
-			console.log("Row clicked:", item);
-			if (item) {
-				this.toggleInvoiceSelection(item);
-			}
+                        return payload;
+                },
+                async resolveOverpayment(total_payments) {
+                        const invoice_total = flt(this.total_selected_invoices || 0);
+                        const overpayment_amount = flt(total_payments - invoice_total);
+
+                        if (overpayment_amount <= 0) {
+                                return null;
+                        }
+
+                        if (flt(this.total_payment_methods) <= 0) {
+                                return null;
+                        }
+
+                        const defaultPayment = this.getDefaultProfilePayment();
+                        if (!defaultPayment) {
+                                return null;
+                        }
+
+                        const hasNonDefaultPayment = this.payment_methods.some((payment) => {
+                                const amount = flt(payment.amount);
+                                if (amount <= 0) {
+                                        return false;
+                                }
+                                if (payment.is_default) {
+                                        return false;
+                                }
+                                return payment.mode_of_payment !== defaultPayment.mode_of_payment;
+                        });
+
+                        if (!hasNonDefaultPayment) {
+                                return null;
+                        }
+
+                        const resolution = await this.promptOverpaymentResolution(overpayment_amount, defaultPayment);
+                        if (!resolution) {
+                                return false;
+                        }
+
+                        return {
+                                overpayment_resolution: resolution,
+                                overpayment_amount: flt(overpayment_amount),
+                                default_cash_mode_of_payment: defaultPayment.mode_of_payment,
+                                default_cash_account:
+                                        defaultPayment.account || defaultPayment.default_account || "",
+                        };
+                },
+                getDefaultProfilePayment() {
+                        if (!this.pos_profile || !Array.isArray(this.pos_profile.payments)) {
+                                return null;
+                        }
+
+                        const defaultPayment = this.pos_profile.payments.find((method) => {
+                                const flag = method.default;
+                                return flag === 1 || flag === "1" || flag === true || flag === "Yes";
+                        });
+
+                        if (defaultPayment) {
+                                return defaultPayment;
+                        }
+
+                        if (this.pos_profile.posa_cash_mode_of_payment) {
+                                return this.pos_profile.payments.find(
+                                        (method) => method.mode_of_payment === this.pos_profile.posa_cash_mode_of_payment,
+                                );
+                        }
+
+                        return null;
+                },
+                async promptOverpaymentResolution(amount, defaultPayment) {
+                        const formattedAmount = this.formatCurrency(amount);
+                        const message = `
+                                <div class="pos-overpayment-message">
+                                        <p>${__("You received {0} more than the invoice total using {1}.", [
+                                                formattedAmount,
+                                                __(defaultPayment.mode_of_payment),
+                                        ])}</p>
+                                        <p>${__("How would you like to handle the extra amount?")}</p>
+                                </div>
+                        `;
+
+                        return new Promise((resolve) => {
+                                const dialog = new frappe.ui.Dialog({
+                                        title: __("Overpayment detected"),
+                                        fields: [
+                                                {
+                                                        fieldname: "info",
+                                                        fieldtype: "HTML",
+                                                        options: message,
+                                                },
+                                                {
+                                                        fieldname: "action",
+                                                        fieldtype: "Select",
+                                                        label: __("Select Action"),
+                                                        options: [
+                                                                {
+                                                                        label: __("Return payment from cash"),
+                                                                        value: "return_cash",
+                                                                },
+                                                                {
+                                                                        label: __("Credit amount in customer balance"),
+                                                                        value: "credit_balance",
+                                                                },
+                                                        ],
+                                                        default: "return_cash",
+                                                },
+                                        ],
+                                });
+
+                                let resolved = false;
+                                const finalize = (value) => {
+                                        if (resolved) return;
+                                        resolved = true;
+                                        dialog.$wrapper.off("hidden.bs.modal", onHide);
+                                        resolve(value);
+                                };
+
+                                const onHide = () => finalize(null);
+                                dialog.$wrapper.on("hidden.bs.modal", onHide);
+
+                                dialog.set_primary_action(__("Continue"), (values) => {
+                                        if (!values || !values.action) {
+                                                frappe.msgprint(__("Please select how to handle the extra amount."));
+                                                return;
+                                        }
+                                        finalize(values.action);
+                                        dialog.hide();
+                                });
+
+                                dialog.set_secondary_action_label(__("Cancel"));
+                                dialog.set_secondary_action(() => {
+                                        finalize(null);
+                                        dialog.hide();
+                                });
+
+                                dialog.show();
+                        });
+                },
+                selectSingleInvoice(item) {
+                        console.log("Row clicked:", item);
+                        if (item) {
+                                this.toggleInvoiceSelection(item);
+                        }
 		},
 		isInvoiceSelected(item) {
 			return this.selected_invoices.some((i) => i.voucher_no === item.voucher_no);

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -3,7 +3,7 @@
 
 import frappe, erpnext, json
 from frappe import _
-from frappe.utils import nowdate, getdate, flt
+from frappe.utils import nowdate, getdate, flt, fmt_money
 from erpnext.accounts.party import get_party_account
 from erpnext.accounts.utils import get_account_currency
 from erpnext.accounts.doctype.journal_entry.journal_entry import (
@@ -271,6 +271,11 @@ def process_pos_payment(payload):
     allow_mpesa_reconcile_payments = data.pos_profile.get("posa_allow_mpesa_reconcile_payments")
     today = nowdate()
 
+    overpayment_resolution = data.get("overpayment_resolution")
+    overpayment_amount = flt(data.get("overpayment_amount") or 0)
+    default_cash_mode = data.get("default_cash_mode_of_payment")
+    default_cash_account = data.get("default_cash_account")
+
     # prepare invoice list once so allocations can update remaining amounts
     remaining_invoices = []
     for invoice in data.selected_invoices:
@@ -453,6 +458,26 @@ def process_pos_payment(payload):
                 errors.append(str(e))
                 frappe.log_error(f"Error creating payment entry: {str(e)}", "POS Payment Error")
 
+    change_journal_entry = None
+    if overpayment_resolution == "return_cash" and overpayment_amount > 0:
+        try:
+            cash_mode = default_cash_mode or (data.pos_profile.get("posa_cash_mode_of_payment") if data.pos_profile else None)
+            linked_payment_entry = get_payment_entry_for_change(new_payments_entry)
+            change_journal_entry = create_pos_change_journal_entry(
+                company=company,
+                customer=customer,
+                amount=overpayment_amount,
+                currency=currency,
+                cash_account=default_cash_account,
+                cash_mode_of_payment=cash_mode,
+                posting_date=today,
+                reference=pos_opening_shift_name,
+                linked_payment_entry=linked_payment_entry,
+            )
+        except Exception as e:
+            errors.append(_("Failed to create change journal entry: {0}").format(str(e)))
+            frappe.log_error(frappe.get_traceback(), "POS Change Journal Error")
+
     # Old allocation logic disabled
     # then show the results
     msg = ""
@@ -497,7 +522,140 @@ def process_pos_payment(payload):
         "all_payments_entry": all_payments_entry,
         "reconciled_payments": reconciled_payments,
         "errors": errors,
+        "change_journal_entry": change_journal_entry.name if change_journal_entry else None,
     }
+
+
+def get_payment_entry_for_change(payment_entries):
+    if not payment_entries:
+        return None
+
+    for entry in payment_entries:
+        if not entry:
+            continue
+
+        name = None
+        unallocated = 0
+
+        if isinstance(entry, dict):
+            name = entry.get("name")
+            unallocated = flt(entry.get("unallocated_amount") or 0)
+        else:
+            name = getattr(entry, "name", None)
+            unallocated = flt(getattr(entry, "unallocated_amount", 0))
+
+        if not name:
+            continue
+
+        if unallocated <= 0:
+            try:
+                unallocated = flt(frappe.db.get_value("Payment Entry", name, "unallocated_amount") or 0)
+            except Exception:
+                unallocated = 0
+
+        if unallocated > 0:
+            return name
+
+    return None
+
+
+def create_pos_change_journal_entry(
+    company,
+    customer,
+    amount,
+    currency,
+    cash_account=None,
+    cash_mode_of_payment=None,
+    posting_date=None,
+    reference=None,
+    linked_payment_entry=None,
+):
+    amount = flt(amount)
+    if amount <= 0:
+        return None
+
+    receivable_account = get_party_account("Customer", customer, company)
+    if not receivable_account:
+        raise frappe.ValidationError(
+            _("Customer account is not configured for company {0}").format(company)
+        )
+
+    cash_account_to_use = cash_account or None
+    if not cash_account_to_use and cash_mode_of_payment:
+        bank = get_bank_cash_account(company, cash_mode_of_payment)
+        if bank and bank.account:
+            cash_account_to_use = bank.account
+
+    if not cash_account_to_use:
+        raise frappe.ValidationError(
+            _("Cash mode of payment is not linked with an account for returning change.")
+        )
+
+    je = frappe.new_doc("Journal Entry")
+    je.company = company
+    je.posting_date = posting_date or nowdate()
+    je.voucher_type = "Journal Entry"
+    je.remark = _("Change returned to customer {0} for POS overpayment").format(customer)
+    if reference:
+        je.user_remark = _("Generated from POS Opening Shift {0}").format(reference)
+
+    je.append(
+        "accounts",
+        {
+            "account": receivable_account,
+            "party_type": "Customer",
+            "party": customer,
+            "debit_in_account_currency": amount,
+            "credit_in_account_currency": 0,
+        },
+    )
+    je.append(
+        "accounts",
+        {
+            "account": cash_account_to_use,
+            "debit_in_account_currency": 0,
+            "credit_in_account_currency": amount,
+        },
+    )
+
+    je.flags.ignore_permissions = True
+    je.insert(ignore_permissions=True)
+    je.submit()
+
+    formatted_amount = fmt_money(amount, currency=currency) if currency else amount
+
+    if linked_payment_entry and frappe.db.exists("Payment Entry", linked_payment_entry):
+        try:
+            frappe.db.set_value(
+                "Payment Entry", linked_payment_entry, "posa_linked_je", je.name
+            )
+        except Exception:
+            pass
+
+        try:
+            frappe.get_doc(
+                {
+                    "doctype": "Comment",
+                    "comment_type": "Info",
+                    "reference_doctype": "Payment Entry",
+                    "reference_name": linked_payment_entry,
+                    "content": _(
+                        "Change journal entry {0} created for {1}."
+                    ).format(je.name, formatted_amount),
+                }
+            ).insert(ignore_permissions=True)
+        except Exception:
+            pass
+
+        try:
+            je.add_comment(
+                "Info",
+                _("Linked with Payment Entry {0}").format(linked_payment_entry),
+            )
+        except Exception:
+            pass
+
+    return je
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- prompt the cashier when new payments exceed the invoice total using a non-default mode so they can choose cash change or customer credit
- include payment metadata in the payload and transmit overpayment choices for online/offline submissions
- create and link a change journal entry that debits the customer and credits the cash account when the cashier returns change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901985693088326b31132c7891af33e