### PR TITLE
Show promotional freebies with zero pricing

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1453,7 +1453,30 @@ export default {
                         // this.eventBus.emit("set_pos_coupons", data.posa_coupons);
                 },
                 handleSetOffers(data) {
-                        this.posOffers = data;
+                        const offers = Array.isArray(data) ? data : [];
+                        this.posOffers = offers;
+
+                        const activeRows = [...(this.items || []), ...(this.packed_items || [])]
+                                .map((item) => item && item.posa_row_id)
+                                .filter((rowId) => !!rowId);
+
+                        if (typeof this.scheduleOfferRefresh === "function") {
+                                this.scheduleOfferRefresh(activeRows);
+                        } else if (typeof this.handelOffers === "function") {
+                                this.handelOffers(activeRows);
+                        }
+
+                        if (typeof this.$nextTick === "function") {
+                                this.$nextTick(() => {
+                                        if (
+                                                typeof this.handelOffers === "function" &&
+                                                !this._offerRefreshPending &&
+                                                !this.isApplyingOffer
+                                        ) {
+                                                this.handelOffers(activeRows);
+                                        }
+                                });
+                        }
                 },
                 async handleUpdateInvoiceOffers(data) {
                         await this.updateInvoiceOffers(data);

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -427,16 +427,24 @@
 					</v-btn-toggle>
 				</v-col>
 				<v-col cols="5" class="dynamic-margin-xs">
-					<v-btn
-						size="small"
-						block
-						color="warning"
-						variant="text"
-						@click="show_offers"
-						class="action-btn-consistent"
-					>
-						{{ offersCount }} {{ __("Offers") }}
-					</v-btn>
+                                        <v-btn
+                                                size="small"
+                                                block
+                                                color="warning"
+                                                variant="text"
+                                                @click="show_offers"
+                                                class="action-btn-consistent"
+                                        >
+                                                <span>
+                                                        {{ combinedOffersCount }} {{ __("Offers") }}
+                                                        <span
+                                                                v-if="promotionalSchemesCount"
+                                                                class="text-caption text-medium-emphasis ms-1"
+                                                        >
+                                                                ({{ promotionalSchemesCount }} {{ __("Promotions") }})
+                                                        </span>
+                                                </span>
+                                        </v-btn>
 				</v-col>
 				<v-col cols="4" class="dynamic-margin-xs">
 					<v-btn
@@ -556,10 +564,12 @@ export default {
 		search_backup: "",
 		// Limit the displayed items to avoid overly large lists
 		itemsPerPage: 50,
-		offersCount: 0,
-		appliedOffersCount: 0,
-		couponsCount: 0,
-		appliedCouponsCount: 0,
+                offersCount: 0,
+                appliedOffersCount: 0,
+                promotionalSchemesCount: 0,
+                activePromotionalSchemesCount: 0,
+                couponsCount: 0,
+                appliedCouponsCount: 0,
 		new_line: false,
 		qty: 1,
 		refresh_interval: null,
@@ -3550,24 +3560,29 @@ export default {
 			}
 			return 260;
 		},
-		cardColumnWidth() {
-			const columns = Math.max(1, this.cardColumns);
-			const containerWidth = this.cardContainerWidth || 0;
-			if (!containerWidth) {
-				return 240;
-			}
+                cardColumnWidth() {
+                        const columns = Math.max(1, this.cardColumns);
+                        const containerWidth = this.cardContainerWidth || 0;
+                        if (!containerWidth) {
+                                return 240;
+                        }
 
-			const gapTotal = this.cardGap * (columns - 1);
-			const paddingTotal = this.cardPadding * 2;
-			const available = Math.max(0, containerWidth - gapTotal - paddingTotal);
-			const width = Math.floor(available / columns);
-			return Math.max(180, width);
-		},
-		displayedItems() {
-			const baseItems = Array.isArray(this.filteredItems) ? [...this.filteredItems] : [];
+                        const gapTotal = this.cardGap * (columns - 1);
+                        const paddingTotal = this.cardPadding * 2;
+                        const available = Math.max(0, containerWidth - gapTotal - paddingTotal);
+                        const width = Math.floor(available / columns);
+                        return Math.max(180, width);
+                },
+                combinedOffersCount() {
+                        const offers = Number(this.offersCount || 0);
+                        const promotions = Number(this.promotionalSchemesCount || 0);
+                        return offers + promotions;
+                },
+                displayedItems() {
+                        const baseItems = Array.isArray(this.filteredItems) ? [...this.filteredItems] : [];
 
-			if (!baseItems.length) {
-				return [];
+                        if (!baseItems.length) {
+                                return [];
 			}
 
 			const searchTerm = this.get_search(this.first_search).trim().toLowerCase();
@@ -3749,10 +3764,12 @@ export default {
 		this.eventBus.on("update_cur_items_details", () => {
 			this.update_cur_items_details();
 		});
-		this.eventBus.on("update_offers_counters", (data) => {
-			this.offersCount = data.offersCount;
-			this.appliedOffersCount = data.appliedOffersCount;
-		});
+                this.eventBus.on("update_offers_counters", (data) => {
+                        this.offersCount = data.offersCount;
+                        this.appliedOffersCount = data.appliedOffersCount;
+                        this.promotionalSchemesCount = data.promotionalSchemesCount || 0;
+                        this.activePromotionalSchemesCount = data.activePromotionalSchemesCount || 0;
+                });
                 this.eventBus.on("update_coupons_counters", (data) => {
                         this.couponsCount = data.couponsCount;
                         this.appliedCouponsCount = data.appliedCouponsCount;

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -33,10 +33,19 @@
 			<!-- Item name column -->
 			<template v-slot:item.item_name="{ item }">
 				<div class="d-flex align-center">
-					<span>{{ item.item_name }}</span>
-					<v-chip v-if="item.is_bundle" color="secondary" size="x-small" class="ml-1">
-						{{ __("Bundle") }}
-					</v-chip>
+                                        <span>{{ item.item_name }}</span>
+                                        <v-chip
+                                                v-if="item.is_free_item"
+                                                color="success"
+                                                size="x-small"
+                                                class="ml-1"
+                                                variant="tonal"
+                                        >
+                                                {{ __("Free") }}
+                                        </v-chip>
+                                        <v-chip v-if="item.is_bundle" color="secondary" size="x-small" class="ml-1">
+                                                {{ __("Bundle") }}
+                                        </v-chip>
 					<v-chip v-if="item.name_overridden" color="primary" size="x-small" class="ml-1">
 						{{ __("Edited") }}
 					</v-chip>

--- a/frontend/src/posapp/components/pos/PosOffers.vue
+++ b/frontend/src/posapp/components/pos/PosOffers.vue
@@ -68,12 +68,58 @@
 					</template>
 				</v-data-table>
 			</div>
-		</v-card>
+                </v-card>
 
-		<v-card flat style="max-height: 11vh; height: 11vh" class="cards mb-0 mt-3 py-0">
-			<v-row align="start" no-gutters>
-				<v-col cols="12">
-					<v-btn
+                <v-card
+                        v-if="promotionalSchemeCatalog.length"
+                        class="selection mx-auto mt-3 pos-themed-card"
+                        style="max-height: 40vh; overflow-y: auto"
+                >
+                        <v-card-title class="d-flex align-center justify-space-between">
+                                <span class="text-h6 text-primary">{{ __("Promotional Schemes") }}</span>
+                                <span class="text-caption text-medium-emphasis">
+                                        {{ promotionalSchemesAvailable }}
+                                        {{ promotionalSchemesAvailable === 1 ? __("Scheme") : __("Schemes") }}
+                                </span>
+                        </v-card-title>
+                        <v-divider></v-divider>
+                        <v-list density="compact">
+                                <v-list-item v-for="scheme in promotionalSchemeCatalog" :key="scheme.key">
+                                        <v-list-item-title class="text-body-2 text-high-emphasis d-flex align-center">
+                                                <span>{{ scheme.title }}</span>
+                                                <v-chip
+                                                        v-if="scheme.is_active"
+                                                        size="x-small"
+                                                        color="success"
+                                                        variant="elevated"
+                                                        class="ms-2"
+                                                >
+                                                        {{ __("Active") }}
+                                                </v-chip>
+                                        </v-list-item-title>
+                                        <v-list-item-subtitle class="text-caption text-medium-emphasis">
+                                                <template v-if="scheme.description">
+                                                        {{ scheme.description }}<br />
+                                                </template>
+                                                <span v-if="scheme.apply_on_label">{{ __("Apply On") }}: {{ scheme.apply_on_label }}</span>
+                                                <span v-if="scheme.target">
+                                                        &nbsp;•&nbsp;{{ __("Target") }}: {{ scheme.target }}
+                                                </span>
+                                                <span v-if="scheme.min_qty != null && scheme.min_qty !== 0">
+                                                        &nbsp;•&nbsp;{{ __("Min Qty") }}: {{ scheme.min_qty }}
+                                                </span>
+                                                <span v-if="scheme.given_qty != null && scheme.given_qty !== 0">
+                                                        &nbsp;•&nbsp;{{ __("Free Qty") }}: {{ scheme.given_qty }}
+                                                </span>
+                                        </v-list-item-subtitle>
+                                </v-list-item>
+                        </v-list>
+                </v-card>
+
+                <v-card flat style="max-height: 11vh; height: 11vh" class="cards mb-0 mt-3 py-0">
+                        <v-row align="start" no-gutters>
+                                <v-col cols="12">
+                                        <v-btn
 						block
 						class="pa-1"
 						size="large"
@@ -100,21 +146,24 @@ export default {
 		const { selectedCustomer } = storeToRefs(customersStore);
 		return { selectedCustomer };
 	},
-	data: () => ({
-		loading: false,
-		pos_profile: "",
-		pos_offers: [],
-		allItems: [],
-		groupItemCache: {},
-		discount_percentage_offer_name: null,
-		itemsPerPage: 1000,
-		expanded: [],
-		singleExpand: true,
-		items_headers: [
-			{ title: __("Name"), value: "name", align: "start" },
-			{ title: __("Apply On"), value: "apply_on", align: "start" },
-			{ title: __("Offer"), value: "offer", align: "start" },
-			{ title: __("Applied"), value: "offer_applied", align: "start" },
+        data: () => ({
+                loading: false,
+                pos_profile: "",
+                pos_offers: [],
+                allItems: [],
+                groupItemCache: {},
+                discount_percentage_offer_name: null,
+                itemsPerPage: 1000,
+                expanded: [],
+                singleExpand: true,
+                promotionalSchemesAvailable: 0,
+                promotionalSchemesApplicable: 0,
+                promotionalSchemeCatalog: [],
+                items_headers: [
+                        { title: __("Name"), value: "name", align: "start" },
+                        { title: __("Apply On"), value: "apply_on", align: "start" },
+                        { title: __("Offer"), value: "offer", align: "start" },
+                        { title: __("Applied"), value: "offer_applied", align: "start" },
 		],
 	}),
 
@@ -186,21 +235,86 @@ export default {
 			}
 			return result;
 		},
-		updatePosOffers(offers) {
-			const toRemove = [];
-			this.pos_offers.forEach((pos_offer) => {
-				const offer = offers.find((offer) => offer.name === pos_offer.name);
-				if (!offer) {
-					toRemove.push(pos_offer.row_id);
-				}
-			});
-			this.removeOffers(toRemove);
-			offers.forEach((offer) => {
-				const pos_offer = this.pos_offers.find((pos_offer) => offer.name === pos_offer.name);
-				if (pos_offer) {
-					pos_offer.items = offer.items;
-					if (pos_offer.offer === "Grand Total" && !this.discount_percentage_offer_name) {
-						pos_offer.offer_applied = !!pos_offer.auto;
+                updatePosOffers(payload) {
+                        let offers = [];
+                        let sourceOffers = [];
+
+                        if (Array.isArray(payload)) {
+                                offers = payload;
+                                sourceOffers = payload;
+                        } else if (payload && typeof payload === "object") {
+                                offers = Array.isArray(payload.offers) ? payload.offers : [];
+                                sourceOffers = Array.isArray(payload.sourceOffers) ? payload.sourceOffers : offers;
+                        }
+
+                        const promotionalSourceOffers = Array.isArray(sourceOffers)
+                                ? sourceOffers.filter((offer) => offer && offer.promo_source === "Promotional Scheme")
+                                : [];
+                        const promotionalApplicable = Array.isArray(offers)
+                                ? offers.filter((offer) => offer && offer.promo_source === "Promotional Scheme")
+                                : [];
+
+                        this.promotionalSchemesAvailable = promotionalSourceOffers.length;
+                        this.promotionalSchemesApplicable = promotionalApplicable.length;
+
+                        const promoCatalog = [];
+                        const seenPromotions = new Set();
+                        promotionalSourceOffers.forEach((offer) => {
+                                if (!offer) {
+                                        return;
+                                }
+                                const key = offer.promotional_scheme_rule || offer.name || offer.row_id;
+                                if (key && seenPromotions.has(key)) {
+                                        return;
+                                }
+                                if (key) {
+                                        seenPromotions.add(key);
+                                }
+
+                                const targetField =
+                                        offer.item ||
+                                        offer.item_group ||
+                                        offer.brand ||
+                                        offer.apply_item_code ||
+                                        offer.apply_item_group ||
+                                        offer.give_item ||
+                                        "";
+
+                                const isActive = promotionalApplicable.some(
+                                        (active) =>
+                                                active &&
+                                                ((active.promotional_scheme_rule &&
+                                                        active.promotional_scheme_rule === offer.promotional_scheme_rule) ||
+                                                        active.name === offer.name),
+                                );
+
+                                promoCatalog.push({
+                                        key: key || Math.random().toString(36).substring(2, 10),
+                                        title: offer.title || offer.name || key,
+                                        description: offer.description || "",
+                                        apply_on_label: offer.apply_on ? __(offer.apply_on) : "",
+                                        target: targetField,
+                                        min_qty: offer.min_qty ?? null,
+                                        given_qty: offer.given_qty ?? null,
+                                        is_active: isActive,
+                                });
+                        });
+                        this.promotionalSchemeCatalog = promoCatalog;
+
+                        const toRemove = [];
+                        this.pos_offers.forEach((pos_offer) => {
+                                const offer = offers.find((offer) => offer && offer.name === pos_offer.name);
+                                if (!offer) {
+                                        toRemove.push(pos_offer.row_id);
+                                }
+                        });
+                        this.removeOffers(toRemove);
+                        offers.forEach((offer) => {
+                                const pos_offer = this.pos_offers.find((pos_offer) => offer.name === pos_offer.name);
+                                if (pos_offer) {
+                                        pos_offer.items = offer.items;
+                                        if (pos_offer.offer === "Grand Total" && !this.discount_percentage_offer_name) {
+                                                pos_offer.offer_applied = !!pos_offer.auto;
 					}
 					if (
 						offer.apply_on == "Item Group" &&
@@ -241,13 +355,15 @@ export default {
 						}
 					}
 					this.pos_offers.push(newOffer);
-					this.eventBus.emit("show_message", {
-						title: __("New Offer Available"),
-						color: "warning",
-					});
-				}
-			});
-		},
+                                        this.eventBus.emit("show_message", {
+                                                title: __("New Offer Available"),
+                                                color: "warning",
+                                        });
+                                }
+                        });
+                        this.updateCounters();
+                        this.updatePosCoupuns();
+                },
 		removeOffers(offers_id_list) {
 			this.pos_offers = this.pos_offers.filter((offer) => !offers_id_list.includes(offer.row_id));
 		},
@@ -295,12 +411,14 @@ export default {
 			}
 			return [];
 		},
-		updateCounters() {
-			this.eventBus.emit("update_offers_counters", {
-				offersCount: this.offersCount,
-				appliedOffersCount: this.appliedOffersCount,
-			});
-		},
+                updateCounters() {
+                        this.eventBus.emit("update_offers_counters", {
+                                offersCount: this.offersCount,
+                                appliedOffersCount: this.appliedOffersCount,
+                                promotionalSchemesCount: this.promotionalSchemesAvailable,
+                                activePromotionalSchemesCount: this.promotionalSchemesApplicable,
+                        });
+                },
 		updatePosCoupuns() {
 			const applyedOffers = this.pos_offers.filter(
 				(offer) => offer.offer_applied && offer.coupon_based,

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -383,13 +383,14 @@ export default {
 			});
 		}
 
-		if (this.items.length > 0) {
-			this.items.forEach((item) => {
-				if (!item.posa_row_id) {
-					item.posa_row_id = this.makeid(20);
-				}
-				if (item.batch_no) {
-					this.set_batch_qty(item, item.batch_no);
+                if (this.items.length > 0) {
+                        this.items.forEach((item) => {
+                                this.enforceFreeItemPricing(item);
+                                if (!item.posa_row_id) {
+                                        item.posa_row_id = this.makeid(20);
+                                }
+                                if (item.batch_no) {
+                                        this.set_batch_qty(item, item.batch_no);
 				}
 				if (!item.original_item_name) {
 					item.original_item_name = item.item_name;
@@ -409,14 +410,17 @@ export default {
 			console.log("Warning: No items in return invoice");
 		}
 
-		if (this.packed_items.length > 0) {
-			this.update_items_details(this.packed_items);
-			this.packed_items.forEach((pi) => {
-				if (!pi.posa_row_id) {
-					pi.posa_row_id = this.makeid(20);
-				}
-			});
-		}
+                if (this.packed_items.length > 0) {
+                        this.packed_items.forEach((pi) => {
+                                this.enforceFreeItemPricing(pi);
+                        });
+                        this.update_items_details(this.packed_items);
+                        this.packed_items.forEach((pi) => {
+                                if (!pi.posa_row_id) {
+                                        pi.posa_row_id = this.makeid(20);
+                                }
+                        });
+                }
 
 		this.customer = data.customer;
 		this.posting_date = this.formatDateForBackend(data.posting_date || frappe.datetime.nowdate());
@@ -2546,19 +2550,84 @@ export default {
                 item.has_serial_no = data.has_serial_no;
                 item.has_batch_no = data.has_batch_no;
 
-		item.amount = this.flt(item.qty * item.rate, this.currency_precision);
-		item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
+                item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
 
-		console.log(`Updated rates for ${item.item_code} on expand:`, {
-			base_rate: item.base_rate,
-			rate: item.rate,
-			base_price_list_rate: item.base_price_list_rate,
+                this.enforceFreeItemPricing(item);
+
+                console.log(`Updated rates for ${item.item_code} on expand:`, {
+                        base_rate: item.base_rate,
+                        rate: item.rate,
+                        base_price_list_rate: item.base_price_list_rate,
 			price_list_rate: item.price_list_rate,
 			exchange_rate: this.exchange_rate,
 			selected_currency: this.selected_currency,
-			default_currency: this.pos_profile.currency,
-		});
-	},
+                        default_currency: this.pos_profile.currency,
+                });
+        },
+
+        enforceFreeItemPricing(item) {
+                if (!item) {
+                        return;
+                }
+
+                const flag = item.is_free_item;
+                const normalized =
+                        typeof flag === "string"
+                                ? flag.trim().toLowerCase()
+                                : typeof flag === "number"
+                                ? flag
+                                : flag === true
+                                ? 1
+                                : 0;
+
+                if (!(normalized === 1 || normalized === "1" || normalized === "yes" || normalized === "true")) {
+                        return;
+                }
+
+                const zeroFields = [
+                        "rate",
+                        "base_rate",
+                        "price_list_rate",
+                        "base_price_list_rate",
+                        "amount",
+                        "base_amount",
+                        "net_rate",
+                        "net_amount",
+                        "base_net_rate",
+                        "base_net_amount",
+                        "gross_rate",
+                        "gross_amount",
+                        "discount_amount",
+                        "base_discount_amount",
+                        "discount_amount_per_item",
+                        "tax_amount",
+                        "base_tax_amount",
+                ];
+
+                zeroFields.forEach((field) => {
+                        if (Object.prototype.hasOwnProperty.call(item, field)) {
+                                item[field] = 0;
+                        }
+                });
+
+                item.discount_percentage = 0;
+
+                if (!item.posa_offer_applied) {
+                        item.posa_offer_applied = 1;
+                }
+
+                if (typeof item.qty === "number") {
+                        item.amount = 0;
+                        item.base_amount = 0;
+                        if (Object.prototype.hasOwnProperty.call(item, "net_amount")) {
+                                item.net_amount = 0;
+                        }
+                        if (Object.prototype.hasOwnProperty.call(item, "gross_amount")) {
+                                item.gross_amount = 0;
+                        }
+                }
+        },
 	// Fetch customer details (info, price list, etc)
 	async fetch_customer_details() {
 		var vm = this;

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -276,10 +276,19 @@ export default {
 				}
 			}
 
-			const offers = sourceOffers.map((offer) => cache.get(offer.name)).filter((entry) => !!entry);
+                        const offers = sourceOffers.map((offer) => cache.get(offer.name)).filter((entry) => !!entry);
 
-			this.setItemGiveOffer(offers);
-			this.updatePosOffers(offers);
+                        this.setItemGiveOffer(offers);
+
+                        const appliedOfferMap = new Map(
+                                Array.isArray(this.posa_offers)
+                                        ? this.posa_offers.map((entry) => [entry.row_id, entry])
+                                        : [],
+                        );
+                        const offersToApply = offers.filter((offer) => offer && (offer.auto || appliedOfferMap.has(offer.row_id)));
+
+                        await this.updateInvoiceOffers(offersToApply);
+                        this.updatePosOffers(offers);
 		} catch (error) {
 			console.error("Failed to process offers:", error);
 		}
@@ -1312,7 +1321,11 @@ export default {
 			}
 		}
 
-		new_item.posa_row_id = this.makeid(20);
+                if (typeof this.enforceFreeItemPricing === "function") {
+                        this.enforceFreeItemPricing(new_item);
+                }
+
+                new_item.posa_row_id = this.makeid(20);
 
 		if ((!this.pos_profile.posa_auto_set_batch && new_item.has_batch_no) || new_item.has_serial_no) {
 			// Store only the item's row ID for the expanded state

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -223,12 +223,13 @@ export default {
 
 	async handelOffers(changedRowIds = [], removedRows = {}) {
 		try {
-			const sourceOffers = Array.isArray(this.posOffers) ? this.posOffers : [];
-			if (!sourceOffers.length) {
-				this.updatePosOffers([]);
-				this._cachedOfferResults = new Map();
-				return;
-			}
+                        const sourceOffers = Array.isArray(this.posOffers) ? this.posOffers : [];
+                        if (!sourceOffers.length) {
+                                await this.updateInvoiceOffers([]);
+                                this.updatePosOffers([]);
+                                this._cachedOfferResults = new Map();
+                                return;
+                        }
 
 			const allItems = [...(this.items || []), ...(this.packed_items || [])];
 			const itemMap = new Map();

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -380,20 +380,22 @@ export default {
                 }
         },
 
-	isOfferAffected(offer, changedSet, itemMap, removedInfo = {}) {
-		if (!offer) {
-			return false;
-		}
+        isOfferAffected(offer, changedSet, itemMap, removedInfo = {}) {
+                if (!offer) {
+                        return false;
+                }
 
-		if (!changedSet || !changedSet.size) {
-			return true;
-		}
+                if (!changedSet || !changedSet.size) {
+                        return true;
+                }
 
-		const applyOn = offer.apply_on;
-		const normalizedBrand = applyOn === "Brand" ? this.normalizeBrand(offer.brand) : null;
+                const applyOn = offer.apply_type || offer.apply_on;
+                const normalizedBrand = applyOn === "Brand" ? this.normalizeBrand(offer.brand) : null;
+                const targetItemCode = applyOn === "Item Code" ? offer.item || offer.apply_item_code : null;
+                const targetGroup = applyOn === "Item Group" ? offer.item_group || offer.apply_item_group : null;
 
-		for (const rowId of changedSet) {
-			const item = itemMap.get(rowId);
+                for (const rowId of changedSet) {
+                        const item = itemMap.get(rowId);
 			const fallback = removedInfo[rowId];
 			const meta = item
 				? {
@@ -419,51 +421,52 @@ export default {
 				return true;
 			}
 
-			switch (applyOn) {
-				case "Item Code":
-					if (meta.item_code === offer.item) {
-						return true;
-					}
-					break;
-				case "Item Group":
-					if (meta.item_group === offer.item_group) {
-						return true;
-					}
-					break;
-				case "Brand":
-					if (!normalizedBrand) {
-						return true;
-					}
-					if (!meta.brand) {
-						return true;
-					}
-					if (meta.brand === normalizedBrand) {
-						return true;
-					}
-					break;
-				case "Transaction":
-					return true;
-				default:
-					break;
-			}
-		}
+                        switch (applyOn) {
+                                case "Item Code":
+                                        if (targetItemCode && meta.item_code === targetItemCode) {
+                                                return true;
+                                        }
+                                        break;
+                                case "Item Group":
+                                        if (targetGroup && meta.item_group === targetGroup) {
+                                                return true;
+                                        }
+                                        break;
+                                case "Brand":
+                                        if (!normalizedBrand) {
+                                                return true;
+                                        }
+                                        if (!meta.brand) {
+                                                return true;
+                                        }
+                                        if (meta.brand === normalizedBrand) {
+                                                return true;
+                                        }
+                                        break;
+                                case "Transaction":
+                                        return true;
+                                default:
+                                        break;
+                        }
+                }
 
-		return false;
-	},
+                return false;
+        },
 
-	async buildOfferEvaluationContext(allItems, offers) {
-		const context = {
-			itemMap: new Map(),
-			itemCodeBuckets: new Map(),
-			itemGroupBuckets: new Map(),
-			brandBuckets: new Map(),
-			transactionBucket: { items: [], qty: 0, amount: 0 },
-		};
+        async buildOfferEvaluationContext(allItems, offers) {
+                const context = {
+                        itemMap: new Map(),
+                        itemCodeBuckets: new Map(),
+                        itemGroupBuckets: new Map(),
+                        brandBuckets: new Map(),
+                        transactionBucket: { items: [], qty: 0, amount: 0 },
+                };
 
-		const needItemCode = offers.some((offer) => offer.apply_on === "Item Code");
-		const needGroup = offers.some((offer) => offer.apply_on === "Item Group");
-		const needBrand = offers.some((offer) => offer.apply_on === "Brand");
-		const needTransaction = offers.some((offer) => offer.apply_on === "Transaction");
+                const resolveApplyOn = (offer) => offer.apply_type || offer.apply_on;
+                const needItemCode = offers.some((offer) => resolveApplyOn(offer) === "Item Code");
+                const needGroup = offers.some((offer) => resolveApplyOn(offer) === "Item Group");
+                const needBrand = offers.some((offer) => resolveApplyOn(offer) === "Brand");
+                const needTransaction = offers.some((offer) => resolveApplyOn(offer) === "Transaction");
 
 		const brandCandidates = [];
 
@@ -532,38 +535,41 @@ export default {
                 return context;
         },
 
-	evaluateOffer(offer, context = {}) {
-		if (!offer) {
-			return null;
-		}
+        evaluateOffer(offer, context = {}) {
+                if (!offer) {
+                        return null;
+                }
 
-		if (offer.apply_on === "Item Code") {
-			return this.getItemOffer({ ...offer }, context);
-		}
-		if (offer.apply_on === "Item Group") {
-			return this.getGroupOffer({ ...offer }, context);
-		}
-		if (offer.apply_on === "Brand") {
-			return this.getBrandOffer({ ...offer }, context);
-		}
-		if (offer.apply_on === "Transaction") {
-			return this.getTransactionOffer({ ...offer }, context);
-		}
-		return null;
-	},
+                const applyOn = offer.apply_type || offer.apply_on;
 
-	setItemGiveOffer(offers) {
-		// Set item give offer for replace
-		offers.forEach((offer) => {
-			if (offer.apply_on == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
-				offer.give_item = offer.item;
-				offer.apply_item_code = offer.item;
-			} else if (
-				offer.apply_on == "Item Group" &&
-				offer.apply_type == "Item Group" &&
-				offer.replace_cheapest_item
-			) {
-				const offerItemCode = this.getCheapestItem(offer).item_code;
+                if (applyOn === "Item Code") {
+                        return this.getItemOffer({ ...offer }, context);
+                }
+                if (applyOn === "Item Group") {
+                        return this.getGroupOffer({ ...offer }, context);
+                }
+                if (applyOn === "Brand") {
+                        return this.getBrandOffer({ ...offer }, context);
+                }
+                if (applyOn === "Transaction") {
+                        return this.getTransactionOffer({ ...offer }, context);
+                }
+                return null;
+        },
+
+        setItemGiveOffer(offers) {
+                // Set item give offer for replace
+                offers.forEach((offer) => {
+                        const applyOn = offer.apply_type || offer.apply_on;
+                        if (applyOn == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
+                                offer.give_item = offer.item;
+                                offer.apply_item_code = offer.item;
+                        } else if (
+                                applyOn == "Item Group" &&
+                                offer.apply_type == "Item Group" &&
+                                offer.replace_cheapest_item
+                        ) {
+                                const offerItemCode = this.getCheapestItem(offer).item_code;
 				offer.give_item = offerItemCode;
 				offer.apply_item_code = offerItemCode;
 			}
@@ -669,10 +675,11 @@ export default {
 		}
 	},
 
-	getItemOffer(offer, context = {}) {
-		if (!offer || offer.apply_on !== "Item Code") {
-			return null;
-		}
+        getItemOffer(offer, context = {}) {
+                const applyOn = offer?.apply_type || offer?.apply_on;
+                if (!offer || applyOn !== "Item Code") {
+                        return null;
+                }
 
 		if (!this.checkOfferCoupon(offer)) {
 			return null;
@@ -722,10 +729,11 @@ export default {
                 return offer;
         },
 
-	getGroupOffer(offer, context = {}) {
-		if (!offer || offer.apply_on !== "Item Group") {
-			return null;
-		}
+        getGroupOffer(offer, context = {}) {
+                const applyOn = offer?.apply_type || offer?.apply_on;
+                if (!offer || applyOn !== "Item Group") {
+                        return null;
+                }
 
 		if (!this.checkOfferCoupon(offer)) {
 			return null;
@@ -775,10 +783,11 @@ export default {
                 return offer;
         },
 
-	getBrandOffer(offer, context = {}) {
-		if (!offer || offer.apply_on !== "Brand") {
-			return null;
-		}
+        getBrandOffer(offer, context = {}) {
+                const applyOn = offer?.apply_type || offer?.apply_on;
+                if (!offer || applyOn !== "Brand") {
+                        return null;
+                }
 
 		if (!this.checkOfferCoupon(offer)) {
 			return null;
@@ -832,10 +841,11 @@ export default {
                 offer.items = items;
                 return offer;
         },
-	getTransactionOffer(offer, context = {}) {
-		if (!offer || offer.apply_on !== "Transaction") {
-			return null;
-		}
+        getTransactionOffer(offer, context = {}) {
+                const applyOn = offer?.apply_type || offer?.apply_on;
+                if (!offer || applyOn !== "Transaction") {
+                        return null;
+                }
 
 		if (!this.checkOfferCoupon(offer)) {
 			return null;
@@ -1102,8 +1112,9 @@ export default {
 			} else if (Array.isArray(offer.items)) {
 				itemsRowID = offer.items;
 			}
-			if (offer.apply_on == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
-				const item = await this.ApplyOnGiveProduct(offer, offer.item);
+                        const applyOn = offer.apply_type || offer.apply_on;
+                        if (applyOn == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
+                                const item = await this.ApplyOnGiveProduct(offer, offer.item);
 				if (!item) {
 					this.isApplyingOffer = false;
 					return;
@@ -1133,11 +1144,11 @@ export default {
 				}
 				this.items.unshift(item);
 				offer.give_item_row_id = item.posa_row_id;
-			} else if (
-				offer.apply_on == "Item Group" &&
-				offer.apply_type == "Item Group" &&
-				offer.replace_cheapest_item
-			) {
+                        } else if (
+                                applyOn == "Item Group" &&
+                                offer.apply_type == "Item Group" &&
+                                offer.replace_cheapest_item
+                        ) {
 				const itemsList = [];
 				itemsRowID.forEach((row_id) => {
 					const resolved = this.getItemFromRowID(row_id);

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -119,6 +119,68 @@ export default {
                 const parsed = Number(value);
                 return Number.isFinite(parsed) ? parsed : 0;
         },
+        resolveOfferItemQty(item) {
+                if (!item) {
+                        return 0;
+                }
+
+                const hasStockQty =
+                        item.stock_qty !== undefined && item.stock_qty !== null && item.stock_qty !== "";
+                if (hasStockQty) {
+                        const stockQty = this.normalizeNumber(item.stock_qty);
+                        if (Math.abs(stockQty) > 0) {
+                                return stockQty;
+                        }
+                }
+
+                const qty = this.normalizeNumber(item.qty);
+                if (!qty) {
+                        return 0;
+                }
+
+                const conversion = this.normalizeNumber(item.conversion_factor || 1);
+                if (!conversion || conversion === 1) {
+                        return qty;
+                }
+
+                return qty * conversion;
+        },
+        resolveOfferItemRate(item) {
+                if (!item) {
+                        return 0;
+                }
+
+                const candidates = [
+                        item.original_price_list_rate,
+                        item.base_price_list_rate,
+                        item.price_list_rate,
+                        item.original_rate,
+                        item.base_rate,
+                        item.rate,
+                ];
+
+                for (const value of candidates) {
+                        const normalized = this.normalizeNumber(value);
+                        if (Math.abs(normalized) > 0) {
+                                return normalized;
+                        }
+                }
+
+                return 0;
+        },
+        resolveOfferItemAmount(item) {
+                const qty = this.resolveOfferItemQty(item);
+                if (!qty) {
+                        return 0;
+                }
+
+                const rate = this.resolveOfferItemRate(item);
+                if (!rate) {
+                        return 0;
+                }
+
+                return qty * rate;
+        },
         computeOfferFreeQuantity(offer, totalQty) {
                 const baseFreeQty = this.normalizeNumber(offer?.given_qty);
                 if (baseFreeQty <= 0) {
@@ -226,7 +288,7 @@ export default {
                         const sourceOffers = Array.isArray(this.posOffers) ? this.posOffers : [];
                         if (!sourceOffers.length) {
                                 await this.updateInvoiceOffers([]);
-                                this.updatePosOffers([]);
+                                this.updatePosOffers([], []);
                                 this._cachedOfferResults = new Map();
                                 return;
                         }
@@ -279,6 +341,15 @@ export default {
 
                         const offers = sourceOffers.map((offer) => cache.get(offer.name)).filter((entry) => !!entry);
 
+                        offers.forEach((offer) => {
+                                if (!offer) {
+                                        return;
+                                }
+                                if (this.normalizeBoolean(offer.auto)) {
+                                        offer.offer_applied = true;
+                                }
+                        });
+
                         this.setItemGiveOffer(offers);
 
                         const appliedOfferMap = new Map(
@@ -286,14 +357,28 @@ export default {
                                         ? this.posa_offers.map((entry) => [entry.row_id, entry])
                                         : [],
                         );
-                        const offersToApply = offers.filter((offer) => offer && (offer.auto || appliedOfferMap.has(offer.row_id)));
+                        const offersToApply = offers.filter((offer) => {
+                                if (!offer) {
+                                        return false;
+                                }
+
+                                const isAuto = this.normalizeBoolean(offer.auto);
+                                const isApplied = this.normalizeBoolean(offer.offer_applied);
+                                const alreadyApplied = appliedOfferMap.has(offer.row_id);
+
+                                if (isAuto && !isApplied) {
+                                        offer.offer_applied = true;
+                                }
+
+                                return isAuto || isApplied || alreadyApplied;
+                        });
 
                         await this.updateInvoiceOffers(offersToApply);
-                        this.updatePosOffers(offers);
-		} catch (error) {
-			console.error("Failed to process offers:", error);
-		}
-	},
+                        this.updatePosOffers(offers, sourceOffers);
+                } catch (error) {
+                        console.error("Failed to process offers:", error);
+                }
+        },
 
 	isOfferAffected(offer, changedSet, itemMap, removedInfo = {}) {
 		if (!offer) {
@@ -382,71 +467,70 @@ export default {
 
 		const brandCandidates = [];
 
-		(Array.isArray(allItems) ? allItems : []).forEach((item) => {
-			if (!item) {
-				return;
-			}
-			if (item.posa_row_id) {
-				context.itemMap.set(item.posa_row_id, item);
-			}
+                (Array.isArray(allItems) ? allItems : []).forEach((item) => {
+                        if (!item) {
+                                return;
+                        }
+                        if (item.posa_row_id) {
+                                context.itemMap.set(item.posa_row_id, item);
+                        }
 
-			const qty = item.stock_qty || 0;
-			const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-			const amount = qty * rate;
+                        const qty = this.resolveOfferItemQty(item);
+                        const amount = this.resolveOfferItemAmount(item);
 
-			if (needItemCode && !item.posa_is_offer && item.item_code) {
-				let bucket = context.itemCodeBuckets.get(item.item_code);
-				if (!bucket) {
-					bucket = { items: [], qty: 0, amount: 0 };
-					context.itemCodeBuckets.set(item.item_code, bucket);
-				}
-				bucket.items.push(item);
-				bucket.qty += qty;
-				bucket.amount += amount;
-			}
+                        if (needItemCode && !item.posa_is_offer && item.item_code) {
+                                let bucket = context.itemCodeBuckets.get(item.item_code);
+                                if (!bucket) {
+                                        bucket = { items: [], qty: 0, amount: 0 };
+                                        context.itemCodeBuckets.set(item.item_code, bucket);
+                                }
+                                bucket.items.push(item);
+                                bucket.qty += qty;
+                                bucket.amount += amount;
+                        }
 
-			if (needGroup && !item.posa_is_offer && item.item_group) {
-				let bucket = context.itemGroupBuckets.get(item.item_group);
-				if (!bucket) {
+                        if (needGroup && !item.posa_is_offer && item.item_group) {
+                                let bucket = context.itemGroupBuckets.get(item.item_group);
+                                if (!bucket) {
 					bucket = { items: [], qty: 0, amount: 0 };
 					context.itemGroupBuckets.set(item.item_group, bucket);
-				}
-				bucket.items.push(item);
-				bucket.qty += qty;
-				bucket.amount += amount;
-			}
+                                }
+                                bucket.items.push(item);
+                                bucket.qty += qty;
+                                bucket.amount += amount;
+                        }
 
-			if (needBrand && !item.posa_is_offer && item.item_code) {
-				brandCandidates.push(item);
-			}
+                        if (needBrand && !item.posa_is_offer && item.item_code) {
+                                brandCandidates.push(item);
+                        }
 
-			if (needTransaction && !item.posa_is_offer && !item.posa_is_replace) {
-				context.transactionBucket.items.push(item);
-				context.transactionBucket.qty += qty;
-				context.transactionBucket.amount += amount;
-			}
-		});
+                        if (needTransaction && !item.posa_is_offer && !item.posa_is_replace) {
+                                context.transactionBucket.items.push(item);
+                                context.transactionBucket.qty += qty;
+                                context.transactionBucket.amount += amount;
+                        }
+                });
 
-		if (needBrand) {
-			for (const item of brandCandidates) {
+                if (needBrand) {
+                        for (const item of brandCandidates) {
 				const brand = await this.getItemBrand(item);
 				if (!brand) {
 					continue;
 				}
 				let bucket = context.brandBuckets.get(brand);
-				if (!bucket) {
-					bucket = { items: [], qty: 0, amount: 0 };
-					context.brandBuckets.set(brand, bucket);
-				}
-				bucket.items.push(item);
-				bucket.qty += item.stock_qty || 0;
-				const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-				bucket.amount += (item.stock_qty || 0) * rate;
-			}
-		}
+                                if (!bucket) {
+                                        bucket = { items: [], qty: 0, amount: 0 };
+                                        context.brandBuckets.set(brand, bucket);
+                                }
+                                bucket.items.push(item);
+                                const qty = this.resolveOfferItemQty(item);
+                                bucket.qty += qty;
+                                bucket.amount += this.resolveOfferItemAmount(item);
+                        }
+                }
 
-		return context;
-	},
+                return context;
+        },
 
 	evaluateOffer(offer, context = {}) {
 		if (!offer) {
@@ -599,14 +683,14 @@ export default {
 			return null;
 		}
 
-		const items = [];
-		let totalQty = 0;
-		let totalAmount = 0;
+                const items = [];
+                let totalQty = 0;
+                let totalAmount = 0;
 
-		bucket.items.forEach((item) => {
-			if (!item || item.posa_is_offer) {
-				return;
-			}
+                bucket.items.forEach((item) => {
+                        if (!item || item.posa_is_offer) {
+                                return;
+                        }
 			if (
 				offer.offer === "Item Price" &&
 				item.posa_offer_applied &&
@@ -614,12 +698,12 @@ export default {
 			) {
 				return;
 			}
-			const qty = item.stock_qty || 0;
-			const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-			totalQty += qty;
-			totalAmount += qty * rate;
-			items.push(item.posa_row_id);
-		});
+                        const qty = this.resolveOfferItemQty(item);
+                        const amount = this.resolveOfferItemAmount(item);
+                        totalQty += qty;
+                        totalAmount += amount;
+                        items.push(item.posa_row_id);
+                });
 
 		if (!totalQty && !totalAmount) {
 			return null;
@@ -652,11 +736,11 @@ export default {
 			return null;
 		}
 
-		const items = [];
-		let totalQty = 0;
-		let totalAmount = 0;
+                const items = [];
+                let totalQty = 0;
+                let totalAmount = 0;
 
-		bucket.items.forEach((item) => {
+                bucket.items.forEach((item) => {
 			if (!item || item.posa_is_offer) {
 				return;
 			}
@@ -667,12 +751,12 @@ export default {
 			) {
 				return;
 			}
-			const qty = item.stock_qty || 0;
-			const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-			totalQty += qty;
-			totalAmount += qty * rate;
-			items.push(item.posa_row_id);
-		});
+                        const qty = this.resolveOfferItemQty(item);
+                        const amount = this.resolveOfferItemAmount(item);
+                        totalQty += qty;
+                        totalAmount += amount;
+                        items.push(item.posa_row_id);
+                });
 
 		if (!totalQty && !totalAmount) {
 			return null;
@@ -710,11 +794,11 @@ export default {
 			return null;
 		}
 
-		const items = [];
-		let totalQty = 0;
-		let totalAmount = 0;
+                const items = [];
+                let totalQty = 0;
+                let totalAmount = 0;
 
-		bucket.items.forEach((item) => {
+                bucket.items.forEach((item) => {
 			if (!item || item.posa_is_offer) {
 				return;
 			}
@@ -725,12 +809,12 @@ export default {
 			) {
 				return;
 			}
-			const qty = item.stock_qty || 0;
-			const rate = item.original_price_list_rate ?? item.price_list_rate ?? 0;
-			totalQty += qty;
-			totalAmount += qty * rate;
-			items.push(item.posa_row_id);
-		});
+                        const qty = this.resolveOfferItemQty(item);
+                        const amount = this.resolveOfferItemAmount(item);
+                        totalQty += qty;
+                        totalAmount += amount;
+                        items.push(item.posa_row_id);
+                });
 
 		if (!totalQty && !totalAmount) {
 			return null;
@@ -775,9 +859,17 @@ export default {
                 return offer;
         },
 
-	updatePosOffers(offers) {
-		this.eventBus.emit("update_pos_offers", offers);
-	},
+        updatePosOffers(offers, sourceOffers = undefined) {
+                if (sourceOffers === undefined) {
+                        this.eventBus.emit("update_pos_offers", offers);
+                        return;
+                }
+
+                this.eventBus.emit("update_pos_offers", {
+                        offers,
+                        sourceOffers,
+                });
+        },
 
 	async updateInvoiceOffers(offers) {
 		this.posa_offers.forEach((invoiceOffer) => {

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -63,14 +63,127 @@ export default {
 		this._pendingOfferRowIds = new Set();
 		this._pendingRemovedRowInfo = {};
 	},
-	normalizeBrand(brand) {
-		return (brand || "").trim().toLowerCase();
-	},
-	async getItemBrand(item) {
-		let brand = this.normalizeBrand(item.brand);
-		if (brand) {
-			item.brand = brand;
-			return brand;
+        normalizeBrand(brand) {
+                return (brand || "").trim().toLowerCase();
+        },
+        normalizeBoolean(value) {
+                if (typeof value === "boolean") {
+                        return value;
+                }
+                if (value === null || value === undefined) {
+                        return false;
+                }
+                if (typeof value === "number") {
+                        return value !== 0;
+                }
+                if (typeof value === "string") {
+                        const normalized = value.trim().toLowerCase();
+                        if (!normalized) {
+                                return false;
+                        }
+                        return ["1", "true", "yes"].includes(normalized);
+                }
+
+                return false;
+        },
+        normalizeNumber(value) {
+                if (value === null || value === undefined || value === "") {
+                        return 0;
+                }
+
+                if (typeof value === "number") {
+                        return Number.isFinite(value) ? value : 0;
+                }
+
+                if (typeof value === "boolean") {
+                        return value ? 1 : 0;
+                }
+
+                if (typeof value === "string") {
+                        const parsed = Number(value);
+                        if (!Number.isNaN(parsed)) {
+                                return parsed;
+                        }
+                }
+
+                if (typeof this.flt === "function") {
+                        const converted = this.flt(value);
+                        return Number.isFinite(converted) ? converted : 0;
+                }
+
+                if (typeof flt === "function") {
+                        const converted = flt(value);
+                        return Number.isFinite(converted) ? converted : 0;
+                }
+
+                const parsed = Number(value);
+                return Number.isFinite(parsed) ? parsed : 0;
+        },
+        computeOfferFreeQuantity(offer, totalQty) {
+                const baseFreeQty = this.normalizeNumber(offer?.given_qty);
+                if (baseFreeQty <= 0) {
+                        return 0;
+                }
+
+                let effectiveQty = this.normalizeNumber(totalQty);
+                if (effectiveQty <= 0) {
+                        return 0;
+                }
+
+                const maxQty = this.normalizeNumber(offer?.max_qty);
+                if (maxQty > 0) {
+                        effectiveQty = Math.min(effectiveQty, maxQty);
+                }
+
+                const skipQty = this.normalizeNumber(offer?.apply_recursion_over);
+                if (skipQty > 0) {
+                        effectiveQty = Math.max(0, effectiveQty - skipQty);
+                }
+
+                if (effectiveQty <= 0) {
+                        return 0;
+                }
+
+                const isRecursive = this.normalizeBoolean(offer?.is_recursive);
+                const recurseFor = this.normalizeNumber(offer?.recurse_for);
+                const shouldRound = this.normalizeBoolean(offer?.round_free_qty);
+
+                let freeQty = baseFreeQty;
+
+                if (isRecursive && recurseFor > 0) {
+                        freeQty = (effectiveQty * baseFreeQty) / recurseFor;
+
+                        if (shouldRound) {
+                                const factor = Math.floor(effectiveQty / recurseFor);
+                                freeQty = factor * baseFreeQty;
+                        }
+                }
+
+                const normalizedFreeQty = this.normalizeNumber(freeQty);
+                if (normalizedFreeQty <= 0) {
+                        return 0;
+                }
+
+                const precisionCandidates = [this.float_precision, this.currency_precision, 6];
+                const precision = precisionCandidates.find(
+                        (value) => typeof value === "number" && Number.isFinite(value) && value >= 0,
+                );
+
+                if (typeof this.flt === "function") {
+                        return this.flt(normalizedFreeQty, precision ?? 6);
+                }
+
+                if (typeof flt === "function") {
+                        return flt(normalizedFreeQty, precision ?? 6);
+                }
+
+                return normalizedFreeQty;
+        },
+        async getItemBrand(item) {
+                let brand = this.normalizeBrand(item.brand);
+                if (brand) {
+                        item.brand = brand;
+                        return brand;
 		}
 
 		this.brand_cache = this.brand_cache || {};
@@ -387,50 +500,65 @@ export default {
 		return combined.find((el) => el.posa_row_id == row_id);
 	},
 
-	checkQtyAnountOffer(offer, qty, amount) {
-		let min_qty = false;
-		let max_qty = false;
-		let min_amt = false;
-		let max_amt = false;
-		const applys = [];
+        checkQtyAnountOffer(offer, qty, amount) {
+                const totalQty = this.normalizeNumber(qty);
+                const totalAmount = this.normalizeNumber(amount);
 
-		if (offer.min_qty || offer.min_qty == 0) {
-			if (qty >= offer.min_qty) {
-				min_qty = true;
-			}
-			applys.push(min_qty);
-		}
+                let min_qty = null;
+                let max_qty = null;
+                let min_amt = null;
+                let max_amt = null;
 
-		if (offer.max_qty > 0) {
-			if (qty <= offer.max_qty) {
-				max_qty = true;
-			}
-			applys.push(max_qty);
-		}
+                const checks = [];
 
-		if (offer.min_amt > 0) {
-			if (amount >= offer.min_amt) {
-				min_amt = true;
-			}
-			applys.push(min_amt);
-		}
+                if (offer.min_qty !== undefined && offer.min_qty !== null && offer.min_qty !== "") {
+                        const requiredQty = this.normalizeNumber(offer.min_qty);
+                        min_qty = totalQty >= requiredQty;
+                        checks.push(min_qty);
+                }
 
-		if (offer.max_amt > 0) {
-			if (amount <= offer.max_amt) {
-				max_amt = true;
-			}
-			applys.push(max_amt);
-		}
-		let apply = false;
-		if (!applys.includes(false)) {
-			apply = true;
-		}
-		const res = {
-			apply: apply,
-			conditions: { min_qty, max_qty, min_amt, max_amt },
-		};
-		return res;
-	},
+                const maxQty = this.normalizeNumber(offer.max_qty);
+                if (maxQty > 0) {
+                        max_qty = totalQty <= maxQty;
+                        checks.push(max_qty);
+                }
+
+                const minAmt = this.normalizeNumber(offer.min_amt);
+                if (minAmt > 0) {
+                        min_amt = totalAmount >= minAmt;
+                        checks.push(min_amt);
+                }
+
+                const maxAmt = this.normalizeNumber(offer.max_amt);
+                if (maxAmt > 0) {
+                        max_amt = totalAmount <= maxAmt;
+                        checks.push(max_amt);
+                }
+
+                const allConditionsMet = checks.every((condition) => condition !== false);
+
+                const res = {
+                        apply: allConditionsMet,
+                        conditions: { min_qty, max_qty, min_amt, max_amt },
+                        adjusted_given_qty: null,
+                };
+
+                if (!allConditionsMet) {
+                        return res;
+                }
+
+                if (offer.offer === "Give Product") {
+                        const computedQty = this.computeOfferFreeQuantity(offer, totalQty);
+                        if (computedQty <= 0) {
+                                res.apply = false;
+                                return res;
+                        }
+
+                        res.adjusted_given_qty = computedQty;
+                }
+
+                return res;
+        },
 
 	checkOfferCoupon(offer) {
 		if (offer.coupon_based) {
@@ -487,14 +615,18 @@ export default {
 			return null;
 		}
 
-		const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
-		if (!res.apply) {
-			return null;
-		}
+                const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
+                if (!res.apply) {
+                        return null;
+                }
 
-		offer.items = items;
-		return offer;
-	},
+                if (res.adjusted_given_qty != null) {
+                        offer.given_qty = res.adjusted_given_qty;
+                }
+
+                offer.items = items;
+                return offer;
+        },
 
 	getGroupOffer(offer, context = {}) {
 		if (!offer || offer.apply_on !== "Item Group") {
@@ -536,14 +668,18 @@ export default {
 			return null;
 		}
 
-		const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
-		if (!res.apply) {
-			return null;
-		}
+                const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
+                if (!res.apply) {
+                        return null;
+                }
 
-		offer.items = items;
-		return offer;
-	},
+                if (res.adjusted_given_qty != null) {
+                        offer.given_qty = res.adjusted_given_qty;
+                }
+
+                offer.items = items;
+                return offer;
+        },
 
 	getBrandOffer(offer, context = {}) {
 		if (!offer || offer.apply_on !== "Brand") {
@@ -590,14 +726,18 @@ export default {
 			return null;
 		}
 
-		const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
-		if (!res.apply) {
-			return null;
-		}
+                const res = this.checkQtyAnountOffer(offer, totalQty, totalAmount);
+                if (!res.apply) {
+                        return null;
+                }
 
-		offer.items = items;
-		return offer;
-	},
+                if (res.adjusted_given_qty != null) {
+                        offer.given_qty = res.adjusted_given_qty;
+                }
+
+                offer.items = items;
+                return offer;
+        },
 	getTransactionOffer(offer, context = {}) {
 		if (!offer || offer.apply_on !== "Transaction") {
 			return null;
@@ -612,14 +752,18 @@ export default {
 			return null;
 		}
 
-		const res = this.checkQtyAnountOffer(offer, bucket.qty, bucket.amount);
-		if (!res.apply) {
-			return null;
-		}
+                const res = this.checkQtyAnountOffer(offer, bucket.qty, bucket.amount);
+                if (!res.apply) {
+                        return null;
+                }
 
-		offer.items = bucket.items.map((item) => item.posa_row_id);
-		return offer;
-	},
+                if (res.adjusted_given_qty != null) {
+                        offer.given_qty = res.adjusted_given_qty;
+                }
+
+                offer.items = bucket.items.map((item) => item.posa_row_id);
+                return offer;
+        },
 
 	updatePosOffers(offers) {
 		this.eventBus.emit("update_pos_offers", offers);
@@ -1131,12 +1275,25 @@ export default {
 			(offer.discount_type === "Rate" && !offer.rate) ||
 			(offer.discount_type === "Discount Percentage" && offer.discount_percentage == 100);
 
-		new_item.is_free_item = is_free ? 1 : 0;
+                new_item.is_free_item = is_free ? 1 : 0;
 
-		// Set price list rate based on currency similar to invoice logic
-		if (is_free) {
-			new_item.base_price_list_rate = 0;
-			new_item.price_list_rate = 0;
+                if (is_free) {
+                        new_item.base_rate = 0;
+                        new_item.rate = 0;
+                        new_item.base_discount_amount = 0;
+                        new_item.discount_amount = 0;
+                        new_item.amount = 0;
+                        new_item.base_amount = 0;
+                        new_item.net_rate = 0;
+                        new_item.net_amount = 0;
+                        new_item.gross_rate = 0;
+                        new_item.gross_amount = 0;
+                }
+
+                // Set price list rate based on currency similar to invoice logic
+                if (is_free) {
+                        new_item.base_price_list_rate = 0;
+                        new_item.price_list_rate = 0;
 		} else {
 			// Use the item's price list rate if available
 			new_item.price_list_rate = item.price_list_rate ?? item.rate ?? 0;

--- a/posawesome/posawesome/api/offers.py
+++ b/posawesome/posawesome/api/offers.py
@@ -237,7 +237,7 @@ def _build_product_discount_offers(scheme, pos_profile):
     if not slabs:
         return []
 
-    targets = _get_scheme_targets(scheme)
+    default_targets = _get_scheme_targets(scheme)
     profile_warehouse = getattr(pos_profile, "warehouse", None)
 
     offers = []
@@ -295,33 +295,74 @@ def _build_product_discount_offers(scheme, pos_profile):
             offers.append(offer_template)
             continue
 
-        if not targets:
+        slab_targets = _get_product_discount_targets(scheme, slab, default_targets)
+        if not slab_targets:
             continue
 
-        for target in targets:
+        for target in slab_targets:
             new_offer = offer_template.copy()
-            new_offer["name"] = _make_offer_identifier(scheme.name, target, slab.name)
+            target_value = target.get("value")
+            target_type = target.get("type") or scheme.apply_on
+
+            new_offer["name"] = _make_offer_identifier(scheme.name, target_value, slab.name)
             new_offer["row_id"] = new_offer["name"]
 
-            if scheme.apply_on == "Item Code":
-                new_offer["item"] = target
+            if target_type == "Item Code":
+                new_offer["item"] = target_value
                 new_offer["apply_type"] = "Item Code"
-                new_offer["apply_item_code"] = target
+                new_offer["apply_item_code"] = target_value
                 new_offer["replace_item"] = 1 if slab.same_item else 0
-            elif scheme.apply_on == "Item Group":
-                new_offer["item_group"] = target
+            elif target_type == "Item Group":
+                new_offer["item_group"] = target_value
                 new_offer["apply_type"] = "Item Group"
-                new_offer["apply_item_group"] = target
+                new_offer["apply_item_group"] = target_value
                 if slab.same_item:
                     new_offer["replace_cheapest_item"] = 1
-            elif scheme.apply_on == "Brand":
-                new_offer["brand"] = target
+            elif target_type == "Brand":
+                new_offer["brand"] = target_value
+                new_offer["apply_type"] = "Brand"
                 if slab.same_item:
                     new_offer["replace_cheapest_item"] = 1
 
             offers.append(new_offer)
 
     return offers
+
+
+def _get_product_discount_targets(scheme, slab, default_targets):
+    targets = []
+
+    buying_item_code = cstr(getattr(slab, "buying_item_code", "")).strip()
+    buying_item_group = cstr(getattr(slab, "buying_item_group", "")).strip()
+    buying_brand = cstr(getattr(slab, "buying_brand", "")).strip()
+
+    if buying_item_code:
+        targets.append({"type": "Item Code", "value": buying_item_code})
+
+    if buying_item_group:
+        targets.append({"type": "Item Group", "value": buying_item_group})
+
+    if buying_brand:
+        targets.append({"type": "Brand", "value": buying_brand})
+
+    if not targets:
+        apply_on = scheme.apply_on
+        if apply_on == "Transaction":
+            return []
+
+        for value in default_targets:
+            targets.append({"type": apply_on, "value": value})
+
+    # remove duplicates while preserving order
+    seen = set()
+    unique_targets = []
+    for entry in targets:
+        key = (entry.get("type"), cstr(entry.get("value")))
+        if key[1] and key not in seen:
+            seen.add(key)
+            unique_targets.append(entry)
+
+    return unique_targets
 
 
 def _get_scheme_targets(scheme):

--- a/posawesome/posawesome/api/offers.py
+++ b/posawesome/posawesome/api/offers.py
@@ -280,6 +280,9 @@ def _build_product_discount_offers(scheme, pos_profile):
             "promotional_scheme": scheme.name,
             "promotional_scheme_rule": slab.name,
             "round_free_qty": slab.round_free_qty,
+            "is_recursive": getattr(slab, "is_recursive", 0),
+            "recurse_for": flt(getattr(slab, "recurse_for", 0)),
+            "apply_recursion_over": flt(getattr(slab, "apply_recursion_over", 0)),
         }
 
         if slab.free_item and not slab.same_item:


### PR DESCRIPTION
## Summary
- zero out pricing fields for promotional give-product items so they stay free in the cart
- display a "Free" badge in the POS items table to highlight zero-cost offer rows

## Testing
- yarn build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd936a86c8326b0a50caea75a0835)