### PR TITLE
feat: prompt change handling for non-cash overpayments

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -713,11 +713,11 @@
 		</v-dialog>
 
 		<!-- Phone Payment Dialog -->
-		<v-dialog v-model="phone_dialog" max-width="400px">
-			<v-card>
-				<v-card-title>
-					<span class="text-h5 text-primary">{{ __("Confirm Mobile Number") }}</span>
-				</v-card-title>
+                <v-dialog v-model="phone_dialog" max-width="400px">
+                        <v-card>
+                                <v-card-title>
+                                        <span class="text-h5 text-primary">{{ __("Confirm Mobile Number") }}</span>
+                                </v-card-title>
 				<v-card-text class="pa-0">
 					<v-container>
 						<v-text-field
@@ -737,13 +737,54 @@
 					<v-btn color="error" theme="dark" @click="phone_dialog = false">
 						{{ __("Close") }}
 					</v-btn>
-					<v-btn color="primary" theme="dark" @click="request_payment">
-						{{ __("Request") }}
-					</v-btn>
-				</v-card-actions>
-			</v-card>
-		</v-dialog>
-	</div>
+                                        <v-btn color="primary" theme="dark" @click="request_payment">
+                                                {{ __("Request") }}
+                                        </v-btn>
+                                </v-card-actions>
+                        </v-card>
+                </v-dialog>
+                <v-dialog v-model="overpayment_dialog" max-width="480" persistent>
+                        <v-card>
+                                <v-card-title class="text-h6">
+                                        {{ __("Confirm Change Handling") }}
+                                </v-card-title>
+                                <v-card-text>
+                                        <p class="mb-2">
+                                                {{
+                                                        __(
+                                                                "Received payments exceed the invoice total by {0}.",
+                                                                [formatCurrency(change_due, displayCurrency)],
+                                                        )
+                                                }}
+                                        </p>
+                                        <p class="mb-0">
+                                                {{ __("How would you like to handle the difference?") }}
+                                        </p>
+                                </v-card-text>
+                                <v-card-actions class="d-flex flex-column">
+                                        <v-btn
+                                                color="primary"
+                                                class="mb-2"
+                                                block
+                                                @click="handleOverpaymentChoice('cash')"
+                                        >
+                                                {{ __("Return payment from cash") }}
+                                        </v-btn>
+                                        <v-btn
+                                                color="secondary"
+                                                class="mb-2"
+                                                block
+                                                @click="handleOverpaymentChoice('credit')"
+                                        >
+                                                {{ __("Credit amount to customer balance") }}
+                                        </v-btn>
+                                        <v-btn variant="text" block @click="cancelOverpaymentDialog">
+                                                {{ __("Cancel") }}
+                                        </v-btn>
+                                </v-card-actions>
+                        </v-card>
+                </v-dialog>
+        </div>
 </template>
 
 <script>
@@ -794,10 +835,11 @@ export default {
 			is_cashback: true, // Cashback enabled
 			is_credit_return: false, // Is this a credit return?
 			redeem_customer_credit: false, // Redeem customer credit?
-			customer_credit_dict: [], // List of available customer credits
-			paid_change_rules: [], // Validation rules for paid change
-			phone_dialog: false, // Show phone payment dialog
-			custom_days_dialog: false, // Show custom days dialog
+                        customer_credit_dict: [], // List of available customer credits
+                        paid_change_rules: [], // Validation rules for paid change
+                        phone_dialog: false, // Show phone payment dialog
+                        overpayment_dialog: false, // Show overpayment handling dialog
+                        custom_days_dialog: false, // Show custom days dialog
 			custom_days_value: null, // Custom days entry
 			new_delivery_date: null, // New delivery date value
 			new_po_date: null, // New PO date value
@@ -809,10 +851,12 @@ export default {
 			sales_persons: [], // List of sales persons
 			sales_person: "", // Selected sales person
 			addresses: [], // List of customer addresses
-			is_user_editing_paid_change: false, // User interaction flag
-			highlightSubmit: false, // Highlight state for submit button
-		};
-	},
+                        is_user_editing_paid_change: false, // User interaction flag
+                        highlightSubmit: false, // Highlight state for submit button
+                        overpayment_resolution: null, // Selected handling for overpayment change
+                        pending_submit_args: null, // Pending submit arguments while awaiting confirmation
+                };
+        },
 	computed: {
 		invoice_doc: {
 			get() {
@@ -1025,6 +1069,23 @@ export default {
                                 this.invoice_doc.paid_change = effectivePaid;
                                 this.invoice_doc.credit_change = creditAmount > 0 ? creditAmount : 0;
                         }
+
+                        if (this.change_due > 0 && this.shouldPromptForOverpaymentAction()) {
+                                if (creditAmount > 0) {
+                                        this.overpayment_resolution = "credit";
+                                } else if (this.overpayment_resolution !== "cash") {
+                                        this.overpayment_resolution = null;
+                                }
+                        } else if (this.change_due <= 0) {
+                                this.overpayment_resolution = null;
+                        }
+                },
+                change_due(newVal, oldVal) {
+                        if (!newVal || newVal <= 0) {
+                                this.overpayment_resolution = null;
+                        } else if (oldVal !== undefined && newVal !== oldVal) {
+                                this.overpayment_resolution = null;
+                        }
                 },
 		// Watch loyalty_amount to handle loyalty points redemption
 		loyalty_amount(value) {
@@ -1225,16 +1286,30 @@ export default {
 			});
 		},
 		// Submit payment after validation
-		async submit(event, payment_received = false, print = false) {
-			// For return invoices, ensure payment amounts are negative
-			if (this.invoice_doc.is_return) {
-				this.ensureReturnPaymentsAreNegative();
-			}
-			// Validate total payments only if not credit sale and invoice total is not zero
-			if (
-				!this.is_credit_sale &&
-				!this.invoice_doc.is_return &&
-				this.total_payments <= 0 &&
+                async submit(event, payment_received = false, print = false) {
+                        // For return invoices, ensure payment amounts are negative
+                        if (this.invoice_doc.is_return) {
+                                this.ensureReturnPaymentsAreNegative();
+                        }
+
+                        if (!this.shouldPromptForOverpaymentAction()) {
+                                this.overpayment_resolution = null;
+                        }
+
+                        if (
+                                this.shouldPromptForOverpaymentAction() &&
+                                !this.overpayment_resolution &&
+                                !payment_received
+                        ) {
+                                this.pending_submit_args = { event, payment_received, print };
+                                this.overpayment_dialog = true;
+                                return;
+                        }
+                        // Validate total payments only if not credit sale and invoice total is not zero
+                        if (
+                                !this.is_credit_sale &&
+                                !this.invoice_doc.is_return &&
+                                this.total_payments <= 0 &&
 				(this.invoice_doc.rounded_total || this.invoice_doc.grand_total) > 0
 			) {
 				this.eventBus.emit("show_message", {
@@ -1421,13 +1496,19 @@ export default {
                                 this.paid_change = paidChange;
                         }
 
+                        this.overpayment_resolution = paidChange > 0 ? "cash" : creditChange > 0 ? "credit" : null;
+                        if (this.invoice_doc) {
+                                this.invoice_doc.change_return_mode = this.overpayment_resolution;
+                        }
+
                         let data = {
                                 total_change: changeLimit,
                                 paid_change: paidChange,
                                 credit_change: creditChange,
-				redeemed_customer_credit: this.redeemed_customer_credit,
-				customer_credit_dict: this.customer_credit_dict,
-				is_cashback: this.is_cashback,
+                                change_return_mode: this.overpayment_resolution,
+                                redeemed_customer_credit: this.redeemed_customer_credit,
+                                customer_credit_dict: this.customer_credit_dict,
+                                is_cashback: this.is_cashback,
 			};
 			const vm = this;
 
@@ -1513,12 +1594,15 @@ export default {
 					if (print) {
 						vm.load_print_page();
 					}
-					vm.customer_credit_dict = [];
-					vm.redeem_customer_credit = false;
-					vm.is_cashback = true;
-					vm.is_credit_return = false;
-					vm.sales_person = "";
-					vm.eventBus.emit("set_last_invoice", vm.invoice_doc.name);
+                                        vm.customer_credit_dict = [];
+                                        vm.redeem_customer_credit = false;
+                                        vm.is_cashback = true;
+                                        vm.is_credit_return = false;
+                                        vm.sales_person = "";
+                                        vm.overpayment_resolution = null;
+                                        vm.pending_submit_args = null;
+                                        vm.overpayment_dialog = false;
+                                        vm.eventBus.emit("set_last_invoice", vm.invoice_doc.name);
                                         vm.eventBus.emit("show_message", {
                                                 title:
                                                         vm.invoiceType === "Order" && vm.pos_profile.posa_create_only_sales_order
@@ -2122,11 +2206,106 @@ export default {
                                 this.invoice_doc.credit_change = requestedCredit;
                                 this.invoice_doc.paid_change = remainingPaidChange;
                         }
+
+                        if (requestedCredit > 0) {
+                                this.overpayment_resolution = "credit";
+                        } else if (this.overpayment_resolution !== "cash") {
+                                this.overpayment_resolution = null;
+                        }
                 },
-		// Format currency value
-		formatCurrency(value) {
-			return this.$options.mixins[0].methods.formatCurrency.call(this, value, this.currency_precision);
-		},
+                shouldPromptForOverpaymentAction() {
+                        if (!this.invoice_doc || this.invoice_doc.is_return) {
+                                return false;
+                        }
+
+                        const changeAmount = Math.max(-this.diff_payment, 0);
+                        if (changeAmount <= 0) {
+                                return false;
+                        }
+
+                        const payments = Array.isArray(this.invoice_doc.payments)
+                                ? this.invoice_doc.payments
+                                : [];
+                        if (!payments.length) {
+                                return false;
+                        }
+
+                        const defaultPayment = payments.find((payment) => payment.default === 1);
+                        if (!defaultPayment) {
+                                return false;
+                        }
+
+                        const defaultIsCash = (defaultPayment.mode_of_payment || "")
+                                .toLowerCase()
+                                .includes("cash");
+                        if (!defaultIsCash) {
+                                return false;
+                        }
+
+                        const hasPositiveCashPayment = payments.some((payment) => {
+                                return (
+                                        (payment.mode_of_payment || "")
+                                                .toLowerCase()
+                                                .includes("cash") && this.flt(payment.amount) > 0
+                                );
+                        });
+
+                        if (hasPositiveCashPayment) {
+                                return false;
+                        }
+
+                        const nonCashTotal = payments
+                                .filter((payment) => {
+                                        const isDefault =
+                                                payment.default === 1 || payment.idx === defaultPayment?.idx;
+                                        const isCash = (payment.mode_of_payment || "")
+                                                .toLowerCase()
+                                                .includes("cash");
+                                        return !isDefault && !isCash;
+                                })
+                                .reduce((sum, payment) => sum + this.flt(payment.amount), 0);
+
+                        return nonCashTotal > 0;
+                },
+                handleOverpaymentChoice(option) {
+                        const changeAmount = Math.max(-this.diff_payment, 0);
+                        if (!changeAmount) {
+                                this.overpayment_dialog = false;
+                                this.pending_submit_args = null;
+                                return;
+                        }
+
+                        if (option === "credit") {
+                                this.overpayment_resolution = "credit";
+                                this.updateCreditChange(changeAmount);
+                        } else {
+                                this.overpayment_resolution = "cash";
+                                this.paid_change = changeAmount;
+                                this.credit_change = 0;
+                                if (this.invoice_doc) {
+                                        this.invoice_doc.paid_change = changeAmount;
+                                        this.invoice_doc.credit_change = 0;
+                                }
+                        }
+
+                        this.overpayment_dialog = false;
+                        const pending = this.pending_submit_args;
+                        this.pending_submit_args = null;
+                        if (pending) {
+                                this.submit(pending.event, pending.payment_received, pending.print);
+                        }
+                },
+                cancelOverpaymentDialog() {
+                        this.overpayment_dialog = false;
+                        this.pending_submit_args = null;
+                        if (this.change_due > 0) {
+                                this.overpayment_resolution = null;
+                        }
+                },
+                // Format currency value
+                formatCurrency(value) {
+                        return this.$options.mixins[0].methods.formatCurrency.call(this, value, this.currency_precision);
+                },
 		// Get change amount for display
 		get_change_amount() {
 			return Math.max(0, this.total_payments - this.invoice_doc.grand_total);

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1046,8 +1046,29 @@ export default {
 	watch: {
 		// Watch diff_payment to update paid_change
                 diff_payment(newVal) {
-                        if (!this.is_user_editing_paid_change) {
-                                this.paid_change = newVal < 0 ? -newVal : 0;
+                        if (this.is_user_editing_paid_change) {
+                                return;
+                        }
+
+                        const isOverpayment = newVal < 0;
+                        if (!isOverpayment) {
+                                if (this.paid_change !== 0) {
+                                        this.paid_change = 0;
+                                }
+                                return;
+                        }
+
+                        const shouldPrompt = this.shouldPromptForOverpaymentAction();
+                        if (shouldPrompt && this.overpayment_resolution !== "cash") {
+                                if (this.paid_change !== 0) {
+                                        this.paid_change = 0;
+                                }
+                                return;
+                        }
+
+                        const change = -newVal;
+                        if (this.paid_change !== change) {
+                                this.paid_change = change;
                         }
                 },
                 // Watch paid_change to validate and update credit_change
@@ -1302,6 +1323,13 @@ export default {
                                 !payment_received
                         ) {
                                 this.pending_submit_args = { event, payment_received, print };
+                                this.paid_change = 0;
+                                this.credit_change = 0;
+                                if (this.invoice_doc) {
+                                        this.invoice_doc.paid_change = 0;
+                                        this.invoice_doc.credit_change = 0;
+                                        this.invoice_doc.change_return_mode = null;
+                                }
                                 this.overpayment_dialog = true;
                                 return;
                         }
@@ -1496,9 +1524,16 @@ export default {
                                 this.paid_change = paidChange;
                         }
 
-                        this.overpayment_resolution = paidChange > 0 ? "cash" : creditChange > 0 ? "credit" : null;
+                        let changeReturnMode = this.overpayment_resolution;
+                        if (!this.shouldPromptForOverpaymentAction()) {
+                                changeReturnMode = paidChange > 0 ? "cash" : creditChange > 0 ? "credit" : null;
+                        } else if (!changeReturnMode) {
+                                changeReturnMode = null;
+                        }
+
+                        this.overpayment_resolution = changeReturnMode;
                         if (this.invoice_doc) {
-                                this.invoice_doc.change_return_mode = this.overpayment_resolution;
+                                this.invoice_doc.change_return_mode = changeReturnMode;
                         }
 
                         let data = {
@@ -2202,15 +2237,16 @@ export default {
                         this.credit_change = requestedCredit ? -requestedCredit : 0;
                         this.paid_change = remainingPaidChange;
 
-                        if (this.invoice_doc) {
-                                this.invoice_doc.credit_change = requestedCredit;
-                                this.invoice_doc.paid_change = remainingPaidChange;
-                        }
-
                         if (requestedCredit > 0) {
                                 this.overpayment_resolution = "credit";
                         } else if (this.overpayment_resolution !== "cash") {
                                 this.overpayment_resolution = null;
+                        }
+
+                        if (this.invoice_doc) {
+                                this.invoice_doc.credit_change = requestedCredit;
+                                this.invoice_doc.paid_change = remainingPaidChange;
+                                this.invoice_doc.change_return_mode = this.overpayment_resolution;
                         }
                 },
                 shouldPromptForOverpaymentAction() {
@@ -2278,6 +2314,9 @@ export default {
                         if (option === "credit") {
                                 this.overpayment_resolution = "credit";
                                 this.updateCreditChange(changeAmount);
+                                if (this.invoice_doc) {
+                                        this.invoice_doc.change_return_mode = "credit";
+                                }
                         } else {
                                 this.overpayment_resolution = "cash";
                                 this.paid_change = changeAmount;
@@ -2285,6 +2324,7 @@ export default {
                                 if (this.invoice_doc) {
                                         this.invoice_doc.paid_change = changeAmount;
                                         this.invoice_doc.credit_change = 0;
+                                        this.invoice_doc.change_return_mode = "cash";
                                 }
                         }
 
@@ -2300,6 +2340,13 @@ export default {
                         this.pending_submit_args = null;
                         if (this.change_due > 0) {
                                 this.overpayment_resolution = null;
+                                this.paid_change = 0;
+                                this.credit_change = 0;
+                                if (this.invoice_doc) {
+                                        this.invoice_doc.paid_change = 0;
+                                        this.invoice_doc.credit_change = 0;
+                                        this.invoice_doc.change_return_mode = null;
+                                }
                         }
                 },
                 // Format currency value

--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -101,11 +101,13 @@ doc_events = {
         "validate": "posawesome.posawesome.api.invoice.validate",
         "before_submit": "posawesome.posawesome.api.invoice.before_submit",
         "before_cancel": "posawesome.posawesome.api.invoice.before_cancel",
+        "on_cancel": "posawesome.posawesome.api.invoice.on_cancel",
     },
     "POS Invoice": {
         "validate": "posawesome.posawesome.api.invoice.validate",
         "before_submit": "posawesome.posawesome.api.invoice.before_submit",
         "before_cancel": "posawesome.posawesome.api.invoice.before_cancel",
+        "on_cancel": "posawesome.posawesome.api.invoice.on_cancel",
     },
     "Customer": {
         "validate": "posawesome.posawesome.api.customer.validate",

--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -8,7 +8,10 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.utils import add_days, flt
 
 from posawesome.posawesome.api.utilities import get_company_domain  # Updated import
-from posawesome.posawesome.api.payments import get_posawesome_credit_redeem_remark
+from posawesome.posawesome.api.payments import (
+    get_posawesome_cash_return_remark,
+    get_posawesome_credit_redeem_remark,
+)
 from posawesome.posawesome.doctype.delivery_charges.delivery_charges import (
     get_applicable_delivery_charges,
 )
@@ -34,11 +37,23 @@ def before_cancel(doc, method):
 
 
 def on_cancel(doc, method):
-    cancel_posawesome_credit_journal_entries(doc)
+    cancel_posawesome_payment_journal_entries(doc)
 
 
-def cancel_posawesome_credit_journal_entries(doc):
-    remark = get_posawesome_credit_redeem_remark(doc.name)
+def cancel_posawesome_payment_journal_entries(doc):
+    cancel_posawesome_journal_entries(
+        doc,
+        get_posawesome_credit_redeem_remark(doc.name),
+        "POSAwesome Credit Journal Cancellation Error",
+    )
+    cancel_posawesome_journal_entries(
+        doc,
+        get_posawesome_cash_return_remark(doc.name),
+        "POSAwesome Cash Refund Journal Cancellation Error",
+    )
+
+
+def cancel_posawesome_journal_entries(doc, remark, log_title):
     linked_journal_entries = frappe.get_all(
         "Journal Entry",
         filters={"docstatus": 1, "user_remark": remark},
@@ -63,7 +78,7 @@ def cancel_posawesome_credit_journal_entries(doc):
         except Exception:
             frappe.log_error(
                 frappe.get_traceback(),
-                "POSAwesome Credit Journal Cancellation Error",
+                log_title,
             )
             frappe.throw(
                 _(

--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -9,6 +9,8 @@ from frappe.utils import add_days, flt
 
 from posawesome.posawesome.api.utilities import get_company_domain  # Updated import
 from posawesome.posawesome.api.payments import (
+    build_posawesome_cash_return_remark,
+    build_posawesome_credit_redeem_remark,
     get_posawesome_cash_return_remark,
     get_posawesome_credit_redeem_remark,
 )
@@ -43,22 +45,49 @@ def on_cancel(doc, method):
 def cancel_posawesome_payment_journal_entries(doc):
     cancel_posawesome_journal_entries(
         doc,
-        get_posawesome_credit_redeem_remark(doc.name),
+        {
+            get_posawesome_credit_redeem_remark(doc.name),
+            build_posawesome_credit_redeem_remark(doc.name),
+        },
         "POSAwesome Credit Journal Cancellation Error",
     )
     cancel_posawesome_journal_entries(
         doc,
-        get_posawesome_cash_return_remark(doc.name),
+        {
+            get_posawesome_cash_return_remark(doc.name),
+            build_posawesome_cash_return_remark(doc.name),
+        },
         "POSAwesome Cash Refund Journal Cancellation Error",
     )
 
 
-def cancel_posawesome_journal_entries(doc, remark, log_title):
-    linked_journal_entries = frappe.get_all(
-        "Journal Entry",
-        filters={"docstatus": 1, "user_remark": remark},
-        pluck="name",
+def cancel_posawesome_journal_entries(doc, remark_candidates, log_title):
+    remark_candidates = {remark.strip() for remark in remark_candidates if remark}
+
+    linked_journal_entries = set()
+
+    if remark_candidates:
+        filters = {"docstatus": 1, "user_remark": ["in", list(remark_candidates)]}
+        linked_journal_entries.update(
+            frappe.get_all(
+                "Journal Entry",
+                filters=filters,
+                pluck="name",
+            )
+        )
+
+    reference_matches = frappe.get_all(
+        "Journal Entry Account",
+        filters={
+            "docstatus": 1,
+            "parenttype": "Journal Entry",
+            "reference_type": doc.doctype,
+            "reference_name": doc.name,
+        },
+        pluck="parent",
     )
+
+    linked_journal_entries.update(reference_matches)
 
     for journal_entry in linked_journal_entries:
         je_doc = frappe.get_doc("Journal Entry", journal_entry)
@@ -72,6 +101,14 @@ def cancel_posawesome_journal_entries(doc, remark, log_title):
 
         if not has_reference:
             continue
+
+        if remark_candidates:
+            user_remark = (je_doc.user_remark or "").strip()
+            remarks = (je_doc.remark or "").strip()
+            if user_remark not in remark_candidates and remarks not in remark_candidates:
+                normalized = user_remark or remarks
+                if "POS Awesome" not in (normalized or ""):
+                    continue
 
         try:
             je_doc.cancel()

--- a/posawesome/posawesome/api/payments.py
+++ b/posawesome/posawesome/api/payments.py
@@ -15,12 +15,20 @@ from erpnext.accounts.doctype.payment_request.payment_request import (
 from posawesome.posawesome.api.utilities import ensure_child_doctype
 
 
+def build_posawesome_credit_redeem_remark(invoice_name):
+    return f"POS Awesome credit redemption for Sales Invoice {invoice_name}"
+
+
+def build_posawesome_cash_return_remark(invoice_name):
+    return f"POS Awesome cash refund for Sales Invoice {invoice_name}"
+
+
 def get_posawesome_credit_redeem_remark(invoice_name):
-    return _("POS Awesome credit redemption for Sales Invoice {0}").format(invoice_name)
+    return _(build_posawesome_credit_redeem_remark(invoice_name))
 
 
 def get_posawesome_cash_return_remark(invoice_name):
-    return _("POS Awesome cash refund for Sales Invoice {0}").format(invoice_name)
+    return _(build_posawesome_cash_return_remark(invoice_name))
 
 
 def _get_pos_cost_center(invoice_doc):

--- a/posawesome/posawesome/api/payments.py
+++ b/posawesome/posawesome/api/payments.py
@@ -19,6 +19,19 @@ def get_posawesome_credit_redeem_remark(invoice_name):
     return _("POS Awesome credit redemption for Sales Invoice {0}").format(invoice_name)
 
 
+def get_posawesome_cash_return_remark(invoice_name):
+    return _("POS Awesome cash refund for Sales Invoice {0}").format(invoice_name)
+
+
+def _get_pos_cost_center(invoice_doc):
+    cost_center = frappe.get_value("POS Profile", invoice_doc.pos_profile, "cost_center")
+    if not cost_center:
+        cost_center = frappe.get_value("Company", invoice_doc.company, "cost_center")
+    if not cost_center:
+        frappe.throw(_("Cost Center is not set in pos profile {0}").format(invoice_doc.pos_profile))
+    return cost_center
+
+
 @frappe.whitelist()
 def create_payment_request(doc):
     doc = json.loads(doc)
@@ -215,12 +228,9 @@ def get_amount(ref_doc, payment_account=None):
 def redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, cash_account, payments):
     # redeeming customer credit with journal voucher
     today = nowdate()
+    cost_center = None
     if data.get("redeemed_customer_credit"):
-        cost_center = frappe.get_value("POS Profile", invoice_doc.pos_profile, "cost_center")
-        if not cost_center:
-            cost_center = frappe.get_value("Company", invoice_doc.company, "cost_center")
-        if not cost_center:
-            frappe.throw(_("Cost Center is not set in pos profile {}").format(invoice_doc.pos_profile))
+        cost_center = _get_pos_cost_center(invoice_doc)
         for row in data.get("customer_credit_dict"):
             if row["type"] == "Invoice" and row["credit_to_redeem"]:
                 outstanding_invoice = frappe.get_doc("Sales Invoice", row["credit_origin"])
@@ -272,6 +282,60 @@ def redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, c
                 except Exception as e:
                     frappe.log_error(frappe.get_traceback(), "POSAwesome JV Error")
                     frappe.throw(_("Unable to create Journal Entry for customer credit."))
+
+    if data.get("change_return_mode") == "cash":
+        change_amount = flt(data.get("paid_change"))
+        if change_amount > 0:
+            cost_center = cost_center or _get_pos_cost_center(invoice_doc)
+            cash_account_name = (cash_account or {}).get("account") if isinstance(cash_account, dict) else None
+            if not cash_account_name:
+                cash_account_name = frappe.get_value("Company", invoice_doc.company, "default_cash_account")
+            if not cash_account_name:
+                frappe.throw(_("Cash account is not configured for company {0}").format(invoice_doc.company))
+
+            jv_doc = frappe.get_doc(
+                {
+                    "doctype": "Journal Entry",
+                    "voucher_type": "Journal Entry",
+                    "posting_date": today,
+                    "company": invoice_doc.company,
+                }
+            )
+
+            debit_row = jv_doc.append("accounts", {})
+            debit_row.update(
+                {
+                    "account": invoice_doc.debit_to,
+                    "party_type": "Customer",
+                    "party": invoice_doc.customer,
+                    "reference_type": invoice_doc.doctype,
+                    "reference_name": invoice_doc.name,
+                    "debit_in_account_currency": change_amount,
+                    "cost_center": cost_center,
+                }
+            )
+
+            credit_row = jv_doc.append("accounts", {})
+            credit_row.update(
+                {
+                    "account": cash_account_name,
+                    "credit_in_account_currency": change_amount,
+                    "cost_center": cost_center,
+                }
+            )
+
+            ensure_child_doctype(jv_doc, "accounts", "Journal Entry Account")
+
+            jv_doc.flags.ignore_permissions = True
+            frappe.flags.ignore_account_permission = True
+            jv_doc.user_remark = get_posawesome_cash_return_remark(invoice_doc.name)
+            jv_doc.set_missing_values()
+            try:
+                jv_doc.save()
+                jv_doc.submit()
+            except Exception:
+                frappe.log_error(frappe.get_traceback(), "POSAwesome Cash Return JV Error")
+                frappe.throw(_("Unable to create Journal Entry for cash refund."))
 
     if is_payment_entry and total_cash > 0:
         for payment in payments:


### PR DESCRIPTION
## Summary
- add a payment dialog that forces users to choose how to handle change when overpaying with a non-cash mode
- persist the selection through invoice submission and reset related state after successful submit
- create a journal entry that refunds the excess from cash when that option is selected

## Testing
- python -m py_compile posawesome/posawesome/api/payments.py

------
https://chatgpt.com/codex/tasks/task_e_6901985693088326b31132c7891af33e