### PR TITLE
Handle overpayment change for non-default POS payments

### DIFF
--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -369,7 +369,55 @@
 				</v-card>
 			</v-col>
 		</v-row>
-	</div>
+        <v-dialog v-model="overpaymentDialog" max-width="520">
+                <v-card class="pos-themed-card">
+                        <v-card-title class="text-h6">
+                                {{ __("Overpayment detected") }}
+                        </v-card-title>
+                        <v-card-text>
+                                <p>
+                                        {{
+                                                __("The entered payments exceed the selected invoices by {0}.").format(
+                                                        `${
+                                                                pos_profile && pos_profile.currency
+                                                                        ? currencySymbol(pos_profile.currency)
+                                                                        : ""
+                                                        }${formatCurrency(overpaymentAmount)}`,
+                                                )
+                                        }}
+                                </p>
+                                <p>{{ __("How would you like to handle the extra amount?") }}</p>
+                        </v-card-text>
+                        <v-divider></v-divider>
+                        <v-card-actions class="justify-end flex-wrap">
+                                <v-btn
+                                        variant="text"
+                                        color="secondary"
+                                        @click="cancelOverpaymentResolution"
+                                        :disabled="overpaymentActionLoading"
+                                >
+                                        {{ __("Cancel") }}
+                                </v-btn>
+                                <v-btn
+                                        color="primary"
+                                        theme="dark"
+                                        @click="confirmOverpaymentResolution('return_cash')"
+                                        :loading="overpaymentActionLoading"
+                                >
+                                        {{ __("Return payment from cash") }}
+                                </v-btn>
+                                <v-btn
+                                        color="success"
+                                        theme="dark"
+                                        @click="confirmOverpaymentResolution('credit_balance')"
+                                        :loading="overpaymentActionLoading"
+                                >
+                                        {{ __("Credit amount in customer balance") }}
+                                </v-btn>
+                        </v-card-actions>
+                </v-card>
+        </v-dialog>
+        </div>
 </template>
 
 <script>
@@ -409,8 +457,8 @@ export default {
 	},
 	data: function () {
 		return {
-			dialog: false,
-			pos_profile: "",
+                        dialog: false,
+                        pos_profile: "",
 			pos_opening_shift: "",
 			customer_name: "",
 			customer_info: "",
@@ -419,18 +467,23 @@ export default {
 			invoices_loading: false,
 			unallocated_payments_loading: false,
 			mpesa_payments_loading: false,
-			payment_methods: [],
+                        payment_methods: [],
+                        defaultPaymentModes: [],
 			outstanding_invoices: [],
 			unallocated_payments: [],
 			mpesa_payments: [],
 			selected_invoices: [],
 			selected_payments: [],
-			selected_mpesa_payments: [],
-			pos_profiles_list: [],
-			pos_profile_search: "",
+                        selected_mpesa_payments: [],
+                        pos_profiles_list: [],
+                        pos_profile_search: "",
 			payment_methods_list: [],
 			mpesa_search_name: "",
-			mpesa_search_mobile: "",
+                        mpesa_search_mobile: "",
+                        overpaymentDialog: false,
+                        overpaymentAmount: 0,
+                        overpaymentActionLoading: false,
+                        pendingSubmission: null,
 			invoices_headers: [
 				{
 					title: "",
@@ -813,18 +866,30 @@ export default {
 					vm.mpesa_payments_loading = false;
 				});
 		},
-		set_payment_methods() {
-			// get payment methods from pos profile
-			if (!this.pos_profile.posa_allow_make_new_payments) return;
-			this.payment_methods = [];
-			this.pos_profile.payments.forEach((method) => {
-				this.payment_methods.push({
-					mode_of_payment: method.mode_of_payment,
-					amount: 0,
-					row_id: method.name,
-				});
-			});
-		},
+                set_payment_methods() {
+                        // get payment methods from pos profile
+                        if (!this.pos_profile.posa_allow_make_new_payments) return;
+                        this.payment_methods = [];
+                        this.defaultPaymentModes = [];
+                        this.pos_profile.payments.forEach((method) => {
+                                const isDefault =
+                                        method.default === 1 ||
+                                        method.default === true ||
+                                        method.default === "1" ||
+                                        method.is_default === 1 ||
+                                        method.is_default === true ||
+                                        method.is_default === "1";
+                                if (isDefault) {
+                                        this.defaultPaymentModes.push(method.mode_of_payment);
+                                }
+                                this.payment_methods.push({
+                                        mode_of_payment: method.mode_of_payment,
+                                        amount: 0,
+                                        row_id: method.name,
+                                        is_default: isDefault,
+                                });
+                        });
+                },
 		clear_all(with_customer_info = true) {
 			this.customer_name = "";
 			if (with_customer_info) {
@@ -841,214 +906,191 @@ export default {
 			this.selected_mpesa_payments = [];
 			this.set_payment_methods();
 		},
-		submit() {
-			if (this.isSubmitting) return;
-			this.isSubmitting = true;
-			const customer = this.customer_name;
-			const vm = this;
+                submit() {
+                        this.startSubmission({ print: false });
+                },
+                submit_and_print() {
+                        this.startSubmission({ print: true });
+                },
+                startSubmission({ print }) {
+                        if (this.isSubmitting) return;
+                        this.isSubmitting = true;
+                        const customer = this.customer_name;
 
-			if (!customer) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please select a customer"));
-				return;
-			}
+                        if (!customer) {
+                                this.isSubmitting = false;
+                                frappe.throw(__("Please select a customer"));
+                                return;
+                        }
 
-			// Check if we have selected invoices
-			if (this.selected_invoices.length == 0) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please select an invoice"));
-				return;
-			}
+                        if (this.selected_invoices.length === 0) {
+                                this.isSubmitting = false;
+                                frappe.throw(__("Please select an invoice"));
+                                return;
+                        }
 
-			// Calculate payment values
-			let total_payments =
-				this.total_selected_payments +
-				this.total_selected_mpesa_payments +
-				this.total_payment_methods;
+                        const total_payments =
+                                (this.total_selected_payments || 0) +
+                                (this.total_selected_mpesa_payments || 0) +
+                                (this.total_payment_methods || 0);
 
-			if (total_payments <= 0) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please make a payment or select an payment"));
-				return;
-			}
+                        if (total_payments <= 0) {
+                                this.isSubmitting = false;
+                                frappe.throw(__("Please make a payment or select an payment"));
+                                return;
+                        }
 
-			this.payment_methods.forEach((payment) => {
-				payment.amount = flt(payment.amount);
-			});
+                        this.payment_methods.forEach((payment) => {
+                                payment.amount = flt(payment.amount);
+                        });
 
-			const payload = {};
-			payload.customer = customer;
-			payload.company = this.company;
-			payload.currency = this.pos_profile.currency;
-			payload.pos_opening_shift_name = this.pos_opening_shift.name;
-			payload.pos_profile_name = this.pos_profile.name;
-			payload.pos_profile = this.pos_profile;
-			payload.payment_methods = this.payment_methods;
-			payload.selected_invoices = this.selected_invoices;
-			payload.selected_payments = this.selected_payments;
-			payload.total_selected_invoices = flt(this.total_selected_invoices);
-			payload.selected_mpesa_payments = this.selected_mpesa_payments;
-			payload.total_selected_payments = flt(this.total_selected_payments);
-			payload.total_payment_methods = flt(this.total_payment_methods);
-			payload.total_selected_mpesa_payments = flt(this.total_selected_mpesa_payments);
+                        const payload = {};
+                        payload.customer = customer;
+                        payload.company = this.company;
+                        payload.currency = this.pos_profile.currency;
+                        payload.pos_opening_shift_name = this.pos_opening_shift.name;
+                        payload.pos_profile_name = this.pos_profile.name;
+                        payload.pos_profile = this.pos_profile;
+                        payload.payment_methods = this.payment_methods;
+                        payload.selected_invoices = this.selected_invoices;
+                        payload.selected_payments = this.selected_payments;
+                        payload.total_selected_invoices = flt(this.total_selected_invoices);
+                        payload.selected_mpesa_payments = this.selected_mpesa_payments;
+                        payload.total_selected_payments = flt(this.total_selected_payments);
+                        payload.total_payment_methods = flt(this.total_payment_methods);
+                        payload.total_selected_mpesa_payments = flt(this.total_selected_mpesa_payments);
+                        payload.default_payment_modes = [...this.defaultPaymentModes];
 
-			if (isOffline()) {
-				try {
-					saveOfflinePayment({ args: { payload } });
-					vm.eventBus.emit("show_message", {
-						title: __("Payment saved offline"),
-						color: "warning",
-					});
-					vm.clear_all(false);
-					vm.customer_name = customer;
-					vm.get_outstanding_invoices();
-					vm.get_unallocated_payments();
-					vm.set_mpesa_search_params();
-					vm.get_draft_mpesa_payments_register();
-				} catch (error) {
-					frappe.msgprint(
-						__("Cannot Save Offline Payment: ") + (error.message || __("Unknown error")),
-					);
-				}
-				vm.isSubmitting = false;
-				return;
-			}
+                        const overpaymentInfo = this.evaluateOverpayment(total_payments, payload.total_selected_invoices);
+                        payload.overpayment_amount = overpaymentInfo.amount;
+                        if (!overpaymentInfo.shouldPrompt) {
+                                payload.overpayment_resolution = "credit_balance";
+                        }
 
-			frappe.call({
-				method: "posawesome.posawesome.api.payment_entry.process_pos_payment",
-				args: { payload },
-				freeze: true,
-				freeze_message: __("Processing Payment"),
-				callback: function (r) {
-					vm.isSubmitting = false;
-					if (r.message) {
-						frappe.utils.play_sound("submit");
-						vm.clear_all(false);
-						vm.customer_name = customer;
-						vm.get_outstanding_invoices();
-						vm.get_unallocated_payments();
-						vm.set_mpesa_search_params();
-						vm.get_draft_mpesa_payments_register();
-					}
-				},
-				error: function () {
-					vm.isSubmitting = false;
-				},
-			});
-		},
-		submit_and_print() {
-			if (this.isSubmitting) return;
-			this.isSubmitting = true;
-			const customer = this.customer_name;
-			const vm = this;
-			if (!customer) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please select a customer"));
-				return;
-			}
+                        if (overpaymentInfo.shouldPrompt) {
+                                this.isSubmitting = false;
+                                this.pendingSubmission = {
+                                        payload,
+                                        customer,
+                                        print,
+                                        overpaymentAmount: overpaymentInfo.amount,
+                                };
+                                this.overpaymentAmount = overpaymentInfo.amount;
+                                this.overpaymentDialog = true;
+                                this.overpaymentActionLoading = false;
+                                return;
+                        }
 
-			// Check if we have selected invoices
-			if (this.selected_invoices.length == 0) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please select an invoice"));
-				return;
-			}
+                        this.processPayload({ payload, customer, print });
+                },
+                evaluateOverpayment(totalPayments, invoiceTotal) {
+                        const tolerance = 0.0001;
+                        const difference = flt(totalPayments) - flt(invoiceTotal);
+                        const amount = difference > tolerance ? difference : 0;
+                        const hasNonDefaultPayments = (this.payment_methods || []).some(
+                                (method) => !method.is_default && flt(method.amount) > 0,
+                        );
 
-			// Calculate payment values
-			let total_payments =
-				this.total_selected_payments +
-				this.total_selected_mpesa_payments +
-				this.total_payment_methods;
+                        return {
+                                shouldPrompt: hasNonDefaultPayments && amount > 0,
+                                amount,
+                        };
+                },
+                processPayload({ payload, customer, print = false }) {
+                        const vm = this;
 
-			if (total_payments <= 0) {
-				this.isSubmitting = false;
-				frappe.throw(__("Please make a payment or select an payment"));
-				return;
-			}
+                        const finalize = () => {
+                                vm.isSubmitting = false;
+                                vm.overpaymentActionLoading = false;
+                                vm.pendingSubmission = null;
+                                vm.overpaymentAmount = 0;
+                        };
 
-			this.payment_methods.forEach((payment) => {
-				payment.amount = flt(payment.amount);
-			});
+                        if (isOffline()) {
+                                try {
+                                        saveOfflinePayment({ args: { payload } });
+                                        vm.eventBus.emit("show_message", {
+                                                title: __("Payment saved offline"),
+                                                color: "warning",
+                                        });
+                                        vm.clear_all(false);
+                                        vm.customer_name = customer;
+                                        vm.get_outstanding_invoices();
+                                        vm.get_unallocated_payments();
+                                        vm.set_mpesa_search_params();
+                                        vm.get_draft_mpesa_payments_register();
+                                } catch (error) {
+                                        frappe.msgprint(
+                                                __("Cannot Save Offline Payment: ") + (error.message || __("Unknown error")),
+                                        );
+                                }
+                                finalize();
+                                return;
+                        }
 
-			const payload = {};
-			payload.customer = customer;
-			payload.company = this.company;
-			payload.currency = this.pos_profile.currency;
-			payload.pos_opening_shift_name = this.pos_opening_shift.name;
-			payload.pos_profile_name = this.pos_profile.name;
-			payload.pos_profile = this.pos_profile;
-			payload.payment_methods = this.payment_methods;
-			payload.selected_invoices = this.selected_invoices;
-			payload.selected_payments = this.selected_payments;
-			payload.total_selected_invoices = flt(this.total_selected_invoices);
-			payload.selected_mpesa_payments = this.selected_mpesa_payments;
-			payload.total_selected_payments = flt(this.total_selected_payments);
-			payload.total_payment_methods = flt(this.total_payment_methods);
-			payload.total_selected_mpesa_payments = flt(this.total_selected_mpesa_payments);
+                        frappe.call({
+                                method: "posawesome.posawesome.api.payment_entry.process_pos_payment",
+                                args: { payload },
+                                freeze: true,
+                                freeze_message: __("Processing Payment"),
+                                callback(r) {
+                                        if (r.message) {
+                                                frappe.utils.play_sound("submit");
 
-			if (isOffline()) {
-				try {
-					saveOfflinePayment({ args: { payload } });
-					vm.eventBus.emit("show_message", {
-						title: __("Payment saved offline"),
-						color: "warning",
-					});
-					vm.clear_all(false);
-					vm.customer_name = customer;
-					vm.get_outstanding_invoices();
-					vm.get_unallocated_payments();
-					vm.set_mpesa_search_params();
-					vm.get_draft_mpesa_payments_register();
-				} catch (error) {
-					frappe.msgprint(
-						__("Cannot Save Offline Payment: ") + (error.message || __("Unknown error")),
-					);
-				}
-				vm.isSubmitting = false;
-				return;
-			}
+                                                if (print) {
+                                                        const payment_name =
+                                                                r.message.new_payments_entry &&
+                                                                r.message.new_payments_entry.length > 0
+                                                                        ? r.message.new_payments_entry[0].name
+                                                                        : null;
 
-			frappe.call({
-				method: "posawesome.posawesome.api.payment_entry.process_pos_payment",
-				args: { payload },
-				freeze: true,
-				freeze_message: __("Processing Payment"),
-				callback: function (r) {
-					vm.isSubmitting = false;
-					if (r.message) {
-						console.log("Server response:", JSON.stringify(r.message));
-						frappe.utils.play_sound("submit");
+                                                        if (payment_name) {
+                                                                vm.load_print_page(payment_name);
+                                                        } else {
+                                                                frappe.msgprint(
+                                                                        __(
+                                                                                "Payment submitted but print function could not be executed. Payment name not found.",
+                                                                        ),
+                                                                );
+                                                        }
+                                                }
 
-						// Extract payment name from server response
-						const payment_name =
-							r.message.new_payments_entry && r.message.new_payments_entry.length > 0
-								? r.message.new_payments_entry[0].name
-								: null;
-
-						if (payment_name) {
-							console.log("Opening print view with payment name:", payment_name);
-							vm.load_print_page(payment_name);
-						} else {
-							console.log("No payment_name found in response");
-							frappe.msgprint(
-								__(
-									"Payment submitted but print function could not be executed. Payment name not found.",
-								),
-							);
-						}
-						vm.clear_all(false);
-						vm.customer_name = customer;
-						vm.get_outstanding_invoices();
-						vm.get_unallocated_payments();
-						vm.set_mpesa_search_params();
-						vm.get_draft_mpesa_payments_register();
-					}
-				},
-				error: function () {
-					vm.isSubmitting = false;
-				},
-			});
-		},
+                                                vm.clear_all(false);
+                                                vm.customer_name = customer;
+                                                vm.get_outstanding_invoices();
+                                                vm.get_unallocated_payments();
+                                                vm.set_mpesa_search_params();
+                                                vm.get_draft_mpesa_payments_register();
+                                        }
+                                        finalize();
+                                },
+                                error() {
+                                        finalize();
+                                },
+                        });
+                },
+                confirmOverpaymentResolution(resolution) {
+                        if (!this.pendingSubmission) {
+                                this.overpaymentDialog = false;
+                                return;
+                        }
+                        const action = resolution === "return_cash" ? "return_cash" : "credit_balance";
+                        this.pendingSubmission.payload.overpayment_resolution = action;
+                        this.pendingSubmission.payload.overpayment_amount = this.pendingSubmission.overpaymentAmount;
+                        this.overpaymentDialog = false;
+                        this.overpaymentActionLoading = true;
+                        this.isSubmitting = true;
+                        this.processPayload({
+                                payload: this.pendingSubmission.payload,
+                                customer: this.pendingSubmission.customer,
+                                print: this.pendingSubmission.print,
+                        });
+                },
+                cancelOverpaymentResolution() {
+                        this.overpaymentDialog = false;
+                        this.pendingSubmission = null;
+                        this.overpaymentAmount = 0;
+                },
 		selectSingleInvoice(item) {
 			console.log("Row clicked:", item);
 			if (item) {

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -270,6 +270,15 @@ def process_pos_payment(payload):
     allow_reconcile_payments = data.pos_profile.get("posa_allow_reconcile_payments")
     allow_mpesa_reconcile_payments = data.pos_profile.get("posa_allow_mpesa_reconcile_payments")
     today = nowdate()
+    overpayment_resolution = data.get("overpayment_resolution") or "credit_balance"
+    default_payment_modes = set(data.get("default_payment_modes") or [])
+    if not default_payment_modes and data.pos_profile.get("payments"):
+        default_payment_modes = {
+            method.get("mode_of_payment")
+            for method in data.pos_profile.get("payments", [])
+            if method.get("default") in (1, "1", True)
+            or method.get("is_default") in (1, "1", True)
+        }
 
     # prepare invoice list once so allocations can update remaining amounts
     remaining_invoices = []
@@ -289,7 +298,9 @@ def process_pos_payment(payload):
     new_payments_entry = []
     all_payments_entry = []
     reconciled_payments = []
+    change_journal_entries = []
     errors = []
+    non_default_overpayment = 0
 
     # first process mpesa payments
     if (
@@ -403,6 +414,7 @@ def process_pos_payment(payload):
                 if not amount:
                     continue
                 mode_of_payment = payment_method.get("mode_of_payment")
+                is_default_mode = mode_of_payment in default_payment_modes if default_payment_modes else False
                 payment_entry = create_payment_entry(
                     company=company,
                     customer=customer,
@@ -446,12 +458,38 @@ def process_pos_payment(payload):
 
                 payment_entry.save(ignore_permissions=True)
                 payment_entry.submit()
+                unallocated_amount = flt(payment_entry.unallocated_amount)
+                if unallocated_amount > 0 and not is_default_mode:
+                    non_default_overpayment += unallocated_amount
 
                 new_payments_entry.append(payment_entry)
                 all_payments_entry.append(payment_entry)
             except Exception as e:
                 errors.append(str(e))
                 frappe.log_error(f"Error creating payment entry: {str(e)}", "POS Payment Error")
+
+    if overpayment_resolution == "return_cash" and non_default_overpayment > 0:
+        cash_mode = next(iter(default_payment_modes), None)
+        if not cash_mode:
+            errors.append(
+                _("Default cash mode of payment not configured; unable to return change from cash.")
+            )
+        else:
+            try:
+                change_entry = create_change_return_entry(
+                    company=company,
+                    customer=customer,
+                    amount=non_default_overpayment,
+                    currency=currency,
+                    mode_of_payment=cash_mode,
+                    reference_no=pos_opening_shift_name,
+                )
+                if change_entry:
+                    change_journal_entries.append(change_entry)
+                    all_payments_entry.append(change_entry)
+            except Exception as e:
+                frappe.log_error(f"Failed to create change return entry: {str(e)}", "POS Payment Error")
+                errors.append(str(e))
 
     # Old allocation logic disabled
     # then show the results
@@ -480,6 +518,18 @@ def process_pos_payment(payload):
             )
         msg += "</tbody>"
         msg += "</table>"
+    if len(change_journal_entries) > 0:
+        msg += "<h4>Change Returned</h4>"
+        msg += "<table class='table table-bordered'>"
+        msg += "<thead><tr><th>Journal Entry</th><th>Amount</th></tr></thead>"
+        msg += "<tbody>"
+        for journal_entry in change_journal_entries:
+            msg += "<tr><td>{0}</td><td>{1}</td></tr>".format(
+                journal_entry.get("name"),
+                journal_entry.get("total_credit") or journal_entry.get("total_debit") or non_default_overpayment,
+            )
+        msg += "</tbody>"
+        msg += "</table>"
     if len(errors) > 0:
         msg += "<h4>Errors</h4>"
         msg += "<table class='table table-bordered'>"
@@ -496,6 +546,7 @@ def process_pos_payment(payload):
         "new_payments_entry": new_payments_entry,
         "all_payments_entry": all_payments_entry,
         "reconciled_payments": reconciled_payments,
+        "change_journal_entries": change_journal_entries,
         "errors": errors,
     }
 
@@ -509,6 +560,51 @@ def get_available_pos_profiles(company, currency):
         pluck="name",
     )
     return pos_profiles_list
+
+
+def create_change_return_entry(company, customer, amount, currency, mode_of_payment, reference_no=None):
+    amount = flt(amount)
+    if amount <= 0:
+        return None
+
+    receivable_account = get_party_account("Customer", customer, company)
+    if not receivable_account:
+        frappe.throw(
+            _("Receivable account not found for customer {0} in company {1}").format(customer, company)
+        )
+
+    bank_account = get_bank_cash_account(company, mode_of_payment)
+    if not bank_account or not bank_account.get("account"):
+        frappe.throw(
+            _("Cash account not found for mode of payment {0} in company {1}").format(mode_of_payment, company)
+        )
+
+    journal_entry = frappe.new_doc("Journal Entry")
+    journal_entry.voucher_type = "Journal Entry"
+    journal_entry.company = company
+    journal_entry.posting_date = nowdate()
+    journal_entry.multi_currency = 0
+    journal_entry.user_remark = _("Return change for POS payment")
+
+    customer_row = journal_entry.append("accounts", {})
+    customer_row.account = receivable_account
+    customer_row.party_type = "Customer"
+    customer_row.party = customer
+    customer_row.debit_in_account_currency = amount
+    if reference_no:
+        customer_row.reference_type = "POS Opening Shift"
+        customer_row.reference_name = reference_no
+
+    cash_row = journal_entry.append("accounts", {})
+    cash_row.account = bank_account.get("account")
+    cash_row.credit_in_account_currency = amount
+
+    journal_entry.set_missing_values()
+    journal_entry.flags.ignore_permissions = True
+    journal_entry.insert(ignore_permissions=True)
+    journal_entry.submit()
+
+    return journal_entry
 
 
 def get_party_account(party_type, party, company):


### PR DESCRIPTION
## Summary
- prompt operators to resolve overpayments when non-default payment methods exceed the invoice total in the POS payments screen
- track default payment modes on the frontend and send the operator’s choice back with the submission payload
- create a journal entry to return change from cash when requested and include the entry in the processing summary

## Testing
- yarn lint *(fails: command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6901985693088326b31132c7891af33e