### PR TITLE
Fix cash overpayment change handling

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1489,16 +1489,32 @@ export default {
                         const changeLimit = !this.invoice_doc.is_return
                                 ? Math.max(-this.diff_payment, 0)
                                 : 0;
-                        const paidChange = !this.invoice_doc.is_return
-                                ? this.flt(Math.min(this.paid_change, changeLimit), this.currency_precision)
-                                : 0;
-                        const creditChange = !this.invoice_doc.is_return
-                                ? this.flt(Math.max(changeLimit - paidChange, 0), this.currency_precision)
-                                : 0;
-                        const changeResolution =
+
+                        const resolvedChange =
                                 !this.invoice_doc.is_return && this.overpayment_resolution_confirmed
                                         ? this.overpayment_resolution
                                         : null;
+
+                        const allowCashChange =
+                                resolvedChange === "cash" && this.shouldRecordCashChange(changeLimit);
+
+                        let changeResolution = null;
+                        if (!this.invoice_doc.is_return) {
+                                if (resolvedChange === "credit") {
+                                        changeResolution = "credit";
+                                } else if (allowCashChange) {
+                                        changeResolution = "cash";
+                                }
+                        }
+
+                        const paidChange =
+                                !this.invoice_doc.is_return && changeResolution
+                                        ? this.flt(Math.min(this.paid_change, changeLimit), this.currency_precision)
+                                        : 0;
+                        const creditChange =
+                                !this.invoice_doc.is_return && changeResolution
+                                        ? this.flt(Math.max(changeLimit - paidChange, 0), this.currency_precision)
+                                        : 0;
 
                         if (this.invoice_doc) {
                                 this.invoice_doc.paid_change = paidChange;
@@ -1509,7 +1525,7 @@ export default {
                         }
 
                         if (!this.invoice_doc.is_return) {
-                                this.credit_change = creditChange ? -creditChange : 0;
+                                this.credit_change = changeResolution ? (creditChange ? -creditChange : 0) : 0;
                                 this.paid_change = paidChange;
                                 this.overpayment_resolution = changeResolution;
                                 this.overpayment_resolution_confirmed = Boolean(changeResolution);
@@ -2269,6 +2285,48 @@ export default {
                         }
 
                         return 0;
+                },
+                shouldRecordCashChange(changeLimit) {
+                        if (
+                                !changeLimit ||
+                                changeLimit <= 0 ||
+                                !this.invoice_doc ||
+                                this.invoice_doc.is_return
+                        ) {
+                                return false;
+                        }
+
+                        const invoiceTotal = this.flt(
+                                this.invoice_doc.base_rounded_total ||
+                                        this.invoice_doc.base_grand_total ||
+                                        this.invoice_doc.rounded_total ||
+                                        this.invoice_doc.grand_total ||
+                                        0,
+                                this.currency_precision,
+                        );
+                        let nonCashTotal = 0;
+
+                        (this.invoice_doc.payments || []).forEach((payment) => {
+                                const amount = this.flt(payment.amount);
+                                if (amount <= 0) {
+                                        return;
+                                }
+
+                                if (!this.isCashLikePayment(payment)) {
+                                        nonCashTotal += amount;
+                                }
+                        });
+
+                        return nonCashTotal > invoiceTotal;
+                },
+                isCashLikePayment(payment) {
+                        if (!payment) {
+                                return false;
+                        }
+
+                        const type = String(payment.type || "").toLowerCase();
+                        const mode = String(payment.mode_of_payment || "").toLowerCase();
+                        return type === "cash" || mode.includes("cash");
                 },
                 shouldPromptForOverpaymentAction() {
                         const changeAmount = this.getOutstandingChangeAmount();

--- a/posawesome/posawesome/api/payments.py
+++ b/posawesome/posawesome/api/payments.py
@@ -43,7 +43,7 @@ def _is_cash_payment_row(payment) -> bool:
     return payment_type == "cash" or "cash" in mode_of_payment
 
 
-def _should_record_cash_change(invoice_doc, payments) -> bool:
+def _should_record_cash_change(invoice_doc, payments=None, recorded_payments=None) -> bool:
     if not invoice_doc:
         return False
 
@@ -56,7 +56,8 @@ def _should_record_cash_change(invoice_doc, payments) -> bool:
     )
 
     non_cash_total = 0
-    for payment in payments or []:
+    payment_rows = payments or recorded_payments or []
+    for payment in payment_rows:
         amount = flt(payment.get("amount"))
         if amount <= 0:
             continue
@@ -320,7 +321,9 @@ def redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, c
 
     if data.get("change_return_mode") == "cash":
         change_amount = flt(data.get("paid_change"))
-        if change_amount > 0 and _should_record_cash_change(invoice_doc, payments):
+        if change_amount > 0 and _should_record_cash_change(
+            invoice_doc, data.get("payments"), payments
+        ):
             existing_cost_center = locals().get("cost_center")
             cost_center = existing_cost_center or _get_pos_cost_center(invoice_doc)
             cash_account_name = cash_account.get("account") if isinstance(cash_account, dict) else None

--- a/posawesome/posawesome/api/payments.py
+++ b/posawesome/posawesome/api/payments.py
@@ -34,6 +34,40 @@ def _get_pos_cost_center(invoice_doc):
     return cost_center
 
 
+def _is_cash_payment_row(payment) -> bool:
+    if not payment:
+        return False
+
+    payment_type = (payment.get("type") or "").lower()
+    mode_of_payment = (payment.get("mode_of_payment") or "").lower()
+    return payment_type == "cash" or "cash" in mode_of_payment
+
+
+def _should_record_cash_change(invoice_doc, payments) -> bool:
+    if not invoice_doc:
+        return False
+
+    invoice_total = flt(
+        invoice_doc.get("base_rounded_total")
+        or invoice_doc.get("base_grand_total")
+        or invoice_doc.get("rounded_total")
+        or invoice_doc.get("grand_total")
+        or 0,
+    )
+
+    non_cash_total = 0
+    for payment in payments or []:
+        amount = flt(payment.get("amount"))
+        if amount <= 0:
+            continue
+
+        if not _is_cash_payment_row(payment):
+            non_cash_total += amount
+
+    # Allow a small tolerance to avoid floating point issues
+    return flt(non_cash_total - invoice_total, 6) > 0
+
+
 @frappe.whitelist()
 def create_payment_request(doc):
     doc = json.loads(doc)
@@ -286,7 +320,7 @@ def redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, c
 
     if data.get("change_return_mode") == "cash":
         change_amount = flt(data.get("paid_change"))
-        if change_amount > 0:
+        if change_amount > 0 and _should_record_cash_change(invoice_doc, payments):
             existing_cost_center = locals().get("cost_center")
             cost_center = existing_cost_center or _get_pos_cost_center(invoice_doc)
             cash_account_name = cash_account.get("account") if isinstance(cash_account, dict) else None


### PR DESCRIPTION
## Summary
- prevent the POS payments UI from marking cash overpayments as change unless a non-cash mode exceeds the invoice total
- guard the backend cash change journal entry so it only posts when the overpayment originates from non-cash payments

## Testing
- yarn --cwd frontend build

------
https://chatgpt.com/codex/tasks/task_e_69037dbb3e9083269bc15fc136b3f666