### PR TITLE
Add pricing rule selection to POS view

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -430,6 +430,7 @@ export default {
                         invoiceHeight: null,
                         paymentVisible: false, // Track current payment view state
                         _busHandlers: {},
+                        pricingRuleContextPending: false,
                 };
         },
 
@@ -1442,6 +1443,11 @@ export default {
 
                         this.fetch_price_lists();
                         this.update_price_list();
+
+                        this.pricingRuleContextPending = false;
+                        this.$nextTick(() => {
+                                this.handleRequestPricingRuleContext();
+                        });
                 },
                 handleClearInvoice() {
                         this.clear_invoice();

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1493,6 +1493,9 @@ export default {
 
                         try {
                                 await this.load_invoice(data);
+                                if (typeof this.rehydratePricingRuleFreebieState === "function") {
+                                        this.rehydratePricingRuleFreebieState({ mergeDuplicates: true });
+                                }
                         } finally {
                                 if (resumePricingRules) {
                                         const resume = () => {
@@ -1523,6 +1526,9 @@ export default {
 
                         try {
                                 await this.new_order(data);
+                                if (typeof this.rehydratePricingRuleFreebieState === "function") {
+                                        this.rehydratePricingRuleFreebieState({ mergeDuplicates: true });
+                                }
                         } finally {
                                 if (resumePricingRules) {
                                         const resume = () => {
@@ -1574,6 +1580,9 @@ export default {
 
                         try {
                                 await this.load_invoice(data.invoice_doc);
+                                if (typeof this.rehydratePricingRuleFreebieState === "function") {
+                                        this.rehydratePricingRuleFreebieState({ mergeDuplicates: true });
+                                }
                         } finally {
                                 if (resumePricingRules) {
                                         const resume = () => {
@@ -1594,6 +1603,9 @@ export default {
                                         if (item.qty > 0) item.qty = -Math.abs(item.qty);
                                         if (item.stock_qty > 0) item.stock_qty = -Math.abs(item.stock_qty);
                                 });
+                                if (typeof this.rehydratePricingRuleFreebieState === "function") {
+                                        this.rehydratePricingRuleFreebieState({ mergeDuplicates: true });
+                                }
                         }
                         if (data.return_doc) {
                                 console.log("Return against existing invoice:", data.return_doc.name);

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -378,22 +378,12 @@ export default {
 			posa_coupons: [], // Coupons applied
 			isApplyingOffer: false, // Flag to prevent offer watcher loops
 			allItems: [], // All items for offer logic
-			discount_percentage_offer_name: null, // Track which offer is applied
-			invoiceTypes: ["Invoice", "Order", "Quotation"], // Types of invoices
-			invoiceType: "Invoice", // Current invoice type
-			itemsPerPage: 1000, // Items per page in table
-			itemSearch: "", // Search query for added items
-			expanded: [], // Array of expanded row IDs
-			singleExpand: true, // Only one row expanded at a time
-			cancel_dialog: false, // Cancel dialog visibility
-			float_precision: 6, // Float precision for calculations
-			currency_precision: 6, // Currency precision for display
-			new_line: false, // Add new line for item
-                        available_stock_cache: {},
-                        item_detail_cache: {},
-                        item_stock_cache: {},
-                        brand_cache: {},
-                        stockUnsubscribe: null,
+			_pricingRuleOriginals: new WeakMap(),
+			available_stock_cache: {},
+			item_detail_cache: {},
+			item_stock_cache: {},
+			brand_cache: {},
+			stockUnsubscribe: null,
 			delivery_charges: [], // List of delivery charges
 			base_delivery_charges_rate: 0, // Delivery charge in company currency
 			delivery_charges_rate: 0, // Selected delivery charge rate
@@ -1447,16 +1437,22 @@ export default {
                         this.pricingRuleContextPending = false;
                         this.$nextTick(() => {
                                 this.handleRequestPricingRuleContext();
+                                if (typeof this.schedulePricingRuleRefresh === "function") {
+                                        this.schedulePricingRuleRefresh();
+                                }
                         });
                 },
                 handleClearInvoice() {
                         this.clear_invoice();
+                        this._pricingRuleOriginals = new WeakMap();
                         this.eventBus.emit("focus_item_search");
                 },
                 handleLoadInvoice(data) {
+                        this._pricingRuleOriginals = new WeakMap();
                         this.load_invoice(data);
                 },
                 handleLoadOrder(data) {
+                        this._pricingRuleOriginals = new WeakMap();
                         this.new_order(data);
                         // this.eventBus.emit("set_pos_coupons", data.posa_coupons);
                 },
@@ -1481,6 +1477,7 @@ export default {
                 },
                 handleLoadReturnInvoice(data) {
                         console.log("Invoice component received load_return_invoice event with data:", data);
+                        this._pricingRuleOriginals = new WeakMap();
                         this.load_invoice(data.invoice_doc);
                         this.invoiceType = "Return";
                         this.invoiceTypes = ["Return"];
@@ -1583,6 +1580,9 @@ export default {
                 this._busHandlers = {};
                 if (typeof this.cancelScheduledOfferRefresh === "function") {
                         this.cancelScheduledOfferRefresh();
+                }
+                if (typeof this.cancelScheduledPricingRuleRefresh === "function") {
+                        this.cancelScheduledPricingRuleRefresh();
                 }
                 if (this._suppressClosePaymentsTimer) {
                         clearTimeout(this._suppressClosePaymentsTimer);

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -375,10 +375,21 @@ export default {
 			show_packed_dialog: false, // Packing list dialog visibility
 			posOffers: [], // All available offers
 			posa_offers: [], // Offers applied to this invoice
-			posa_coupons: [], // Coupons applied
-			isApplyingOffer: false, // Flag to prevent offer watcher loops
-			allItems: [], // All items for offer logic
-			_pricingRuleOriginals: new WeakMap(),
+                        posa_coupons: [], // Coupons applied
+                        isApplyingOffer: false, // Flag to prevent offer watcher loops
+                        allItems: [], // All items for offer logic
+                        discount_percentage_offer_name: null, // Track which offer is applied
+                        invoiceTypes: ["Invoice", "Order", "Quotation"], // Types of invoices
+                        invoiceType: "Invoice", // Current invoice type
+                        itemsPerPage: 1000, // Items per page in table
+                        itemSearch: "", // Search query for added items
+                        expanded: [], // Array of expanded row IDs
+                        singleExpand: true, // Only one row expanded at a time
+                        cancel_dialog: false, // Cancel dialog visibility
+                        float_precision: 6, // Float precision for calculations
+                        currency_precision: 6, // Currency precision for display
+                        new_line: false, // Add new line for item
+                        _pricingRuleOriginals: new WeakMap(),
 			available_stock_cache: {},
 			item_detail_cache: {},
 			item_stock_cache: {},

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1458,6 +1458,24 @@ export default {
                         this._pricingRuleOriginals = new WeakMap();
                         this.eventBus.emit("focus_item_search");
                 },
+                handleSuppressPricingRuleRefresh(options = {}) {
+                        if (typeof this.suppressPricingRuleRefresh === "function") {
+                                this.suppressPricingRuleRefresh();
+                        }
+
+                        if (
+                                options &&
+                                options.cancelScheduled &&
+                                typeof this.cancelScheduledPricingRuleRefresh === "function"
+                        ) {
+                                this.cancelScheduledPricingRuleRefresh();
+                        }
+                },
+                handleResumePricingRuleRefresh(options = {}) {
+                        if (typeof this.resumePricingRuleRefresh === "function") {
+                                this.resumePricingRuleRefresh(options || {});
+                        }
+                },
                 async handleLoadInvoice(data) {
                         this._pricingRuleOriginals = new WeakMap();
                         if (typeof this.cancelScheduledPricingRuleRefresh === "function") {
@@ -1639,6 +1657,8 @@ export default {
                         request_pricing_rule_context: this.handleRequestPricingRuleContext,
                         apply_pricing_rule_updates: this.handleApplyPricingRuleUpdates,
                         reset_pricing_rules: this.handleResetPricingRules,
+                        suppress_pricing_rule_refresh: this.handleSuppressPricingRuleRefresh,
+                        resume_pricing_rule_refresh: this.handleResumePricingRuleRefresh,
                 };
 
                 Object.entries(this._busHandlers).forEach(([eventName, handler]) => {

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -342,6 +342,7 @@ import invoiceComputed from "./invoiceComputed";
 import invoiceWatchers from "./invoiceWatchers";
 import offerMethods from "./invoiceOfferMethods";
 import shortcutMethods from "./invoiceShortcuts";
+import pricingRuleMethods from "./invoicePricingRuleMethods.js";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
@@ -471,8 +472,9 @@ export default {
 
         methods: {
                 ...shortcutMethods,
-		...offerMethods,
-		...invoiceItemMethods,
+                ...offerMethods,
+                ...invoiceItemMethods,
+                ...pricingRuleMethods,
                 focusCustomerSearchField() {
                         const customerComponent = this.$refs.customerComponent;
                         if (!customerComponent) {
@@ -1542,6 +1544,9 @@ export default {
                         reset_posting_date: this.handleResetPostingDate,
                         calc_uom: this.calc_uom,
                         show_payment: this.handleShowPayment,
+                        request_pricing_rule_context: this.handleRequestPricingRuleContext,
+                        apply_pricing_rule_updates: this.handleApplyPricingRuleUpdates,
+                        reset_pricing_rules: this.handleResetPricingRules,
                 };
 
                 Object.entries(this._busHandlers).forEach(([eventName, handler]) => {

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1458,13 +1458,65 @@ export default {
                         this._pricingRuleOriginals = new WeakMap();
                         this.eventBus.emit("focus_item_search");
                 },
-                handleLoadInvoice(data) {
+                async handleLoadInvoice(data) {
                         this._pricingRuleOriginals = new WeakMap();
-                        this.load_invoice(data);
+                        if (typeof this.cancelScheduledPricingRuleRefresh === "function") {
+                                this.cancelScheduledPricingRuleRefresh();
+                        }
+
+                        let resumePricingRules = null;
+                        if (
+                                typeof this.suppressPricingRuleRefresh === "function" &&
+                                typeof this.resumePricingRuleRefresh === "function"
+                        ) {
+                                this.suppressPricingRuleRefresh();
+                                resumePricingRules = () => this.resumePricingRuleRefresh({ cancelPending: true });
+                        }
+
+                        try {
+                                await this.load_invoice(data);
+                        } finally {
+                                if (resumePricingRules) {
+                                        const resume = () => {
+                                                resumePricingRules();
+                                        };
+                                        if (typeof this.$nextTick === "function") {
+                                                this.$nextTick(resume);
+                                        } else {
+                                                resume();
+                                        }
+                                }
+                        }
                 },
-                handleLoadOrder(data) {
+                async handleLoadOrder(data) {
                         this._pricingRuleOriginals = new WeakMap();
-                        this.new_order(data);
+                        if (typeof this.cancelScheduledPricingRuleRefresh === "function") {
+                                this.cancelScheduledPricingRuleRefresh();
+                        }
+
+                        let resumePricingRules = null;
+                        if (
+                                typeof this.suppressPricingRuleRefresh === "function" &&
+                                typeof this.resumePricingRuleRefresh === "function"
+                        ) {
+                                this.suppressPricingRuleRefresh();
+                                resumePricingRules = () => this.resumePricingRuleRefresh({ cancelPending: true });
+                        }
+
+                        try {
+                                await this.new_order(data);
+                        } finally {
+                                if (resumePricingRules) {
+                                        const resume = () => {
+                                                resumePricingRules();
+                                        };
+                                        if (typeof this.$nextTick === "function") {
+                                                this.$nextTick(resume);
+                                        } else {
+                                                resume();
+                                        }
+                                }
+                        }
                         // this.eventBus.emit("set_pos_coupons", data.posa_coupons);
                 },
                 handleSetOffers(data) {
@@ -1486,10 +1538,36 @@ export default {
                         });
                         this.primeInvoiceStockState();
                 },
-                handleLoadReturnInvoice(data) {
+                async handleLoadReturnInvoice(data) {
                         console.log("Invoice component received load_return_invoice event with data:", data);
                         this._pricingRuleOriginals = new WeakMap();
-                        this.load_invoice(data.invoice_doc);
+                        if (typeof this.cancelScheduledPricingRuleRefresh === "function") {
+                                this.cancelScheduledPricingRuleRefresh();
+                        }
+
+                        let resumePricingRules = null;
+                        if (
+                                typeof this.suppressPricingRuleRefresh === "function" &&
+                                typeof this.resumePricingRuleRefresh === "function"
+                        ) {
+                                this.suppressPricingRuleRefresh();
+                                resumePricingRules = () => this.resumePricingRuleRefresh({ cancelPending: true });
+                        }
+
+                        try {
+                                await this.load_invoice(data.invoice_doc);
+                        } finally {
+                                if (resumePricingRules) {
+                                        const resume = () => {
+                                                resumePricingRules();
+                                        };
+                                        if (typeof this.$nextTick === "function") {
+                                                this.$nextTick(resume);
+                                        } else {
+                                                resume();
+                                        }
+                                }
+                        }
                         this.invoiceType = "Return";
                         this.invoiceTypes = ["Return"];
                         this.invoice_doc.is_return = 1;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -426,24 +426,36 @@
 						<v-btn size="small" value="card">{{ __("Card") }}</v-btn>
 					</v-btn-toggle>
 				</v-col>
-				<v-col cols="5" class="dynamic-margin-xs">
-					<v-btn
-						size="small"
-						block
-						color="warning"
-						variant="text"
-						@click="show_offers"
-						class="action-btn-consistent"
-					>
-						{{ offersCount }} {{ __("Offers") }}
-					</v-btn>
-				</v-col>
-				<v-col cols="4" class="dynamic-margin-xs">
-					<v-btn
-						size="small"
-						block
-						color="primary"
-						variant="text"
+                                <v-col cols="3" class="dynamic-margin-xs">
+                                        <v-btn
+                                                size="small"
+                                                block
+                                                color="warning"
+                                                variant="text"
+                                                @click="show_offers"
+                                                class="action-btn-consistent"
+                                        >
+                                                {{ offersCount }} {{ __("Offers") }}
+                                        </v-btn>
+                                </v-col>
+                                <v-col cols="3" class="dynamic-margin-xs">
+                                        <v-btn
+                                                size="small"
+                                                block
+                                                color="secondary"
+                                                variant="text"
+                                                @click="show_pricing_rules"
+                                                class="action-btn-consistent"
+                                        >
+                                                {{ pricingRulesCount }} {{ __("Pricing Rules") }}
+                                        </v-btn>
+                                </v-col>
+                                <v-col cols="3" class="dynamic-margin-xs">
+                                        <v-btn
+                                                size="small"
+                                                block
+                                                color="primary"
+                                                variant="text"
 						@click="show_coupons"
 						class="action-btn-consistent"
 						>{{ couponsCount }} {{ __("Coupons") }}</v-btn
@@ -556,10 +568,12 @@ export default {
 		search_backup: "",
 		// Limit the displayed items to avoid overly large lists
 		itemsPerPage: 50,
-		offersCount: 0,
-		appliedOffersCount: 0,
-		couponsCount: 0,
-		appliedCouponsCount: 0,
+                offersCount: 0,
+                appliedOffersCount: 0,
+                pricingRulesCount: 0,
+                appliedPricingRulesCount: 0,
+                couponsCount: 0,
+                appliedCouponsCount: 0,
 		new_line: false,
 		qty: 1,
 		refresh_interval: null,
@@ -1338,12 +1352,15 @@ export default {
 			}
 		},
 
-		show_offers() {
-			this.eventBus.emit("show_offers", "true");
-		},
-		show_coupons() {
-			this.eventBus.emit("show_coupons", "true");
-		},
+                show_offers() {
+                        this.eventBus.emit("show_offers", "true");
+                },
+                show_pricing_rules() {
+                        this.eventBus.emit("show_pricing_rules", "true");
+                },
+                show_coupons() {
+                        this.eventBus.emit("show_coupons", "true");
+                },
                 async initializeItems() {
                         await this.ensureStorageHealth();
                         if (
@@ -3756,10 +3773,14 @@ export default {
 		this.eventBus.on("update_cur_items_details", () => {
 			this.update_cur_items_details();
 		});
-		this.eventBus.on("update_offers_counters", (data) => {
-			this.offersCount = data.offersCount;
-			this.appliedOffersCount = data.appliedOffersCount;
-		});
+                this.eventBus.on("update_offers_counters", (data) => {
+                        this.offersCount = data.offersCount;
+                        this.appliedOffersCount = data.appliedOffersCount;
+                });
+                this.eventBus.on("update_pricing_rules_counters", (data) => {
+                        this.pricingRulesCount = data.pricingRulesCount || 0;
+                        this.appliedPricingRulesCount = data.appliedPricingRulesCount || 0;
+                });
                 this.eventBus.on("update_coupons_counters", (data) => {
                         this.couponsCount = data.couponsCount;
                         this.appliedCouponsCount = data.appliedCouponsCount;
@@ -3959,6 +3980,7 @@ export default {
                 this.eventBus.off("register_pos_profile");
                 this.eventBus.off("update_cur_items_details");
                 this.eventBus.off("update_offers_counters");
+                this.eventBus.off("update_pricing_rules_counters");
                 this.eventBus.off("update_coupons_counters");
                 this.eventBus.off("cart_quantities_updated", this.handleCartQuantitiesUpdated);
                 this.eventBus.off("invoice_stock_adjusted", this.handleInvoiceStockAdjusted);

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -796,11 +796,11 @@ export default {
 		return { invoiceStore, selectedCustomer, customerInfoFromStore: customerInfo };
 	},
 	data() {
-		return {
-			loading: false, // UI loading state
-			pos_profile: "", // POS profile settings
-			pos_settings: "", // POS settings
-			stock_settings: "", // Stock settings
+                return {
+                        loading: false, // UI loading state
+                        pos_profile: "", // POS profile settings
+                        pos_settings: "", // POS settings
+                        stock_settings: "", // Stock settings
 			invoiceType: "Invoice", // Type of invoice
 			is_return: false, // Is this a return invoice?
 			loyalty_amount: 0, // Loyalty points to redeem
@@ -826,10 +826,11 @@ export default {
 			mpesa_modes: [], // List of available M-Pesa modes
 			sales_persons: [], // List of sales persons
 			sales_person: "", // Selected sales person
-			addresses: [], // List of customer addresses
-			is_user_editing_paid_change: false, // User interaction flag
+                        addresses: [], // List of customer addresses
+                        is_user_editing_paid_change: false, // User interaction flag
                         highlightSubmit: false, // Highlight state for submit button
                         last_payment_change_was_cash: null, // Track last edited payment type
+                        activePricingRuleSubmissionGuards: 0, // Track active submission guards for pricing rules
                 };
         },
 	computed: {
@@ -1236,11 +1237,11 @@ export default {
 			});
 		},
 		// Highlight and focus the submit button when payment screen opens
-		handleShowPayment(data) {
-			if (data === "true") {
-				this.$nextTick(() => {
-					setTimeout(() => {
-						const btn = this.$refs.submitButton;
+                handleShowPayment(data) {
+                        if (data === "true") {
+                                this.$nextTick(() => {
+                                        setTimeout(() => {
+                                                const btn = this.$refs.submitButton;
 						const el = btn && btn.$el ? btn.$el : btn;
 						if (el) {
 							el.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -1251,13 +1252,53 @@ export default {
 				});
 			} else {
 				this.highlightSubmit = false;
-			}
-		},
-		// Reset all cash payments to zero
-		reset_cash_payments() {
-			this.invoice_doc.payments.forEach((payment) => {
-				if (payment.mode_of_payment.toLowerCase() === "cash") {
-					payment.amount = 0;
+                        }
+                },
+                ensurePricingRulesSuppressedForSubmission(options = {}) {
+                        const wasSuppressed = this.activePricingRuleSubmissionGuards > 0;
+                        this.activePricingRuleSubmissionGuards += 1;
+
+                        if (wasSuppressed) {
+                                return;
+                        }
+
+                        this.eventBus.emit("suppress_pricing_rule_refresh", {
+                                cancelScheduled: true,
+                                reason: "invoice_submission",
+                                ...options,
+                        });
+                },
+                resumePricingRulesAfterSubmission(options = {}) {
+                        const force = Boolean(options && options.force);
+
+                        if (force) {
+                                this.activePricingRuleSubmissionGuards = 0;
+                        } else if (this.activePricingRuleSubmissionGuards > 0) {
+                                this.activePricingRuleSubmissionGuards -= 1;
+                        }
+
+                        if (this.activePricingRuleSubmissionGuards > 0 && !force) {
+                                return;
+                        }
+
+                        const rest = { ...(options || {}) };
+                        if (Object.prototype.hasOwnProperty.call(rest, "force")) {
+                                delete rest.force;
+                        }
+                        const payload = {
+                                cancelPending: true,
+                                flushPending: false,
+                                reason: "invoice_submission",
+                                ...rest,
+                        };
+
+                        this.eventBus.emit("resume_pricing_rule_refresh", payload);
+                },
+                // Reset all cash payments to zero
+                reset_cash_payments() {
+                        this.invoice_doc.payments.forEach((payment) => {
+                                if (payment.mode_of_payment.toLowerCase() === "cash") {
+                                        payment.amount = 0;
 				}
 			});
 		},
@@ -1453,11 +1494,13 @@ export default {
 			this.submit_invoice(print);
 		},
 		// Submit invoice to backend after all validations
-		submit_invoice(print) {
-			// For return invoices, ensure payments are negative one last time
-			if (this.invoice_doc.is_return) {
-				this.ensureReturnPaymentsAreNegative();
-			}
+                submit_invoice(print) {
+                        this.ensurePricingRulesSuppressedForSubmission();
+
+                        // For return invoices, ensure payments are negative one last time
+                        if (this.invoice_doc.is_return) {
+                                this.ensureReturnPaymentsAreNegative();
+                        }
 			let totalPayedAmount = 0;
 			this.invoice_doc.payments.forEach((payment) => {
 				payment.amount = this.flt(payment.amount);
@@ -1499,132 +1542,147 @@ export default {
 				customer_credit_dict: this.customer_credit_dict,
 				is_cashback: this.is_cashback,
 			};
-			const vm = this;
+                        const vm = this;
 
-			if (isOffline()) {
-				try {
-					saveOfflineInvoice({ data: data, invoice: this.invoice_doc });
-					this.eventBus.emit("pending_invoices_changed", getPendingOfflineInvoiceCount());
-					vm.eventBus.emit("show_message", {
-						title: __("Invoice saved offline"),
-						color: "warning",
-					});
-					if (print) {
-						this.print_offline_invoice(this.invoice_doc);
-					}
-					vm.eventBus.emit("clear_invoice");
-					vm.eventBus.emit("focus_item_search");
-					vm.eventBus.emit("reset_posting_date");
-					vm.back_to_invoice();
-					vm.loading = false;
-					return;
-				} catch (error) {
-					vm.eventBus.emit("show_message", {
-						title: __("Cannot Save Offline Invoice: ") + (error.message || __("Unknown error")),
-						color: "error",
-					});
-					vm.loading = false;
-					return;
-				}
-			}
-			frappe.call({
-				method:
-					this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
-						? "posawesome.posawesome.api.sales_orders.submit_sales_order"
-						: this.invoiceType === "Quotation"
-							? "posawesome.posawesome.api.quotations.submit_quotation"
-							: "posawesome.posawesome.api.invoices.submit_invoice",
-				args: {
-					data: data,
-					invoice: this.invoice_doc,
-					order: this.invoice_doc,
-				},
-				callback: function (r) {
-					if (r.exc) {
-						console.error("Error submitting invoice:", r.exc);
-						// Show detailed error message to help debugging
-						let errorMsg = r.exc.toString();
-						if (errorMsg.includes("Amount must be negative")) {
-							vm.eventBus.emit("show_message", {
-								title: __("Fixing payment amounts for return invoice..."),
-								color: "warning",
-							});
-							// Force fix the amounts
-							vm.invoice_doc.payments.forEach((payment) => {
-								if (payment.amount > 0) {
-									payment.amount = -Math.abs(payment.amount);
-								}
-								if (payment.base_amount > 0) {
-									payment.base_amount = -Math.abs(payment.base_amount);
-								}
-							});
-							// Retry submission once
-							console.log("Retrying submission with fixed payment amounts");
-							setTimeout(() => {
-								vm.submit_invoice(print);
-							}, 500);
-						} else {
-							vm.eventBus.emit("show_message", {
-								title: __("Error submitting invoice: ") + errorMsg,
-								color: "error",
-							});
-						}
-						vm.loading = false;
-						return;
-					}
-					if (!r.message) {
-						vm.eventBus.emit("show_message", {
-							title: __("Error submitting invoice: No response from server"),
-							color: "error",
-						});
-						vm.loading = false;
-						return;
-					}
-					if (print) {
-						vm.load_print_page();
-					}
-					vm.customer_credit_dict = [];
-					vm.redeem_customer_credit = false;
-					vm.is_cashback = true;
-					vm.is_credit_return = false;
-					vm.sales_person = "";
-					vm.eventBus.emit("set_last_invoice", vm.invoice_doc.name);
+                        if (isOffline()) {
+                                try {
+                                        saveOfflineInvoice({ data: data, invoice: this.invoice_doc });
+                                        this.eventBus.emit("pending_invoices_changed", getPendingOfflineInvoiceCount());
                                         vm.eventBus.emit("show_message", {
-                                                title:
-                                                        vm.invoiceType === "Order" && vm.pos_profile.posa_create_only_sales_order
-                                                                ? __("Sales Order {0} is Submitted", [r.message.name])
-                                                                : vm.invoiceType === "Quotation"
-                                                                        ? __("Quotation {0} is Submitted", [r.message.name])
-                                                                        : __("Invoice {0} is Submitted", [r.message.name]),
-                                                color: "success",
+                                                title: __("Invoice saved offline"),
+                                                color: "warning",
                                         });
-                                        frappe.utils.play_sound("submit");
-                                        // Update local stock quantities immediately after successful
-                                        // invoice submission so item availability reflects changes
-                                        const submittedItems = Array.isArray(vm.invoice_doc.items)
-                                                ? vm.invoice_doc.items
-                                                : [];
-                                        updateLocalStock(submittedItems);
-                                        stockCoordinator.applyInvoiceConsumption(submittedItems, {
-                                                source: "invoice",
-                                        });
-                                        const submittedCodes = submittedItems
-                                                .map((item) => (item ? item.item_code : null))
-                                                .filter((code) => code !== undefined && code !== null);
-                                        vm.eventBus.emit("invoice_stock_adjusted", {
-                                                items: submittedItems,
-                                                item_codes: submittedCodes,
-                                                timestamp: Date.now(),
-                                        });
-                                        vm.addresses = [];
+                                        if (print) {
+                                                this.print_offline_invoice(this.invoice_doc);
+                                        }
                                         vm.eventBus.emit("clear_invoice");
                                         vm.eventBus.emit("focus_item_search");
                                         vm.eventBus.emit("reset_posting_date");
                                         vm.back_to_invoice();
-					vm.loading = false;
-				},
-			});
-		},
+                                        return;
+                                } catch (error) {
+                                        vm.eventBus.emit("show_message", {
+                                                title: __("Cannot Save Offline Invoice: ") + (error.message || __("Unknown error")),
+                                                color: "error",
+                                        });
+                                        return;
+                                } finally {
+                                        this.resumePricingRulesAfterSubmission({ cancelPending: true, flushPending: false });
+                                        vm.loading = false;
+                                }
+                        }
+                        const finalizeSubmission = () => {
+                                vm.resumePricingRulesAfterSubmission({ cancelPending: true, flushPending: false });
+                                vm.loading = false;
+                        };
+
+                        frappe.call({
+                                method:
+                                        this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
+                                                ? "posawesome.posawesome.api.sales_orders.submit_sales_order"
+                                                : this.invoiceType === "Quotation"
+                                                        ? "posawesome.posawesome.api.quotations.submit_quotation"
+                                                        : "posawesome.posawesome.api.invoices.submit_invoice",
+                                args: {
+                                        data: data,
+                                        invoice: this.invoice_doc,
+                                        order: this.invoice_doc,
+                                },
+                                callback: function (r) {
+                                        try {
+                                                if (r.exc) {
+                                                        console.error("Error submitting invoice:", r.exc);
+                                                        // Show detailed error message to help debugging
+                                                        let errorMsg = r.exc.toString();
+                                                        if (errorMsg.includes("Amount must be negative")) {
+                                                                vm.eventBus.emit("show_message", {
+                                                                        title: __("Fixing payment amounts for return invoice..."),
+                                                                        color: "warning",
+                                                                });
+                                                                // Force fix the amounts
+                                                                vm.invoice_doc.payments.forEach((payment) => {
+                                                                        if (payment.amount > 0) {
+                                                                                payment.amount = -Math.abs(payment.amount);
+                                                                        }
+                                                                        if (payment.base_amount > 0) {
+                                                                                payment.base_amount = -Math.abs(payment.base_amount);
+                                                                        }
+                                                                });
+                                                                // Retry submission once
+                                                                console.log("Retrying submission with fixed payment amounts");
+                                                                setTimeout(() => {
+                                                                        vm.submit_invoice(print);
+                                                                }, 500);
+                                                        } else {
+                                                                vm.eventBus.emit("show_message", {
+                                                                        title: __("Error submitting invoice: ") + errorMsg,
+                                                                        color: "error",
+                                                                });
+                                                        }
+                                                        return;
+                                                }
+                                                if (!r.message) {
+                                                        vm.eventBus.emit("show_message", {
+                                                                title: __("Error submitting invoice: No response from server"),
+                                                                color: "error",
+                                                        });
+                                                        return;
+                                                }
+                                                if (print) {
+                                                        vm.load_print_page();
+                                                }
+                                                vm.customer_credit_dict = [];
+                                                vm.redeem_customer_credit = false;
+                                                vm.is_cashback = true;
+                                                vm.is_credit_return = false;
+                                                vm.sales_person = "";
+                                                vm.eventBus.emit("set_last_invoice", vm.invoice_doc.name);
+                                                vm.eventBus.emit("show_message", {
+                                                        title:
+                                                                vm.invoiceType === "Order" && vm.pos_profile.posa_create_only_sales_order
+                                                                        ? __("Sales Order {0} is Submitted", [r.message.name])
+                                                                        : vm.invoiceType === "Quotation"
+                                                                                ? __("Quotation {0} is Submitted", [r.message.name])
+                                                                                : __("Invoice {0} is Submitted", [r.message.name]),
+                                                        color: "success",
+                                                });
+                                                frappe.utils.play_sound("submit");
+                                                // Update local stock quantities immediately after successful
+                                                // invoice submission so item availability reflects changes
+                                                const submittedItems = Array.isArray(vm.invoice_doc.items)
+                                                        ? vm.invoice_doc.items
+                                                        : [];
+                                                updateLocalStock(submittedItems);
+                                                stockCoordinator.applyInvoiceConsumption(submittedItems, {
+                                                        source: "invoice",
+                                                });
+                                                const submittedCodes = submittedItems
+                                                        .map((item) => (item ? item.item_code : null))
+                                                        .filter((code) => code !== undefined && code !== null);
+                                                vm.eventBus.emit("invoice_stock_adjusted", {
+                                                        items: submittedItems,
+                                                        item_codes: submittedCodes,
+                                                        timestamp: Date.now(),
+                                                });
+                                                vm.addresses = [];
+                                                vm.eventBus.emit("clear_invoice");
+                                                vm.eventBus.emit("focus_item_search");
+                                                vm.eventBus.emit("reset_posting_date");
+                                                vm.back_to_invoice();
+                                        } finally {
+                                                finalizeSubmission();
+                                        }
+                                },
+                                error: function (error) {
+                                        console.error("Invoice submission failed", error);
+                                        finalizeSubmission();
+                                        vm.eventBus.emit("show_message", {
+                                                title: __("Error submitting invoice"),
+                                                color: "error",
+                                        });
+                                },
+                        });
+                },
 		// Set full amount for a payment method (or negative for returns)
 		set_full_amount(idx) {
 			const isReturn = this.invoice_doc.is_return || this.invoiceType === "Return";
@@ -2350,29 +2408,31 @@ export default {
 				this.set_mpesa_payment(data);
 			});
 			// Clear any stored invoice when parent emits clear_invoice
-			this.eventBus.on("clear_invoice", () => {
-				this.invoice_doc = "";
-				this.is_return = false;
-				this.is_credit_return = false;
-			});
+                        this.eventBus.on("clear_invoice", () => {
+                                this.invoice_doc = "";
+                                this.is_return = false;
+                                this.is_credit_return = false;
+                                this.resumePricingRulesAfterSubmission({ force: true });
+                        });
 			// Scroll to top when payment view is shown
 			this.eventBus.on("show_payment", this.handleShowPayment);
 		});
 	},
 	// Lifecycle hook: beforeUnmount
-	beforeUnmount() {
-		// Remove all event listeners
-		this.eventBus.off("send_invoice_doc_payment");
-		this.eventBus.off("register_pos_profile");
-		this.eventBus.off("add_the_new_address");
-		this.eventBus.off("update_invoice_type");
-		this.eventBus.off("set_pos_settings");
-		this.eventBus.off("set_mpesa_payment");
-		this.eventBus.off("clear_invoice");
-		this.eventBus.off("network-online", this.syncPendingInvoices);
-		this.eventBus.off("server-online", this.syncPendingInvoices);
-		this.eventBus.off("show_payment", this.handleShowPayment);
-	},
+        beforeUnmount() {
+                // Remove all event listeners
+                this.eventBus.off("send_invoice_doc_payment");
+                this.eventBus.off("register_pos_profile");
+                this.eventBus.off("add_the_new_address");
+                this.eventBus.off("update_invoice_type");
+                this.eventBus.off("set_pos_settings");
+                this.eventBus.off("set_mpesa_payment");
+                this.eventBus.off("clear_invoice");
+                this.eventBus.off("network-online", this.syncPendingInvoices);
+                this.eventBus.off("server-online", this.syncPendingInvoices);
+                this.eventBus.off("show_payment", this.handleShowPayment);
+                this.resumePricingRulesAfterSubmission({ force: true });
+        },
 	// Lifecycle hook: unmounted
 	unmounted() {
 		// Remove keyboard shortcut listener

--- a/frontend/src/posapp/components/pos/Pos.vue
+++ b/frontend/src/posapp/components/pos/Pos.vue
@@ -13,13 +13,13 @@
 		<Variants></Variants>
 		<OpeningDialog v-if="dialog" :dialog="dialog"></OpeningDialog>
 		<v-row v-show="!dialog" dense class="ma-0 dynamic-main-row">
-			<v-col
-				v-show="!payment && !showOffers && !coupons"
-				xl="5"
-				lg="5"
-				md="5"
-				sm="5"
-				cols="12"
+                        <v-col
+                                v-show="!payment && !showOffers && !coupons && !pricingRules"
+                                xl="5"
+                                lg="5"
+                                md="5"
+                                sm="5"
+                                cols="12"
 				class="pos dynamic-col"
 			>
 				<ItemsSelector></ItemsSelector>
@@ -27,9 +27,12 @@
 			<v-col v-show="showOffers" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
 				<PosOffers></PosOffers>
 			</v-col>
-			<v-col v-show="coupons" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
-				<PosCoupons></PosCoupons>
-			</v-col>
+                        <v-col v-show="pricingRules" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
+                                <PosPricingRules></PosPricingRules>
+                        </v-col>
+                        <v-col v-show="coupons" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
+                                <PosCoupons></PosCoupons>
+                        </v-col>
 			<v-col v-show="payment" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
 				<Payments></Payments>
 			</v-col>
@@ -48,6 +51,7 @@ import OpeningDialog from "./OpeningDialog.vue";
 import Payments from "./Payments.vue";
 import PosOffers from "./PosOffers.vue";
 import PosCoupons from "./PosCoupons.vue";
+import PosPricingRules from "./PosPricingRules.vue";
 import Drafts from "./Drafts.vue";
 import SalesOrders from "./SalesOrders.vue";
 import ClosingDialog from "./ClosingDialog.vue";
@@ -87,12 +91,13 @@ export default {
 		return { ...responsive, ...rtl, ...shift, ...offers };
 	},
 	data: function () {
-		return {
-			dialog: false,
+                return {
+                        dialog: false,
 
-			payment: false,
-			showOffers: false,
-			coupons: false,
+                        payment: false,
+                        showOffers: false,
+                        pricingRules: false,
+                        coupons: false,
 			itemsLoaded: false,
 			customersLoaded: false,
 		};
@@ -106,10 +111,11 @@ export default {
 		Drafts,
 		ClosingDialog,
 
-		Returns,
-		PosOffers,
-		PosCoupons,
-		NewAddress,
+                Returns,
+                PosOffers,
+                PosCoupons,
+                PosPricingRules,
+                NewAddress,
 		Variants,
 		MpesaPayments,
 		SalesOrders,
@@ -152,21 +158,30 @@ export default {
 					this.get_offers(data.pos_profile.name, data.pos_profile);
 				}
 			});
-			this.eventBus.on("show_payment", (data) => {
-				this.payment = data === "true";
-				this.showOffers = false;
-				this.coupons = false;
-			});
-			this.eventBus.on("show_offers", (data) => {
-				this.showOffers = data === "true";
-				this.payment = false;
-				this.coupons = false;
-			});
-			this.eventBus.on("show_coupons", (data) => {
-				this.coupons = data === "true";
-				this.showOffers = false;
-				this.payment = false;
-			});
+                        this.eventBus.on("show_payment", (data) => {
+                                this.payment = data === "true";
+                                this.showOffers = false;
+                                this.pricingRules = false;
+                                this.coupons = false;
+                        });
+                        this.eventBus.on("show_offers", (data) => {
+                                this.showOffers = data === "true";
+                                this.payment = false;
+                                this.pricingRules = false;
+                                this.coupons = false;
+                        });
+                        this.eventBus.on("show_pricing_rules", (data) => {
+                                this.pricingRules = data === "true";
+                                this.showOffers = false;
+                                this.payment = false;
+                                this.coupons = false;
+                        });
+                        this.eventBus.on("show_coupons", (data) => {
+                                this.coupons = data === "true";
+                                this.showOffers = false;
+                                this.pricingRules = false;
+                                this.payment = false;
+                        });
 			this.eventBus.on("open_closing_dialog", () => {
 				this.get_closing_data();
 			});
@@ -185,8 +200,9 @@ export default {
 		this.eventBus.off("register_pos_data");
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("LoadPosProfile");
-		this.eventBus.off("show_offers");
-		this.eventBus.off("show_coupons");
+                this.eventBus.off("show_offers");
+                this.eventBus.off("show_pricing_rules");
+                this.eventBus.off("show_coupons");
 		this.eventBus.off("open_closing_dialog");
 		this.eventBus.off("submit_closing_pos");
 		this.eventBus.off("items_loaded");

--- a/frontend/src/posapp/components/pos/PosPricingRules.vue
+++ b/frontend/src/posapp/components/pos/PosPricingRules.vue
@@ -1,0 +1,227 @@
+<template>
+        <div>
+                <v-card class="selection mx-auto mt-3 pos-themed-card" style="max-height: 80vh; height: 80vh">
+                        <v-card-title>
+                                <span class="text-h6 text-primary">{{ __("Pricing Rules") }}</span>
+                        </v-card-title>
+                        <div class="my-0 py-0 overflow-y-auto" style="max-height: 75vh">
+                                <v-skeleton-loader
+                                        v-if="loading"
+                                        type="table"
+                                        class="px-4"
+                                        :loading="loading"
+                                />
+                                <template v-else>
+                                        <v-data-table
+                                                :headers="headers"
+                                                :items="pricingRules"
+                                                class="elevation-1"
+                                                :items-per-page="itemsPerPage"
+                                                hide-default-footer
+                                        >
+                                                <template #item.actions="{ item }">
+                                                        <v-btn
+                                                                size="small"
+                                                                color="primary"
+                                                                :loading="applying === item.name"
+                                                                @click="applyRule(item)"
+                                                        >
+                                                                {{ __("Apply") }}
+                                                        </v-btn>
+                                                </template>
+                                                <template #item.discount="{ item }">
+                                                        <span v-if="item.discount_percentage">
+                                                                {{ item.discount_percentage }}%
+                                                        </span>
+                                                        <span v-else-if="item.discount_amount">
+                                                {{ formatRuleCurrency(item.discount_amount) }}
+                                                        </span>
+                                                        <span v-else-if="item.margin_rate_or_amount">
+                                                {{ formatRuleCurrency(item.margin_rate_or_amount) }}
+                                                        </span>
+                                                        <span v-else>
+                                                                —
+                                                        </span>
+                                                </template>
+                                                <template #no-data>
+                                                        <div class="py-6 text-center text-medium-emphasis">
+                                                                {{ __("No pricing rules available for the current cart") }}
+                                                        </div>
+                                                </template>
+                                        </v-data-table>
+                                </template>
+                        </div>
+                </v-card>
+
+                <v-card flat style="max-height: 11vh; height: 11vh" class="cards mb-0 mt-3 py-0">
+                        <v-row align="center" no-gutters>
+                                <v-col cols="12" class="pb-2">
+                                        <v-btn
+                                                block
+                                                class="pa-1"
+                                                size="large"
+                                                color="secondary"
+                                                variant="tonal"
+                                                @click="clearAppliedRules"
+                                                :disabled="!appliedRules.length"
+                                        >
+                                                {{ __("Clear Pricing Rules") }}
+                                        </v-btn>
+                                </v-col>
+                                <v-col cols="12">
+                                        <v-btn
+                                                block
+                                                class="pa-1"
+                                                size="large"
+                                                color="warning"
+                                                theme="dark"
+                                                @click="back_to_invoice"
+                                        >
+                                                {{ __("Back") }}
+                                        </v-btn>
+                                </v-col>
+                        </v-row>
+                </v-card>
+        </div>
+</template>
+
+<script>
+/* global __, frappe */
+import format from "../../format";
+
+export default {
+        mixins: [format],
+        data() {
+                return {
+                        pricingRules: [],
+                        loading: false,
+                        applying: null,
+                        itemsPerPage: 1000,
+                        headers: [
+                                { title: __("Name"), value: "title", align: "start" },
+                                { title: __("Apply On"), value: "apply_on", align: "start" },
+                                { title: __("Discount"), value: "discount", align: "end" },
+                                { title: __("Priority"), value: "priority", align: "end" },
+                                { title: __("Actions"), value: "actions", align: "end", sortable: false },
+                        ],
+                        invoiceContext: null,
+                        appliedRules: [],
+                        profileHandler: null,
+                        pos_profile: null,
+                };
+        },
+        methods: {
+                back_to_invoice() {
+                        this.eventBus.emit("show_pricing_rules", "false");
+                },
+                formatRuleCurrency(value) {
+                        return this.formatCurrency(value);
+                },
+                refreshContext() {
+                        this.eventBus.emit("request_pricing_rule_context");
+                },
+                async fetchPricingRules() {
+                        if (!this.invoiceContext) {
+                                return;
+                        }
+                        this.loading = true;
+                        try {
+                                const { message } = await frappe.call({
+                                        method: "posawesome.posawesome.api.pricing_rules.get_pos_pricing_rules",
+                                        args: { context: JSON.stringify(this.invoiceContext) },
+                                });
+                                this.pricingRules = message || [];
+                                this.emitCounters();
+                        } catch (error) {
+                                console.error("Failed to load pricing rules", error);
+                                this.pricingRules = [];
+                                this.emitCounters();
+                                this.eventBus.emit("show_message", {
+                                        title: __("Failed to fetch pricing rules"),
+                                        color: "error",
+                                });
+                        } finally {
+                                this.loading = false;
+                        }
+                },
+                emitCounters() {
+                        this.eventBus.emit("update_pricing_rules_counters", {
+                                pricingRulesCount: this.pricingRules.length,
+                                appliedPricingRulesCount: this.appliedRules.length,
+                        });
+                },
+                async applyRule(rule) {
+                        if (!rule || !rule.name) {
+                                return;
+                        }
+                        if (!this.invoiceContext) {
+                                this.refreshContext();
+                                return;
+                        }
+                        this.applying = rule.name;
+                        try {
+                                const { message } = await frappe.call({
+                                        method: "posawesome.posawesome.api.pricing_rules.apply_pos_pricing_rule",
+                                        args: {
+                                                context: JSON.stringify(this.invoiceContext),
+                                                pricing_rule: rule.name,
+                                        },
+                                });
+                                const updates = Array.isArray(message) ? message : [];
+                                this.eventBus.emit("apply_pricing_rule_updates", {
+                                        updates,
+                                        pricing_rule: rule.name,
+                                });
+                                this.eventBus.emit("show_message", {
+                                        title: __("Applied pricing rule {0}", [rule.name]),
+                                        color: "success",
+                                });
+                                this.refreshContext();
+                        } catch (error) {
+                                console.error("Failed to apply pricing rule", error);
+                                this.eventBus.emit("show_message", {
+                                        title: __("Unable to apply pricing rule"),
+                                        color: "error",
+                                });
+                        } finally {
+                                this.applying = null;
+                        }
+                },
+                clearAppliedRules() {
+                        this.eventBus.emit("reset_pricing_rules");
+                        this.appliedRules = [];
+                        this.emitCounters();
+                        this.refreshContext();
+                },
+                handlePricingRuleContext(context) {
+                        this.invoiceContext = context;
+                        this.appliedRules = context?.applied_pricing_rules || [];
+                        this.fetchPricingRules();
+                },
+        },
+        created() {
+                this.$nextTick(() => {
+                        this.eventBus.on("pricing_rule_context", this.handlePricingRuleContext);
+                        this.profileHandler = (data) => {
+                                this.pos_profile = data.pos_profile;
+                        };
+                        this.eventBus.on("register_pos_profile", this.profileHandler);
+                        this.refreshContext();
+                });
+        },
+        beforeUnmount() {
+                this.eventBus.off("pricing_rule_context", this.handlePricingRuleContext);
+                if (this.profileHandler) {
+                        this.eventBus.off("register_pos_profile", this.profileHandler);
+                        this.profileHandler = null;
+                }
+        },
+};
+</script>
+
+<style scoped>
+.selection {
+        border-radius: 12px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+</style>

--- a/frontend/src/posapp/components/pos/PosPricingRules.vue
+++ b/frontend/src/posapp/components/pos/PosPricingRules.vue
@@ -29,6 +29,10 @@
                                                                 {{ __("Apply") }}
                                                         </v-btn>
                                                 </template>
+                                                <template #item.min_qty="{ item }">
+                                                        <span v-if="item.min_qty">{{ item.min_qty }}</span>
+                                                        <span v-else>—</span>
+                                                </template>
                                                 <template #item.discount="{ item }">
                                                         <span v-if="item.discount_percentage">
                                                                 {{ item.discount_percentage }}%
@@ -100,6 +104,7 @@ export default {
                         headers: [
                                 { title: __("Name"), value: "title", align: "start" },
                                 { title: __("Apply On"), value: "apply_on", align: "start" },
+                                { title: __("Min Qty"), value: "min_qty", align: "end" },
                                 { title: __("Discount"), value: "discount", align: "end" },
                                 { title: __("Priority"), value: "priority", align: "end" },
                                 { title: __("Actions"), value: "actions", align: "end", sortable: false },

--- a/frontend/src/posapp/components/pos/PosPricingRules.vue
+++ b/frontend/src/posapp/components/pos/PosPricingRules.vue
@@ -122,6 +122,11 @@ export default {
                 formatRuleCurrency(value) {
                         return this.formatCurrency(value);
                 },
+                handlePanelToggle(state) {
+                        if (state === "true") {
+                                this.refreshContext();
+                        }
+                },
                 refreshContext() {
                         this.eventBus.emit("request_pricing_rule_context");
                 },
@@ -207,6 +212,7 @@ export default {
         created() {
                 this.$nextTick(() => {
                         this.eventBus.on("pricing_rule_context", this.handlePricingRuleContext);
+                        this.eventBus.on("show_pricing_rules", this.handlePanelToggle);
                         this.profileHandler = (data) => {
                                 this.pos_profile = data.pos_profile;
                         };
@@ -216,6 +222,7 @@ export default {
         },
         beforeUnmount() {
                 this.eventBus.off("pricing_rule_context", this.handlePricingRuleContext);
+                this.eventBus.off("show_pricing_rules", this.handlePanelToggle);
                 if (this.profileHandler) {
                         this.eventBus.off("register_pos_profile", this.profileHandler);
                         this.profileHandler = null;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -643,13 +643,16 @@ export default {
 		return old_invoice;
 	},
 
-	// Build the invoice document object for backend submission
-	get_invoice_doc() {
-		let doc = {};
-		const sourceDoc = this.invoice_doc || {};
+        // Build the invoice document object for backend submission
+        get_invoice_doc() {
+                if (typeof this.rehydratePricingRuleFreebieState === "function") {
+                        this.rehydratePricingRuleFreebieState({ mergeDuplicates: false, emitCounters: false });
+                }
+                let doc = {};
+                const sourceDoc = this.invoice_doc || {};
 
-		if (sourceDoc.name) {
-			doc = { ...sourceDoc };
+                if (sourceDoc.name) {
+                        doc = { ...sourceDoc };
 		}
 
 		// Always set these fields first
@@ -987,29 +990,29 @@ export default {
 	},
 
 	// Prepare items array for invoice doc
-	get_invoice_items() {
-		const items_list = [];
-		const isReturn = this.isReturnInvoice;
-		const usesPosInvoice = this.pos_profile.create_pos_invoice_instead_of_sales_invoice;
+        get_invoice_items() {
+                const items_list = [];
+                const isReturn = this.isReturnInvoice;
+                const usesPosInvoice = this.pos_profile.create_pos_invoice_instead_of_sales_invoice;
 
-		this.items.forEach((item) => {
-			const new_item = {
-				item_code: item.item_code,
-				// Retain the item name for offline invoices
-				// Fallback to item_code if item_name is not available
-				item_name: item.item_name || item.item_code,
-				name_overridden: item.name_overridden ? 1 : 0,
-				posa_row_id: item.posa_row_id,
-				posa_offers: item.posa_offers,
-				posa_offer_applied: item.posa_offer_applied,
-				posa_is_offer: item.posa_is_offer,
-				posa_is_replace: item.posa_is_replace,
-				is_free_item: item.is_free_item,
-				qty: flt(item.qty),
-				uom: item.uom,
-				conversion_factor: item.conversion_factor,
-				serial_no: item.serial_no,
-				// Link to original invoice item when doing returns
+                this.items.forEach((item) => {
+                        const new_item = {
+                                item_code: item.item_code,
+                                // Retain the item name for offline invoices
+                                // Fallback to item_code if item_name is not available
+                                item_name: item.item_name || item.item_code,
+                                name_overridden: item.name_overridden ? 1 : 0,
+                                posa_row_id: item.posa_row_id,
+                                posa_offers: item.posa_offers,
+                                posa_offer_applied: item.posa_offer_applied,
+                                posa_is_offer: item.posa_is_offer,
+                                posa_is_replace: item.posa_is_replace,
+                                is_free_item: item.is_free_item ? 1 : 0,
+                                qty: flt(item.qty),
+                                uom: item.uom,
+                                conversion_factor: item.conversion_factor,
+                                serial_no: item.serial_no,
+                                // Link to original invoice item when doing returns
 				// Needed for backend validation that the item exists in
 				// the referenced Sales or POS Invoice
 				...(item.sales_invoice_item && { sales_invoice_item: item.sales_invoice_item }),
@@ -1058,22 +1061,53 @@ export default {
 				new_item.amount = flt(item.qty) * new_item.rate;
 				new_item.base_amount = new_item.amount;
 				new_item.discount_amount = flt(item.discount_amount);
-				new_item.base_discount_amount = item.base_discount_amount || flt(item.discount_amount);
-			}
+                                new_item.base_discount_amount = item.base_discount_amount || flt(item.discount_amount);
+                        }
 
-			// For returns, ensure all amounts are negative
-			if (isReturn) {
+                        // For returns, ensure all amounts are negative
+                        if (isReturn) {
 				new_item.qty = -Math.abs(new_item.qty);
 				new_item.amount = -Math.abs(new_item.amount);
 				new_item.base_amount = -Math.abs(new_item.base_amount);
 				new_item.discount_amount = -Math.abs(new_item.discount_amount);
-				new_item.base_discount_amount = -Math.abs(new_item.base_discount_amount);
-			}
+                                new_item.base_discount_amount = -Math.abs(new_item.base_discount_amount);
+                        }
 
-			items_list.push(new_item);
-		});
+                        const pricingRules = item.pricing_rules;
+                        if (Array.isArray(pricingRules)) {
+                                new_item.pricing_rules = JSON.stringify(pricingRules);
+                        } else if (pricingRules !== undefined && pricingRules !== null) {
+                                if (typeof pricingRules === "string") {
+                                        new_item.pricing_rules = pricingRules;
+                                } else {
+                                        new_item.pricing_rules = JSON.stringify([pricingRules]);
+                                }
+                        }
 
-		return items_list;
+                        if (item.pricing_rule && !new_item.pricing_rule) {
+                                new_item.pricing_rule = item.pricing_rule;
+                        }
+                        if (item.applied_pricing_rule && !new_item.applied_pricing_rule) {
+                                new_item.applied_pricing_rule = item.applied_pricing_rule;
+                        }
+                        if (item.applied_pricing_rules && !new_item.applied_pricing_rules) {
+                                new_item.applied_pricing_rules = item.applied_pricing_rules;
+                        }
+
+                        if (item.posa_pricing_rule_freebie) {
+                                new_item.posa_pricing_rule_freebie = item.posa_pricing_rule_freebie;
+                        }
+                        if (item.posa_pricing_rule_key) {
+                                new_item.posa_pricing_rule_key = item.posa_pricing_rule_key;
+                        }
+                        if (item.posa_pricing_rule_source_row) {
+                                new_item.posa_pricing_rule_source_row = item.posa_pricing_rule_source_row;
+                        }
+
+                        items_list.push(new_item);
+                });
+
+                return items_list;
 	},
 
 	// Prepare items array for order doc

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -639,17 +639,207 @@ export default {
 
                 this.removePricingRuleFreeItems(ruleId);
 
-                if (!Array.isArray(freebies) || !freebies.length) {
+                const aggregatedFreebies = this.aggregatePricingRuleFreebies(freebies);
+                if (!aggregatedFreebies.length) {
                         return;
                 }
 
-                for (const detail of freebies) {
+                for (const detail of aggregatedFreebies) {
                         try {
                                 await this.addFreeItemFromPricingRule(ruleId, detail);
                         } catch (error) {
                                 console.error("Failed to add free item from pricing rule", ruleId, error);
                         }
                 }
+        },
+
+        aggregatePricingRuleFreebies(freebies = []) {
+                if (!Array.isArray(freebies) || !freebies.length) {
+                        return [];
+                }
+
+                const groups = new Map();
+
+                freebies.forEach((candidate) => {
+                        const normalized = this.normalizePricingRuleFreebie(candidate);
+                        if (!normalized) {
+                                return;
+                        }
+
+                        const { key, detail, qty, stockQty } = normalized;
+                        if (!groups.has(key)) {
+                                groups.set(key, {
+                                        detail,
+                                        qty,
+                                        stockQty,
+                                });
+                                return;
+                        }
+
+                        const entry = groups.get(key);
+                        entry.qty += qty;
+
+                        const nextStock =
+                                (Number.isFinite(entry.stockQty) ? entry.stockQty : 0) +
+                                (Number.isFinite(stockQty) ? stockQty : 0);
+                        entry.stockQty = nextStock || entry.qty * (entry.detail.conversion_factor || 1);
+
+                        entry.detail = {
+                                ...entry.detail,
+                                qty: entry.qty,
+                        };
+
+                        if (entry.detail.quantity !== undefined) {
+                                entry.detail.quantity = entry.qty;
+                        }
+                        if (entry.detail.free_qty !== undefined) {
+                                entry.detail.free_qty = entry.qty;
+                        }
+
+                        const effectiveStock = entry.stockQty;
+                        if (entry.detail.stock_qty !== undefined) {
+                                entry.detail.stock_qty = effectiveStock;
+                        }
+                        if (entry.detail.free_stock_qty !== undefined) {
+                                entry.detail.free_stock_qty = effectiveStock;
+                        }
+                });
+
+                return Array.from(groups.values()).map(({ detail, qty, stockQty }) => {
+                        const aggregated = {
+                                ...detail,
+                                qty,
+                        };
+
+                        if (aggregated.quantity !== undefined) {
+                                aggregated.quantity = qty;
+                        }
+                        if (aggregated.free_qty !== undefined) {
+                                aggregated.free_qty = qty;
+                        }
+
+                        const effectiveStock =
+                                Number.isFinite(stockQty) && stockQty !== null
+                                        ? stockQty
+                                        : qty * (aggregated.conversion_factor || 1);
+
+                        aggregated.stock_qty = effectiveStock;
+                        if (aggregated.free_stock_qty !== undefined) {
+                                aggregated.free_stock_qty = effectiveStock;
+                        }
+
+                        return aggregated;
+                });
+        },
+
+        normalizePricingRuleFreebie(detail) {
+                if (!detail) {
+                        return null;
+                }
+
+                const itemCode =
+                        detail.item_code || detail.free_item_code || detail.free_item || detail.item_code;
+                if (!itemCode) {
+                        return null;
+                }
+
+                const rawQty =
+                        detail.qty !== undefined && detail.qty !== null
+                                ? detail.qty
+                                : detail.free_qty !== undefined && detail.free_qty !== null
+                                ? detail.free_qty
+                                : detail.quantity !== undefined && detail.quantity !== null
+                                ? detail.quantity
+                                : 0;
+
+                const qty = Math.abs(flt(rawQty || 0));
+                if (!qty) {
+                        return null;
+                }
+
+                const conversionFactorRaw =
+                        detail.conversion_factor !== undefined && detail.conversion_factor !== null
+                                ? detail.conversion_factor
+                                : detail.free_conversion_factor !== undefined && detail.free_conversion_factor !== null
+                                ? detail.free_conversion_factor
+                                : null;
+                const conversionFactor = conversionFactorRaw ? flt(conversionFactorRaw) || 1 : 1;
+
+                const stockCandidate =
+                        detail.stock_qty !== undefined && detail.stock_qty !== null
+                                ? detail.stock_qty
+                                : detail.free_stock_qty !== undefined && detail.free_stock_qty !== null
+                                ? detail.free_stock_qty
+                                : null;
+                const stockQty = stockCandidate !== null ? flt(stockCandidate) : qty * conversionFactor;
+
+                const batchNo = detail.batch_no || detail.free_batch_no || "";
+                const serialNo = detail.serial_no || detail.free_serial_no || "";
+                const sourceRow =
+                        detail.source_row ||
+                        detail.child_docname ||
+                        detail.parent_detail_docname ||
+                        detail.posa_row_id ||
+                        "";
+                const warehouse = detail.warehouse || detail.free_warehouse || "";
+                const uom = detail.uom || detail.free_uom || detail.stock_uom || "";
+                const stockUom = detail.stock_uom || detail.free_stock_uom || uom || "";
+
+                const normalizedDetail = {
+                        ...detail,
+                        item_code: itemCode,
+                        qty,
+                        stock_qty: stockQty,
+                        conversion_factor: conversionFactor,
+                };
+
+                if (detail.quantity !== undefined) {
+                        normalizedDetail.quantity = qty;
+                }
+                if (detail.free_qty !== undefined) {
+                        normalizedDetail.free_qty = qty;
+                }
+                if (detail.free_stock_qty !== undefined) {
+                        normalizedDetail.free_stock_qty = stockQty;
+                }
+                if (detail.free_conversion_factor !== undefined) {
+                        normalizedDetail.free_conversion_factor = conversionFactor;
+                }
+                if (uom) {
+                        normalizedDetail.uom = uom;
+                }
+                if (stockUom) {
+                        normalizedDetail.stock_uom = stockUom;
+                }
+                if (batchNo) {
+                        normalizedDetail.batch_no = batchNo;
+                }
+                if (serialNo) {
+                        normalizedDetail.serial_no = serialNo;
+                }
+                if (warehouse) {
+                        normalizedDetail.warehouse = warehouse;
+                }
+                if (sourceRow) {
+                        normalizedDetail.source_row = sourceRow;
+                }
+
+                const key = [
+                        itemCode,
+                        sourceRow || "",
+                        batchNo || "",
+                        serialNo || "",
+                        normalizedDetail.uom || "",
+                        normalizedDetail.warehouse || "",
+                ].join("::");
+
+                return {
+                        key,
+                        detail: normalizedDetail,
+                        qty,
+                        stockQty,
+                        conversionFactor,
+                };
         },
 
         async addFreeItemFromPricingRule(ruleId, detail) {

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -27,8 +27,38 @@ function parseAppliedRules(value) {
         return [];
 }
 
+function extractRuleIds(candidate) {
+        if (!candidate) {
+                return [];
+        }
+        if (Array.isArray(candidate)) {
+                return candidate
+                        .flatMap((entry) => extractRuleIds(entry))
+                        .map((entry) => entry)
+                        .filter(Boolean);
+        }
+        if (typeof candidate === "object") {
+                const ref = candidate.pricing_rule || candidate.name || candidate.rule;
+                return extractRuleIds(ref);
+        }
+        return parseAppliedRules(candidate);
+}
+
+function firstAppliedRule(...candidates) {
+        for (const candidate of candidates) {
+                const parsed = extractRuleIds(candidate);
+                if (parsed.length) {
+                        return parsed[0];
+                }
+        }
+        return null;
+}
+
 export default {
         buildPricingRuleContext() {
+                if (!this.pos_profile || typeof this.pos_profile !== "object" || !this.pos_profile.name) {
+                        return null;
+                }
                 const docType = this.invoiceType === "Quotation"
                         ? "Quotation"
                         : this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
@@ -168,11 +198,20 @@ export default {
         },
 
         handleRequestPricingRuleContext() {
+                if (!this.pos_profile || typeof this.pos_profile !== "object" || !this.pos_profile.name) {
+                        this.pricingRuleContextPending = true;
+                        return;
+                }
                 const context = this.buildPricingRuleContext();
+                if (!context) {
+                        this.pricingRuleContextPending = true;
+                        return;
+                }
+                this.pricingRuleContextPending = false;
                 this.eventBus.emit("pricing_rule_context", context);
         },
 
-        handleApplyPricingRuleUpdates(payload) {
+        async handleApplyPricingRuleUpdates(payload) {
                 if (!payload || !Array.isArray(payload.updates)) {
                         return;
                 }
@@ -187,6 +226,8 @@ export default {
                         const key = item.posa_row_id || item.name || item.item_code;
                         itemMap.set(key, item);
                 });
+
+                const freebiesByRule = new Map();
 
                 updates.forEach((detail) => {
                         const rowId = detail.posa_row_id || detail.child_docname || detail.name || detail.item_code;
@@ -216,6 +257,9 @@ export default {
                         if (detail.margin_rate_or_amount !== undefined) {
                                 item.margin_rate_or_amount = flt(detail.margin_rate_or_amount);
                         }
+                        if (detail.is_free_item !== undefined) {
+                                item.is_free_item = detail.is_free_item ? 1 : 0;
+                        }
 
                         if (selectedCurrency !== baseCurrency) {
                                 if (item.base_price_list_rate !== undefined) {
@@ -242,19 +286,68 @@ export default {
                                 item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
                         }
 
-                        if (detail.free_item_data && detail.free_item_data.length) {
-                                this.eventBus.emit("show_message", {
-                                        title: __("The selected pricing rule includes free items. Please review them manually."),
-                                        color: "warning",
-                                });
+                        if (detail.free_item_data) {
+                                const ruleId = firstAppliedRule(
+                                        detail.pricing_rule,
+                                        detail.pricing_rules,
+                                        detail.pricing_rule_name,
+                                        detail.rule,
+                                        detail.free_item_data,
+                                        payload.pricing_rule,
+                                );
+                                if (ruleId && !freebiesByRule.has(ruleId)) {
+                                        freebiesByRule.set(ruleId, []);
+                                }
+                                if (ruleId) {
+                                        const existing = freebiesByRule.get(ruleId) || [];
+                                        const dataArray = Array.isArray(detail.free_item_data)
+                                                ? detail.free_item_data
+                                                : [];
+                                        dataArray.forEach((entry) => {
+                                                if (!entry) {
+                                                        return;
+                                                }
+                                                existing.push({
+                                                        ...entry,
+                                                        source_row:
+                                                                detail.posa_row_id ||
+                                                                detail.child_docname ||
+                                                                detail.name ||
+                                                                detail.item_code,
+                                                });
+                                        });
+                                        freebiesByRule.set(ruleId, existing);
+                                }
                         }
                 });
+
+                const requestedRule = firstAppliedRule(payload?.pricing_rule);
+                if (requestedRule && !freebiesByRule.has(requestedRule)) {
+                        freebiesByRule.set(requestedRule, []);
+                }
+
+                for (const [ruleId, freebies] of freebiesByRule.entries()) {
+                        try {
+                                await this.syncFreeItemsForPricingRule(ruleId, freebies);
+                        } catch (error) {
+                                console.error("Failed to synchronise free items for pricing rule", ruleId, error);
+                        }
+                }
 
                 this.$forceUpdate();
                 this.emitPricingRuleCounters();
         },
 
         handleResetPricingRules() {
+                if (typeof this.remove_item === "function") {
+                        const freebies = (this.items || []).filter(
+                                (item) => item && item.is_free_item && item.posa_pricing_rule_freebie,
+                        );
+                        freebies.forEach((item) => {
+                                this.remove_item(item);
+                        });
+                }
+
                 (this.items || []).forEach((item) => {
                         if (!item) {
                                 return;
@@ -280,5 +373,163 @@ export default {
 
                 this.$forceUpdate();
                 this.emitPricingRuleCounters();
+        },
+
+        removePricingRuleFreeItems(ruleId) {
+                if (!ruleId || typeof this.remove_item !== "function") {
+                        return;
+                }
+                const removable = (this.items || []).filter(
+                        (item) => item && item.is_free_item && item.posa_pricing_rule_freebie === ruleId,
+                );
+                removable.forEach((item) => {
+                        this.remove_item(item);
+                });
+        },
+
+        async syncFreeItemsForPricingRule(ruleId, freebies = []) {
+                if (!ruleId) {
+                        return;
+                }
+
+                this.removePricingRuleFreeItems(ruleId);
+
+                if (!Array.isArray(freebies) || !freebies.length) {
+                        return;
+                }
+
+                for (const detail of freebies) {
+                        try {
+                                await this.addFreeItemFromPricingRule(ruleId, detail);
+                        } catch (error) {
+                                console.error("Failed to add free item from pricing rule", ruleId, error);
+                        }
+                }
+        },
+
+        async addFreeItemFromPricingRule(ruleId, detail) {
+                if (!ruleId || !detail || !detail.item_code) {
+                        return null;
+                }
+
+                const quantity = flt(detail.qty || detail.free_qty || detail.quantity || 0);
+                const qty = quantity ? Math.abs(quantity) : 0;
+                if (!qty) {
+                        return null;
+                }
+
+                const rawStockQty =
+                        detail.stock_qty !== undefined ? detail.stock_qty : detail.free_stock_qty || detail.stock_qty;
+                const stockQtyValue = rawStockQty !== undefined ? flt(rawStockQty) : null;
+                const conversionFactorRaw = detail.conversion_factor || detail.free_conversion_factor;
+                const conversionFactor = conversionFactorRaw ? flt(conversionFactorRaw) || 1 : 1;
+                const stockQty = stockQtyValue !== null ? stockQtyValue : qty * conversionFactor;
+
+                const beforeIds = new Set(
+                        (this.items || [])
+                                .filter((item) => item && item.posa_pricing_rule_freebie === ruleId)
+                                .map((item) => item.posa_row_id),
+                );
+
+                let baseItem = null;
+                if (typeof this.resolveOfferItem === "function") {
+                        try {
+                                baseItem = await this.resolveOfferItem(detail.item_code);
+                        } catch (error) {
+                                console.error("Failed to resolve pricing rule free item", detail.item_code, error);
+                        }
+                }
+
+                const payload = baseItem ? { ...baseItem } : { item_code: detail.item_code };
+                payload.item_name =
+                        detail.item_name || detail.free_item_name || payload.item_name || detail.item_code;
+                payload.description = detail.description || payload.description || payload.item_name;
+                payload.qty = qty;
+                payload.stock_qty = stockQty;
+                payload.uom = detail.uom || payload.uom || detail.stock_uom || payload.stock_uom;
+                payload.stock_uom = detail.stock_uom || payload.stock_uom || payload.uom;
+                payload.conversion_factor = conversionFactor || 1;
+                payload.warehouse = detail.warehouse || payload.warehouse || this.pos_profile?.warehouse;
+
+                const baseRate = flt(
+                        detail.rate !== undefined
+                                ? detail.rate
+                                : detail.base_rate !== undefined
+                                ? detail.base_rate
+                                : 0,
+                );
+                const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+                const exchangeRate = this.exchange_rate || 1;
+                const isForeignCurrency = this.selected_currency && baseCurrency && this.selected_currency !== baseCurrency;
+                const displayRate = isForeignCurrency
+                        ? this.flt(baseRate * exchangeRate, this.currency_precision)
+                        : baseRate;
+
+                payload.base_rate = baseRate;
+                payload.base_price_list_rate = baseRate;
+                payload.rate = displayRate;
+                payload.price_list_rate = displayRate;
+                payload.discount_amount = 0;
+                payload.discount_percentage = 0;
+                payload.pricing_rules = JSON.stringify([ruleId]);
+                payload.posa_is_offer = 1;
+                payload.posa_is_replace = payload.posa_is_replace || "";
+                payload.is_free_item = 1;
+                payload.posa_pricing_rule_freebie = ruleId;
+                payload.posa_pricing_rule_source_row =
+                        detail.source_row || detail.child_docname || detail.parent_detail_docname || null;
+
+                if (detail.batch_no) {
+                        payload.batch_no = detail.batch_no;
+                        payload.has_batch_no = 1;
+                }
+                if (detail.serial_no) {
+                        payload.serial_no = detail.serial_no;
+                }
+
+                const originalNewLine = this.new_line;
+                try {
+                        this.new_line = true;
+                        await this.add_item(payload, { skipNotification: true });
+                } finally {
+                        this.new_line = originalNewLine;
+                }
+
+                const addedItem = (this.items || []).find((item) => {
+                        if (!item || item.posa_pricing_rule_freebie !== ruleId) {
+                                return false;
+                        }
+                        if (beforeIds.has(item.posa_row_id)) {
+                                return false;
+                        }
+                        if (payload.posa_pricing_rule_source_row) {
+                                return item.posa_pricing_rule_source_row === payload.posa_pricing_rule_source_row;
+                        }
+                        return true;
+                });
+
+                if (addedItem) {
+                        addedItem.is_free_item = 1;
+                        addedItem.pricing_rules = JSON.stringify([ruleId]);
+                        addedItem.posa_pricing_rule_freebie = ruleId;
+                        addedItem.posa_pricing_rule_source_row = payload.posa_pricing_rule_source_row;
+                        addedItem.discount_amount = 0;
+                        addedItem.discount_percentage = 0;
+                        addedItem.base_rate = baseRate;
+                        addedItem.base_price_list_rate = baseRate;
+                        addedItem.rate = displayRate;
+                        addedItem.price_list_rate = displayRate;
+                        addedItem.amount = this.flt(addedItem.qty * addedItem.rate, this.currency_precision);
+                        addedItem.base_amount = this.flt(
+                                addedItem.qty * (addedItem.base_rate !== undefined ? addedItem.base_rate : addedItem.rate),
+                                this.currency_precision,
+                        );
+                        if (detail.batch_no && this.setBatchQty) {
+                                this.setBatchQty(addedItem, detail.batch_no, false);
+                        }
+                        this.calc_item_price(addedItem);
+                }
+
+                return addedItem || null;
         },
 };

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -220,6 +220,8 @@ export default {
                 const baseCurrency = this.price_list_currency || this.pos_profile.currency;
                 const selectedCurrency = this.selected_currency || baseCurrency;
                 const exchangeRate = this.exchange_rate || 1;
+                const requestedRuleRaw = firstAppliedRule(payload?.pricing_rule);
+                const requestedRule = requestedRuleRaw ? `${requestedRuleRaw}` : null;
 
                 const itemMap = new Map();
                 (this.items || []).forEach((item) => {
@@ -287,7 +289,7 @@ export default {
                         }
 
                         if (detail.free_item_data) {
-                                const ruleId = firstAppliedRule(
+                                let ruleId = firstAppliedRule(
                                         detail.pricing_rule,
                                         detail.pricing_rules,
                                         detail.pricing_rule_name,
@@ -295,6 +297,13 @@ export default {
                                         detail.free_item_data,
                                         payload.pricing_rule,
                                 );
+                                if (requestedRule) {
+                                        const normalisedRuleId = ruleId ? `${ruleId}` : null;
+                                        if (normalisedRuleId && normalisedRuleId !== requestedRule) {
+                                                return;
+                                        }
+                                        ruleId = normalisedRuleId || requestedRule;
+                                }
                                 if (ruleId && !freebiesByRule.has(ruleId)) {
                                         freebiesByRule.set(ruleId, []);
                                 }
@@ -321,7 +330,6 @@ export default {
                         }
                 });
 
-                const requestedRule = firstAppliedRule(payload?.pricing_rule);
                 if (requestedRule && !freebiesByRule.has(requestedRule)) {
                         freebiesByRule.set(requestedRule, []);
                 }

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -637,19 +637,60 @@ export default {
                         return;
                 }
 
-                this.removePricingRuleFreeItems(ruleId);
-
                 const aggregatedFreebies = this.aggregatePricingRuleFreebies(freebies);
+
+                const existingItems = (this.items || []).filter(
+                        (item) => item && item.is_free_item && item.posa_pricing_rule_freebie === ruleId,
+                );
+
                 if (!aggregatedFreebies.length) {
+                        if (typeof this.remove_item === "function") {
+                                existingItems.forEach((item) => this.remove_item(item));
+                        }
                         return;
                 }
 
+                const existingByKey = new Map();
+                existingItems.forEach((item) => {
+                        const key = item.posa_pricing_rule_key || this.getPricingRuleFreebieKey(item);
+                        if (key) {
+                                existingByKey.set(key, item);
+                        }
+                });
+
+                const retainedKeys = new Set();
+
                 for (const detail of aggregatedFreebies) {
+                        const key = detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail);
+                        if (!key) {
+                                continue;
+                        }
+
+                        const existingItem = existingByKey.get(key);
+                        if (existingItem) {
+                                try {
+                                        this.updateFreeItemFromPricingRule(existingItem, detail, ruleId);
+                                        retainedKeys.add(key);
+                                } catch (error) {
+                                        console.error("Failed to update free item from pricing rule", ruleId, error);
+                                }
+                                continue;
+                        }
+
                         try {
                                 await this.addFreeItemFromPricingRule(ruleId, detail);
+                                retainedKeys.add(key);
                         } catch (error) {
                                 console.error("Failed to add free item from pricing rule", ruleId, error);
                         }
+                }
+
+                if (typeof this.remove_item === "function" && existingByKey.size) {
+                        existingByKey.forEach((item, key) => {
+                                if (!retainedKeys.has(key)) {
+                                        this.remove_item(item);
+                                }
+                        });
                 }
         },
 
@@ -672,6 +713,7 @@ export default {
                                         detail,
                                         qty,
                                         stockQty,
+                                        key,
                                 });
                                 return;
                         }
@@ -689,6 +731,8 @@ export default {
                                 qty: entry.qty,
                         };
 
+                        entry.key = key;
+
                         if (entry.detail.quantity !== undefined) {
                                 entry.detail.quantity = entry.qty;
                         }
@@ -705,11 +749,16 @@ export default {
                         }
                 });
 
-                return Array.from(groups.values()).map(({ detail, qty, stockQty }) => {
+                return Array.from(groups.values()).map(({ detail, qty, stockQty, key }) => {
                         const aggregated = {
                                 ...detail,
                                 qty,
                         };
+
+                        const detailKey = detail.posa_pricing_rule_key || key;
+                        if (detailKey) {
+                                aggregated.posa_pricing_rule_key = detailKey;
+                        }
 
                         if (aggregated.quantity !== undefined) {
                                 aggregated.quantity = qty;
@@ -793,6 +842,17 @@ export default {
                         conversion_factor: conversionFactor,
                 };
 
+                const key = this.getPricingRuleFreebieKey({
+                        ...normalizedDetail,
+                        item_code: itemCode,
+                        qty,
+                        stock_qty: stockQty,
+                        conversion_factor: conversionFactor,
+                });
+                if (key) {
+                        normalizedDetail.posa_pricing_rule_key = key;
+                }
+
                 if (detail.quantity !== undefined) {
                         normalizedDetail.quantity = qty;
                 }
@@ -824,15 +884,6 @@ export default {
                         normalizedDetail.source_row = sourceRow;
                 }
 
-                const key = [
-                        itemCode,
-                        sourceRow || "",
-                        batchNo || "",
-                        serialNo || "",
-                        normalizedDetail.uom || "",
-                        normalizedDetail.warehouse || "",
-                ].join("::");
-
                 return {
                         key,
                         detail: normalizedDetail,
@@ -840,6 +891,35 @@ export default {
                         stockQty,
                         conversionFactor,
                 };
+        },
+
+        getPricingRuleFreebieKey(detail = {}) {
+                if (!detail) {
+                        return "";
+                }
+
+                const itemCode =
+                        detail.item_code || detail.free_item_code || detail.free_item || detail.item_code;
+                if (!itemCode) {
+                        return "";
+                }
+
+                const sourceRow =
+                        detail.posa_pricing_rule_source_row ||
+                        detail.source_row ||
+                        detail.child_docname ||
+                        detail.parent_detail_docname ||
+                        detail.posa_row_id ||
+                        "";
+
+                const batchNo = detail.batch_no || detail.free_batch_no || "";
+                const serialNo = detail.serial_no || detail.free_serial_no || "";
+                const uom = detail.uom || detail.free_uom || detail.stock_uom || "";
+                const warehouse = detail.warehouse || detail.free_warehouse || "";
+
+                return [itemCode, sourceRow || "", batchNo || "", serialNo || "", uom || "", warehouse || ""].join(
+                        "::",
+                );
         },
 
         async addFreeItemFromPricingRule(ruleId, detail) {
@@ -865,6 +945,8 @@ export default {
                                 .filter((item) => item && item.posa_pricing_rule_freebie === ruleId)
                                 .map((item) => item.posa_row_id),
                 );
+
+                const key = detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail);
 
                 let baseItem = null;
                 if (typeof this.resolveOfferItem === "function") {
@@ -913,6 +995,9 @@ export default {
                 payload.posa_pricing_rule_freebie = ruleId;
                 payload.posa_pricing_rule_source_row =
                         detail.source_row || detail.child_docname || detail.parent_detail_docname || null;
+                if (key) {
+                        payload.posa_pricing_rule_key = key;
+                }
 
                 if (detail.batch_no) {
                         payload.batch_no = detail.batch_no;
@@ -948,6 +1033,9 @@ export default {
                         addedItem.pricing_rules = JSON.stringify([ruleId]);
                         addedItem.posa_pricing_rule_freebie = ruleId;
                         addedItem.posa_pricing_rule_source_row = payload.posa_pricing_rule_source_row;
+                        if (key) {
+                                addedItem.posa_pricing_rule_key = key;
+                        }
                         addedItem.discount_amount = 0;
                         addedItem.discount_percentage = 0;
                         addedItem.base_rate = baseRate;
@@ -966,5 +1054,84 @@ export default {
                 }
 
                 return addedItem || null;
+        },
+
+        updateFreeItemFromPricingRule(item, detail, ruleId) {
+                if (!item || !detail) {
+                        return;
+                }
+
+                const quantity = flt(detail.qty || detail.free_qty || detail.quantity || 0);
+                const qty = quantity ? Math.abs(quantity) : 0;
+                if (!qty) {
+                        if (typeof this.remove_item === "function") {
+                                this.remove_item(item);
+                        }
+                        return;
+                }
+
+                const rawStockQty =
+                        detail.stock_qty !== undefined ? detail.stock_qty : detail.free_stock_qty || detail.stock_qty;
+                const stockQtyValue = rawStockQty !== undefined ? flt(rawStockQty) : null;
+                const conversionFactorRaw = detail.conversion_factor || detail.free_conversion_factor;
+                const conversionFactor = conversionFactorRaw ? flt(conversionFactorRaw) || 1 : 1;
+                const stockQty = stockQtyValue !== null ? stockQtyValue : qty * conversionFactor;
+
+                const key = detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail);
+
+                const baseRate = flt(
+                        detail.rate !== undefined
+                                ? detail.rate
+                                : detail.base_rate !== undefined
+                                ? detail.base_rate
+                                : item.base_rate !== undefined
+                                ? item.base_rate
+                                : 0,
+                );
+                const baseCurrency = this.price_list_currency || this.pos_profile?.currency;
+                const exchangeRate = this.exchange_rate || 1;
+                const isForeignCurrency =
+                        this.selected_currency && baseCurrency && this.selected_currency !== baseCurrency;
+                const displayRate = isForeignCurrency
+                        ? this.flt(baseRate * exchangeRate, this.currency_precision)
+                        : baseRate;
+
+                item.qty = qty;
+                item.stock_qty = stockQty;
+                item.conversion_factor = conversionFactor || 1;
+                item.uom = detail.uom || item.uom || detail.stock_uom || item.stock_uom;
+                item.stock_uom = detail.stock_uom || item.stock_uom || item.uom;
+                item.warehouse = detail.warehouse || item.warehouse || this.pos_profile?.warehouse;
+                item.batch_no = detail.batch_no || item.batch_no || "";
+                if (item.batch_no) {
+                        item.has_batch_no = 1;
+                }
+                item.serial_no = detail.serial_no || item.serial_no || "";
+                item.is_free_item = 1;
+                item.pricing_rules = JSON.stringify([ruleId]);
+                item.posa_pricing_rule_freebie = ruleId;
+                item.posa_pricing_rule_source_row =
+                        detail.source_row || detail.child_docname || detail.parent_detail_docname || item.posa_pricing_rule_source_row || null;
+                if (key) {
+                        item.posa_pricing_rule_key = key;
+                }
+
+                item.base_rate = baseRate;
+                item.base_price_list_rate = baseRate;
+                item.rate = displayRate;
+                item.price_list_rate = displayRate;
+                item.discount_amount = 0;
+                item.discount_percentage = 0;
+                item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                item.base_amount = this.flt(
+                        item.qty * (item.base_rate !== undefined ? item.base_rate : item.rate),
+                        this.currency_precision,
+                );
+
+                if (detail.batch_no && this.setBatchQty) {
+                        this.setBatchQty(item, detail.batch_no, false);
+                }
+
+                this.calc_item_price(item);
         },
 };

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -637,7 +637,7 @@ export default {
                         return;
                 }
 
-                const aggregatedFreebies = this.aggregatePricingRuleFreebies(freebies);
+                const aggregatedFreebies = this.aggregatePricingRuleFreebies(ruleId, freebies);
 
                 const existingItems = (this.items || []).filter(
                         (item) => item && item.is_free_item && item.posa_pricing_rule_freebie === ruleId,
@@ -652,7 +652,8 @@ export default {
 
                 const existingByKey = new Map();
                 existingItems.forEach((item) => {
-                        const key = item.posa_pricing_rule_key || this.getPricingRuleFreebieKey(item);
+                        const key =
+                                item.posa_pricing_rule_key || this.getPricingRuleFreebieKey(item, ruleId);
                         if (!key) {
                                 return;
                         }
@@ -667,7 +668,8 @@ export default {
                 const retainedKeys = new Set();
 
                 for (const detail of aggregatedFreebies) {
-                        const key = detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail);
+                        const key =
+                                detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail, ruleId);
                         if (!key) {
                                 continue;
                         }
@@ -705,7 +707,7 @@ export default {
                 }
         },
 
-        aggregatePricingRuleFreebies(freebies = []) {
+        aggregatePricingRuleFreebies(ruleId, freebies = []) {
                 if (!Array.isArray(freebies) || !freebies.length) {
                         return [];
                 }
@@ -713,7 +715,7 @@ export default {
                 const groups = new Map();
 
                 freebies.forEach((candidate) => {
-                        const normalized = this.normalizePricingRuleFreebie(candidate);
+                        const normalized = this.normalizePricingRuleFreebie(ruleId, candidate);
                         if (!normalized) {
                                 return;
                         }
@@ -792,7 +794,7 @@ export default {
                 });
         },
 
-        normalizePricingRuleFreebie(detail) {
+        normalizePricingRuleFreebie(ruleId, detail) {
                 if (!detail) {
                         return null;
                 }
@@ -853,13 +855,16 @@ export default {
                         conversion_factor: conversionFactor,
                 };
 
-                const key = this.getPricingRuleFreebieKey({
-                        ...normalizedDetail,
-                        item_code: itemCode,
-                        qty,
-                        stock_qty: stockQty,
-                        conversion_factor: conversionFactor,
-                });
+                const key = this.getPricingRuleFreebieKey(
+                        {
+                                ...normalizedDetail,
+                                item_code: itemCode,
+                                qty,
+                                stock_qty: stockQty,
+                                conversion_factor: conversionFactor,
+                        },
+                        ruleId,
+                );
                 if (key) {
                         normalizedDetail.posa_pricing_rule_key = key;
                 }
@@ -893,6 +898,7 @@ export default {
                 }
                 if (sourceRow) {
                         normalizedDetail.source_row = sourceRow;
+                        normalizedDetail.posa_pricing_rule_source_row = sourceRow;
                 }
 
                 return {
@@ -904,7 +910,7 @@ export default {
                 };
         },
 
-        getPricingRuleFreebieKey(detail = {}) {
+        getPricingRuleFreebieKey(detail = {}, ruleId = "") {
                 if (!detail) {
                         return "";
                 }
@@ -915,22 +921,38 @@ export default {
                         return "";
                 }
 
-                const sourceRow =
-                        detail.posa_pricing_rule_source_row ||
-                        detail.source_row ||
-                        detail.child_docname ||
-                        detail.parent_detail_docname ||
-                        detail.posa_row_id ||
-                        "";
-
                 const batchNo = detail.batch_no || detail.free_batch_no || "";
                 const serialNo = detail.serial_no || detail.free_serial_no || "";
                 const uom = detail.uom || detail.free_uom || detail.stock_uom || "";
                 const warehouse = detail.warehouse || detail.free_warehouse || "";
+                const conversionFactorRaw =
+                        detail.conversion_factor !== undefined && detail.conversion_factor !== null
+                                ? detail.conversion_factor
+                                : detail.free_conversion_factor !== undefined && detail.free_conversion_factor !== null
+                                ? detail.free_conversion_factor
+                                : null;
+                const conversionFactor = conversionFactorRaw ? flt(conversionFactorRaw) || 1 : 1;
 
-                return [itemCode, sourceRow || "", batchNo || "", serialNo || "", uom || "", warehouse || ""].join(
-                        "::",
-                );
+                const resolvedRuleId =
+                        firstAppliedRule(
+                                ruleId,
+                                detail.posa_pricing_rule_freebie,
+                                detail.pricing_rule,
+                                detail.rule,
+                                detail.pricing_rules,
+                        ) || "";
+
+                const parts = [
+                        resolvedRuleId || "",
+                        itemCode,
+                        batchNo || "",
+                        serialNo || "",
+                        uom || "",
+                        warehouse || "",
+                        `${conversionFactor || 1}`,
+                ];
+
+                return parts.join("::");
         },
 
         async addFreeItemFromPricingRule(ruleId, detail) {
@@ -957,7 +979,7 @@ export default {
                                 .map((item) => item.posa_row_id),
                 );
 
-                const key = detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail);
+                const key = detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail, ruleId);
 
                 let baseItem = null;
                 if (typeof this.resolveOfferItem === "function") {
@@ -1088,7 +1110,7 @@ export default {
                 const conversionFactor = conversionFactorRaw ? flt(conversionFactorRaw) || 1 : 1;
                 const stockQty = stockQtyValue !== null ? stockQtyValue : qty * conversionFactor;
 
-                const key = detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail);
+                const key = detail.posa_pricing_rule_key || this.getPricingRuleFreebieKey(detail, ruleId);
 
                 const baseRate = flt(
                         detail.rate !== undefined

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -1,0 +1,276 @@
+/* global __, frappe, flt */
+
+function parseAppliedRules(value) {
+        if (!value) {
+                return [];
+        }
+        if (Array.isArray(value)) {
+                return value.filter(Boolean);
+        }
+        if (typeof value === "string") {
+                try {
+                        const parsed = JSON.parse(value);
+                        if (Array.isArray(parsed)) {
+                                return parsed.filter(Boolean);
+                        }
+                } catch (error) {
+                        // Ignore JSON parse failures and treat as comma-separated
+                        if (value.includes(",")) {
+                                return value
+                                        .split(",")
+                                        .map((rule) => rule && rule.trim())
+                                        .filter(Boolean);
+                        }
+                }
+                return value ? [value] : [];
+        }
+        return [];
+}
+
+export default {
+        buildPricingRuleContext() {
+                const docType = this.invoiceType === "Quotation"
+                        ? "Quotation"
+                        : this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
+                        ? "Sales Order"
+                        : this.pos_profile.create_pos_invoice_instead_of_sales_invoice
+                        ? "POS Invoice"
+                        : "Sales Invoice";
+
+                const childDoctype = `${docType} Item`;
+                const transactionDate = this.posting_date || frappe.datetime.nowdate();
+                const currency = this.selected_currency || this.pos_profile.currency;
+                const conversionRate = this.conversion_rate || 1;
+                const priceListCurrency = this.price_list_currency || currency;
+                const plcConversionRate = this.exchange_rate || 1;
+                const priceList = this.pos_profile.selling_price_list;
+
+                const items = (this.items || []).map((item) => {
+                        const key = item.posa_row_id || item.name || item.item_code;
+                        const data = {
+                                name: key,
+                                item_code: item.item_code,
+                                item_name: item.item_name,
+                                item_group: item.item_group,
+                                brand: item.brand,
+                                qty: flt(item.qty),
+                                stock_qty: flt(item.stock_qty || item.qty * (item.conversion_factor || 1)),
+                                uom: item.uom,
+                                stock_uom: item.stock_uom || item.uom,
+                                warehouse: item.warehouse || this.pos_profile.warehouse,
+                                price_list_rate: flt(item.base_price_list_rate || item.price_list_rate),
+                                rate: flt(item.base_rate || item.rate),
+                                discount_percentage: flt(item.discount_percentage),
+                                discount_amount: flt(item.discount_amount || 0),
+                                conversion_factor: flt(item.conversion_factor || 1),
+                                serial_no: item.serial_no,
+                                batch_no: item.batch_no,
+                                pricing_rules: item.pricing_rules || "",
+                                is_free_item: item.is_free_item,
+                        };
+                        return data;
+                });
+
+                const appliedRules = this.collectAppliedPricingRules(items);
+
+                const context = {
+                        doctype: docType,
+                        child_doctype: childDoctype,
+                        transaction_date: transactionDate,
+                        customer: this.customer || null,
+                        customer_group: this.customer_info?.customer_group || this.invoice_doc?.customer_group || null,
+                        territory: this.customer_info?.territory || this.invoice_doc?.territory || null,
+                        currency,
+                        conversion_rate: conversionRate,
+                        price_list: priceList,
+                        price_list_currency: priceListCurrency,
+                        plc_conversion_rate: plcConversionRate,
+                        company: this.pos_profile.company,
+                        campaign: this.invoice_doc?.campaign || this.pos_profile.campaign || null,
+                        sales_partner: this.invoice_doc?.sales_partner || null,
+                        ignore_pricing_rule: 0,
+                        pos_profile: this.pos_profile.name,
+                        coupon_code: this.invoice_doc?.coupon_code || null,
+                        is_return: this.isReturnInvoice ? 1 : 0,
+                        update_stock: this.invoice_doc?.update_stock || 0,
+                        items,
+                        applied_pricing_rules: appliedRules,
+                        doc: {
+                                doctype: docType,
+                                company: this.pos_profile.company,
+                                customer: this.customer || null,
+                                currency,
+                                conversion_rate: conversionRate,
+                                price_list_currency: priceListCurrency,
+                                plc_conversion_rate: plcConversionRate,
+                                selling_price_list: priceList,
+                                is_return: this.isReturnInvoice ? 1 : 0,
+                                items: items.map((item) => ({
+                                        doctype: childDoctype,
+                                        name: item.name,
+                                        item_code: item.item_code,
+                                        item_name: item.item_name,
+                                        item_group: item.item_group,
+                                        brand: item.brand,
+                                        qty: item.qty,
+                                        stock_qty: item.stock_qty,
+                                        uom: item.uom,
+                                        stock_uom: item.stock_uom,
+                                        warehouse: item.warehouse,
+                                        price_list_rate: item.price_list_rate,
+                                        rate: item.rate,
+                                        discount_percentage: item.discount_percentage,
+                                        discount_amount: item.discount_amount,
+                                        conversion_factor: item.conversion_factor,
+                                        serial_no: item.serial_no,
+                                        batch_no: item.batch_no,
+                                        pricing_rules: item.pricing_rules,
+                                })),
+                        },
+                };
+
+                return context;
+        },
+
+        collectAppliedPricingRules(items = null) {
+                const source = Array.isArray(items) ? items : this.items || [];
+                const ruleSet = new Set();
+                source.forEach((item) => {
+                        const values = parseAppliedRules(item.pricing_rules);
+                        values.forEach((value) => {
+                                if (value) {
+                                        ruleSet.add(value);
+                                }
+                        });
+                });
+                return Array.from(ruleSet);
+        },
+
+        emitPricingRuleCounters(total = null) {
+                if (total !== null && total !== undefined) {
+                        this._pricingRulesTotal = total;
+                }
+                const applied = this.collectAppliedPricingRules();
+                const effectiveTotal =
+                        total !== null && total !== undefined
+                                ? total
+                                : this._pricingRulesTotal || 0;
+                this.eventBus.emit("update_pricing_rules_counters", {
+                        pricingRulesCount: effectiveTotal,
+                        appliedPricingRulesCount: applied.length,
+                });
+        },
+
+        handleRequestPricingRuleContext() {
+                const context = this.buildPricingRuleContext();
+                this.eventBus.emit("pricing_rule_context", context);
+        },
+
+        handleApplyPricingRuleUpdates(payload) {
+                if (!payload || !Array.isArray(payload.updates)) {
+                        return;
+                }
+
+                const updates = payload.updates;
+                const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+                const selectedCurrency = this.selected_currency || baseCurrency;
+                const exchangeRate = this.exchange_rate || 1;
+
+                const itemMap = new Map();
+                (this.items || []).forEach((item) => {
+                        const key = item.posa_row_id || item.name || item.item_code;
+                        itemMap.set(key, item);
+                });
+
+                updates.forEach((detail) => {
+                        const rowId = detail.posa_row_id || detail.child_docname || detail.name || detail.item_code;
+                        const item = itemMap.get(rowId);
+                        if (!item) {
+                                return;
+                        }
+
+                        if (detail.pricing_rules !== undefined) {
+                                item.pricing_rules = detail.pricing_rules;
+                        }
+                        if (detail.discount_percentage !== undefined) {
+                                item.discount_percentage = flt(detail.discount_percentage);
+                        }
+                        if (detail.discount_amount !== undefined) {
+                                item.discount_amount = flt(detail.discount_amount);
+                        }
+                        if (detail.price_list_rate !== undefined) {
+                                item.base_price_list_rate = flt(detail.price_list_rate);
+                        }
+                        if (detail.rate !== undefined) {
+                                item.base_rate = flt(detail.rate);
+                        }
+                        if (detail.margin_type !== undefined) {
+                                item.margin_type = detail.margin_type;
+                        }
+                        if (detail.margin_rate_or_amount !== undefined) {
+                                item.margin_rate_or_amount = flt(detail.margin_rate_or_amount);
+                        }
+
+                        if (selectedCurrency !== baseCurrency) {
+                                if (item.base_price_list_rate !== undefined) {
+                                        item.price_list_rate = this.flt(
+                                                item.base_price_list_rate / exchangeRate,
+                                                this.currency_precision,
+                                        );
+                                }
+                                if (item.base_rate !== undefined) {
+                                        item.rate = this.flt(item.base_rate / exchangeRate, this.currency_precision);
+                                }
+                        } else {
+                                if (item.base_price_list_rate !== undefined) {
+                                        item.price_list_rate = item.base_price_list_rate;
+                                }
+                                if (item.base_rate !== undefined) {
+                                        item.rate = item.base_rate;
+                                }
+                        }
+
+                        this.calc_item_price(item);
+                        item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                        if (item.base_rate !== undefined) {
+                                item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
+                        }
+
+                        if (detail.free_item_data && detail.free_item_data.length) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("The selected pricing rule includes free items. Please review them manually."),
+                                        color: "warning",
+                                });
+                        }
+                });
+
+                this.$forceUpdate();
+        },
+
+        handleResetPricingRules() {
+                (this.items || []).forEach((item) => {
+                        if (!item) {
+                                return;
+                        }
+                        item.pricing_rules = "";
+                        item.discount_percentage = 0;
+                        item.discount_amount = 0;
+                        if (item.base_price_list_rate !== undefined && item.base_price_list_rate !== null) {
+                                item.price_list_rate = item.base_price_list_rate;
+                        }
+                        if (item.base_rate !== undefined && item.base_rate !== null) {
+                                item.rate = item.base_rate;
+                        } else {
+                                item.rate = item.price_list_rate;
+                        }
+                        this.calc_item_price(item);
+                        item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                        item.base_amount = this.flt(
+                                item.qty * (item.base_rate !== undefined ? item.base_rate : item.rate),
+                                this.currency_precision,
+                        );
+                });
+
+                this.$forceUpdate();
+        },
+};

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -73,6 +73,7 @@ export default {
 
                 const appliedRules = this.collectAppliedPricingRules(items);
 
+                const transactionType = "selling";
                 const context = {
                         doctype: docType,
                         child_doctype: childDoctype,
@@ -89,6 +90,8 @@ export default {
                         campaign: this.invoice_doc?.campaign || this.pos_profile.campaign || null,
                         sales_partner: this.invoice_doc?.sales_partner || null,
                         ignore_pricing_rule: 0,
+                        transaction_type: transactionType,
+                        is_pos: 1,
                         pos_profile: this.pos_profile.name,
                         coupon_code: this.invoice_doc?.coupon_code || null,
                         is_return: this.isReturnInvoice ? 1 : 0,
@@ -104,6 +107,9 @@ export default {
                                 price_list_currency: priceListCurrency,
                                 plc_conversion_rate: plcConversionRate,
                                 selling_price_list: priceList,
+                                transaction_type: transactionType,
+                                ignore_pricing_rule: 0,
+                                is_pos: 1,
                                 is_return: this.isReturnInvoice ? 1 : 0,
                                 items: items.map((item) => ({
                                         doctype: childDoctype,
@@ -245,6 +251,7 @@ export default {
                 });
 
                 this.$forceUpdate();
+                this.emitPricingRuleCounters();
         },
 
         handleResetPricingRules() {
@@ -272,5 +279,6 @@ export default {
                 });
 
                 this.$forceUpdate();
+                this.emitPricingRuleCounters();
         },
 };

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -653,9 +653,15 @@ export default {
                 const existingByKey = new Map();
                 existingItems.forEach((item) => {
                         const key = item.posa_pricing_rule_key || this.getPricingRuleFreebieKey(item);
-                        if (key) {
-                                existingByKey.set(key, item);
+                        if (!key) {
+                                return;
                         }
+
+                        if (!existingByKey.has(key)) {
+                                existingByKey.set(key, []);
+                        }
+
+                        existingByKey.get(key).push(item);
                 });
 
                 const retainedKeys = new Set();
@@ -666,7 +672,8 @@ export default {
                                 continue;
                         }
 
-                        const existingItem = existingByKey.get(key);
+                        const existingCandidates = existingByKey.get(key) || [];
+                        const existingItem = existingCandidates.length ? existingCandidates[0] : null;
                         if (existingItem) {
                                 try {
                                         this.updateFreeItemFromPricingRule(existingItem, detail, ruleId);
@@ -686,10 +693,14 @@ export default {
                 }
 
                 if (typeof this.remove_item === "function" && existingByKey.size) {
-                        existingByKey.forEach((item, key) => {
-                                if (!retainedKeys.has(key)) {
-                                        this.remove_item(item);
-                                }
+                        existingByKey.forEach((items, key) => {
+                                const shouldRetain = retainedKeys.has(key);
+
+                                items.forEach((item, index) => {
+                                        if (!shouldRetain || index > 0) {
+                                                this.remove_item(item);
+                                        }
+                                });
                         });
                 }
         },

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -197,6 +197,149 @@ export default {
                 });
         },
 
+        rehydratePricingRuleFreebieState(options = {}) {
+                const items = Array.isArray(this.items) ? this.items : [];
+                if (!items.length) {
+                        return;
+                }
+
+                const mergeDuplicates = options && options.mergeDuplicates !== false;
+                const shouldEmitCounters = options && options.emitCounters !== false;
+                const freebiesByKey = new Map();
+                const duplicates = [];
+                let mutated = false;
+
+                items.forEach((item) => {
+                        if (!item || !item.is_free_item) {
+                                return;
+                        }
+
+                        const parsedRules = parseAppliedRules(item.pricing_rules);
+                        const ruleIdRaw = firstAppliedRule(
+                                item.posa_pricing_rule_freebie,
+                                parsedRules,
+                                item.pricing_rule,
+                                item.rule,
+                                item.applied_pricing_rule,
+                                item.applied_pricing_rules,
+                        );
+                        const ruleId = ruleIdRaw ? `${ruleIdRaw}` : null;
+                        if (!ruleId) {
+                                return;
+                        }
+
+                        if (item.is_free_item !== 1) {
+                                item.is_free_item = 1;
+                                mutated = true;
+                        }
+
+                        if (item.posa_pricing_rule_freebie !== ruleId) {
+                                item.posa_pricing_rule_freebie = ruleId;
+                                mutated = true;
+                        }
+
+                        if (!parsedRules.length || !parsedRules.includes(ruleId)) {
+                                item.pricing_rules = JSON.stringify([ruleId]);
+                                mutated = true;
+                        } else {
+                                const serialized = JSON.stringify(parsedRules);
+                                if (item.pricing_rules !== serialized) {
+                                        item.pricing_rules = serialized;
+                                        mutated = true;
+                                }
+                        }
+
+                        const key = item.posa_pricing_rule_key || this.getPricingRuleFreebieKey(item, ruleId);
+                        if (key && item.posa_pricing_rule_key !== key) {
+                                item.posa_pricing_rule_key = key;
+                                mutated = true;
+                        }
+
+                        if (!mergeDuplicates) {
+                                return;
+                        }
+
+                        const compositeKey = key
+                                ? `${ruleId}::${key}`
+                                : [
+                                          ruleId,
+                                          item.item_code || "",
+                                          item.batch_no || "",
+                                          item.serial_no || "",
+                                          item.uom || "",
+                                          item.warehouse || "",
+                                          item.conversion_factor !== undefined && item.conversion_factor !== null
+                                                  ? `${flt(item.conversion_factor) || 1}`
+                                                  : "",
+                                  ].join("::");
+
+                        const existing = freebiesByKey.get(compositeKey);
+                        if (!existing) {
+                                freebiesByKey.set(compositeKey, item);
+                                return;
+                        }
+
+                        if (existing === item) {
+                                return;
+                        }
+
+                        const qty = flt(existing.qty || 0) + flt(item.qty || 0);
+                        const stockQty = flt(existing.stock_qty || 0) + flt(item.stock_qty || 0);
+                        if (!Number.isNaN(qty)) {
+                                existing.qty = qty;
+                                mutated = true;
+                        }
+                        if (!Number.isNaN(stockQty)) {
+                                existing.stock_qty = stockQty;
+                                mutated = true;
+                        }
+                        if (!existing.conversion_factor && item.conversion_factor) {
+                                existing.conversion_factor = item.conversion_factor;
+                                mutated = true;
+                        }
+                        if (!existing.batch_no && item.batch_no) {
+                                existing.batch_no = item.batch_no;
+                                mutated = true;
+                        }
+                        if (!existing.serial_no && item.serial_no) {
+                                existing.serial_no = item.serial_no;
+                                mutated = true;
+                        }
+                        if (!existing.warehouse && item.warehouse) {
+                                existing.warehouse = item.warehouse;
+                                mutated = true;
+                        }
+
+                        existing.amount = this.flt(existing.qty * (existing.rate || 0), this.currency_precision);
+                        const baseRate =
+                                existing.base_rate !== undefined && existing.base_rate !== null
+                                        ? existing.base_rate
+                                        : existing.rate || 0;
+                        existing.base_amount = this.flt(existing.qty * baseRate, this.currency_precision);
+                        if (typeof this.calc_item_price === "function") {
+                                this.calc_item_price(existing);
+                        }
+
+                        duplicates.push(item);
+                });
+
+                if (mergeDuplicates && duplicates.length && typeof this.remove_item === "function") {
+                        duplicates.forEach((item) => this.remove_item(item));
+                        mutated = true;
+                }
+
+                if (mutated) {
+                        if (typeof this.$forceUpdate === "function") {
+                                this.$forceUpdate();
+                        }
+                        if (shouldEmitCounters && typeof this.emitPricingRuleCounters === "function") {
+                                this.emitPricingRuleCounters();
+                        }
+                } else if (options && options.emitCounters === true && typeof this.emitPricingRuleCounters === "function") {
+                        this.emitPricingRuleCounters();
+                }
+        },
+
         handleRequestPricingRuleContext() {
                 if (!this.pos_profile || typeof this.pos_profile !== "object" || !this.pos_profile.name) {
                         this.pricingRuleContextPending = true;

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -537,12 +537,76 @@ export default {
                 });
         },
 
+        isPricingRuleRefreshSuppressed() {
+                return Number.isFinite(this._pricingRuleRefreshSuppressCount)
+                        ? this._pricingRuleRefreshSuppressCount > 0
+                        : false;
+        },
+
+        suppressPricingRuleRefresh() {
+                const count = Number.isFinite(this._pricingRuleRefreshSuppressCount)
+                        ? this._pricingRuleRefreshSuppressCount
+                        : 0;
+                this._pricingRuleRefreshSuppressCount = count + 1;
+        },
+
+        resumePricingRuleRefresh(options = {}) {
+                const { cancelPending = false, flushPending = true } = options || {};
+                const count = Number.isFinite(this._pricingRuleRefreshSuppressCount)
+                        ? this._pricingRuleRefreshSuppressCount
+                        : 0;
+
+                if (count > 0) {
+                        this._pricingRuleRefreshSuppressCount = count - 1;
+                } else {
+                        this._pricingRuleRefreshSuppressCount = 0;
+                }
+
+                if (this.isPricingRuleRefreshSuppressed()) {
+                        return;
+                }
+
+                if (cancelPending) {
+                        this.cancelScheduledPricingRuleRefresh();
+                        this._pricingRuleRefreshRequestedDuringSuppression = false;
+                        this._pricingRuleRefreshSuppressedRows = null;
+                        return;
+                }
+
+                const shouldFlush = flushPending !== false && this._pricingRuleRefreshRequestedDuringSuppression;
+                const suppressedRows = this._pricingRuleRefreshSuppressedRows;
+                this._pricingRuleRefreshRequestedDuringSuppression = false;
+                this._pricingRuleRefreshSuppressedRows = null;
+
+                if (shouldFlush) {
+                        const rowIds = Array.isArray(suppressedRows)
+                                ? suppressedRows
+                                : suppressedRows instanceof Set
+                                ? Array.from(suppressedRows)
+                                : [];
+                        this.schedulePricingRuleRefresh(rowIds);
+                }
+        },
+
         schedulePricingRuleRefresh(changedRowIds = []) {
                 if (typeof changedRowIds === "boolean") {
                         changedRowIds = [];
                 } else if (changedRowIds && typeof changedRowIds === "object" && !Array.isArray(changedRowIds)) {
                         const options = changedRowIds || {};
                         changedRowIds = Array.isArray(options.rowIds) ? options.rowIds : [];
+                }
+
+                if (this.isPricingRuleRefreshSuppressed()) {
+                        this._pricingRuleRefreshRequestedDuringSuppression = true;
+                        if (Array.isArray(changedRowIds) && changedRowIds.length) {
+                                const existing = this._pricingRuleRefreshSuppressedRows;
+                                if (existing instanceof Set) {
+                                        changedRowIds.forEach((id) => existing.add(id));
+                                } else {
+                                        this._pricingRuleRefreshSuppressedRows = new Set(changedRowIds);
+                                }
+                        }
+                        return;
                 }
 
                 if (this._pricingRuleAutoApplying) {
@@ -579,9 +643,16 @@ export default {
 
                 this._pricingRuleRefreshPending = false;
                 this._pricingRuleRefreshRequested = false;
+                this._pricingRuleRefreshRequestedDuringSuppression = false;
+                this._pricingRuleRefreshSuppressedRows = null;
         },
 
         async processPendingPricingRuleRefresh() {
+                if (this.isPricingRuleRefreshSuppressed()) {
+                        this._pricingRuleRefreshRequestedDuringSuppression = true;
+                        return;
+                }
+
                 if (this._pricingRuleAutoApplying) {
                         this._pricingRuleRefreshRequested = true;
                         return;

--- a/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
+++ b/frontend/src/posapp/components/pos/invoicePricingRuleMethods.js
@@ -212,16 +212,27 @@ export default {
         },
 
         async handleApplyPricingRuleUpdates(payload) {
-                if (!payload || !Array.isArray(payload.updates)) {
+                if (!payload) {
                         return;
                 }
 
-                const updates = payload.updates;
+                const updates = Array.isArray(payload.updates) ? payload.updates : [];
+                const baseActiveRules = Array.isArray(payload.active_rule_ids)
+                        ? payload.active_rule_ids
+                        : [];
+                const touchedRuleIds = new Set(
+                        baseActiveRules
+                                .map((ruleId) => (ruleId !== undefined && ruleId !== null ? `${ruleId}` : null))
+                                .filter(Boolean),
+                );
                 const baseCurrency = this.price_list_currency || this.pos_profile.currency;
                 const selectedCurrency = this.selected_currency || baseCurrency;
                 const exchangeRate = this.exchange_rate || 1;
                 const requestedRuleRaw = firstAppliedRule(payload?.pricing_rule);
                 const requestedRule = requestedRuleRaw ? `${requestedRuleRaw}` : null;
+                const shouldCleanupInactive = payload?.pricing_rule
+                        ? payload.cleanup_inactive === true
+                        : true;
 
                 const itemMap = new Map();
                 (this.items || []).forEach((item) => {
@@ -230,6 +241,8 @@ export default {
                 });
 
                 const freebiesByRule = new Map();
+                this._pricingRuleOriginals =
+                        this._pricingRuleOriginals instanceof WeakMap ? this._pricingRuleOriginals : new WeakMap();
 
                 updates.forEach((detail) => {
                         const rowId = detail.posa_row_id || detail.child_docname || detail.name || detail.item_code;
@@ -237,6 +250,31 @@ export default {
                         if (!item) {
                                 return;
                         }
+
+                        if (!this._pricingRuleOriginals.has(item)) {
+                                this._pricingRuleOriginals.set(item, {
+                                        base_price_list_rate: item.base_price_list_rate,
+                                        base_rate: item.base_rate,
+                                        price_list_rate: item.price_list_rate,
+                                        rate: item.rate,
+                                        discount_percentage: item.discount_percentage,
+                                        discount_amount: item.discount_amount,
+                                });
+                        }
+
+                        const detailRuleIds = extractRuleIds(
+                                detail.pricing_rule,
+                                detail.pricing_rules,
+                                detail.pricing_rule_name,
+                                detail.rule,
+                                detail.applied_pricing_rule,
+                                detail.applied_pricing_rules,
+                        );
+                        detailRuleIds.forEach((ruleId) => {
+                                if (ruleId) {
+                                        touchedRuleIds.add(`${ruleId}`);
+                                }
+                        });
 
                         if (detail.pricing_rules !== undefined) {
                                 item.pricing_rules = detail.pricing_rules;
@@ -334,6 +372,10 @@ export default {
                         freebiesByRule.set(requestedRule, []);
                 }
 
+                if (requestedRule) {
+                        touchedRuleIds.add(requestedRule);
+                }
+
                 for (const [ruleId, freebies] of freebiesByRule.entries()) {
                         try {
                                 await this.syncFreeItemsForPricingRule(ruleId, freebies);
@@ -342,8 +384,106 @@ export default {
                         }
                 }
 
+                if (shouldCleanupInactive) {
+                        this.cleanupInactivePricingRules(touchedRuleIds);
+                }
+
                 this.$forceUpdate();
                 this.emitPricingRuleCounters();
+        },
+
+        cleanupInactivePricingRules(activeRuleIds = new Set(), options = {}) {
+                const activeSet = activeRuleIds instanceof Set
+                        ? new Set(Array.from(activeRuleIds).map((id) => `${id}`))
+                        : new Set(
+                                  (Array.isArray(activeRuleIds) ? activeRuleIds : [])
+                                          .map((id) => (id !== undefined && id !== null ? `${id}` : null))
+                                          .filter(Boolean),
+                          );
+                const shouldEmit = Boolean(options.emitCounters);
+
+                const previouslyApplied = this.collectAppliedPricingRules();
+                previouslyApplied.forEach((ruleId) => {
+                        if (!activeSet.has(`${ruleId}`)) {
+                                this.removePricingRuleFreeItems(ruleId);
+                        }
+                });
+
+                (this.items || []).forEach((item) => {
+                        if (!item) {
+                                return;
+                        }
+
+                        const applied = parseAppliedRules(item.pricing_rules);
+                        if (!applied.length) {
+                                return;
+                        }
+
+                        const stillActive = applied.filter((ruleId) => activeSet.has(`${ruleId}`));
+
+                        if (stillActive.length) {
+                                item.pricing_rules = JSON.stringify(stillActive);
+                                return;
+                        }
+
+                        item.pricing_rules = "";
+                        const originalsMap = this._pricingRuleOriginals instanceof WeakMap ? this._pricingRuleOriginals : null;
+                        const original = originalsMap ? originalsMap.get(item) : null;
+                        const hasOriginal = original && typeof original === "object";
+
+                        if (hasOriginal) {
+                                if (original.base_price_list_rate !== undefined && original.base_price_list_rate !== null) {
+                                        item.base_price_list_rate = original.base_price_list_rate;
+                                }
+                                if (original.base_rate !== undefined && original.base_rate !== null) {
+                                        item.base_rate = original.base_rate;
+                                }
+                                if (original.price_list_rate !== undefined && original.price_list_rate !== null) {
+                                        item.price_list_rate = original.price_list_rate;
+                                }
+                                if (original.rate !== undefined && original.rate !== null) {
+                                        item.rate = original.rate;
+                                } else if (original.base_rate !== undefined && original.base_rate !== null) {
+                                        item.rate = original.base_rate;
+                                }
+                                item.discount_percentage =
+                                        original.discount_percentage !== undefined &&
+                                        original.discount_percentage !== null
+                                                ? original.discount_percentage
+                                                : 0;
+                                item.discount_amount =
+                                        original.discount_amount !== undefined && original.discount_amount !== null
+                                                ? original.discount_amount
+                                                : 0;
+                        } else {
+                                item.discount_percentage = 0;
+                                item.discount_amount = 0;
+
+                                if (item.base_price_list_rate !== undefined && item.base_price_list_rate !== null) {
+                                        item.price_list_rate = item.base_price_list_rate;
+                                }
+                                if (item.base_rate !== undefined && item.base_rate !== null) {
+                                        item.rate = item.base_rate;
+                                } else if (item.price_list_rate !== undefined && item.price_list_rate !== null) {
+                                        item.rate = item.price_list_rate;
+                                        item.base_rate = item.price_list_rate;
+                                }
+                        }
+
+                        this.calc_item_price(item);
+                        item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                        item.base_amount = this.flt(
+                                item.qty * (item.base_rate !== undefined && item.base_rate !== null ? item.base_rate : item.rate),
+                                this.currency_precision,
+                        );
+                        if (originalsMap) {
+                                originalsMap.delete(item);
+                        }
+                });
+
+                if (shouldEmit) {
+                        this.emitPricingRuleCounters();
+                }
         },
 
         handleResetPricingRules() {
@@ -379,6 +519,8 @@ export default {
                         );
                 });
 
+                this._pricingRuleOriginals = new WeakMap();
+
                 this.$forceUpdate();
                 this.emitPricingRuleCounters();
         },
@@ -393,6 +535,101 @@ export default {
                 removable.forEach((item) => {
                         this.remove_item(item);
                 });
+        },
+
+        schedulePricingRuleRefresh(changedRowIds = []) {
+                if (typeof changedRowIds === "boolean") {
+                        changedRowIds = [];
+                } else if (changedRowIds && typeof changedRowIds === "object" && !Array.isArray(changedRowIds)) {
+                        const options = changedRowIds || {};
+                        changedRowIds = Array.isArray(options.rowIds) ? options.rowIds : [];
+                }
+
+                if (this._pricingRuleAutoApplying) {
+                        this._pricingRuleRefreshRequested = true;
+                        return;
+                }
+
+                if (this._pricingRuleRefreshPending) {
+                        return;
+                }
+
+                this._pricingRuleRefreshPending = true;
+                const scheduler =
+                        typeof window !== "undefined" && typeof window.requestAnimationFrame === "function"
+                                ? window.requestAnimationFrame.bind(window)
+                                : (cb) => setTimeout(cb, 16);
+
+                this._pricingRuleRefreshHandle = scheduler(() => {
+                        this._pricingRuleRefreshHandle = null;
+                        this._pricingRuleRefreshPending = false;
+                        this.processPendingPricingRuleRefresh();
+                });
+        },
+
+        cancelScheduledPricingRuleRefresh() {
+                if (this._pricingRuleRefreshHandle != null) {
+                        if (typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+                                window.cancelAnimationFrame(this._pricingRuleRefreshHandle);
+                        } else {
+                                clearTimeout(this._pricingRuleRefreshHandle);
+                        }
+                        this._pricingRuleRefreshHandle = null;
+                }
+
+                this._pricingRuleRefreshPending = false;
+                this._pricingRuleRefreshRequested = false;
+        },
+
+        async processPendingPricingRuleRefresh() {
+                if (this._pricingRuleAutoApplying) {
+                        this._pricingRuleRefreshRequested = true;
+                        return;
+                }
+
+                const context = this.buildPricingRuleContext();
+                if (!context || !this.pos_profile || !this.pos_profile.name) {
+                        return;
+                }
+
+                const items = Array.isArray(context.items) ? context.items : [];
+                if (!items.length) {
+                        if (this._pricingRuleOriginals instanceof WeakMap) {
+                                this._pricingRuleOriginals = new WeakMap();
+                        }
+                        this.cleanupInactivePricingRules(new Set(), { emitCounters: true });
+                        this.$forceUpdate();
+                        return;
+                }
+
+                this._pricingRuleAutoApplying = true;
+
+                try {
+                        const { message } = await frappe.call({
+                                method: "posawesome.posawesome.api.pricing_rules.auto_apply_pos_pricing_rules",
+                                args: { context: JSON.stringify(context) },
+                        });
+
+                        const response = message || {};
+                        const updates = Array.isArray(response.updates) ? response.updates : [];
+                        const activeRules = Array.isArray(response.active_pricing_rules)
+                                ? response.active_pricing_rules
+                                : [];
+
+                        await this.handleApplyPricingRuleUpdates({
+                                updates,
+                                active_rule_ids: activeRules,
+                        });
+                } catch (error) {
+                        console.error("Failed to auto apply pricing rules", error);
+                } finally {
+                        this._pricingRuleAutoApplying = false;
+                }
+
+                if (this._pricingRuleRefreshRequested) {
+                        this._pricingRuleRefreshRequested = false;
+                        this.schedulePricingRuleRefresh();
+                }
         },
 
         async syncFreeItemsForPricingRule(ruleId, freebies = []) {

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -90,12 +90,18 @@ export default {
                 this.fetch_customer_balance();
                 this.set_delivery_charges();
                 this.sync_invoice_customer_details();
+                if (typeof this.schedulePricingRuleRefresh === "function") {
+                        this.schedulePricingRuleRefresh();
+                }
         },
         // Watch for customer_info change and emit to edit form
         customer_info() {
                 const customersStore = useCustomersStore();
                 customersStore.setCustomerInfo(this.customer_info || {});
                 this.sync_invoice_customer_details(this.customer_info);
+                if (typeof this.schedulePricingRuleRefresh === "function") {
+                        this.schedulePricingRuleRefresh();
+                }
         },
 	// Watch for expanded row change and update item detail
 	expanded(data_value) {
@@ -134,9 +140,15 @@ export default {
                         if (!previous) {
                                 if (snapshot.order.length) {
                                         this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                        if (typeof this.schedulePricingRuleRefresh === "function") {
+                                                this.schedulePricingRuleRefresh([...new Set(snapshot.order)]);
+                                        }
                                 }
                         } else if (changed.size) {
                                 this.scheduleOfferRefresh(Array.from(changed));
+                                if (typeof this.schedulePricingRuleRefresh === "function") {
+                                        this.schedulePricingRuleRefresh(Array.from(changed));
+                                }
                         }
 
                         if (typeof this.emitCartQuantities === "function") {
@@ -164,9 +176,15 @@ export default {
                         if (!previous) {
                                 if (snapshot.order.length) {
                                         this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                        if (typeof this.schedulePricingRuleRefresh === "function") {
+                                                this.schedulePricingRuleRefresh([...new Set(snapshot.order)]);
+                                        }
                                 }
                         } else if (changed.size) {
                                 this.scheduleOfferRefresh(Array.from(changed));
+                                if (typeof this.schedulePricingRuleRefresh === "function") {
+                                        this.schedulePricingRuleRefresh(Array.from(changed));
+                                }
                         }
 
                         if (typeof this.emitCartQuantities === "function") {
@@ -206,12 +224,15 @@ export default {
                 }
         },
 	// Keep display date in sync with posting_date
-	posting_date: {
-		handler(newVal) {
-			this.posting_date_display = this.formatDateForDisplay(newVal);
-		},
-		immediate: true,
-	},
+        posting_date: {
+                handler(newVal) {
+                        this.posting_date_display = this.formatDateForDisplay(newVal);
+                        if (typeof this.schedulePricingRuleRefresh === "function") {
+                                this.schedulePricingRuleRefresh();
+                        }
+                },
+                immediate: true,
+        },
 	// Update posting_date when user changes the display value
 	posting_date_display(newVal) {
 		this.posting_date = this.formatDateForBackend(newVal);
@@ -227,11 +248,11 @@ export default {
 		this.apply_cached_price_list(applied);
 
 		// If multi-currency is enabled, sync currency with the price list currency
-		if (this.pos_profile.posa_allow_multi_currency && applied) {
-			frappe.call({
-				method: "posawesome.posawesome.api.invoices.get_price_list_currency",
-				args: { price_list: applied },
-				callback: (r) => {
+                if (this.pos_profile.posa_allow_multi_currency && applied) {
+                        frappe.call({
+                                method: "posawesome.posawesome.api.invoices.get_price_list_currency",
+                                args: { price_list: applied },
+                                callback: (r) => {
 					if (r.message) {
 						// Store price list currency for later use
 						this.price_list_currency = r.message;
@@ -259,23 +280,32 @@ export default {
 		if (typeof this.clearItemStockCache === "function") {
 			this.clearItemStockCache();
 		}
-		if (this.available_stock_cache) {
-			this.available_stock_cache = {};
-		}
-	},
+                if (this.available_stock_cache) {
+                        this.available_stock_cache = {};
+                }
+                if (typeof this.schedulePricingRuleRefresh === "function") {
+                        this.schedulePricingRuleRefresh();
+                }
+        },
 
 	// Reactively update item prices when currency changes
-	selected_currency() {
-		clearPriceListCache();
-		if (this.items && this.items.length) {
-			this.update_item_rates();
-		}
-	},
+        selected_currency() {
+                clearPriceListCache();
+                if (this.items && this.items.length) {
+                        this.update_item_rates();
+                }
+                if (typeof this.schedulePricingRuleRefresh === "function") {
+                        this.schedulePricingRuleRefresh();
+                }
+        },
 
-	// Reactively update item prices when exchange rate changes
-	exchange_rate() {
-		if (this.items && this.items.length) {
-			this.update_item_rates();
-		}
-	},
+        // Reactively update item prices when exchange rate changes
+        exchange_rate() {
+                if (this.items && this.items.length) {
+                        this.update_item_rates();
+                }
+                if (typeof this.schedulePricingRuleRefresh === "function") {
+                        this.schedulePricingRuleRefresh();
+                }
+        },
 };

--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -35,7 +35,11 @@ from .offers import (
     get_offers,
     get_pos_coupon,
 )
-from .pricing_rules import apply_pos_pricing_rule, get_pos_pricing_rules
+from .pricing_rules import (
+    apply_pos_pricing_rule,
+    auto_apply_pos_pricing_rules,
+    get_pos_pricing_rules,
+)
 from .payments import (
     create_payment_request,
     get_available_credit,

--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -35,6 +35,7 @@ from .offers import (
     get_offers,
     get_pos_coupon,
 )
+from .pricing_rules import apply_pos_pricing_rule, get_pos_pricing_rules
 from .payments import (
     create_payment_request,
     get_available_credit,

--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -13,9 +13,12 @@ from posawesome.posawesome.doctype.delivery_charges.delivery_charges import (
     get_applicable_delivery_charges,
 )
 from posawesome.posawesome.doctype.pos_coupon.pos_coupon import update_coupon_code_count
+from posawesome.posawesome.api.pricing_rules import normalize_pricing_rule_freebies
 
 
 def validate(doc, method):
+    # Consolidate any pricing-rule freebies before running additional validations.
+    normalize_pricing_rule_freebies(doc)
     validate_shift(doc)
     set_patient(doc)
     auto_set_delivery_charges(doc)
@@ -24,6 +27,8 @@ def validate(doc, method):
 
 
 def before_submit(doc, method):
+    # Ensure pricing-rule freebies stay consolidated before submission.
+    normalize_pricing_rule_freebies(doc)
     add_loyalty_point(doc)
     create_sales_order(doc)
     update_coupon(doc, "used")

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -31,6 +31,7 @@ from posawesome.posawesome.api.utilities import (
     ensure_child_doctype,
     set_batch_nos_for_bundels,
 )  # Updated imports
+from posawesome.posawesome.api.pricing_rules import normalize_pricing_rule_freebies
 
 from .items import get_stock_availability
 
@@ -346,6 +347,8 @@ def update_invoice(data):
     # Set missing values first
     invoice_doc.set_missing_values()
 
+    normalize_pricing_rule_freebies(invoice_doc)
+
     # Reapply any custom item names after defaults are set
     _apply_item_name_overrides(invoice_doc, overrides)
 
@@ -453,6 +456,7 @@ def update_invoice(data):
     invoice_doc.flags.ignore_permissions = True
     frappe.flags.ignore_account_permission = True
     invoice_doc.docstatus = 0
+    normalize_pricing_rule_freebies(invoice_doc)
     invoice_doc.save()
 
     # Return both the invoice doc and the updated data
@@ -611,6 +615,7 @@ def submit_invoice(invoice, data):
     invoice_doc.flags.ignore_permissions = True
     frappe.flags.ignore_account_permission = True
     invoice_doc.posa_is_printed = 1
+    normalize_pricing_rule_freebies(invoice_doc)
     invoice_doc.save()
 
     if data.get("due_date"):
@@ -682,6 +687,7 @@ def submit_in_background_job(kwargs):
     items.append(grand_total)
 
     invoice_doc.remarks = "\n".join(items)
+    normalize_pricing_rule_freebies(invoice_doc)
     invoice_doc.save()
 
     invoice_doc.submit()
@@ -939,6 +945,7 @@ def update_invoice_from_order(data):
     data = json.loads(data)
     invoice_doc = frappe.get_doc("Sales Invoice", data.get("name"))
     invoice_doc.update(data)
+    normalize_pricing_rule_freebies(invoice_doc)
     invoice_doc.save()
     return invoice_doc
 

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -409,14 +409,61 @@ def normalize_pricing_rule_freebies(doc) -> bool:
         return False
 
     mutated = False
-    seen = {}
-    to_remove = []
+    freebies = []
 
     for child in list(doc.items):
         if not _is_pricing_rule_freebie(child):
             continue
 
-        rule_id = _resolve_freebie_rule_identifier(child)
+        entry = {
+            "child": child,
+            "rule_id": _resolve_freebie_rule_identifier(child),
+            "base_key": "::".join(_build_freebie_key_parts(child, "")),
+        }
+        freebies.append(entry)
+
+    if not freebies:
+        return False
+
+    # Ensure freebies that share the same underlying characteristics adopt
+    # a single rule identifier before running the consolidation logic. ERPNext
+    # may regenerate free rows without POS metadata which leaves the rule id
+    # blank. We reuse any available identifier from the matching rows so both
+    # copies collapse into one later on.
+    by_base_key = {}
+    for entry in freebies:
+        by_base_key.setdefault(entry["base_key"], []).append(entry)
+
+    for candidates in by_base_key.values():
+        resolved = [c for c in candidates if c["rule_id"]]
+        if not resolved:
+            continue
+
+        resolved.sort(
+            key=lambda c: 0
+            if _child_value(c["child"], "posa_pricing_rule_freebie")
+            else 1
+        )
+        canonical_rule = resolved[0]["rule_id"]
+
+        for entry in candidates:
+            if entry["rule_id"] == canonical_rule:
+                continue
+
+            child = entry["child"]
+            try:
+                child.posa_pricing_rule_freebie = canonical_rule
+            except Exception:
+                pass
+            entry["rule_id"] = canonical_rule
+            mutated = True
+
+    seen = {}
+    to_remove = []
+
+    for entry in freebies:
+        child = entry["child"]
+        rule_id = entry["rule_id"] or _resolve_freebie_rule_identifier(child)
         if not rule_id:
             continue
 

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Tuple
 
 import frappe
 from frappe import _
@@ -320,6 +320,239 @@ def _is_pricing_rule_freebie(item) -> bool:
         return bool(item.get("posa_pricing_rule_freebie"))
     except AttributeError:
         return False
+
+
+def _resolve_freebie_rule_identifier(item) -> str:
+    if not item:
+        return ""
+
+    identifiers = _extract_rule_identifiers(
+        getattr(item, "posa_pricing_rule_freebie", None),
+        item.get("posa_pricing_rule_freebie") if hasattr(item, "get") else None,
+        item.get("pricing_rule") if hasattr(item, "get") else None,
+        item.get("pricing_rules") if hasattr(item, "get") else None,
+        item.get("pricing_rule_name") if hasattr(item, "get") else None,
+        item.get("rule") if hasattr(item, "get") else None,
+        item.get("applied_pricing_rule") if hasattr(item, "get") else None,
+        item.get("applied_pricing_rules") if hasattr(item, "get") else None,
+    )
+
+    for identifier in identifiers:
+        parsed = _parse_rule_identifier(identifier)
+        if parsed:
+            return parsed
+
+    return ""
+
+
+def _child_value(item, fieldname: str, default=None):
+    if hasattr(item, "get"):
+        try:
+            value = item.get(fieldname)
+        except Exception:
+            value = None
+        else:
+            if value is not None:
+                return value
+
+    return getattr(item, fieldname, default)
+
+
+def _build_freebie_key_parts(item, rule_id: str) -> Tuple[str, ...]:
+    if not item:
+        return (rule_id or "",)
+
+    item_code = _child_value(item, "item_code")
+    if not item_code:
+        item_code = _child_value(item, "free_item_code") or _child_value(item, "free_item")
+
+    batch_no = _child_value(item, "batch_no") or _child_value(item, "free_batch_no")
+    serial_no = _child_value(item, "serial_no") or _child_value(item, "free_serial_no")
+    uom = (
+        _child_value(item, "uom")
+        or _child_value(item, "stock_uom")
+        or _child_value(item, "free_uom")
+    )
+    warehouse = _child_value(item, "warehouse") or _child_value(item, "free_warehouse")
+
+    raw_factor = _child_value(item, "conversion_factor")
+    if raw_factor is None:
+        raw_factor = _child_value(item, "free_conversion_factor")
+    conversion_factor = flt(raw_factor or 1) or 1
+
+    parts = (
+        str(rule_id or ""),
+        str(item_code or ""),
+        str(batch_no or ""),
+        str(serial_no or ""),
+        str(uom or ""),
+        str(warehouse or ""),
+        str(conversion_factor or 1),
+    )
+
+    return parts
+
+
+def _build_freebie_composite_key(item, rule_id: str) -> str:
+    explicit_key = _child_value(item, "posa_pricing_rule_key")
+
+    if explicit_key:
+        return str(explicit_key)
+
+    return "::".join(_build_freebie_key_parts(item, rule_id))
+
+
+def normalize_pricing_rule_freebies(doc) -> bool:
+    """Merge duplicate pricing rule freebies on the provided document."""
+
+    if not doc or not getattr(doc, "items", None):
+        return False
+
+    mutated = False
+    seen = {}
+    to_remove = []
+
+    for child in list(doc.items):
+        if not _is_pricing_rule_freebie(child):
+            continue
+
+        rule_id = _resolve_freebie_rule_identifier(child)
+        if not rule_id:
+            continue
+
+        if _child_value(child, "is_free_item") != 1:
+            try:
+                child.is_free_item = 1
+            except Exception:
+                pass
+            mutated = True
+
+        if _child_value(child, "posa_pricing_rule_freebie") != rule_id:
+            try:
+                child.posa_pricing_rule_freebie = rule_id
+            except Exception:
+                pass
+            mutated = True
+
+        composite = _build_freebie_composite_key(child, rule_id)
+
+        identifiers = set(
+            _extract_rule_identifiers(
+                _child_value(child, "pricing_rules"),
+                _child_value(child, "applied_pricing_rules"),
+                _child_value(child, "pricing_rule"),
+                _child_value(child, "rule"),
+            )
+        )
+        identifiers.add(rule_id)
+
+        serialized = json.dumps(sorted(identifiers))
+        current_serialized = _child_value(child, "pricing_rules")
+        if current_serialized != serialized:
+            try:
+                child.pricing_rules = serialized
+            except Exception:
+                pass
+            mutated = True
+
+        if _child_value(child, "applied_pricing_rules") != serialized:
+            try:
+                child.applied_pricing_rules = serialized
+            except Exception:
+                pass
+            mutated = True
+
+        if _child_value(child, "applied_pricing_rule") != rule_id:
+            try:
+                child.applied_pricing_rule = rule_id
+            except Exception:
+                pass
+            mutated = True
+
+        existing = seen.get(composite)
+        if not existing:
+            seen[composite] = child
+            continue
+
+        qty = flt(_child_value(existing, "qty") or 0)
+        stock_qty = flt(_child_value(existing, "stock_qty") or 0)
+
+        incoming_qty = flt(_child_value(child, "qty") or 0)
+        incoming_stock_qty = _child_value(child, "stock_qty")
+        if incoming_stock_qty is None:
+            incoming_stock_qty = incoming_qty * flt(_child_value(child, "conversion_factor") or 1)
+
+        if incoming_qty > 0 and (qty <= 0 or incoming_qty >= qty):
+            existing.qty = incoming_qty
+        else:
+            existing.qty = qty
+
+        if incoming_stock_qty and flt(incoming_stock_qty) > 0 and (
+            stock_qty <= 0 or flt(incoming_stock_qty) >= stock_qty
+        ):
+            existing.stock_qty = flt(incoming_stock_qty)
+        else:
+            existing.stock_qty = stock_qty
+
+        rate = flt(_child_value(existing, "rate") or 0)
+        base_rate = flt(_child_value(existing, "base_rate")) or rate
+
+        try:
+            amount_precision = existing.precision("amount")
+        except Exception:
+            amount_precision = 2
+
+        try:
+            base_amount_precision = existing.precision("base_amount")
+        except Exception:
+            base_amount_precision = 2
+
+        existing.amount = flt(existing.qty * rate, amount_precision)
+        existing.base_amount = flt(existing.qty * base_rate, base_amount_precision)
+        if hasattr(existing, "net_amount"):
+            try:
+                net_precision = existing.precision("net_amount")
+            except Exception:
+                net_precision = amount_precision
+            existing.net_amount = flt(existing.amount, net_precision)
+        if hasattr(existing, "base_net_amount"):
+            try:
+                base_net_precision = existing.precision("base_net_amount")
+            except Exception:
+                base_net_precision = base_amount_precision
+            existing.base_net_amount = flt(existing.base_amount, base_net_precision)
+
+        existing_serialized = _child_value(existing, "pricing_rules")
+        if existing_serialized != serialized:
+            try:
+                existing.pricing_rules = serialized
+            except Exception:
+                pass
+
+        if _child_value(existing, "applied_pricing_rules") != serialized:
+            try:
+                existing.applied_pricing_rules = serialized
+            except Exception:
+                pass
+
+        if _child_value(existing, "applied_pricing_rule") != rule_id:
+            try:
+                existing.applied_pricing_rule = rule_id
+            except Exception:
+                pass
+
+        to_remove.append(child)
+        mutated = True
+
+    for duplicate in to_remove:
+        try:
+            doc.remove(duplicate)
+        except Exception:
+            items = [item for item in doc.items if item != duplicate]
+            doc.set("items", items)
+        mutated = True
+
+    return mutated
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -59,6 +59,8 @@ def _prepare_context(context_json: str) -> Dict:
         row.setdefault("rate", flt(row.get("rate")))
         row.setdefault("discount_percentage", flt(row.get("discount_percentage")))
         row.setdefault("discount_amount", flt(row.get("discount_amount")))
+        if row.get("is_free_item") is not None:
+            row["is_free_item"] = cint(row.get("is_free_item"))
         prepared_items.append(row)
 
     context["items"] = prepared_items
@@ -100,6 +102,10 @@ def _prepare_context(context_json: str) -> Dict:
                 "serial_no": row.get("serial_no"),
                 "batch_no": row.get("batch_no"),
                 "pricing_rules": row.get("pricing_rules"),
+                "is_free_item": row.get("is_free_item"),
+                "posa_pricing_rule_freebie": row.get("posa_pricing_rule_freebie"),
+                "posa_pricing_rule_key": row.get("posa_pricing_rule_key"),
+                "posa_pricing_rule_source_row": row.get("posa_pricing_rule_source_row"),
                 "parenttype": context.doctype,
             }
         )

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -338,11 +338,7 @@ def apply_pos_pricing_rule(context: str, pricing_rule: str) -> List[Dict]:
             )
         )
 
-        if (
-            rule_identifier not in matched_identifiers
-            and not has_free_item_data
-            and not has_rate_or_discount_change
-        ):
+        if rule_identifier not in matched_identifiers:
             continue
 
         detail["posa_row_id"] = child.get("name")

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -31,10 +31,18 @@ def _prepare_context(context_json: str) -> Dict:
     context.setdefault("doctype", "Sales Invoice")
     context.setdefault("child_doctype", "Sales Invoice Item")
     context.setdefault("transaction_date", today())
-    context.setdefault("currency", frappe.get_cached_value("Company", context.get("company"), "default_currency") if context.get("company") else None)
+    context.setdefault(
+        "currency",
+        frappe.get_cached_value("Company", context.get("company"), "default_currency")
+        if context.get("company")
+        else None,
+    )
     context.setdefault("conversion_rate", context.get("conversion_rate") or 1)
     context.setdefault("plc_conversion_rate", context.get("plc_conversion_rate") or 1)
     context.setdefault("price_list_currency", context.get("price_list_currency") or context.get("currency"))
+    context.setdefault("transaction_type", "selling")
+    context.setdefault("ignore_pricing_rule", 0)
+    context.setdefault("is_pos", 1)
 
     raw_items = context.get("items") or []
     prepared_items = []
@@ -64,6 +72,9 @@ def _prepare_context(context_json: str) -> Dict:
         "plc_conversion_rate": context.get("plc_conversion_rate"),
         "selling_price_list": context.get("price_list"),
         "is_return": cint(context.get("is_return")),
+        "transaction_type": context.get("transaction_type") or "selling",
+        "ignore_pricing_rule": cint(context.get("ignore_pricing_rule")),
+        "is_pos": cint(context.get("is_pos")),
         "items": [],
     }
 
@@ -141,7 +152,7 @@ def _build_item_args(context: Dict, item: Dict) -> Dict:
         "supplier_group": context.get("supplier_group"),
         "is_return": cint(context.get("is_return")),
         "update_stock": cint(context.get("update_stock")),
-        "transaction_type": context.get("transaction_type"),
+        "transaction_type": context.get("transaction_type") or "selling",
     }
     return frappe._dict(args)
 
@@ -166,6 +177,7 @@ def _as_serializable_rule(rule) -> Dict:
         "margin_rate_or_amount": flt(doc.get("margin_rate_or_amount")),
         "priority": cint(doc.get("priority")),
         "apply_multiple_pricing_rules": cint(doc.get("apply_multiple_pricing_rules")),
+        "min_qty": flt(doc.get("min_qty")) if doc.get("min_qty") else None,
         "company": doc.get("company"),
         "currency": doc.get("currency"),
         "valid_from": doc.get("valid_from"),

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -189,6 +189,8 @@ def _as_serializable_rule(rule) -> Dict:
 def _collect_pricing_rules(context: Dict, doc) -> List[Dict]:
     rules: Dict[str, Dict] = {}
     for item in context.get("items", []):
+        if _is_pricing_rule_freebie(item):
+            continue
         args = _build_item_args(context, item)
         try:
             item_rules = get_pricing_rules(args, doc)
@@ -293,6 +295,27 @@ def _collect_matched_identifiers(detail) -> Set[str]:
     }
 
 
+def _is_pricing_rule_freebie(item) -> bool:
+    if not item:
+        return False
+
+    try:
+        flag = item.get("is_free_item")
+    except AttributeError:
+        flag = None
+
+    if flag is not None:
+        try:
+            return bool(cint(flag))
+        except Exception:
+            return bool(flag)
+
+    try:
+        return bool(item.get("posa_pricing_rule_freebie"))
+    except AttributeError:
+        return False
+
+
 @frappe.whitelist()
 def get_pos_pricing_rules(context: str) -> List[Dict]:
     """Return applicable pricing rules for the provided POS invoice context."""
@@ -324,6 +347,8 @@ def apply_pos_pricing_rule(context: str, pricing_rule: str) -> List[Dict]:
     rule_identifier = _parse_rule_identifier(pricing_rule)
 
     for child in doc.items:
+        if _is_pricing_rule_freebie(child):
+            continue
         args = _build_item_args(parsed_context, child.as_dict())
         args.pricing_rules = json.dumps([rule_identifier])
         try:
@@ -358,6 +383,8 @@ def auto_apply_pos_pricing_rules(context: str) -> Dict[str, List]:
     active_rules: Set[str] = set()
 
     for child in doc.items:
+        if _is_pricing_rule_freebie(child):
+            continue
         args = _build_item_args(parsed_context, child.as_dict())
         try:
             detail = get_pricing_rule_for_item(args, doc=doc.as_dict(), for_validate=True)

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -214,6 +214,64 @@ def _parse_rule_identifier(pricing_rule) -> str:
     return pricing_rule
 
 
+def _extract_rule_identifiers(*candidates) -> List[str]:
+    identifiers: List[str] = []
+
+    def _walk(value):
+        if not value:
+            return
+
+        if isinstance(value, (list, tuple, set)):
+            for entry in value:
+                _walk(entry)
+            return
+
+        if isinstance(value, dict):
+            for key in (
+                "pricing_rule",
+                "pricing_rules",
+                "pricing_rule_name",
+                "rule",
+                "name",
+            ):
+                if value.get(key):
+                    _walk(value.get(key))
+            return
+
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return
+
+            try:
+                loaded = json.loads(stripped)
+            except Exception:
+                loaded = None
+
+            if isinstance(loaded, (list, tuple, set, dict)):
+                _walk(loaded)
+                return
+
+            if isinstance(loaded, str) and loaded != stripped:
+                _walk(loaded)
+                return
+
+            if "," in stripped:
+                for part in stripped.split(","):
+                    _walk(part)
+                return
+
+            identifiers.append(stripped)
+            return
+
+        identifiers.append(str(value))
+
+    for candidate in candidates:
+        _walk(candidate)
+
+    return [identifier for identifier in identifiers if identifier]
+
+
 @frappe.whitelist()
 def get_pos_pricing_rules(context: str) -> List[Dict]:
     """Return applicable pricing rules for the provided POS invoice context."""
@@ -254,6 +312,39 @@ def apply_pos_pricing_rule(context: str, pricing_rule: str) -> List[Dict]:
             continue
 
         detail = frappe._dict(detail)
+        matched_identifiers = {
+            _parse_rule_identifier(identifier)
+            for identifier in _extract_rule_identifiers(
+                detail.get("pricing_rule"),
+                detail.get("pricing_rules"),
+                detail.get("pricing_rule_name"),
+                detail.get("rule"),
+                detail.get("applied_pricing_rule"),
+                detail.get("applied_pricing_rules"),
+            )
+            if _parse_rule_identifier(identifier)
+        }
+
+        has_free_item_data = bool(detail.get("free_item_data"))
+        has_rate_or_discount_change = any(
+            key in detail and detail.get(key) is not None
+            for key in (
+                "discount_percentage",
+                "discount_amount",
+                "price_list_rate",
+                "rate",
+                "margin_type",
+                "margin_rate_or_amount",
+            )
+        )
+
+        if (
+            rule_identifier not in matched_identifiers
+            and not has_free_item_data
+            and not has_rate_or_discount_change
+        ):
+            continue
+
         detail["posa_row_id"] = child.get("name")
         results.append(detail)
 

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -1,0 +1,248 @@
+import json
+from typing import Dict, List
+
+import frappe
+from frappe import _
+from frappe.utils import cint, flt, today
+
+try:
+    from erpnext.accounts.doctype.pricing_rule.pricing_rule import get_pricing_rule_for_item
+    from erpnext.accounts.doctype.pricing_rule.utils import get_pricing_rules
+except ImportError:  # pragma: no cover - handled at runtime if ERPNext not present
+    get_pricing_rule_for_item = None
+    get_pricing_rules = None
+
+
+def _ensure_pricing_rule_dependencies_available():
+    if not get_pricing_rules or not get_pricing_rule_for_item:
+        frappe.throw(_("Pricing Rule utilities are unavailable. Please ensure ERPNext is installed."))
+
+
+def _prepare_context(context_json: str) -> Dict:
+    if isinstance(context_json, str):
+        context = frappe.parse_json(context_json)
+    else:
+        context = frappe._dict(context_json or {})
+
+    if not context:
+        frappe.throw(_("Pricing rule context is required."))
+
+    context = frappe._dict(context)
+    context.setdefault("doctype", "Sales Invoice")
+    context.setdefault("child_doctype", "Sales Invoice Item")
+    context.setdefault("transaction_date", today())
+    context.setdefault("currency", frappe.get_cached_value("Company", context.get("company"), "default_currency") if context.get("company") else None)
+    context.setdefault("conversion_rate", context.get("conversion_rate") or 1)
+    context.setdefault("plc_conversion_rate", context.get("plc_conversion_rate") or 1)
+    context.setdefault("price_list_currency", context.get("price_list_currency") or context.get("currency"))
+
+    raw_items = context.get("items") or []
+    prepared_items = []
+    for item in raw_items:
+        row = frappe._dict(item)
+        if not row.get("name"):
+            row["name"] = row.get("item_code")
+        row.setdefault("qty", flt(row.get("qty")))
+        row.setdefault("stock_qty", flt(row.get("stock_qty")) or row.get("qty"))
+        row.setdefault("uom", row.get("uom") or row.get("stock_uom"))
+        row.setdefault("stock_uom", row.get("stock_uom") or row.get("uom"))
+        row.setdefault("conversion_factor", row.get("conversion_factor") or 1)
+        row.setdefault("price_list_rate", flt(row.get("price_list_rate")))
+        row.setdefault("rate", flt(row.get("rate")))
+        row.setdefault("discount_percentage", flt(row.get("discount_percentage")))
+        row.setdefault("discount_amount", flt(row.get("discount_amount")))
+        prepared_items.append(row)
+
+    context["items"] = prepared_items
+    doc_dict = {
+        "doctype": context.doctype,
+        "company": context.get("company"),
+        "customer": context.get("customer"),
+        "currency": context.get("currency"),
+        "conversion_rate": context.get("conversion_rate"),
+        "price_list_currency": context.get("price_list_currency"),
+        "plc_conversion_rate": context.get("plc_conversion_rate"),
+        "selling_price_list": context.get("price_list"),
+        "is_return": cint(context.get("is_return")),
+        "items": [],
+    }
+
+    for row in prepared_items:
+        doc_row = frappe._dict(
+            {
+                "doctype": context.child_doctype,
+                "name": row.name,
+                "item_code": row.get("item_code"),
+                "item_name": row.get("item_name"),
+                "item_group": row.get("item_group"),
+                "brand": row.get("brand"),
+                "qty": row.get("qty"),
+                "stock_qty": row.get("stock_qty"),
+                "uom": row.get("uom"),
+                "stock_uom": row.get("stock_uom"),
+                "warehouse": row.get("warehouse"),
+                "price_list_rate": row.get("price_list_rate"),
+                "rate": row.get("rate"),
+                "discount_percentage": row.get("discount_percentage"),
+                "discount_amount": row.get("discount_amount"),
+                "conversion_factor": row.get("conversion_factor"),
+                "serial_no": row.get("serial_no"),
+                "batch_no": row.get("batch_no"),
+                "pricing_rules": row.get("pricing_rules"),
+                "parenttype": context.doctype,
+            }
+        )
+        doc_dict.setdefault("items", []).append(doc_row)
+
+    context["doc_dict"] = doc_dict
+    return context
+
+
+def _build_item_args(context: Dict, item: Dict) -> Dict:
+    args = {
+        "doctype": context.child_doctype,
+        "name": item.get("name"),
+        "child_docname": item.get("name"),
+        "parenttype": context.doctype,
+        "parent": context.get("doc_name") or context.get("name") or "POS-PRICING",
+        "item_code": item.get("item_code"),
+        "item_group": item.get("item_group"),
+        "brand": item.get("brand"),
+        "qty": item.get("qty"),
+        "stock_qty": item.get("stock_qty"),
+        "uom": item.get("uom"),
+        "stock_uom": item.get("stock_uom"),
+        "warehouse": item.get("warehouse"),
+        "serial_no": item.get("serial_no"),
+        "batch_no": item.get("batch_no"),
+        "price_list_rate": item.get("price_list_rate"),
+        "rate": item.get("rate"),
+        "discount_percentage": item.get("discount_percentage"),
+        "discount_amount": item.get("discount_amount"),
+        "conversion_factor": item.get("conversion_factor"),
+        "is_free_item": item.get("is_free_item"),
+        "pricing_rules": item.get("pricing_rules"),
+        "currency": context.get("currency"),
+        "conversion_rate": context.get("conversion_rate"),
+        "price_list": context.get("price_list"),
+        "price_list_currency": context.get("price_list_currency"),
+        "plc_conversion_rate": context.get("plc_conversion_rate"),
+        "company": context.get("company"),
+        "transaction_date": context.get("transaction_date"),
+        "campaign": context.get("campaign"),
+        "sales_partner": context.get("sales_partner"),
+        "ignore_pricing_rule": 0,
+        "pos_profile": context.get("pos_profile"),
+        "coupon_code": context.get("coupon_code"),
+        "customer": context.get("customer"),
+        "customer_group": context.get("customer_group"),
+        "territory": context.get("territory"),
+        "supplier": context.get("supplier"),
+        "supplier_group": context.get("supplier_group"),
+        "is_return": cint(context.get("is_return")),
+        "update_stock": cint(context.get("update_stock")),
+        "transaction_type": context.get("transaction_type"),
+    }
+    return frappe._dict(args)
+
+
+def _as_serializable_rule(rule) -> Dict:
+    doc = rule
+    if isinstance(rule, str):
+        doc = frappe.get_cached_doc("Pricing Rule", rule)
+    if isinstance(doc, dict):
+        doc = frappe._dict(doc)
+
+    return {
+        "name": doc.get("name"),
+        "title": doc.get("title") or doc.get("name"),
+        "description": doc.get("rule_description") or doc.get("description") or "",
+        "apply_on": doc.get("apply_on"),
+        "price_or_product_discount": doc.get("price_or_product_discount"),
+        "rate_or_discount": doc.get("rate_or_discount"),
+        "discount_percentage": flt(doc.get("discount_percentage")),
+        "discount_amount": flt(doc.get("discount_amount")),
+        "margin_type": doc.get("margin_type"),
+        "margin_rate_or_amount": flt(doc.get("margin_rate_or_amount")),
+        "priority": cint(doc.get("priority")),
+        "apply_multiple_pricing_rules": cint(doc.get("apply_multiple_pricing_rules")),
+        "company": doc.get("company"),
+        "currency": doc.get("currency"),
+        "valid_from": doc.get("valid_from"),
+        "valid_upto": doc.get("valid_upto"),
+        "free_item": doc.get("free_item"),
+    }
+
+
+def _collect_pricing_rules(context: Dict, doc) -> List[Dict]:
+    rules: Dict[str, Dict] = {}
+    for item in context.get("items", []):
+        args = _build_item_args(context, item)
+        try:
+            item_rules = get_pricing_rules(args, doc)
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), "POS Awesome: failed to fetch pricing rules")
+            continue
+
+        if not item_rules:
+            continue
+
+        for rule in item_rules:
+            serializable = _as_serializable_rule(rule)
+            name = serializable.get("name")
+            if name and name not in rules:
+                rules[name] = serializable
+
+    return list(rules.values())
+
+
+def _parse_rule_identifier(pricing_rule) -> str:
+    if isinstance(pricing_rule, (list, tuple)):
+        return pricing_rule[0] if pricing_rule else ""
+    return pricing_rule
+
+
+@frappe.whitelist()
+def get_pos_pricing_rules(context: str) -> List[Dict]:
+    """Return applicable pricing rules for the provided POS invoice context."""
+
+    _ensure_pricing_rule_dependencies_available()
+    parsed_context = _prepare_context(context)
+    doc = frappe.get_doc(parsed_context.get("doc_dict"))
+    doc.name = parsed_context.get("doc_name") or doc.get("name") or "POS-PRICING"
+    parsed_context["doc_name"] = doc.name
+
+    rules = _collect_pricing_rules(parsed_context, doc)
+    return rules
+
+
+@frappe.whitelist()
+def apply_pos_pricing_rule(context: str, pricing_rule: str) -> List[Dict]:
+    """Apply a specific pricing rule to the provided POS invoice context."""
+
+    _ensure_pricing_rule_dependencies_available()
+    if not pricing_rule:
+        frappe.throw(_("Pricing Rule is required"))
+
+    parsed_context = _prepare_context(context)
+    doc = frappe.get_doc(parsed_context.get("doc_dict"))
+    doc.name = parsed_context.get("doc_name") or doc.get("name") or "POS-PRICING"
+    parsed_context["doc_name"] = doc.name
+
+    results: List[Dict] = []
+    rule_identifier = _parse_rule_identifier(pricing_rule)
+
+    for child in doc.items:
+        args = _build_item_args(parsed_context, child.as_dict())
+        args.pricing_rules = json.dumps([rule_identifier])
+        try:
+            detail = get_pricing_rule_for_item(args, doc=doc.as_dict(), for_validate=True)
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), "POS Awesome: failed to apply pricing rule")
+            continue
+
+        detail = frappe._dict(detail)
+        detail["posa_row_id"] = child.get("name")
+        results.append(detail)
+
+    return results

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Dict, List, Set
 
 import frappe
 from frappe import _
@@ -272,6 +272,27 @@ def _extract_rule_identifiers(*candidates) -> List[str]:
     return [identifier for identifier in identifiers if identifier]
 
 
+def _collect_matched_identifiers(detail) -> Set[str]:
+    if not detail:
+        return set()
+
+    identifiers = _extract_rule_identifiers(
+        detail.get("pricing_rule"),
+        detail.get("pricing_rules"),
+        detail.get("pricing_rule_name"),
+        detail.get("rule"),
+        detail.get("applied_pricing_rule"),
+        detail.get("applied_pricing_rules"),
+        detail.get("free_item_data"),
+    )
+
+    return {
+        _parse_rule_identifier(identifier)
+        for identifier in identifiers
+        if _parse_rule_identifier(identifier)
+    }
+
+
 @frappe.whitelist()
 def get_pos_pricing_rules(context: str) -> List[Dict]:
     """Return applicable pricing rules for the provided POS invoice context."""
@@ -312,31 +333,7 @@ def apply_pos_pricing_rule(context: str, pricing_rule: str) -> List[Dict]:
             continue
 
         detail = frappe._dict(detail)
-        matched_identifiers = {
-            _parse_rule_identifier(identifier)
-            for identifier in _extract_rule_identifiers(
-                detail.get("pricing_rule"),
-                detail.get("pricing_rules"),
-                detail.get("pricing_rule_name"),
-                detail.get("rule"),
-                detail.get("applied_pricing_rule"),
-                detail.get("applied_pricing_rules"),
-            )
-            if _parse_rule_identifier(identifier)
-        }
-
-        has_free_item_data = bool(detail.get("free_item_data"))
-        has_rate_or_discount_change = any(
-            key in detail and detail.get(key) is not None
-            for key in (
-                "discount_percentage",
-                "discount_amount",
-                "price_list_rate",
-                "rate",
-                "margin_type",
-                "margin_rate_or_amount",
-            )
-        )
+        matched_identifiers = _collect_matched_identifiers(detail)
 
         if rule_identifier not in matched_identifiers:
             continue
@@ -345,3 +342,43 @@ def apply_pos_pricing_rule(context: str, pricing_rule: str) -> List[Dict]:
         results.append(detail)
 
     return results
+
+
+@frappe.whitelist()
+def auto_apply_pos_pricing_rules(context: str) -> Dict[str, List]:
+    """Evaluate pricing rules for all items and return the aggregated updates."""
+
+    _ensure_pricing_rule_dependencies_available()
+    parsed_context = _prepare_context(context)
+    doc = frappe.get_doc(parsed_context.get("doc_dict"))
+    doc.name = parsed_context.get("doc_name") or doc.get("name") or "POS-PRICING"
+    parsed_context["doc_name"] = doc.name
+
+    updates: List[Dict] = []
+    active_rules: Set[str] = set()
+
+    for child in doc.items:
+        args = _build_item_args(parsed_context, child.as_dict())
+        try:
+            detail = get_pricing_rule_for_item(args, doc=doc.as_dict(), for_validate=True)
+        except Exception:
+            frappe.log_error(frappe.get_traceback(), "POS Awesome: failed to auto apply pricing rule")
+            continue
+
+        if not detail:
+            continue
+
+        detail = frappe._dict(detail)
+        matched_identifiers = _collect_matched_identifiers(detail)
+
+        if not matched_identifiers and not detail.get("free_item_data"):
+            continue
+
+        detail["posa_row_id"] = child.get("name")
+        updates.append(detail)
+        active_rules.update(matched_identifiers)
+
+    return {
+        "updates": updates,
+        "active_pricing_rules": sorted(active_rules),
+    }


### PR DESCRIPTION
## Summary
- add a pricing rules panel in the POS app with new counters and navigation controls
- expose backend APIs to fetch and apply ERPNext pricing rules for the POS cart
- wire invoice logic to build pricing rule context, apply updates, and reset rules safely

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eef5fa6288326a08d5feeec94a4f6)