### PR TITLE
fix: keep navbar drawer visible and center icons

### DIFF
--- a/frontend/src/posapp/components/navbar/NavbarDrawer.vue
+++ b/frontend/src/posapp/components/navbar/NavbarDrawer.vue
@@ -194,6 +194,17 @@ export default {
         align-items: center;
 }
 
+:deep(.drawer-item .v-list-item__prepend .v-icon__slot) {
+        display: flex;
+        width: 100%;
+        justify-content: center;
+        align-items: center;
+}
+
+:deep(.drawer-item .v-list-item__prepend .v-icon__slot > *) {
+        margin: 0 auto;
+}
+
 /* Hover effect for all list items in the navigation drawer */
 .v-list-item:hover {
 	background-color: rgba(25, 118, 210, 0.08) !important;

--- a/frontend/src/posapp/components/navbar/NavbarDrawer.vue
+++ b/frontend/src/posapp/components/navbar/NavbarDrawer.vue
@@ -1,43 +1,43 @@
 <template>
-	<v-navigation-drawer
-		v-model="drawerOpen"
-		:rail="mini"
-		expand-on-hover
-		width="220"
-		:class="['drawer-custom', { 'drawer-visible': drawerOpen }, rtlClasses]"
-		@mouseleave="handleMouseLeave"
-		temporary
-		:location="isRtl ? 'right' : 'left'"
-		:scrim="scrimColor"
-	>
-		<div v-if="!mini" class="drawer-header">
-			<v-avatar size="40">
-				<v-img :src="companyImg" alt="Company logo" />
-			</v-avatar>
-			<span class="drawer-company">{{ company }}</span>
-		</div>
-		<div v-else class="drawer-header-mini">
-			<v-avatar size="40">
-				<v-img :src="companyImg" alt="Company logo" />
-			</v-avatar>
-		</div>
+        <v-navigation-drawer
+                v-model="drawerOpen"
+                rail
+                width="64"
+                :permanent="!isMobile"
+                :temporary="isMobile"
+                :class="['drawer-custom', rtlClasses]"
+                :location="isRtl ? 'right' : 'left'"
+        >
+                <div class="drawer-header-mini">
+                        <v-avatar size="40">
+                                <v-img :src="companyImg" alt="Company logo" />
+                        </v-avatar>
+                </div>
 
-		<v-divider />
+                <v-divider />
 
-		<v-list density="compact" nav v-model:selected="activeItem" selected-class="active-item">
-			<v-list-item
-				v-for="(item, index) in items"
-				:key="item.text"
-				:value="index"
-				@click="changePage(item.text)"
-				class="drawer-item"
-			>
-				<template v-slot:prepend>
-					<v-icon class="drawer-icon">{{ item.icon }}</v-icon>
-				</template>
-				<v-list-item-title class="drawer-item-title">{{ item.text }}</v-list-item-title>
-			</v-list-item>
-		</v-list>
+                <v-list density="compact" nav v-model:selected="activeItem" selected-class="active-item">
+                        <v-tooltip
+                                v-for="(item, index) in items"
+                                :key="item.text"
+                                location="right"
+                                :text="item.text"
+                                open-delay="150"
+                        >
+                                <template #activator="{ props }">
+                                        <v-list-item
+                                                v-bind="props"
+                                                :value="index"
+                                                @click="changePage(item.text)"
+                                                class="drawer-item"
+                                        >
+                                                <template #prepend>
+                                                        <v-icon class="drawer-icon">{{ item.icon }}</v-icon>
+                                                </template>
+                                        </v-list-item>
+                                </template>
+                        </v-tooltip>
+                </v-list>
 		<!-- Sport section, hidden by default -->
 		<div v-if="showSport">
 			<!-- Sport content goes here -->
@@ -66,61 +66,65 @@ export default {
 		item: Number,
 		isDark: Boolean,
 	},
-	data() {
-		return {
-			mini: false,
-			drawerOpen: this.drawer,
-			activeItem: this.item,
-			showSport: true,
-		};
-	},
-	computed: {
-		scrimColor() {
-			// Use an opaque background in light mode so that
-			// underlying content doesn't show through the drawer
-			return this.isDark ? true : "rgba(255,255,255,1)";
-		},
-	},
-	watch: {
-		drawer(val) {
-			this.drawerOpen = val;
-			if (val) {
-				this.mini = false;
-			}
-		},
-		drawerOpen(val) {
-			document.body.style.overflow = val ? "hidden" : "";
-			this.$emit("update:drawer", val);
-		},
-		item(val) {
-			this.activeItem = val;
-		},
-		activeItem(val) {
-			this.$emit("update:item", val);
-		},
-	},
-	mounted() {},
-	methods: {
-		handleMouseLeave() {
-			if (!this.drawerOpen) return;
-			clearTimeout(this._closeTimeout);
-			this._closeTimeout = setTimeout(() => {
-				this.drawerOpen = false;
-				this.mini = true;
-			}, 250);
-		},
-		changePage(key) {
-			this.$emit("change-page", key);
-			// Close drawer after selection
-			if (window.innerWidth < 1024) {
-				this.closeDrawer();
-			}
-		},
-		closeDrawer() {
-			this.drawerOpen = false;
-			this.mini = true;
-		},
-	},
+        data() {
+                return {
+                        drawerOpen: true,
+                        activeItem: this.item,
+                        showSport: true,
+                        isMobile: false,
+                };
+        },
+        watch: {
+                drawer: {
+                        handler(val) {
+                                if (this.isMobile) {
+                                        this.drawerOpen = val;
+                                } else {
+                                        this.drawerOpen = true;
+                                }
+                        },
+                        immediate: true,
+                },
+                item(val) {
+                        this.activeItem = val;
+                },
+                activeItem(val) {
+                        this.$emit("update:item", val);
+                },
+                isMobile(val) {
+                        if (val) {
+                                this.drawerOpen = this.drawer;
+                        } else {
+                                this.forceDrawerOpen();
+                        }
+                },
+                drawerOpen(val) {
+                        if (this.isMobile) {
+                                this.$emit("update:drawer", val);
+                        } else if (!val) {
+                                this.$nextTick(() => this.forceDrawerOpen());
+                        }
+                },
+        },
+        mounted() {
+                this.updateViewportMode();
+                window.addEventListener("resize", this.updateViewportMode);
+        },
+        beforeUnmount() {
+                window.removeEventListener("resize", this.updateViewportMode);
+        },
+        methods: {
+                updateViewportMode() {
+                        this.isMobile = window.innerWidth < 1024;
+                },
+                forceDrawerOpen() {
+                        this.drawerOpen = true;
+                        this.$emit("update:drawer", true);
+                },
+                changePage(key) {
+                        this.$emit("change-page", key);
+                },
+        },
 };
 </script>
 
@@ -132,49 +136,35 @@ export default {
 	z-index: 1005 !important; /* Higher than navbar but lower than dialogs */
 }
 
-/* Styling for the header section of the expanded navigation drawer */
-.drawer-header {
-	display: flex;
-	align-items: center;
-	height: 64px;
-	padding: 0 16px;
-	background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-}
-
 /* Styling for the header section of the mini navigation drawer */
 .drawer-header-mini {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	height: 64px;
-	background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-/* Styling for the company name text within the drawer header */
-.drawer-company {
-	margin-left: 12px;
-	flex: 1;
-	font-weight: 500;
-	font-size: 1rem;
-	color: #0097a7;
-	font-family: "Roboto", sans-serif;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 64px;
+        background: linear-gradient(135deg, #f8f9fa 0%, #e3f2fd 100%);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 /* Styling for icons within the navigation drawer list items */
 .drawer-icon {
-	font-size: 24px;
-	color: var(--pos-primary);
+        font-size: 24px;
+        color: var(--pos-primary);
 }
 
-/* Styling for the title text of navigation drawer list items */
-.drawer-item-title {
-	margin-left: 8px;
-	font-weight: 500;
-	font-size: 0.95rem;
-	color: var(--pos-text-primary) !important;
-	font-family: "Roboto", sans-serif;
+/* Styling for the navigation drawer list items */
+.drawer-item {
+        justify-content: center;
+        padding-inline: 0;
+        min-height: 56px;
+        text-align: center;
+}
+
+.drawer-item :deep(.v-list-item__prepend) {
+        margin-inline: 0 !important;
+        width: 100%;
+        display: flex;
+        justify-content: center;
 }
 
 /* Hover effect for all list items in the navigation drawer */
@@ -194,32 +184,15 @@ export default {
 	color: var(--pos-text-primary) !important;
 }
 
-.drawer-header,
 .drawer-header-mini {
-	background: var(--pos-navbar-bg) !important;
-	border-bottom: 1px solid var(--pos-border);
-}
-
-:deep([data-theme="dark"]) .drawer-item-title,
-:deep(.v-theme--dark) .drawer-item-title {
-	color: var(--pos-text-primary) !important;
-	font-weight: 500;
-	font-size: 0.95rem;
-	font-family: "Roboto", sans-serif;
-}
-
-:deep([data-theme="dark"]) .drawer-company,
-:deep(.v-theme--dark) .drawer-company {
-	color: var(--text-primary, #ffffff) !important;
-	font-weight: 500;
-	font-size: 1rem;
-	font-family: "Roboto", sans-serif;
+        background: var(--pos-navbar-bg) !important;
+        border-bottom: 1px solid var(--pos-border);
 }
 
 :deep([data-theme="dark"]) .drawer-icon,
 :deep(.v-theme--dark) .drawer-icon {
-	color: var(--pos-primary) !important;
-	font-size: 24px;
+        color: var(--pos-primary) !important;
+        font-size: 24px;
 }
 
 :deep([data-theme="dark"]) .v-list-item:hover,
@@ -238,36 +211,9 @@ export default {
 	border-color: rgba(255, 255, 255, 0.12) !important;
 }
 
-/* Hide drawer by default, show only when activated */
+/* Ensure the drawer rail width stays consistent */
 .drawer-custom {
-	display: none !important;
-}
-.drawer-custom.drawer-visible {
-	display: block !important;
-}
-
-/* Responsive adjustments for width and dark theme */
-@media (max-width: 900px) and (orientation: landscape) {
-	.drawer-custom.drawer-visible {
-		width: 180px !important;
-	}
-}
-
-@media (min-width: 601px) and (max-width: 1024px) {
-	.drawer-custom.drawer-visible {
-		width: 240px !important;
-	}
-}
-
-@media (min-width: 1025px) {
-	.drawer-custom.drawer-visible {
-		width: 300px !important;
-	}
-}
-
-@media (max-width: 1024px) {
-	.drawer-custom.drawer-visible {
-		background-color: var(--pos-navbar-bg) !important;
-	}
+        width: 64px !important;
+        border-right: 1px solid var(--pos-border);
 }
 </style>

--- a/frontend/src/posapp/components/navbar/NavbarDrawer.vue
+++ b/frontend/src/posapp/components/navbar/NavbarDrawer.vue
@@ -2,10 +2,11 @@
         <v-navigation-drawer
                 v-model="drawerOpen"
                 rail
-                width="64"
+                rail-width="64"
                 :permanent="!isMobile"
                 :temporary="isMobile"
                 :class="['drawer-custom', rtlClasses]"
+                :style="railStyles"
                 :location="isRtl ? 'right' : 'left'"
         >
                 <div class="drawer-header-mini">
@@ -72,6 +73,9 @@ export default {
                         activeItem: this.item,
                         showSport: true,
                         isMobile: false,
+                        railStyles: {
+                                "--v-navigation-drawer-rail-width": "64px",
+                        },
                 };
         },
         watch: {
@@ -154,7 +158,9 @@ export default {
 
 /* Styling for the navigation drawer list items */
 .drawer-item {
+        display: flex;
         justify-content: center;
+        align-items: center;
         padding-inline: 0;
         min-height: 56px;
         text-align: center;
@@ -165,6 +171,10 @@ export default {
         width: 100%;
         display: flex;
         justify-content: center;
+}
+
+.drawer-item :deep(.v-list-item__prepend > .v-icon) {
+        margin-inline: 0 !important;
 }
 
 /* Hover effect for all list items in the navigation drawer */
@@ -213,7 +223,6 @@ export default {
 
 /* Ensure the drawer rail width stays consistent */
 .drawer-custom {
-        width: 64px !important;
         border-right: 1px solid var(--pos-border);
 }
 </style>

--- a/frontend/src/posapp/components/navbar/NavbarDrawer.vue
+++ b/frontend/src/posapp/components/navbar/NavbarDrawer.vue
@@ -31,6 +31,7 @@
                                                 :value="index"
                                                 @click="changePage(item.text)"
                                                 class="drawer-item"
+                                                :style="drawerItemInlineStyles"
                                         >
                                                 <template #prepend>
                                                         <v-icon class="drawer-icon">{{ item.icon }}</v-icon>
@@ -77,6 +78,17 @@ export default {
                                 "--v-navigation-drawer-rail-width": "64px",
                         },
                 };
+        },
+        computed: {
+                drawerItemInlineStyles() {
+                        return {
+                                "--v-list-item-padding-top": "0px",
+                                "--v-list-item-padding-bottom": "0px",
+                                "--v-list-item-padding-start": "0px",
+                                "--v-list-item-padding-end": "0px",
+                                "--v-list-item-prepend-width": "100%",
+                        };
+                },
         },
         watch: {
                 drawer: {
@@ -161,20 +173,25 @@ export default {
         display: flex;
         justify-content: center;
         align-items: center;
-        padding-inline: 0;
         min-height: 56px;
         text-align: center;
+        width: 100%;
 }
 
-.drawer-item :deep(.v-list-item__prepend) {
+:deep(.drawer-item .v-list-item__prepend) {
         margin-inline: 0 !important;
         width: 100%;
         display: flex;
         justify-content: center;
+        align-items: center;
 }
 
-.drawer-item :deep(.v-list-item__prepend > .v-icon) {
+:deep(.drawer-item .v-list-item__prepend > .v-icon) {
         margin-inline: 0 !important;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
 }
 
 /* Hover effect for all list items in the navigation drawer */


### PR DESCRIPTION
## Summary
- keep the navigation drawer rail permanently visible on desktop while still syncing with the mobile toggle
- add viewport handling that forces the drawer open on larger screens and updates the parent state accordingly
- center the rail icons and shrink the drawer width so the icons remain fully visible

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6904c61b03848326af37183e56bbc1f5