### PR TITLE
feat: simplify navbar drawer into icon-only rail

### DIFF
--- a/frontend/src/posapp/components/Navbar.vue
+++ b/frontend/src/posapp/components/Navbar.vue
@@ -196,7 +196,10 @@ export default {
 	},
 	data() {
 		return {
-			drawer: false,
+                        drawer:
+                                typeof window !== "undefined"
+                                        ? window.innerWidth >= 1024
+                                        : true,
 			mini: true,
 			item: 0,
 			items: [
@@ -244,32 +247,39 @@ export default {
 			return this.isDark ? this.$vuetify.theme.themes.dark.colors.surface : "white";
 		},
 	},
-	mounted() {
-		this.initializeNavbar();
-		this.setupEventListeners();
-	},
+        mounted() {
+                this.initializeNavbar();
+                this.setupEventListeners();
+                this.syncDrawerToViewport(true);
+                if (typeof window !== "undefined") {
+                        window.addEventListener("resize", this.syncDrawerToViewport);
+                }
+        },
 
-	created() {
+        created() {
 		// Initialize early to prevent reactivity issues
 		this.preInitialize();
 	},
-	unmounted() {
-		if (this.notificationUpdateHandle !== null) {
-			if (this.notificationUpdateUsesTimeout) {
-				clearTimeout(this.notificationUpdateHandle);
+        unmounted() {
+                if (this.notificationUpdateHandle !== null) {
+                        if (this.notificationUpdateUsesTimeout) {
+                                clearTimeout(this.notificationUpdateHandle);
 			} else if (typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
 				window.cancelAnimationFrame(this.notificationUpdateHandle);
 			}
 			this.notificationUpdateHandle = null;
 		}
-		if (this.eventBus) {
-			this.eventBus.off("show_message", this.showMessage);
-			this.eventBus.off("freeze", this.handleFreeze);
-			this.eventBus.off("unfreeze", this.handleUnfreeze);
-			this.eventBus.off("set_company", this.handleSetCompany);
-		}
-	},
-	methods: {
+                if (this.eventBus) {
+                        this.eventBus.off("show_message", this.showMessage);
+                        this.eventBus.off("freeze", this.handleFreeze);
+                        this.eventBus.off("unfreeze", this.handleUnfreeze);
+                        this.eventBus.off("set_company", this.handleSetCompany);
+                }
+                if (typeof window !== "undefined") {
+                        window.removeEventListener("resize", this.syncDrawerToViewport);
+                }
+        },
+        methods: {
 		preInitialize() {
 			// Early initialization to prevent cache-related element destruction
 			// Use reactive assignment instead of direct property modification
@@ -349,10 +359,27 @@ export default {
 				this.eventBus.on("set_company", this.handleSetCompany);
 			}
 		},
-		handleNavClick() {
-			this.drawer = !this.drawer;
-			this.$emit("nav-click");
-		},
+                handleNavClick() {
+                        if (typeof window !== "undefined" && window.innerWidth < 1024) {
+                                this.drawer = !this.drawer;
+                        } else {
+                                this.drawer = true;
+                        }
+                        this.$emit("nav-click");
+                },
+                syncDrawerToViewport(force = false) {
+                        if (typeof window === "undefined") {
+                                return;
+                        }
+                        const isDesktop = window.innerWidth >= 1024;
+                        if (isDesktop) {
+                                if (!this.drawer) {
+                                        this.drawer = true;
+                                }
+                        } else if (force) {
+                                this.drawer = false;
+                        }
+                },
 		goDesk() {
 			window.location.href = "/app";
 		},

--- a/frontend/src/posapp/components/navbar/NavbarDrawer.vue
+++ b/frontend/src/posapp/components/navbar/NavbarDrawer.vue
@@ -1,43 +1,44 @@
 <template>
-	<v-navigation-drawer
-		v-model="drawerOpen"
-		:rail="mini"
-		expand-on-hover
-		width="220"
+        <v-navigation-drawer
+                v-model="drawerOpen"
+                rail
+                width="72"
 		:class="['drawer-custom', { 'drawer-visible': drawerOpen }, rtlClasses]"
 		@mouseleave="handleMouseLeave"
 		temporary
 		:location="isRtl ? 'right' : 'left'"
 		:scrim="scrimColor"
 	>
-		<div v-if="!mini" class="drawer-header">
-			<v-avatar size="40">
-				<v-img :src="companyImg" alt="Company logo" />
-			</v-avatar>
-			<span class="drawer-company">{{ company }}</span>
-		</div>
-		<div v-else class="drawer-header-mini">
-			<v-avatar size="40">
-				<v-img :src="companyImg" alt="Company logo" />
-			</v-avatar>
-		</div>
+                <div class="drawer-header-mini">
+                        <v-avatar size="40">
+                                <v-img :src="companyImg" alt="Company logo" />
+                        </v-avatar>
+                </div>
 
-		<v-divider />
+                <v-divider />
 
-		<v-list density="compact" nav v-model:selected="activeItem" selected-class="active-item">
-			<v-list-item
-				v-for="(item, index) in items"
-				:key="item.text"
-				:value="index"
-				@click="changePage(item.text)"
-				class="drawer-item"
-			>
-				<template v-slot:prepend>
-					<v-icon class="drawer-icon">{{ item.icon }}</v-icon>
-				</template>
-				<v-list-item-title class="drawer-item-title">{{ item.text }}</v-list-item-title>
-			</v-list-item>
-		</v-list>
+                <v-list density="compact" nav v-model:selected="activeItem" selected-class="active-item">
+                        <v-tooltip
+                                v-for="(item, index) in items"
+                                :key="item.text"
+                                location="right"
+                                :text="item.text"
+                                open-delay="150"
+                        >
+                                <template #activator="{ props }">
+                                        <v-list-item
+                                                v-bind="props"
+                                                :value="index"
+                                                @click="changePage(item.text)"
+                                                class="drawer-item"
+                                        >
+                                                <template #prepend>
+                                                        <v-icon class="drawer-icon">{{ item.icon }}</v-icon>
+                                                </template>
+                                        </v-list-item>
+                                </template>
+                        </v-tooltip>
+                </v-list>
 		<!-- Sport section, hidden by default -->
 		<div v-if="showSport">
 			<!-- Sport content goes here -->
@@ -67,9 +68,8 @@ export default {
 		isDark: Boolean,
 	},
 	data() {
-		return {
-			mini: false,
-			drawerOpen: this.drawer,
+                return {
+                        drawerOpen: this.drawer,
 			activeItem: this.item,
 			showSport: true,
 		};
@@ -82,12 +82,9 @@ export default {
 		},
 	},
 	watch: {
-		drawer(val) {
-			this.drawerOpen = val;
-			if (val) {
-				this.mini = false;
-			}
-		},
+                drawer(val) {
+                        this.drawerOpen = val;
+                },
 		drawerOpen(val) {
 			document.body.style.overflow = val ? "hidden" : "";
 			this.$emit("update:drawer", val);
@@ -103,11 +100,10 @@ export default {
 	methods: {
 		handleMouseLeave() {
 			if (!this.drawerOpen) return;
-			clearTimeout(this._closeTimeout);
-			this._closeTimeout = setTimeout(() => {
-				this.drawerOpen = false;
-				this.mini = true;
-			}, 250);
+                        clearTimeout(this._closeTimeout);
+                        this._closeTimeout = setTimeout(() => {
+                                this.drawerOpen = false;
+                        }, 250);
 		},
 		changePage(key) {
 			this.$emit("change-page", key);
@@ -117,10 +113,9 @@ export default {
 			}
 		},
 		closeDrawer() {
-			this.drawerOpen = false;
-			this.mini = true;
-		},
-	},
+                        this.drawerOpen = false;
+                },
+        },
 };
 </script>
 
@@ -132,49 +127,27 @@ export default {
 	z-index: 1005 !important; /* Higher than navbar but lower than dialogs */
 }
 
-/* Styling for the header section of the expanded navigation drawer */
-.drawer-header {
-	display: flex;
-	align-items: center;
-	height: 64px;
-	padding: 0 16px;
-	background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-}
-
 /* Styling for the header section of the mini navigation drawer */
 .drawer-header-mini {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	height: 64px;
-	background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-/* Styling for the company name text within the drawer header */
-.drawer-company {
-	margin-left: 12px;
-	flex: 1;
-	font-weight: 500;
-	font-size: 1rem;
-	color: #0097a7;
-	font-family: "Roboto", sans-serif;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 64px;
+        background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 /* Styling for icons within the navigation drawer list items */
 .drawer-icon {
-	font-size: 24px;
-	color: var(--pos-primary);
+        font-size: 24px;
+        color: var(--pos-primary);
 }
 
-/* Styling for the title text of navigation drawer list items */
-.drawer-item-title {
-	margin-left: 8px;
-	font-weight: 500;
-	font-size: 0.95rem;
-	color: var(--pos-text-primary) !important;
-	font-family: "Roboto", sans-serif;
+/* Styling for the navigation drawer list items */
+.drawer-item {
+        justify-content: center;
+        padding-inline: 0;
+        min-height: 56px;
 }
 
 /* Hover effect for all list items in the navigation drawer */
@@ -194,32 +167,15 @@ export default {
 	color: var(--pos-text-primary) !important;
 }
 
-.drawer-header,
 .drawer-header-mini {
-	background: var(--pos-navbar-bg) !important;
-	border-bottom: 1px solid var(--pos-border);
-}
-
-:deep([data-theme="dark"]) .drawer-item-title,
-:deep(.v-theme--dark) .drawer-item-title {
-	color: var(--pos-text-primary) !important;
-	font-weight: 500;
-	font-size: 0.95rem;
-	font-family: "Roboto", sans-serif;
-}
-
-:deep([data-theme="dark"]) .drawer-company,
-:deep(.v-theme--dark) .drawer-company {
-	color: var(--text-primary, #ffffff) !important;
-	font-weight: 500;
-	font-size: 1rem;
-	font-family: "Roboto", sans-serif;
+        background: var(--pos-navbar-bg) !important;
+        border-bottom: 1px solid var(--pos-border);
 }
 
 :deep([data-theme="dark"]) .drawer-icon,
 :deep(.v-theme--dark) .drawer-icon {
-	color: var(--pos-primary) !important;
-	font-size: 24px;
+        color: var(--pos-primary) !important;
+        font-size: 24px;
 }
 
 :deep([data-theme="dark"]) .v-list-item:hover,
@@ -244,27 +200,10 @@ export default {
 }
 .drawer-custom.drawer-visible {
 	display: block !important;
+	width: 72px !important;
 }
 
 /* Responsive adjustments for width and dark theme */
-@media (max-width: 900px) and (orientation: landscape) {
-	.drawer-custom.drawer-visible {
-		width: 180px !important;
-	}
-}
-
-@media (min-width: 601px) and (max-width: 1024px) {
-	.drawer-custom.drawer-visible {
-		width: 240px !important;
-	}
-}
-
-@media (min-width: 1025px) {
-	.drawer-custom.drawer-visible {
-		width: 300px !important;
-	}
-}
-
 @media (max-width: 1024px) {
 	.drawer-custom.drawer-visible {
 		background-color: var(--pos-navbar-bg) !important;

--- a/frontend/src/posapp/components/navbar/NavbarDrawer.vue
+++ b/frontend/src/posapp/components/navbar/NavbarDrawer.vue
@@ -3,12 +3,10 @@
                 v-model="drawerOpen"
                 rail
                 width="72"
-		:class="['drawer-custom', { 'drawer-visible': drawerOpen }, rtlClasses]"
-		@mouseleave="handleMouseLeave"
-		temporary
-		:location="isRtl ? 'right' : 'left'"
-		:scrim="scrimColor"
-	>
+                :class="['drawer-custom', rtlClasses]"
+                :location="isRtl ? 'right' : 'left'"
+                :scrim="scrimColor"
+        >
                 <div class="drawer-header-mini">
                         <v-avatar size="40">
                                 <v-img :src="companyImg" alt="Company logo" />
@@ -74,21 +72,18 @@ export default {
 			showSport: true,
 		};
 	},
-	computed: {
-		scrimColor() {
-			// Use an opaque background in light mode so that
-			// underlying content doesn't show through the drawer
-			return this.isDark ? true : "rgba(255,255,255,1)";
-		},
-	},
+        computed: {
+                scrimColor() {
+                        return false;
+                },
+        },
 	watch: {
                 drawer(val) {
                         this.drawerOpen = val;
                 },
-		drawerOpen(val) {
-			document.body.style.overflow = val ? "hidden" : "";
-			this.$emit("update:drawer", val);
-		},
+                drawerOpen(val) {
+                        this.$emit("update:drawer", val);
+                },
 		item(val) {
 			this.activeItem = val;
 		},
@@ -98,14 +93,7 @@ export default {
 	},
 	mounted() {},
 	methods: {
-		handleMouseLeave() {
-			if (!this.drawerOpen) return;
-                        clearTimeout(this._closeTimeout);
-                        this._closeTimeout = setTimeout(() => {
-                                this.drawerOpen = false;
-                        }, 250);
-		},
-		changePage(key) {
+                changePage(key) {
 			this.$emit("change-page", key);
 			// Close drawer after selection
 			if (window.innerWidth < 1024) {
@@ -122,9 +110,11 @@ export default {
 <style scoped>
 /* Custom styling for the navigation drawer */
 .drawer-custom {
-	background-color: var(--surface-secondary, #ffffff);
-	transition: var(--transition-normal, all 0.3s ease);
-	z-index: 1005 !important; /* Higher than navbar but lower than dialogs */
+        transition: var(--transition-normal, all 0.3s ease);
+        z-index: 1005 !important; /* Higher than navbar but lower than dialogs */
+        background-color: var(--pos-navbar-bg) !important;
+        color: var(--pos-text-primary) !important;
+        width: 72px !important;
 }
 
 /* Styling for the header section of the mini navigation drawer */
@@ -150,21 +140,22 @@ export default {
         min-height: 56px;
 }
 
+.drawer-item :deep(.v-list-item__prepend) {
+        margin-inline: 0;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+}
+
 /* Hover effect for all list items in the navigation drawer */
 .v-list-item:hover {
-	background-color: rgba(25, 118, 210, 0.08) !important;
+        background-color: rgba(25, 118, 210, 0.08) !important;
 }
 
 /* Styling for the actively selected list item in the navigation drawer */
 .active-item {
 	background-color: rgba(25, 118, 210, 0.12) !important;
 	border-right: 3px solid #1976d2;
-}
-
-/* Theme-aware drawer styling */
-.drawer-custom {
-	background-color: var(--pos-navbar-bg) !important;
-	color: var(--pos-text-primary) !important;
 }
 
 .drawer-header-mini {
@@ -194,19 +185,4 @@ export default {
 	border-color: rgba(255, 255, 255, 0.12) !important;
 }
 
-/* Hide drawer by default, show only when activated */
-.drawer-custom {
-	display: none !important;
-}
-.drawer-custom.drawer-visible {
-	display: block !important;
-	width: 72px !important;
-}
-
-/* Responsive adjustments for width and dark theme */
-@media (max-width: 1024px) {
-	.drawer-custom.drawer-visible {
-		background-color: var(--pos-navbar-bg) !important;
-	}
-}
 </style>


### PR DESCRIPTION
## Summary
- switch the navbar drawer to an icon-only rail with compact width
- add tooltips to display each menu item's label on hover
- tidy related styling and state handling for the simplified drawer

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6904c61b03848326af37183e56bbc1f5