### PR TITLE
feat: auto resolve cash overpayment

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1301,16 +1301,22 @@ export default {
 			});
 		},
 		// Submit payment after validation
-		async submit(event, payment_received = false, print = false) {
-			// For return invoices, ensure payment amounts are negative
-			if (this.invoice_doc.is_return) {
-				this.ensureReturnPaymentsAreNegative();
-			}
+                async submit(event, payment_received = false, print = false) {
+                        // For return invoices, ensure payment amounts are negative
+                        if (this.invoice_doc.is_return) {
+                                this.ensureReturnPaymentsAreNegative();
+                        }
 
-                        if (!this.shouldPromptForOverpaymentAction()) {
+                        const autoResolvedOverpayment = this.tryAutoResolveCashOverpayment();
+
+                        if (!autoResolvedOverpayment && !this.shouldPromptForOverpaymentAction()) {
                                 this.overpayment_resolution = null;
                                 this.overpayment_resolution_confirmed = false;
-                        } else if (!this.overpayment_resolution_confirmed && !payment_received) {
+                        } else if (
+                                !autoResolvedOverpayment &&
+                                !this.overpayment_resolution_confirmed &&
+                                !payment_received
+                        ) {
                                 this.pending_submit_args = { event, payment_received, print };
                                 this.overpayment_dialog = true;
                                 return;
@@ -2273,6 +2279,46 @@ export default {
                 shouldPromptForOverpaymentAction() {
                         const changeAmount = this.getOutstandingChangeAmount();
                         return changeAmount > 0;
+                },
+                tryAutoResolveCashOverpayment() {
+                        if (this.overpayment_resolution_confirmed || !this.invoice_doc || this.invoice_doc.is_return) {
+                                return false;
+                        }
+
+                        const changeAmount = this.getOutstandingChangeAmount();
+                        if (!changeAmount) {
+                                return false;
+                        }
+
+                        const hasCashOverpayment = (this.invoice_doc.payments || []).some((payment) => {
+                                if (!payment || !payment.mode_of_payment) {
+                                        return false;
+                                }
+
+                                const mode = String(payment.mode_of_payment).toLowerCase();
+                                if (!mode.includes("cash")) {
+                                        return false;
+                                }
+
+                                return this.flt(payment.amount) > 0;
+                        });
+
+                        if (!hasCashOverpayment) {
+                                return false;
+                        }
+
+                        this.overpayment_resolution = "cash";
+                        this.overpayment_resolution_confirmed = true;
+                        this.paid_change = changeAmount;
+                        this.credit_change = 0;
+
+                        if (this.invoice_doc) {
+                                this.invoice_doc.paid_change = changeAmount;
+                                this.invoice_doc.credit_change = 0;
+                                this.invoice_doc.change_return_mode = "cash";
+                        }
+
+                        return true;
                 },
                 handleOverpaymentChoice(option) {
                         const changeAmount = this.getOutstandingChangeAmount();


### PR DESCRIPTION
## Summary
- automatically resolve overpayment as cash when the payment uses a cash mode
- skip the overpayment dialog so invoices behave like the previous cash change flow

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903644f735c83268024ec8eba9bd327