### PR TITLE
Add auto reconciliation tool to POS payments register

### DIFF
--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -146,26 +146,41 @@
 								</p>
 							</v-col>
 						</v-row>
-						<v-data-table
-							:headers="unallocated_payments_headers"
-							:items="unallocated_payments"
-							item-key="name"
-							class="elevation-1 mt-0"
-							:loading="unallocated_payments_loading"
-						>
-							<template v-slot:item.select="{ item }">
-								<v-checkbox
-									v-model="selected_payments"
-									:value="item"
+                                                <v-data-table
+                                                        :headers="unallocated_payments_headers"
+                                                        :items="unallocated_payments"
+                                                        item-key="name"
+                                                        class="elevation-1 mt-0"
+                                                        :loading="unallocated_payments_loading"
+                                                        :item-class="paymentRowClass"
+                                                >
+                                                        <template v-slot:item.select="{ item }">
+                                                                <v-checkbox
+                                                                        v-model="selected_payments"
+                                                                        :value="item"
 									color="primary"
 									hide-details
 									@click.stop
-								></v-checkbox>
-							</template>
-							<template v-slot:item.paid_amount="{ item }">
-								{{ currencySymbol(item.currency) }}
-								{{ formatCurrency(item.paid_amount) }}
-							</template>
+                                                                ></v-checkbox>
+                                                        </template>
+                                                        <template v-slot:item.mode_of_payment="{ item }">
+                                                                <span>
+                                                                        {{
+                                                                                item?.is_credit_note
+                                                                                        ? __("Credit Note")
+                                                                                        : item?.mode_of_payment
+                                                                        }}
+                                                                </span>
+                                                        </template>
+                                                        <template v-slot:item.reference_invoice="{ item }">
+                                                                <span v-if="item?.is_credit_note && item?.reference_invoice">
+                                                                        {{ item.reference_invoice }}
+                                                                </span>
+                                                        </template>
+                                                        <template v-slot:item.paid_amount="{ item }">
+                                                                {{ currencySymbol(item.currency) }}
+                                                                {{ formatCurrency(item.paid_amount) }}
+                                                        </template>
 							<template v-slot:item.unallocated_amount="{ item }">
 								<span class="text-primary"
 									>{{ currencySymbol(item.currency) }}
@@ -507,43 +522,49 @@ export default {
 					key: "outstanding_amount",
 				},
 			],
-			unallocated_payments_headers: [
-				{
-					title: "",
-					align: "center",
-					sortable: false,
-					key: "select",
-					width: "50px",
-				},
-				{
-					title: __("Payment ID"),
-					align: "start",
-					sortable: true,
-					key: "name",
-				},
-				{
-					title: __("Customer"),
-					align: "start",
-					sortable: true,
-					key: "customer_name",
-				},
-				{
-					title: __("Date"),
-					align: "start",
-					sortable: true,
-					key: "posting_date",
-				},
-				{
-					title: __("Mode"),
-					align: "start",
-					sortable: true,
-					key: "mode_of_payment",
-				},
-				{
-					title: __("Paid"),
-					align: "end",
-					sortable: true,
-					key: "paid_amount",
+                        unallocated_payments_headers: [
+                                {
+                                        title: "",
+                                        align: "center",
+                                        sortable: false,
+                                        key: "select",
+                                        width: "50px",
+                                },
+                                {
+                                        title: __("Payment ID"),
+                                        align: "start",
+                                        sortable: true,
+                                        key: "name",
+                                },
+                                {
+                                        title: __("Customer"),
+                                        align: "start",
+                                        sortable: true,
+                                        key: "customer_name",
+                                },
+                                {
+                                        title: __("Date"),
+                                        align: "start",
+                                        sortable: true,
+                                        key: "posting_date",
+                                },
+                                {
+                                        title: __("Mode"),
+                                        align: "start",
+                                        sortable: true,
+                                        key: "mode_of_payment",
+                                },
+                                {
+                                        title: __("Reference"),
+                                        align: "start",
+                                        sortable: false,
+                                        key: "reference_invoice",
+                                },
+                                {
+                                        title: __("Paid"),
+                                        align: "end",
+                                        sortable: true,
+                                        key: "paid_amount",
 				},
 				{
 					title: __("Unallocated"),
@@ -593,8 +614,8 @@ export default {
 		UpdateCustomer,
 	},
 
-	methods: {
-		async check_opening_entry() {
+        methods: {
+                async check_opening_entry() {
 			var vm = this;
 			await initPromise;
 			await checkDbHealth();
@@ -687,12 +708,18 @@ export default {
 						this.pos_profiles_list = r.message;
 					}
 				});
-		},
-		create_opening_voucher() {
-			this.dialog = true;
-		},
-		async fetch_customer_details() {
-			var vm = this;
+                },
+                create_opening_voucher() {
+                        this.dialog = true;
+                },
+                paymentRowClass(item) {
+                        if (!item || typeof item !== "object") {
+                                return "";
+                        }
+                        return item.is_credit_note ? "credit-note-row" : "";
+                },
+                async fetch_customer_details() {
+                        var vm = this;
 			if (!this.customer_name) return;
 
 			// When offline, attempt to load details from cached customers
@@ -800,7 +827,14 @@ export default {
                                         currency: this.pos_profile.currency,
                                 })
                                 .then((r) => {
-                                        this.unallocated_payments = r.message || [];
+                                        const payments = Array.isArray(r.message) ? r.message : [];
+                                        this.unallocated_payments = payments.map((payment) => ({
+                                                ...payment,
+                                                is_credit_note: Boolean(payment?.is_credit_note),
+                                                mode_of_payment: payment?.is_credit_note
+                                                        ? __("Credit Note")
+                                                        : payment?.mode_of_payment,
+                                        }));
                                         this.unallocated_payments_loading = false;
                                 });
                 },
@@ -1298,6 +1332,10 @@ input[total_selected_mpesa_payments] {
 }
 
 .selected-row {
-	background-color: #e3f2fd !important;
+        background-color: #e3f2fd !important;
+}
+
+.credit-note-row {
+        background-color: rgba(76, 175, 80, 0.08) !important;
 }
 </style>

--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -64,10 +64,39 @@
 									>{{ __("Clear") }}</v-btn
 								>
 							</v-col>
-						</v-row>
-						<v-data-table
-							:headers="invoices_headers"
-							:items="outstanding_invoices"
+                                                </v-row>
+                                                <v-row
+                                                        v-if="
+                                                                pos_profile.posa_allow_reconcile_payments &&
+                                                                outstanding_invoices.length &&
+                                                                customer_name
+                                                        "
+                                                        class="mb-2"
+                                                >
+                                                        <v-col md="4" cols="12" class="pb-1">
+                                                                <v-btn
+                                                                        block
+                                                                        color="primary"
+                                                                        theme="dark"
+                                                                        :loading="auto_reconcile_loading"
+                                                                        :disabled="
+                                                                                auto_reconcile_loading ||
+                                                                                !unallocated_payments.length
+                                                                        "
+                                                                        @click="autoReconcile"
+                                                                >
+                                                                        {{ __("Auto Reconcile") }}
+                                                                </v-btn>
+                                                        </v-col>
+                                                        <v-col md="8" cols="12" v-if="auto_reconcile_summary">
+                                                                <div class="text-caption text-medium-emphasis">
+                                                                        {{ auto_reconcile_summary }}
+                                                                </div>
+                                                        </v-col>
+                                                </v-row>
+                                                <v-data-table
+                                                        :headers="invoices_headers"
+                                                        :items="outstanding_invoices"
 							item-key="voucher_no"
 							class="elevation-1 mt-0"
 							:loading="invoices_loading"
@@ -424,9 +453,11 @@ export default {
 			unallocated_payments: [],
 			mpesa_payments: [],
 			selected_invoices: [],
-			selected_payments: [],
-			selected_mpesa_payments: [],
-			pos_profiles_list: [],
+                        selected_payments: [],
+                        selected_mpesa_payments: [],
+                        auto_reconcile_loading: false,
+                        auto_reconcile_summary: "",
+                        pos_profiles_list: [],
 			pos_profile_search: "",
 			payment_methods_list: [],
 			mpesa_search_name: "",
@@ -748,38 +779,126 @@ export default {
 					}
 				});
 		},
-		get_unallocated_payments() {
-			if (!this.pos_profile.posa_allow_reconcile_payments) return;
-			this.unallocated_payments_loading = true;
-			if (!this.customer_name) {
-				this.unallocated_payments = [];
-				this.unallocated_payments_loading = false;
-				return;
-			}
+                get_unallocated_payments() {
+                        if (!this.pos_profile.posa_allow_reconcile_payments) return;
+                        this.unallocated_payments_loading = true;
+                        if (!this.customer_name) {
+                                this.unallocated_payments = [];
+                                this.unallocated_payments_loading = false;
+                                return;
+                        }
 
-			if (isOffline()) {
-				this.unallocated_payments = [];
-				this.unallocated_payments_loading = false;
-				return;
-			}
-			return frappe
-				.call("posawesome.posawesome.api.payment_entry.get_unallocated_payments", {
-					customer: this.customer_name,
-					company: this.company,
-					currency: this.pos_profile.currency,
-				})
-				.then((r) => {
-					if (r.message) {
-						this.unallocated_payments = r.message;
-						this.unallocated_payments_loading = false;
-					}
-				});
-		},
-		set_mpesa_search_params() {
-			if (!this.pos_profile.posa_allow_mpesa_reconcile_payments) return;
-			if (!this.customer_name) return;
-			this.mpesa_search_name = this.customer_info.customer_name.split(" ")[0];
-			if (this.customer_info.mobile_no) {
+                        if (isOffline()) {
+                                this.unallocated_payments = [];
+                                this.unallocated_payments_loading = false;
+                                return;
+                        }
+                        return frappe
+                                .call("posawesome.posawesome.api.payment_entry.get_unallocated_payments", {
+                                        customer: this.customer_name,
+                                        company: this.company,
+                                        currency: this.pos_profile.currency,
+                                })
+                                .then((r) => {
+                                        this.unallocated_payments = r.message || [];
+                                        this.unallocated_payments_loading = false;
+                                });
+                },
+                async autoReconcile() {
+                        if (!this.pos_profile.posa_allow_reconcile_payments) {
+                                return;
+                        }
+                        if (!this.customer_name) {
+                                frappe.msgprint(__("Please select a customer before reconciling."));
+                                return;
+                        }
+                        if (!this.outstanding_invoices.length) {
+                                frappe.msgprint(__("There are no outstanding invoices to reconcile."));
+                                return;
+                        }
+                        if (!this.unallocated_payments.length) {
+                                frappe.msgprint(__("No unallocated payments are available for reconciliation."));
+                                return;
+                        }
+                        if (isOffline()) {
+                                frappe.msgprint(__("Auto reconciliation is unavailable while offline."));
+                                return;
+                        }
+
+                        this.auto_reconcile_loading = true;
+                        this.auto_reconcile_summary = "";
+
+                        try {
+                                const response = await frappe.call({
+                                        method: "posawesome.posawesome.api.payment_entry.auto_reconcile_customer_invoices",
+                                        args: {
+                                                customer: this.customer_name,
+                                                company: this.company,
+                                                currency: this.pos_profile.currency,
+                                                pos_profile: this.pos_profile_search || null,
+                                        },
+                                        freeze: true,
+                                        freeze_message: __("Reconciling Payments"),
+                                });
+
+                                const result = response?.message || {};
+                                const { summary, total_allocated, skipped_payments } = result;
+
+                                this.auto_reconcile_summary = summary || "";
+                                if (!this.auto_reconcile_summary) {
+                                        const allocatedText = this.formatCurrency(result.total_allocated || 0);
+                                        const outstandingText = this.formatCurrency(result.remaining_outstanding || 0);
+                                        this.auto_reconcile_summary = __(
+                                                "Auto reconciliation completed. Allocated: {0}{1}. Remaining outstanding: {0}{2}.",
+                                                [
+                                                        this.currencySymbol(this.pos_profile.currency),
+                                                        allocatedText,
+                                                        outstandingText,
+                                                ],
+                                        );
+                                }
+
+                                this.selected_invoices = [];
+                                this.selected_payments = [];
+
+                                await this.get_outstanding_invoices();
+                                await this.get_unallocated_payments();
+
+                                this.$nextTick(() => {
+                                        this.$forceUpdate();
+                                });
+
+                                if (this.auto_reconcile_summary) {
+                                        this.eventBus.emit("show_message", {
+                                                title: this.auto_reconcile_summary,
+                                                color: total_allocated ? "success" : "info",
+                                        });
+                                }
+
+                                if (Array.isArray(skipped_payments) && skipped_payments.length) {
+                                        const escapeHtml = frappe.utils?.escape_html || ((value) => value);
+                                        const skippedMessage = skipped_payments
+                                                .map((row) => `<div>${escapeHtml(row)}</div>`)
+                                                .join("");
+                                        frappe.msgprint({
+                                                title: __("Skipped Payments"),
+                                                message: skippedMessage,
+                                                indicator: "orange",
+                                        });
+                                }
+                        } catch (error) {
+                                console.error("Auto reconciliation failed", error);
+                                this.auto_reconcile_summary = "";
+                                frappe.msgprint(error?.message || __("Failed to auto reconcile payments."));
+                        } finally {
+                                this.auto_reconcile_loading = false;
+                        }
+                },
+                set_mpesa_search_params() {
+                        if (!this.pos_profile.posa_allow_mpesa_reconcile_payments) return;
+                        if (!this.customer_name) return;
+                        this.mpesa_search_name = this.customer_info.customer_name.split(" ")[0];
+                        if (this.customer_info.mobile_no) {
 				this.mpesa_search_mobile =
 					this.customer_info.mobile_no.substring(0, 4) +
 					" ***** " +
@@ -837,10 +956,12 @@ export default {
 			this.outstanding_invoices = [];
 			this.unallocated_payments = [];
 			this.selected_invoices = [];
-			this.selected_payments = [];
-			this.selected_mpesa_payments = [];
-			this.set_payment_methods();
-		},
+                        this.selected_payments = [];
+                        this.selected_mpesa_payments = [];
+                        this.auto_reconcile_summary = "";
+                        this.auto_reconcile_loading = false;
+                        this.set_payment_methods();
+                },
 
 		submit() {
 			return this.processPayment({ printAfter: false });

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -3,7 +3,7 @@
 
 import frappe, erpnext, json
 from frappe import _
-from frappe.utils import nowdate, getdate, flt, fmt_money
+from frappe.utils import nowdate, getdate, flt, fmt_money, cint
 from erpnext.accounts.party import get_party_account
 from erpnext.accounts.utils import get_account_currency
 from erpnext.accounts.doctype.journal_entry.journal_entry import (
@@ -13,11 +13,12 @@ from erpnext.setup.utils import get_exchange_rate
 from erpnext.accounts.doctype.bank_account.bank_account import get_party_bank_account
 from posawesome.posawesome.api.m_pesa import submit_mpesa_payment
 from erpnext.accounts.utils import (
-    QueryPaymentLedger,
     get_outstanding_invoices as _get_outstanding_invoices,
     reconcile_against_document,
 )
-from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+from erpnext.accounts.doctype.payment_reconciliation.payment_reconciliation import (
+    reconcile_dr_cr_note,
+)
 
 
 def create_payment_entry(
@@ -234,6 +235,64 @@ def get_unallocated_payments(customer, company, currency, mode_of_payment=None):
         ],
         order_by="posting_date asc",
     )
+    for payment in unallocated_payment:
+        payment["voucher_type"] = "Payment Entry"
+        payment["is_credit_note"] = 0
+
+    credit_notes = frappe.get_all(
+        "Sales Invoice",
+        filters={
+            "customer": customer,
+            "company": company,
+            "docstatus": 1,
+            "is_return": 1,
+            "outstanding_amount": ("<", 0),
+        },
+        fields=[
+            "name",
+            "posting_date",
+            "customer_name",
+            "return_against",
+            "outstanding_amount",
+            "currency",
+            "conversion_rate",
+            "remarks",
+        ],
+        order_by="posting_date asc",
+    )
+
+    for note in credit_notes:
+        outstanding_credit = abs(flt(note.outstanding_amount or 0))
+        if not outstanding_credit:
+            continue
+
+        unallocated_payment.append(
+            {
+                "name": note.name,
+                "paid_amount": outstanding_credit,
+                "received_amount": outstanding_credit,
+                "customer_name": note.customer_name,
+                "posting_date": note.posting_date,
+                "unallocated_amount": outstanding_credit,
+                "mode_of_payment": _("Credit Note"),
+                "currency": note.currency or currency,
+                "voucher_type": "Sales Invoice",
+                "is_credit_note": 1,
+                "return_against": note.return_against,
+                "reference_invoice": note.return_against,
+                "conversion_rate": note.conversion_rate,
+                "remarks": note.remarks,
+            }
+        )
+
+    unallocated_payment = sorted(
+        unallocated_payment,
+        key=lambda pay: (
+            getdate(pay.get("posting_date")) if pay.get("posting_date") else getdate(nowdate()),
+            pay.get("name"),
+        ),
+    )
+
     return unallocated_payment
 
 
@@ -325,6 +384,124 @@ def auto_reconcile_customer_invoices(customer, company, currency=None, pos_profi
 
     for payment in unallocated_payments:
         payment_name = payment.get("name")
+        if cint(payment.get("is_credit_note")) or payment.get("voucher_type") == "Sales Invoice":
+            try:
+                credit_note_doc = frappe.get_doc("Sales Invoice", payment_name)
+            except Exception as exc:
+                skipped_payments.append(
+                    _("Unable to load Credit Note {0}: {1}").format(payment_name, frappe._(str(exc)))
+                )
+                continue
+
+            outstanding_credit = abs(flt(credit_note_doc.get("outstanding_amount")))
+            if outstanding_credit <= 0:
+                skipped_payments.append(
+                    _("Credit Note {0} has no remaining balance to allocate.").format(payment_name)
+                )
+                continue
+
+            remaining_credit = outstanding_credit
+            note_entries = []
+            invoice_allocations = []
+
+            receivable_account = credit_note_doc.get("debit_to") or get_party_account(
+                "Customer", customer, company
+            )
+            cost_center = getattr(credit_note_doc, "cost_center", None)
+            if not cost_center:
+                try:
+                    cost_center = credit_note_doc.items[0].cost_center if credit_note_doc.items else None
+                except Exception:
+                    cost_center = None
+
+            for invoice in outstanding_invoices:
+                if remaining_credit <= 0:
+                    break
+
+                outstanding = flt(invoice.get("outstanding_amount"))
+                if outstanding <= 0:
+                    continue
+
+                allocation = min(remaining_credit, outstanding)
+                if allocation <= 0:
+                    continue
+
+                note_entries.append(
+                    frappe._dict(
+                        {
+                            "voucher_type": "Sales Invoice",
+                            "voucher_no": payment_name,
+                            "voucher_detail_no": None,
+                            "against_voucher_type": "Sales Invoice",
+                            "against_voucher": invoice.get("voucher_no"),
+                            "account": receivable_account,
+                            "party_type": "Customer",
+                            "party": customer,
+                            "dr_or_cr": "credit_in_account_currency",
+                            "unreconciled_amount": remaining_credit,
+                            "unadjusted_amount": outstanding_credit,
+                            "allocated_amount": allocation,
+                            "difference_amount": 0,
+                            "difference_account": None,
+                            "difference_posting_date": None,
+                            "exchange_rate": flt(credit_note_doc.get("conversion_rate")) or 1,
+                            "debit_or_credit_note_posting_date": credit_note_doc.get("posting_date"),
+                            "cost_center": cost_center,
+                            "currency": credit_note_doc.get("currency") or currency,
+                        }
+                    )
+                )
+
+                invoice_allocations.append(
+                    {
+                        "invoice": invoice.get("voucher_no"),
+                        "amount": allocation,
+                    }
+                )
+
+                invoice["outstanding_amount"] = outstanding - allocation
+                remaining_credit -= allocation
+
+            if not note_entries:
+                skipped_payments.append(
+                    _("No outstanding invoices were available to reconcile Credit Note {0}.").format(
+                        payment_name
+                    )
+                )
+                continue
+
+            try:
+                reconcile_dr_cr_note(note_entries, company)
+            except Exception as exc:
+                _restore_outstandings(invoice_allocations)
+                skipped_payments.append(
+                    _("Failed to reconcile Credit Note {0}: {1}").format(payment_name, frappe._(str(exc)))
+                )
+                frappe.log_error(
+                    title="POS Auto Reconcile Error",
+                    message=f"Failed to auto reconcile credit note {payment_name}: {str(exc)}",
+                )
+                continue
+
+            allocated_credit = outstanding_credit - remaining_credit
+            if allocated_credit <= 0:
+                _restore_outstandings(invoice_allocations)
+                skipped_payments.append(
+                    _("No allocation was recorded for Credit Note {0}.").format(payment_name)
+                )
+                continue
+
+            total_allocated += allocated_credit
+            allocations.append(
+                {
+                    "payment_entry": payment_name,
+                    "allocated_amount": allocated_credit,
+                    "allocations": invoice_allocations,
+                    "type": "Credit Note",
+                }
+            )
+            continue
+
         try:
             pe_doc = frappe.get_doc("Payment Entry", payment_name)
         except Exception as exc:
@@ -427,6 +604,7 @@ def auto_reconcile_customer_invoices(customer, company, currency=None, pos_profi
                 "payment_entry": payment_name,
                 "allocated_amount": allocated_amount,
                 "allocations": invoice_allocations,
+                "type": "Payment Entry",
             }
         )
 
@@ -541,8 +719,116 @@ def process_pos_payment(payload):
     # then reconcile selected payments with invoices
     if allow_reconcile_payments and len(data.selected_payments) > 0 and data.total_selected_payments > 0:
         for pay in data.selected_payments:
+            payment_name = pay.get("name")
+            is_credit_note = cint(pay.get("is_credit_note")) or pay.get("voucher_type") == "Sales Invoice"
+
+            if is_credit_note:
+                try:
+                    credit_note_doc = frappe.get_doc("Sales Invoice", payment_name)
+                    outstanding_credit = abs(flt(credit_note_doc.outstanding_amount))
+                    if outstanding_credit <= 0:
+                        errors.append(
+                            _("Credit note {0} is already fully allocated").format(payment_name)
+                        )
+                        continue
+
+                    total_outstanding = sum(inv["outstanding_amount"] for inv in remaining_invoices)
+                    if total_outstanding <= 0:
+                        errors.append(
+                            _("No outstanding invoices available for allocation of credit note {0}").format(
+                                payment_name
+                            )
+                        )
+                        continue
+
+                    remaining_credit = outstanding_credit
+                    note_entries = []
+                    cost_center = getattr(credit_note_doc, "cost_center", None)
+                    if not cost_center:
+                        try:
+                            cost_center = (
+                                credit_note_doc.items[0].cost_center if credit_note_doc.items else None
+                            )
+                        except Exception:
+                            cost_center = None
+
+                    receivable_account = credit_note_doc.debit_to or get_party_account(
+                        "Customer", customer, company
+                    )
+
+                    for inv in remaining_invoices:
+                        if remaining_credit <= 0:
+                            break
+                        if inv["outstanding_amount"] <= 0:
+                            continue
+
+                        allocation = min(remaining_credit, inv["outstanding_amount"])
+                        if allocation <= 0:
+                            continue
+
+                        note_entries.append(
+                            frappe._dict(
+                                {
+                                    "voucher_type": "Sales Invoice",
+                                    "voucher_no": payment_name,
+                                    "voucher_detail_no": None,
+                                    "against_voucher_type": "Sales Invoice",
+                                    "against_voucher": inv["name"],
+                                    "account": receivable_account,
+                                    "party_type": "Customer",
+                                    "party": customer,
+                                    "dr_or_cr": "credit_in_account_currency",
+                                    "unreconciled_amount": remaining_credit,
+                                    "unadjusted_amount": outstanding_credit,
+                                    "allocated_amount": allocation,
+                                    "difference_amount": 0,
+                                    "difference_account": None,
+                                    "difference_posting_date": None,
+                                    "exchange_rate": flt(credit_note_doc.conversion_rate) or 1,
+                                    "debit_or_credit_note_posting_date": credit_note_doc.posting_date,
+                                    "cost_center": cost_center,
+                                    "currency": credit_note_doc.currency or currency,
+                                }
+                            )
+                        )
+
+                        inv["outstanding_amount"] -= allocation
+                        remaining_credit -= allocation
+
+                    allocated_credit = outstanding_credit - remaining_credit
+                    if allocated_credit <= 0:
+                        errors.append(
+                            _("No allocation made for credit note {0}").format(payment_name)
+                        )
+                        continue
+
+                    reconcile_dr_cr_note(note_entries, company)
+
+                    reconciled_payments.append(
+                        {
+                            "payment_entry": payment_name,
+                            "allocated_amount": allocated_credit,
+                        }
+                    )
+                    all_payments_entry.append(credit_note_doc)
+
+                    if remaining_credit > 0:
+                        errors.append(
+                            _("Credit note {0} still has an unapplied balance of {1}").format(
+                                payment_name,
+                                fmt_money(remaining_credit, currency=credit_note_doc.currency or currency),
+                            )
+                        )
+
+                except Exception as e:
+                    errors.append(str(e))
+                    frappe.log_error(
+                        f"Error allocating credit note {payment_name}: {str(e)}",
+                        "POS Payment Error",
+                    )
+                continue
+
             try:
-                payment_name = pay.get("name")
                 pe_doc = frappe.get_doc("Payment Entry", payment_name)
                 unallocated = flt(pe_doc.unallocated_amount)
                 if unallocated <= 0:

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -3,7 +3,7 @@
 
 import frappe, erpnext, json
 from frappe import _
-from frappe.utils import nowdate, getdate, flt
+from frappe.utils import nowdate, getdate, flt, fmt_money
 from erpnext.accounts.party import get_party_account
 from erpnext.accounts.utils import get_account_currency
 from erpnext.accounts.doctype.journal_entry.journal_entry import (
@@ -235,6 +235,239 @@ def get_unallocated_payments(customer, company, currency, mode_of_payment=None):
         order_by="posting_date asc",
     )
     return unallocated_payment
+
+
+@frappe.whitelist()
+def auto_reconcile_customer_invoices(customer, company, currency=None, pos_profile=None):
+    """Automatically reconcile all unallocated payments against outstanding invoices for a customer.
+
+    This mirrors ERPNext's payment reconciliation tool by fetching all outstanding invoices and
+    available customer payments, then allocating them in chronological order until either side is
+    exhausted. The function returns a summary describing the work that was performed so the client
+    can refresh its UI accordingly.
+    """
+
+    if not customer:
+        frappe.throw(_("Customer is required"))
+    if not company:
+        frappe.throw(_("Company is required"))
+
+    outstanding_invoices = get_outstanding_invoices(
+        customer=customer,
+        company=company,
+        currency=currency,
+        pos_profile=pos_profile,
+    )
+
+    unallocated_payments = get_unallocated_payments(
+        customer=customer,
+        company=company,
+        currency=currency,
+    )
+
+    if not outstanding_invoices:
+        return {
+            "summary": _("No outstanding invoices were found for {0}.").format(customer),
+            "allocations": [],
+            "skipped_payments": [],
+            "total_allocated": 0,
+            "remaining_outstanding": 0,
+            "outstanding_count": 0,
+            "processed_payments": len(unallocated_payments or []),
+            "reconciled_payments": 0,
+        }
+
+    if not unallocated_payments:
+        total_outstanding = sum(flt(inv.get("outstanding_amount") or 0) for inv in outstanding_invoices)
+        outstanding_count = len(outstanding_invoices)
+        return {
+            "summary": _("No unallocated payments were available for reconciliation."),
+            "allocations": [],
+            "skipped_payments": [],
+            "total_allocated": 0,
+            "remaining_outstanding": total_outstanding,
+            "outstanding_count": outstanding_count,
+            "processed_payments": 0,
+            "reconciled_payments": 0,
+        }
+
+    # Sort invoices by posting date (oldest first) to mimic ERPNext's reconciliation behaviour
+    outstanding_invoices = sorted(
+        outstanding_invoices,
+        key=lambda inv: (
+            getdate(inv.get("posting_date")) if inv.get("posting_date") else getdate(nowdate()),
+            getdate(inv.get("due_date")) if inv.get("due_date") else getdate(inv.get("posting_date") or nowdate()),
+            inv.get("voucher_no"),
+        ),
+    )
+
+    # Sort payments oldest first so that earlier payments are consumed before newer ones
+    unallocated_payments = sorted(
+        unallocated_payments,
+        key=lambda pay: (
+            getdate(pay.get("posting_date")) if pay.get("posting_date") else getdate(nowdate()),
+            pay.get("name"),
+        ),
+    )
+
+    allocations = []
+    skipped_payments = []
+    total_allocated = 0
+
+    def _restore_outstandings(invoice_allocs):
+        # Helper to restore outstanding amounts if allocation fails mid-way
+        for alloc in invoice_allocs:
+            for invoice in outstanding_invoices:
+                if invoice.get("voucher_no") == alloc.get("invoice"):
+                    invoice["outstanding_amount"] = flt(invoice.get("outstanding_amount") or 0) + flt(
+                        alloc.get("amount") or 0
+                    )
+
+    for payment in unallocated_payments:
+        payment_name = payment.get("name")
+        try:
+            pe_doc = frappe.get_doc("Payment Entry", payment_name)
+        except Exception as exc:
+            skipped_payments.append(
+                _("Unable to load Payment Entry {0}: {1}").format(payment_name, frappe._(str(exc)))
+            )
+            continue
+
+        unallocated_before = flt(pe_doc.get("unallocated_amount"))
+        if unallocated_before <= 0:
+            skipped_payments.append(
+                _("Payment Entry {0} has no unallocated amount remaining.").format(payment_name)
+            )
+            continue
+
+        remaining_amount = unallocated_before
+        entry_list = []
+        invoice_allocations = []
+
+        for invoice in outstanding_invoices:
+            if remaining_amount <= 0:
+                break
+
+            outstanding = flt(invoice.get("outstanding_amount"))
+            if outstanding <= 0:
+                continue
+
+            allocation = min(remaining_amount, outstanding)
+            if allocation <= 0:
+                continue
+
+            entry_list.append(
+                frappe._dict(
+                    {
+                        "voucher_type": "Payment Entry",
+                        "voucher_no": payment_name,
+                        "voucher_detail_no": None,
+                        "against_voucher_type": "Sales Invoice",
+                        "against_voucher": invoice.get("voucher_no"),
+                        "account": pe_doc.paid_from,
+                        "party_type": "Customer",
+                        "party": customer,
+                        "dr_or_cr": "credit_in_account_currency",
+                        "unreconciled_amount": unallocated_before,
+                        "unadjusted_amount": unallocated_before,
+                        "allocated_amount": allocation,
+                        "grand_total": outstanding,
+                        "outstanding_amount": outstanding,
+                        "exchange_rate": 1,
+                        "is_advance": 0,
+                        "difference_amount": 0,
+                        "cost_center": pe_doc.cost_center,
+                    }
+                )
+            )
+
+            invoice_allocations.append(
+                {
+                    "invoice": invoice.get("voucher_no"),
+                    "amount": allocation,
+                }
+            )
+
+            invoice["outstanding_amount"] = outstanding - allocation
+            remaining_amount -= allocation
+
+        if not entry_list:
+            skipped_payments.append(
+                _("No outstanding invoices were available to reconcile Payment Entry {0}.").format(payment_name)
+            )
+            continue
+
+        try:
+            reconcile_against_document(entry_list)
+        except Exception as exc:
+            _restore_outstandings(invoice_allocations)
+            skipped_payments.append(
+                _("Failed to reconcile Payment Entry {0}: {1}").format(payment_name, frappe._(str(exc)))
+            )
+            frappe.log_error(
+                title="POS Auto Reconcile Error",
+                message=f"Failed to auto reconcile payment {payment_name}: {str(exc)}",
+            )
+            continue
+
+        pe_doc.reload()
+        unallocated_after = flt(pe_doc.get("unallocated_amount"))
+        allocated_amount = flt(unallocated_before - unallocated_after)
+
+        if allocated_amount <= 0:
+            _restore_outstandings(invoice_allocations)
+            skipped_payments.append(
+                _("No allocation was recorded for Payment Entry {0}.").format(payment_name)
+            )
+            continue
+
+        total_allocated += allocated_amount
+        allocations.append(
+            {
+                "payment_entry": payment_name,
+                "allocated_amount": allocated_amount,
+                "allocations": invoice_allocations,
+            }
+        )
+
+    remaining_outstanding = sum(
+        flt(inv.get("outstanding_amount") or 0) for inv in outstanding_invoices if flt(inv.get("outstanding_amount") or 0) > 0
+    )
+    outstanding_count = len(
+        [inv for inv in outstanding_invoices if flt(inv.get("outstanding_amount") or 0) > 0]
+    )
+
+    summary_parts = []
+    if total_allocated:
+        summary_parts.append(
+            _("Allocated {0} across {1} payment(s).").format(
+                fmt_money(total_allocated, currency=currency), len(allocations)
+            )
+        )
+    else:
+        summary_parts.append(_("No allocations were made."))
+
+    summary_parts.append(
+        _("Remaining outstanding: {0} across {1} invoice(s).").format(
+            fmt_money(remaining_outstanding, currency=currency), outstanding_count
+        )
+    )
+
+    if skipped_payments:
+        summary_parts.append(
+            _("{0} payment(s) were skipped.").format(len(skipped_payments))
+        )
+
+    return {
+        "summary": " ".join(summary_parts),
+        "allocations": allocations,
+        "skipped_payments": skipped_payments,
+        "total_allocated": total_allocated,
+        "remaining_outstanding": remaining_outstanding,
+        "outstanding_count": outstanding_count,
+        "processed_payments": len(unallocated_payments),
+        "reconciled_payments": len(allocations),
+    }
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- add a server-side auto_reconcile_customer_invoices endpoint that allocates unallocated payments to outstanding invoices in chronological order
- surface an Auto Reconcile action in Pay.vue that triggers the server reconciliation and refreshes invoice/payment data
- improve client cleanup by resetting reconciliation state and reliably clearing loading indicators when results arrive

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_69044daf6f1083268ee55dcedd3b7922