### PR TITLE
Auto-apply item promotional schemes and mark free items

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -37,14 +37,23 @@
 					<v-chip v-if="item.is_bundle" color="secondary" size="x-small" class="ml-1">
 						{{ __("Bundle") }}
 					</v-chip>
-					<v-chip v-if="item.name_overridden" color="primary" size="x-small" class="ml-1">
-						{{ __("Edited") }}
-					</v-chip>
-					<v-icon
-						v-if="pos_profile.posa_allow_line_item_name_override && !item.posa_is_replace"
-						size="x-small"
-						class="ml-1"
-						@click.stop="openNameDialog(item)"
+                                        <v-chip v-if="item.name_overridden" color="primary" size="x-small" class="ml-1">
+                                                {{ __("Edited") }}
+                                        </v-chip>
+                                        <v-chip
+                                                v-if="isFreeItem(item)"
+                                                color="success"
+                                                size="x-small"
+                                                class="ml-1 free-chip"
+                                                variant="elevated"
+                                        >
+                                                {{ __("Free") }}
+                                        </v-chip>
+                                        <v-icon
+                                                v-if="pos_profile.posa_allow_line_item_name_override && !item.posa_is_replace"
+                                                size="x-small"
+                                                class="ml-1"
+                                                @click.stop="openNameDialog(item)"
 						>mdi-pencil</v-icon
 					>
 					<v-icon
@@ -114,26 +123,40 @@
 			</template>
 
 			<!-- Rate column -->
-			<template v-slot:item.rate="{ item }">
-				<div class="currency-display right-aligned">
-					<span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
-					<span class="amount-value" :class="{ 'negative-number': isNegative(item.rate) }">
-						{{ formatCurrency(item.rate) }}
-					</span>
-				</div>
-			</template>
+                        <template v-slot:item.rate="{ item }">
+                                <div class="currency-display right-aligned" :class="{ 'free-value': isFreeItem(item) }">
+                                        <template v-if="isFreeItem(item)">
+                                                <span class="amount-value free-label">{{ __("Free") }}</span>
+                                                <span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
+                                                <span class="amount-value right-aligned">{{ formatCurrency(0) }}</span>
+                                        </template>
+                                        <template v-else>
+                                                <span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
+                                                <span class="amount-value" :class="{ 'negative-number': isNegative(item.rate) }">
+                                                        {{ formatCurrency(item.rate) }}
+                                                </span>
+                                        </template>
+                                </div>
+                        </template>
 
 			<!-- Amount column -->
-			<template v-slot:item.amount="{ item }">
-				<div class="currency-display right-aligned">
-					<span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
-					<span
-						class="amount-value"
-						:class="{ 'negative-number': isNegative(item.qty * item.rate) }"
-						>{{ formatCurrency(item.qty * item.rate) }}</span
-					>
-				</div>
-			</template>
+                        <template v-slot:item.amount="{ item }">
+                                <div class="currency-display right-aligned" :class="{ 'free-value': isFreeItem(item) }">
+                                        <template v-if="isFreeItem(item)">
+                                                <span class="amount-value free-label">{{ __("Free") }}</span>
+                                                <span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
+                                                <span class="amount-value right-aligned">{{ formatCurrency(0) }}</span>
+                                        </template>
+                                        <template v-else>
+                                                <span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
+                                                <span
+                                                        class="amount-value"
+                                                        :class="{ 'negative-number': isNegative(item.qty * item.rate) }"
+                                                        >{{ formatCurrency(item.qty * item.rate) }}</span
+                                                >
+                                        </template>
+                                </div>
+                        </template>
 
 			<!-- Discount percentage column -->
 			<template v-slot:item.discount_value="{ item }">
@@ -921,11 +944,30 @@ export default {
 			return this._rtlComputed;
 		},
 	},
-	methods: {
-		customItemFilter(value, search, item) {
-			if (search == null) {
-				return true;
-			}
+        methods: {
+                isFreeItem(item) {
+                        if (!item) {
+                                return false;
+                        }
+                        if (item.is_free_item) {
+                                return true;
+                        }
+                        const hasPrecision =
+                                this.pos_profile &&
+                                typeof this.pos_profile.currency_precision === "number";
+                        const precision = hasPrecision ? this.pos_profile.currency_precision : 2;
+                        const threshold = 1 / Math.pow(10, precision + 2);
+                        const rate = typeof item.rate === "number" ? item.rate : parseFloat(item.rate) || 0;
+                        const amount =
+                                typeof item.amount === "number"
+                                        ? item.amount
+                                        : parseFloat(item.qty * item.rate) || 0;
+                        return Math.abs(rate) <= threshold && Math.abs(amount) <= threshold;
+                },
+                customItemFilter(value, search, item) {
+                        if (search == null) {
+                                return true;
+                        }
 
 			const normalized = String(search).toLowerCase().trim();
 			if (!normalized) {
@@ -1293,12 +1335,28 @@ export default {
 
 /* Ensure items table can scroll when many rows exist */
 .items-table-container {
-	overflow-y: auto;
-	width: 100%;
-	max-width: 100%;
-	margin: 0;
-	padding: 0;
-	box-sizing: border-box;
+        overflow-y: auto;
+        width: 100%;
+        max-width: 100%;
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+}
+
+.free-chip {
+        font-weight: 600;
+        text-transform: uppercase;
+}
+
+.currency-display.free-value .free-label {
+        color: rgb(var(--v-theme-success));
+        font-weight: 600;
+        margin-right: 6px;
+}
+
+.currency-display.free-value .currency-symbol,
+.currency-display.free-value .amount-value.right-aligned {
+        opacity: 0.85;
 }
 
 /* Table wrapper styling */

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -127,12 +127,13 @@ export default {
 
 	async handelOffers(changedRowIds = [], removedRows = {}) {
 		try {
-			const sourceOffers = Array.isArray(this.posOffers) ? this.posOffers : [];
-			if (!sourceOffers.length) {
-				this.updatePosOffers([]);
-				this._cachedOfferResults = new Map();
-				return;
-			}
+                        const sourceOffers = Array.isArray(this.posOffers) ? this.posOffers : [];
+                        if (!sourceOffers.length) {
+                                await this.updateInvoiceOffers([]);
+                                this.updatePosOffers([]);
+                                this._cachedOfferResults = new Map();
+                                return;
+                        }
 
 			const allItems = [...(this.items || []), ...(this.packed_items || [])];
 			const itemMap = new Map();
@@ -180,14 +181,24 @@ export default {
 				}
 			}
 
-			const offers = sourceOffers.map((offer) => cache.get(offer.name)).filter((entry) => !!entry);
+                        const offers = sourceOffers.map((offer) => cache.get(offer.name)).filter((entry) => !!entry);
 
-			this.setItemGiveOffer(offers);
-			this.updatePosOffers(offers);
-		} catch (error) {
-			console.error("Failed to process offers:", error);
-		}
-	},
+                        offers.forEach((offer) => {
+                                if (offer && offer.apply_on === "Item Code") {
+                                        offer.auto = true;
+                                        offer.offer_applied = true;
+                                }
+                        });
+
+                        this.setItemGiveOffer(offers);
+                        this.updatePosOffers(offers);
+                        await this.updateInvoiceOffers(
+                                offers.filter((offer) => offer && (offer.offer_applied || offer.auto)),
+                        );
+                } catch (error) {
+                        console.error("Failed to process offers:", error);
+                }
+        },
 
 	isOfferAffected(offer, changedSet, itemMap, removedInfo = {}) {
 		if (!offer) {

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -63,10 +63,27 @@ export default {
 		this._pendingOfferRowIds = new Set();
 		this._pendingRemovedRowInfo = {};
 	},
-	normalizeBrand(brand) {
-		return (brand || "").trim().toLowerCase();
-	},
-	async getItemBrand(item) {
+        normalizeBrand(brand) {
+                return (brand || "").trim().toLowerCase();
+        },
+        getOfferTargetItem(offer = {}) {
+                const candidates = [
+                        offer.item,
+                        offer.apply_item_code,
+                        offer.apply_item,
+                        offer.item_code,
+                        offer.applyItem,
+                ];
+                return candidates.find((code) => typeof code === "string" && code) || null;
+        },
+        isEffectivelyZero(value) {
+                const precision =
+                        typeof this.currency_precision === "number" ? this.currency_precision : 2;
+                const threshold = 1 / Math.pow(10, precision + 2);
+                const numericValue = typeof value === "number" ? value : parseFloat(value) || 0;
+                return Math.abs(numericValue) <= threshold;
+        },
+        async getItemBrand(item) {
 		let brand = this.normalizeBrand(item.brand);
 		if (brand) {
 			item.brand = brand;
@@ -211,12 +228,19 @@ export default {
 				return true;
 			}
 
-			switch (applyOn) {
-				case "Item Code":
-					if (meta.item_code === offer.item) {
-						return true;
-					}
-					break;
+                switch (applyOn) {
+                        case "Item Code":
+                                if (!offer) {
+                                        return true;
+                                }
+                                const targetCode = this.getOfferTargetItem(offer);
+                                if (!targetCode) {
+                                        return true;
+                                }
+                                if (meta.item_code === targetCode) {
+                                        return true;
+                                }
+                                break;
 				case "Item Group":
 					if (meta.item_group === offer.item_group) {
 						return true;
@@ -345,17 +369,27 @@ export default {
 		return null;
 	},
 
-	setItemGiveOffer(offers) {
-		// Set item give offer for replace
-		offers.forEach((offer) => {
-			if (offer.apply_on == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
-				offer.give_item = offer.item;
-				offer.apply_item_code = offer.item;
-			} else if (
-				offer.apply_on == "Item Group" &&
-				offer.apply_type == "Item Group" &&
-				offer.replace_cheapest_item
-			) {
+        setItemGiveOffer(offers) {
+                // Set item give offer for replace
+                offers.forEach((offer) => {
+                        const targetCode = this.getOfferTargetItem(offer);
+                        if (
+                                offer.apply_on == "Item Code" &&
+                                offer.apply_type == "Item Code" &&
+                                offer.replace_item
+                        ) {
+                                if (targetCode) {
+                                        offer.give_item = targetCode;
+                                        offer.apply_item_code = targetCode;
+                                        if (!offer.item) {
+                                                offer.item = targetCode;
+                                        }
+                                }
+                        } else if (
+                                offer.apply_on == "Item Group" &&
+                                offer.apply_type == "Item Group" &&
+                                offer.replace_cheapest_item
+                        ) {
 				const offerItemCode = this.getCheapestItem(offer).item_code;
 				offer.give_item = offerItemCode;
 				offer.apply_item_code = offerItemCode;
@@ -456,12 +490,23 @@ export default {
 			return null;
 		}
 
-		const bucket = context.itemCodeBuckets ? context.itemCodeBuckets.get(offer.item) : null;
-		if (!bucket) {
-			return null;
-		}
+                const targetCode = this.getOfferTargetItem(offer);
+                if (!targetCode) {
+                        return null;
+                }
 
-		const items = [];
+                const bucket = context.itemCodeBuckets
+                        ? context.itemCodeBuckets.get(targetCode)
+                        : null;
+                if (!bucket) {
+                        return null;
+                }
+
+                if (!offer.item) {
+                        offer.item = targetCode;
+                }
+
+                const items = [];
 		let totalQty = 0;
 		let totalAmount = 0;
 
@@ -856,8 +901,9 @@ export default {
 			} else if (Array.isArray(offer.items)) {
 				itemsRowID = offer.items;
 			}
-			if (offer.apply_on == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
-				const item = await this.ApplyOnGiveProduct(offer, offer.item);
+                        if (offer.apply_on == "Item Code" && offer.apply_type == "Item Code" && offer.replace_item) {
+                                const targetCode = this.getOfferTargetItem(offer);
+                                const item = await this.ApplyOnGiveProduct(offer, targetCode);
 				if (!item) {
 					this.isApplyingOffer = false;
 					return;
@@ -1044,8 +1090,8 @@ export default {
 		new_item.qty = offer.given_qty;
 		new_item.stock_qty = offer.given_qty;
 
-		// Handle rate based on currency
-		if (offer.discount_type === "Rate") {
+                // Handle rate based on currency
+                if (offer.discount_type === "Rate") {
 			// offer.rate is always in base currency (PKR)
 			new_item.base_rate = offer.rate;
 			const baseCurrency = this.price_list_currency || this.pos_profile.currency;
@@ -1234,18 +1280,19 @@ export default {
 						}
 
 						// Compute base discount amounts and percentage
-						item.base_discount_amount = this.flt(
-							base_price - base_offer_rate,
-							this.currency_precision,
-						);
-						item.discount_percentage = base_price
-							? this.flt(
-									(item.base_discount_amount / base_price) * 100,
-									this.currency_precision,
-								)
-							: 0;
-					} else if (offer.discount_type === "Discount Percentage") {
-						item.discount_percentage = offer.discount_percentage;
+                                                item.base_discount_amount = this.flt(
+                                                        base_price - base_offer_rate,
+                                                        this.currency_precision,
+                                                );
+                                                item.discount_percentage = base_price
+                                                        ? this.flt(
+                                                                        (item.base_discount_amount / base_price) * 100,
+                                                                        this.currency_precision,
+                                                                )
+                                                        : 0;
+                                                item.is_free_item = this.isEffectivelyZero(item.rate) ? 1 : 0;
+                                        } else if (offer.discount_type === "Discount Percentage") {
+                                                item.discount_percentage = offer.discount_percentage;
 
 						// Calculate discount in base currency first
 						// Use normalized price * current conversion factor
@@ -1281,13 +1328,16 @@ export default {
 							);
 						} else {
 							item.rate = item.base_rate;
-							item.price_list_rate = base_price;
-							item.discount_amount = base_discount;
-						}
-					}
+                                                        item.price_list_rate = base_price;
+                                                        item.discount_amount = base_discount;
+                                                }
+                                                item.is_free_item = this.isEffectivelyZero(item.rate) ? 1 : 0;
+                                        } else {
+                                                item.is_free_item = this.isEffectivelyZero(item.rate) ? 1 : 0;
+                                        }
 
-					// Calculate final amounts
-					item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                                        // Calculate final amounts
+                                        item.amount = this.flt(item.qty * item.rate, this.currency_precision);
 					item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
 
 					item.posa_offer_applied = 1;
@@ -1339,12 +1389,13 @@ export default {
 						item.price_list_rate = item.base_price_list_rate;
 					}
 
-					// Reset all discounts
-					item.discount_percentage = 0;
-					item.discount_amount = 0;
-					item.base_discount_amount = 0;
+                                        // Reset all discounts
+                                        item.discount_percentage = 0;
+                                        item.discount_amount = 0;
+                                        item.base_discount_amount = 0;
+                                        item.is_free_item = 0;
 
-					// Recalculate amounts
+                                        // Recalculate amounts
 					item.amount = this.flt(item.qty * item.rate, this.currency_precision);
 					item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
 


### PR DESCRIPTION
## Summary
- resolve promotional scheme targets using additional offer metadata so item-specific deals auto-apply reliably
- flag items with zero effective rate as free when applying or removing offers so pricing stays consistent
- highlight free items in the POS table with a chip and "Free" labels that show zeroed rate and amount values

## Testing
- yarn lint *(fails: Command "lint" not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e2b4796088326804532b41c3c019c)