### PR TITLE
Handle non-cash overpayments as customer credit change

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -916,9 +916,9 @@ export default {
 
                 // Calculate change to be given back to customer
                 change_due() {
-			if (!this.invoice_doc) {
-				return 0;
-			}
+                        if (!this.invoice_doc) {
+                                return 0;
+                        }
 
 			// For multi-currency, use grand_total instead of rounded_total
 			let invoice_total;
@@ -941,10 +941,29 @@ export default {
                         return change > 0 ? change : 0;
                 },
 
-		// Label for the difference field (To Be Paid/Change)
-		diff_label() {
-			return this.diff_payment > 0
-				? `To Be Paid (${this.displayCurrency})`
+                hasPositiveCashPayment() {
+                        if (!this.invoice_doc || !Array.isArray(this.invoice_doc.payments)) {
+                                return false;
+                        }
+
+                        return this.invoice_doc.payments.some((payment) => {
+                                const type = (payment?.type || "").toLowerCase();
+                                const mode = (payment?.mode_of_payment || "").toLowerCase();
+                                const rawAmount = formatUtils.fromArabicNumerals(String(payment?.amount || 0));
+                                const amount = parseFloat(rawAmount) || 0;
+
+                                if (!amount) {
+                                        return false;
+                                }
+
+                                return type === "cash" || mode.includes("cash");
+                        });
+                },
+
+                // Label for the difference field (To Be Paid/Change)
+                diff_label() {
+                        return this.diff_payment > 0
+                                ? `To Be Paid (${this.displayCurrency})`
 				: `Change (${this.displayCurrency})`;
 		},
 		// Display formatted total payments
@@ -1000,10 +1019,26 @@ export default {
 		},
 	},
 	watch: {
-		// Watch diff_payment to update paid_change
+                // Watch diff_payment to update paid_change
                 diff_payment(newVal) {
                         if (!this.is_user_editing_paid_change) {
-                                this.paid_change = newVal < 0 ? -newVal : 0;
+                                const changeLimit = Math.max(-newVal, 0);
+
+                                if (
+                                        changeLimit > 0 &&
+                                        !this.invoice_doc?.is_return &&
+                                        !this.hasPositiveCashPayment
+                                ) {
+                                        this.credit_change = changeLimit ? -changeLimit : 0;
+                                        this.paid_change = 0;
+
+                                        if (this.invoice_doc) {
+                                                this.invoice_doc.paid_change = 0;
+                                                this.invoice_doc.credit_change = changeLimit;
+                                        }
+                                } else {
+                                        this.paid_change = newVal < 0 ? -newVal : 0;
+                                }
                         }
                 },
                 // Watch paid_change to validate and update credit_change

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -5,6 +5,7 @@ import json
 
 import frappe
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
+from erpnext.accounts.party import get_party_account
 from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
 from erpnext.setup.utils import get_exchange_rate
 from erpnext.stock.doctype.batch.batch import (
@@ -525,14 +526,19 @@ def submit_invoice(invoice, data):
 
         posting_date = invoice_doc.get("posting_date") or nowdate()
         reference_no = invoice_doc.get("posa_pos_opening_shift")
+        customer_account = invoice_doc.get("debit_to") or get_party_account(
+            "Customer", invoice_doc.get("customer"), invoice_doc.get("company")
+        )
+
         advance_payment_entry = frappe.get_doc(
             {
                 "doctype": "Payment Entry",
                 "mode_of_payment": cash_mode_of_payment or "Cash",
-                "paid_to": cash_account["account"],
-                "payment_type": "Receive",
+                "payment_type": "Pay",
                 "party_type": "Customer",
                 "party": invoice_doc.get("customer"),
+                "paid_from": cash_account["account"],
+                "paid_to": customer_account,
                 "paid_amount": invoice_doc.get("credit_change"),
                 "received_amount": invoice_doc.get("credit_change"),
                 "company": invoice_doc.get("company"),


### PR DESCRIPTION
## Summary
- default non-cash overpayments to customer credit change instead of paid change
- treat POS change payouts as Payment Entry refunds from the cash account

## Testing
- python -m compileall posawesome/posawesome/api/invoices.py

------
https://chatgpt.com/codex/tasks/task_e_690389504eb883268600c905b1a573d4