### PR TITLE
Ensure POS offers refresh after fetching

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1452,8 +1452,13 @@ export default {
                         this.new_order(data);
                         // this.eventBus.emit("set_pos_coupons", data.posa_coupons);
                 },
-                handleSetOffers(data) {
-                        this.posOffers = data;
+                async handleSetOffers(data) {
+                        this.posOffers = Array.isArray(data) ? data : [];
+                        try {
+                                await this.handelOffers();
+                        } catch (error) {
+                                console.error("Failed to process offers after refresh", error);
+                        }
                 },
                 async handleUpdateInvoiceOffers(data) {
                         await this.updateInvoiceOffers(data);

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -163,14 +163,43 @@ export default {
 				}
 			}
 
-			const offers = sourceOffers.map((offer) => cache.get(offer.name)).filter((entry) => !!entry);
+                        const evaluatedOffers = sourceOffers
+                                .map((offer) => cache.get(offer.name))
+                                .filter((entry) => !!entry);
 
-			this.setItemGiveOffer(offers);
-			this.updatePosOffers(offers);
-		} catch (error) {
-			console.error("Failed to process offers:", error);
-		}
-	},
+                        this.setItemGiveOffer(evaluatedOffers);
+
+                        const evaluatedByName = new Map();
+                        evaluatedOffers.forEach((offer) => {
+                                if (offer && offer.name) {
+                                        evaluatedByName.set(offer.name, offer);
+                                }
+                        });
+
+                        const offersForDisplay = sourceOffers.map((offer) => {
+                                const evaluated = offer && offer.name ? evaluatedByName.get(offer.name) : null;
+                                if (evaluated) {
+                                        return {
+                                                ...offer,
+                                                ...evaluated,
+                                        };
+                                }
+
+                                return {
+                                        ...offer,
+                                        items:
+                                                Array.isArray(offer?.items) || typeof offer?.items === "string"
+                                                        ? offer.items
+                                                        : [],
+                                        offer_applied: !!offer?.offer_applied,
+                                };
+                        });
+
+                        this.updatePosOffers(offersForDisplay);
+                } catch (error) {
+                        console.error("Failed to process offers:", error);
+                }
+        },
 
 	isOfferAffected(offer, changedSet, itemMap, removedInfo = {}) {
 		if (!offer) {


### PR DESCRIPTION
## Summary
- refresh evaluated POS offers immediately after they are fetched
- guard against malformed offer payloads when updating the invoice offers list
- log an error if the refresh fails so problems surface during debugging

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e22ee175c832683e4d3e7920f2726)