### PR TITLE
fix: improve scale barcode matching

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3054,27 +3054,17 @@ export default {
                                 return null;
                         }
 
-                        const prefixLength = prefix.length;
-                        const expectedItemCodeLength = prefixLength + 5;
-                        const expectedBaseLength = expectedItemCodeLength + 5;
-
-                        if (
-                                normalizedRaw.length !== expectedBaseLength &&
-                                normalizedRaw.length !== expectedBaseLength + 1
-                        ) {
+                        if (normalizedRaw.length < 12 || normalizedRaw.length > 13) {
                                 return null;
                         }
 
-                        const baseCode =
-                                normalizedRaw.length === expectedBaseLength + 1
-                                        ? normalizedRaw.slice(0, -1)
-                                        : normalizedRaw;
-                        if (baseCode.length !== expectedBaseLength) {
+                        const baseCode = normalizedRaw.length === 13 ? normalizedRaw.slice(0, -1) : normalizedRaw;
+                        if (baseCode.length !== 12) {
                                 return null;
                         }
 
-                        const itemCode = baseCode.slice(0, expectedItemCodeLength);
-                        const quantityDigits = baseCode.slice(expectedItemCodeLength);
+                        const itemCode = baseCode.slice(0, 7);
+                        const quantityDigits = baseCode.slice(7);
 
                         if (quantityDigits.length !== 5) {
                                 return null;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3054,17 +3054,27 @@ export default {
                                 return null;
                         }
 
-                        if (normalizedRaw.length < 12 || normalizedRaw.length > 13) {
+                        const prefixLength = prefix.length;
+                        const expectedItemCodeLength = prefixLength + 5;
+                        const expectedBaseLength = expectedItemCodeLength + 5;
+
+                        if (
+                                normalizedRaw.length !== expectedBaseLength &&
+                                normalizedRaw.length !== expectedBaseLength + 1
+                        ) {
                                 return null;
                         }
 
-                        const baseCode = normalizedRaw.length === 13 ? normalizedRaw.slice(0, -1) : normalizedRaw;
-                        if (baseCode.length !== 12) {
+                        const baseCode =
+                                normalizedRaw.length === expectedBaseLength + 1
+                                        ? normalizedRaw.slice(0, -1)
+                                        : normalizedRaw;
+                        if (baseCode.length !== expectedBaseLength) {
                                 return null;
                         }
 
-                        const itemCode = baseCode.slice(0, 7);
-                        const quantityDigits = baseCode.slice(7);
+                        const itemCode = baseCode.slice(0, expectedItemCodeLength);
+                        const quantityDigits = baseCode.slice(expectedItemCodeLength);
 
                         if (quantityDigits.length !== 5) {
                                 return null;


### PR DESCRIPTION
## Summary
- add reusable helpers to decode scale barcodes and extract weight quantities
- search scale scans against multiple candidate codes before falling back to server fetches
- ensure scanned items reuse the matched code when applying barcode-specific configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908c560e7e8832698ec022334cf6d87