### PR TITLE
Add pricing rule center with virtual free items

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -935,6 +935,12 @@ export default {
                         this.calc_stock_qty(item, item[field_name]);
                         if (field_name === "qty") {
                                 this.updateBundleChildrenQty(item);
+                                if (
+                                        !item.posa_pricing_rule_virtual &&
+                                        typeof this.schedulePricingRuleRefresh === "function"
+                                ) {
+                                        this.schedulePricingRuleRefresh(item.posa_row_id);
+                                }
                         }
                         return parsedValue;
                 },
@@ -1364,6 +1370,9 @@ export default {
                         }
                         this.calc_stock_qty(item, item.qty);
                         this.updateBundleChildrenQty(item);
+                        if (!item.posa_pricing_rule_virtual && typeof this.schedulePricingRuleRefresh === "function") {
+                                this.schedulePricingRuleRefresh(item.posa_row_id);
+                        }
                         this.$forceUpdate();
                 },
 
@@ -1380,6 +1389,9 @@ export default {
                         }
                         this.calc_stock_qty(item, item.qty);
                         this.updateBundleChildrenQty(item);
+                        if (!item.posa_pricing_rule_virtual && typeof this.schedulePricingRuleRefresh === "function") {
+                                this.schedulePricingRuleRefresh(item.posa_row_id);
+                        }
                         this.$forceUpdate();
                 },
 

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -376,6 +376,8 @@ export default {
                         posa_offers: [], // Offers applied to this invoice
                         posa_coupons: [], // Coupons applied
                         pos_pricing_rules: [], // Pricing rules applied virtually
+                        pricing_rule_catalog: [], // Available pricing rules from server
+                        pricing_rule_catalog_ready: false,
                         isApplyingOffer: false, // Flag to prevent offer watcher loops
 			allItems: [], // All items for offer logic
 			discount_percentage_offer_name: null, // Track which offer is applied
@@ -473,7 +475,7 @@ export default {
         methods: {
                 ...shortcutMethods,
 		...offerMethods,
-		...invoiceItemMethods,
+                ...invoiceItemMethods,
                 focusCustomerSearchField() {
                         const customerComponent = this.$refs.customerComponent;
                         if (!customerComponent) {
@@ -1421,6 +1423,12 @@ export default {
                                 this.float_precision = prec;
                                 this.currency_precision = prec;
                         }
+                        this.pricing_rule_catalog = [];
+                        this.pricing_rule_catalog_ready = false;
+                        this._manuallySuppressedPricingRules = new Set();
+                        if (typeof this.cancelScheduledPricingRuleRefresh === "function") {
+                                this.cancelScheduledPricingRuleRefresh();
+                        }
                         this.invoiceType = this.pos_profile.posa_default_sales_order ? "Order" : "Invoice";
                         this.initializeItemsHeaders();
 
@@ -1455,6 +1463,11 @@ export default {
                 },
                 handleSetOffers(data) {
                         this.posOffers = data;
+                },
+                handleSetPricingRules(rules) {
+                        if (typeof this.ingestPricingRuleCatalog === "function") {
+                                this.ingestPricingRuleCatalog(Array.isArray(rules) ? rules : []);
+                        }
                 },
                 async handleUpdateInvoiceOffers(data) {
                         await this.updateInvoiceOffers(data);
@@ -1535,6 +1548,7 @@ export default {
                         load_invoice: this.handleLoadInvoice,
                         load_order: this.handleLoadOrder,
                         set_offers: this.handleSetOffers,
+                        set_pricing_rules: this.handleSetPricingRules,
                         update_invoice_offers: this.handleUpdateInvoiceOffers,
                         update_invoice_coupons: this.handleUpdateInvoiceCoupons,
                         toggle_pricing_rule: this.handleTogglePricingRule,
@@ -1567,6 +1581,10 @@ export default {
                 if (typeof this.stockUnsubscribe === "function") {
                         this.stockUnsubscribe();
                         this.stockUnsubscribe = null;
+                }
+
+                if (typeof this.cancelScheduledPricingRuleRefresh === "function") {
+                        this.cancelScheduledPricingRuleRefresh();
                 }
 
                 Object.entries(this._busHandlers || {}).forEach(([eventName, handler]) => {

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -372,10 +372,11 @@ export default {
 			total_tax: 0,
 			packed_dialog_items: [], // Packed items displayed in dialog
 			show_packed_dialog: false, // Packing list dialog visibility
-			posOffers: [], // All available offers
-			posa_offers: [], // Offers applied to this invoice
-			posa_coupons: [], // Coupons applied
-			isApplyingOffer: false, // Flag to prevent offer watcher loops
+                        posOffers: [], // All available offers
+                        posa_offers: [], // Offers applied to this invoice
+                        posa_coupons: [], // Coupons applied
+                        pos_pricing_rules: [], // Pricing rules applied virtually
+                        isApplyingOffer: false, // Flag to prevent offer watcher loops
 			allItems: [], // All items for offer logic
 			discount_percentage_offer_name: null, // Track which offer is applied
 			invoiceTypes: ["Invoice", "Order", "Quotation"], // Types of invoices
@@ -1536,6 +1537,7 @@ export default {
                         set_offers: this.handleSetOffers,
                         update_invoice_offers: this.handleUpdateInvoiceOffers,
                         update_invoice_coupons: this.handleUpdateInvoiceCoupons,
+                        toggle_pricing_rule: this.handleTogglePricingRule,
                         set_all_items: this.handleSetAllItems,
                         load_return_invoice: this.handleLoadReturnInvoice,
                         set_new_line: this.handleSetNewLine,
@@ -1554,6 +1556,7 @@ export default {
                         this.fetch_available_currencies();
                 }
 
+                this.emitPricingRulesState();
                 this.emitCartQuantities();
                 this.$nextTick(() => {
                         this.primeInvoiceStockState();

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -420,35 +420,47 @@
 						readonly
 					></v-text-field>
 				</v-col>
-				<v-col cols="3" class="dynamic-margin-xs">
-					<v-btn-toggle v-model="items_view" color="primary" group density="compact" rounded>
-						<v-btn size="small" value="list">{{ __("List") }}</v-btn>
-						<v-btn size="small" value="card">{{ __("Card") }}</v-btn>
-					</v-btn-toggle>
-				</v-col>
-				<v-col cols="5" class="dynamic-margin-xs">
-					<v-btn
-						size="small"
-						block
-						color="warning"
-						variant="text"
-						@click="show_offers"
-						class="action-btn-consistent"
-					>
-						{{ offersCount }} {{ __("Offers") }}
-					</v-btn>
-				</v-col>
-				<v-col cols="4" class="dynamic-margin-xs">
-					<v-btn
-						size="small"
-						block
-						color="primary"
-						variant="text"
+                                <v-col cols="3" class="dynamic-margin-xs">
+                                        <v-btn-toggle v-model="items_view" color="primary" group density="compact" rounded>
+                                                <v-btn size="small" value="list">{{ __("List") }}</v-btn>
+                                                <v-btn size="small" value="card">{{ __("Card") }}</v-btn>
+                                        </v-btn-toggle>
+                                </v-col>
+                                <v-col cols="3" class="dynamic-margin-xs">
+                                        <v-btn
+                                                size="small"
+                                                block
+                                                color="warning"
+                                                variant="text"
+                                                @click="show_offers"
+                                                class="action-btn-consistent"
+                                        >
+                                                {{ offersCount }} {{ __("Offers") }}
+                                        </v-btn>
+                                </v-col>
+                                <v-col cols="3" class="dynamic-margin-xs">
+                                        <v-btn
+                                                size="small"
+                                                block
+                                                color="secondary"
+                                                variant="text"
+                                                @click="show_pricing_rules"
+                                                class="action-btn-consistent"
+                                        >
+                                                {{ pricingRulesCount }} {{ __("Pricing Rules") }}
+                                        </v-btn>
+                                </v-col>
+                                <v-col cols="3" class="dynamic-margin-xs">
+                                        <v-btn
+                                                size="small"
+                                                block
+                                                color="primary"
+                                                variant="text"
 						@click="show_coupons"
 						class="action-btn-consistent"
-						>{{ couponsCount }} {{ __("Coupons") }}</v-btn
-					>
-				</v-col>
+                                                >{{ couponsCount }} {{ __("Coupons") }}</v-btn
+                                        >
+                                </v-col>
 			</v-row>
 		</v-card>
 
@@ -556,10 +568,12 @@ export default {
 		search_backup: "",
 		// Limit the displayed items to avoid overly large lists
 		itemsPerPage: 50,
-		offersCount: 0,
-		appliedOffersCount: 0,
-		couponsCount: 0,
-		appliedCouponsCount: 0,
+            offersCount: 0,
+            appliedOffersCount: 0,
+            pricingRulesCount: 0,
+            appliedPricingRulesCount: 0,
+            couponsCount: 0,
+            appliedCouponsCount: 0,
 		new_line: false,
 		qty: 1,
 		refresh_interval: null,
@@ -1338,12 +1352,15 @@ export default {
 			}
 		},
 
-		show_offers() {
-			this.eventBus.emit("show_offers", "true");
-		},
-		show_coupons() {
-			this.eventBus.emit("show_coupons", "true");
-		},
+        show_offers() {
+                this.eventBus.emit("show_offers", "true");
+        },
+        show_pricing_rules() {
+                this.eventBus.emit("show_pricing_rules", "true");
+        },
+        show_coupons() {
+                this.eventBus.emit("show_coupons", "true");
+        },
                 async initializeItems() {
                         await this.ensureStorageHealth();
                         if (
@@ -3756,10 +3773,14 @@ export default {
 		this.eventBus.on("update_cur_items_details", () => {
 			this.update_cur_items_details();
 		});
-		this.eventBus.on("update_offers_counters", (data) => {
-			this.offersCount = data.offersCount;
-			this.appliedOffersCount = data.appliedOffersCount;
-		});
+                this.eventBus.on("update_offers_counters", (data) => {
+                        this.offersCount = data.offersCount;
+                        this.appliedOffersCount = data.appliedOffersCount;
+                });
+                this.eventBus.on("update_pricing_rules_counters", (data) => {
+                        this.pricingRulesCount = data.pricingRulesCount;
+                        this.appliedPricingRulesCount = data.appliedPricingRulesCount;
+                });
                 this.eventBus.on("update_coupons_counters", (data) => {
                         this.couponsCount = data.couponsCount;
                         this.appliedCouponsCount = data.appliedCouponsCount;
@@ -3959,6 +3980,7 @@ export default {
                 this.eventBus.off("register_pos_profile");
                 this.eventBus.off("update_cur_items_details");
                 this.eventBus.off("update_offers_counters");
+                this.eventBus.off("update_pricing_rules_counters");
                 this.eventBus.off("update_coupons_counters");
                 this.eventBus.off("cart_quantities_updated", this.handleCartQuantitiesUpdated);
                 this.eventBus.off("invoice_stock_adjusted", this.handleInvoiceStockAdjusted);

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -32,27 +32,36 @@
 		>
 			<!-- Item name column -->
 			<template v-slot:item.item_name="{ item }">
-				<div class="d-flex align-center">
-					<span>{{ item.item_name }}</span>
-					<v-chip v-if="item.is_bundle" color="secondary" size="x-small" class="ml-1">
-						{{ __("Bundle") }}
-					</v-chip>
-					<v-chip v-if="item.name_overridden" color="primary" size="x-small" class="ml-1">
-						{{ __("Edited") }}
-					</v-chip>
-					<v-icon
-						v-if="pos_profile.posa_allow_line_item_name_override && !item.posa_is_replace"
-						size="x-small"
-						class="ml-1"
-						@click.stop="openNameDialog(item)"
-						>mdi-pencil</v-icon
-					>
-					<v-icon
-						v-if="item.name_overridden"
-						size="x-small"
-						class="ml-1"
-						@click.stop="resetItemName(item)"
-						>mdi-undo</v-icon
+                                <div class="d-flex align-center">
+                                        <span>{{ item.item_name }}</span>
+                                        <v-chip v-if="item.is_bundle" color="secondary" size="x-small" class="ml-1">
+                                                {{ __("Bundle") }}
+                                        </v-chip>
+                                        <v-chip v-if="item.name_overridden" color="primary" size="x-small" class="ml-1">
+                                                {{ __("Edited") }}
+                                        </v-chip>
+                                        <v-chip
+                                                v-if="item.is_free_item"
+                                                color="success"
+                                                size="x-small"
+                                                class="ml-1"
+                                                variant="tonal"
+                                        >
+                                                {{ __("Free") }}
+                                        </v-chip>
+                                        <v-icon
+                                                v-if="pos_profile.posa_allow_line_item_name_override && !item.posa_is_replace && !item.posa_pricing_rule_virtual"
+                                                size="x-small"
+                                                class="ml-1"
+                                                @click.stop="openNameDialog(item)"
+                                                >mdi-pencil</v-icon
+                                        >
+                                        <v-icon
+                                                v-if="item.name_overridden && !item.posa_pricing_rule_virtual"
+                                                size="x-small"
+                                                class="ml-1"
+                                                @click.stop="resetItemName(item)"
+                                                >mdi-undo</v-icon
 					>
 				</div>
 			</template>
@@ -60,13 +69,13 @@
 			<!-- Quantity column -->
 			<template v-slot:item.qty="{ item }">
 				<div class="pos-table__qty-counter" :class="{ 'rtl-layout': isRTL }" :title="`RTL: ${isRTL}`">
-					<v-btn
-						:disabled="!!item.posa_is_replace"
-						size="small"
-						variant="flat"
-						class="pos-table__qty-btn pos-table__qty-btn--minus minus-btn qty-control-btn"
-						@click.stop="handleMinusClick(item)"
-					>
+                                        <v-btn
+                                                :disabled="!!item.posa_is_replace || !!item.posa_pricing_rule_virtual"
+                                                size="small"
+                                                variant="flat"
+                                                class="pos-table__qty-btn pos-table__qty-btn--minus minus-btn qty-control-btn"
+                                                @click.stop="handleMinusClick(item)"
+                                        >
 						<v-icon size="small">mdi-minus</v-icon>
 					</v-btn>
 					<div
@@ -78,10 +87,10 @@
 						}"
 						:data-length="memoizedQtyLength(item.qty)"
 						:title="formatFloat(item.qty, hide_qty_decimals ? 0 : undefined)"
-						@click.stop="openQtyEdit(item)"
-					>
-						{{ formatFloat(item.qty, hide_qty_decimals ? 0 : undefined) }}
-					</div>
+                                                @click.stop="!item.posa_pricing_rule_virtual && openQtyEdit(item)"
+                                        >
+                                                {{ formatFloat(item.qty, hide_qty_decimals ? 0 : undefined) }}
+                                        </div>
 					<v-text-field
 						v-else
 						:model-value="editing_qty_value"
@@ -96,13 +105,14 @@
 						:autofocus="true"
 						type="number"
 					></v-text-field>
-					<v-btn
-						:disabled="
-							!!item.posa_is_replace ||
-							((!stock_settings.allow_negative_stock || blockSaleBeyondAvailableQty) &&
-								item.max_qty !== undefined &&
-								item.qty >= item.max_qty)
-						"
+                                        <v-btn
+                                                :disabled="
+                                                        !!item.posa_is_replace ||
+                                                        !!item.posa_pricing_rule_virtual ||
+                                                        ((!stock_settings.allow_negative_stock || blockSaleBeyondAvailableQty) &&
+                                                                item.max_qty !== undefined &&
+                                                                item.qty >= item.max_qty)
+                                                "
 						size="small"
 						variant="flat"
 						class="pos-table__qty-btn pos-table__qty-btn--plus plus-btn qty-control-btn"
@@ -191,7 +201,7 @@
 			<!-- Actions -->
 			<template v-slot:item.actions="{ item }">
 				<v-btn
-					:disabled="!!item.posa_is_replace"
+                                                                                        :disabled="!!item.posa_is_replace || !!item.posa_pricing_rule_virtual"
 					size="small"
 					variant="flat"
 					class="pos-table__delete-btn delete-action-btn"
@@ -270,10 +280,11 @@
 											item-value="uom"
 											hide-details
 											@update:model-value="calcUom(item, $event)"
-											:disabled="
-												!!item.posa_is_replace ||
-												(isReturnInvoice && invoice_doc.return_against)
-											"
+                                                                                        :disabled="
+                                                                                                !!item.posa_is_replace ||
+                                                                                                !!item.posa_pricing_rule_virtual ||
+                                                                                                (isReturnInvoice && invoice_doc.return_against)
+                                                                                        "
 											prepend-inner-icon="mdi-weight"
 										></v-select>
 									</div>

--- a/frontend/src/posapp/components/pos/Pos.vue
+++ b/frontend/src/posapp/components/pos/Pos.vue
@@ -13,23 +13,26 @@
 		<Variants></Variants>
 		<OpeningDialog v-if="dialog" :dialog="dialog"></OpeningDialog>
 		<v-row v-show="!dialog" dense class="ma-0 dynamic-main-row">
-			<v-col
-				v-show="!payment && !showOffers && !coupons"
-				xl="5"
-				lg="5"
-				md="5"
-				sm="5"
-				cols="12"
+                        <v-col
+                                v-show="!payment && !showOffers && !showPricingRules && !coupons"
+                                xl="5"
+                                lg="5"
+                                md="5"
+                                sm="5"
+                                cols="12"
 				class="pos dynamic-col"
 			>
 				<ItemsSelector></ItemsSelector>
 			</v-col>
-			<v-col v-show="showOffers" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
-				<PosOffers></PosOffers>
-			</v-col>
-			<v-col v-show="coupons" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
-				<PosCoupons></PosCoupons>
-			</v-col>
+                        <v-col v-show="showOffers" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
+                                <PosOffers></PosOffers>
+                        </v-col>
+                        <v-col v-show="showPricingRules" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
+                                <PosPricingRules></PosPricingRules>
+                        </v-col>
+                        <v-col v-show="coupons" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
+                                <PosCoupons></PosCoupons>
+                        </v-col>
 			<v-col v-show="payment" xl="5" lg="5" md="5" sm="5" cols="12" class="pos dynamic-col">
 				<Payments></Payments>
 			</v-col>
@@ -48,6 +51,7 @@ import OpeningDialog from "./OpeningDialog.vue";
 import Payments from "./Payments.vue";
 import PosOffers from "./PosOffers.vue";
 import PosCoupons from "./PosCoupons.vue";
+import PosPricingRules from "./PosPricingRules.vue";
 import Drafts from "./Drafts.vue";
 import SalesOrders from "./SalesOrders.vue";
 import ClosingDialog from "./ClosingDialog.vue";
@@ -66,6 +70,7 @@ import {
 import { getCurrentInstance } from "vue";
 import { usePosShift } from "../../composables/usePosShift.js";
 import { useOffers } from "../../composables/useOffers.js";
+import { usePricingRules } from "../../composables/usePricingRules.js";
 // Import the cache cleanup function
 import { clearExpiredCustomerBalances } from "../../../offline/index.js";
 import { useResponsive } from "../../composables/useResponsive.js";
@@ -78,21 +83,23 @@ export default {
 		const instance = getCurrentInstance();
 		const responsive = useResponsive();
 		const rtl = useRtl();
-		const shift = usePosShift(() => {
-			if (instance && instance.proxy) {
-				instance.proxy.dialog = true;
-			}
-		});
-		const offers = useOffers();
-		return { ...responsive, ...rtl, ...shift, ...offers };
-	},
+                const shift = usePosShift(() => {
+                        if (instance && instance.proxy) {
+                                instance.proxy.dialog = true;
+                        }
+                });
+                const offers = useOffers();
+                const pricingRules = usePricingRules();
+                return { ...responsive, ...rtl, ...shift, ...offers, ...pricingRules };
+        },
 	data: function () {
 		return {
 			dialog: false,
 
-			payment: false,
-			showOffers: false,
-			coupons: false,
+                        payment: false,
+                        showOffers: false,
+                        showPricingRules: false,
+                        coupons: false,
 			itemsLoaded: false,
 			customersLoaded: false,
 		};
@@ -107,8 +114,9 @@ export default {
 		ClosingDialog,
 
 		Returns,
-		PosOffers,
-		PosCoupons,
+                PosOffers,
+                PosCoupons,
+                PosPricingRules,
 		NewAddress,
 		Variants,
 		MpesaPayments,
@@ -138,35 +146,46 @@ export default {
 			this.eventBus.on("close_opening_dialog", () => {
 				this.dialog = false;
 			});
-			this.eventBus.on("register_pos_data", (data) => {
-				this.pos_profile = data.pos_profile;
-				this.get_offers(this.pos_profile.name, this.pos_profile);
-				this.pos_opening_shift = data.pos_opening_shift;
-				this.eventBus.emit("register_pos_profile", data);
-				console.info("LoadPosProfile");
-			});
+                        this.eventBus.on("register_pos_data", (data) => {
+                                this.pos_profile = data.pos_profile;
+                                this.get_offers(this.pos_profile.name, this.pos_profile);
+                                this.get_pricing_rules(this.pos_profile.name);
+                                this.pos_opening_shift = data.pos_opening_shift;
+                                this.eventBus.emit("register_pos_profile", data);
+                                console.info("LoadPosProfile");
+                        });
 			// When profile is registered directly from composables,
 			// ensure offers are fetched as well
 			this.eventBus.on("register_pos_profile", (data) => {
-				if (data && data.pos_profile) {
-					this.get_offers(data.pos_profile.name, data.pos_profile);
-				}
-			});
-			this.eventBus.on("show_payment", (data) => {
-				this.payment = data === "true";
-				this.showOffers = false;
-				this.coupons = false;
-			});
-			this.eventBus.on("show_offers", (data) => {
-				this.showOffers = data === "true";
-				this.payment = false;
-				this.coupons = false;
-			});
-			this.eventBus.on("show_coupons", (data) => {
-				this.coupons = data === "true";
-				this.showOffers = false;
-				this.payment = false;
-			});
+                                if (data && data.pos_profile) {
+                                        this.get_offers(data.pos_profile.name, data.pos_profile);
+                                        this.get_pricing_rules(data.pos_profile.name);
+                                }
+                        });
+                        this.eventBus.on("show_payment", (data) => {
+                                this.payment = data === "true";
+                                this.showOffers = false;
+                                this.showPricingRules = false;
+                                this.coupons = false;
+                        });
+                        this.eventBus.on("show_offers", (data) => {
+                                this.showOffers = data === "true";
+                                this.payment = false;
+                                this.showPricingRules = false;
+                                this.coupons = false;
+                        });
+                        this.eventBus.on("show_coupons", (data) => {
+                                this.coupons = data === "true";
+                                this.showOffers = false;
+                                this.showPricingRules = false;
+                                this.payment = false;
+                        });
+                        this.eventBus.on("show_pricing_rules", (data) => {
+                                this.showPricingRules = data === "true";
+                                this.showOffers = false;
+                                this.coupons = false;
+                                this.payment = false;
+                        });
 			this.eventBus.on("open_closing_dialog", () => {
 				this.get_closing_data();
 			});
@@ -185,8 +204,9 @@ export default {
 		this.eventBus.off("register_pos_data");
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("LoadPosProfile");
-		this.eventBus.off("show_offers");
-		this.eventBus.off("show_coupons");
+                this.eventBus.off("show_offers");
+                this.eventBus.off("show_pricing_rules");
+                this.eventBus.off("show_coupons");
 		this.eventBus.off("open_closing_dialog");
 		this.eventBus.off("submit_closing_pos");
 		this.eventBus.off("items_loaded");

--- a/frontend/src/posapp/components/pos/PosPricingRules.vue
+++ b/frontend/src/posapp/components/pos/PosPricingRules.vue
@@ -142,7 +142,16 @@ export default {
                 refreshRuleState(name, applied) {
                         this.pricing_rules = this.pricing_rules.map((entry) => {
                                 if (entry.name === name) {
-                                        return { ...entry, applied };
+                                        const updated = {
+                                                ...entry,
+                                                applied,
+                                                applied_free_qty: applied ? entry.applied_free_qty : 0,
+                                                applied_multiplier: applied ? entry.applied_multiplier : null,
+                                        };
+                                        return {
+                                                ...updated,
+                                                benefit_display: this.buildBenefitDisplay(updated),
+                                        };
                                 }
                                 return entry;
                         });
@@ -167,6 +176,8 @@ export default {
                                 conditions_display: conditions,
                                 applied: Boolean(safeRule.applied),
                                 is_free_item_rule: Boolean(safeRule.is_free_item_rule),
+                                applied_free_qty: this.flt(safeRule.applied_free_qty || 0),
+                                applied_multiplier: safeRule.multiplier || safeRule.applied_multiplier || null,
                         };
                 },
                 buildAppliesDisplay(rule) {
@@ -202,9 +213,13 @@ export default {
                 },
                 buildBenefitDisplay(rule) {
                         if (rule.is_free_item_rule) {
-                                const qty = this.flt(rule.free_qty || 0);
+                                const appliedQty = rule.applied ? this.flt(rule.applied_free_qty || 0) : 0;
+                                const qty = appliedQty || this.flt(rule.free_qty || 0);
                                 const itemName = rule.free_item_name || rule.free_item || __("Free Item");
                                 if (qty) {
+                                        if (rule.applied && rule.applied_multiplier && rule.applied_multiplier > 1) {
+                                                return __("{0} x {1} ({2}×)", [qty, itemName, rule.applied_multiplier]);
+                                        }
                                         return __("{0} x {1}", [qty, itemName]);
                                 }
                                 return itemName;
@@ -242,13 +257,23 @@ export default {
                         const appliedMap = new Map();
                         applied.forEach((row) => {
                                 if (row?.name) {
-                                        appliedMap.set(row.name, true);
+                                        appliedMap.set(row.name, row);
                                 }
                         });
-                        this.pricing_rules = this.pricing_rules.map((rule) => ({
-                                ...rule,
-                                applied: appliedMap.has(rule.name),
-                        }));
+                        this.pricing_rules = this.pricing_rules.map((rule) => {
+                                const appliedRow = appliedMap.get(rule.name);
+                                const applied = Boolean(appliedRow);
+                                const updated = {
+                                        ...rule,
+                                        applied,
+                                        applied_free_qty: appliedRow?.free_qty || 0,
+                                        applied_multiplier: appliedRow?.multiplier || null,
+                                };
+                                return {
+                                        ...updated,
+                                        benefit_display: this.buildBenefitDisplay(updated),
+                                };
+                        });
                         this.updateCounters();
                 },
                 updateCounters() {

--- a/frontend/src/posapp/components/pos/PosPricingRules.vue
+++ b/frontend/src/posapp/components/pos/PosPricingRules.vue
@@ -1,0 +1,289 @@
+<template>
+        <div>
+                <v-card class="selection mx-auto mt-3 pos-themed-card" style="max-height: 80vh; height: 80vh">
+                        <v-card-title>
+                                <span class="text-h6 text-primary">{{ __("Pricing Rules") }}</span>
+                        </v-card-title>
+                        <div class="my-0 py-0 overflow-y-auto" style="max-height: 75vh">
+                                <v-data-table
+                                        :headers="items_headers"
+                                        :items="pricing_rules"
+                                        :items-per-page="itemsPerPage"
+                                        class="elevation-1"
+                                        item-key="name"
+                                        hide-default-footer
+                                >
+                                        <template #item.title="{ item }">
+                                                <div class="d-flex flex-column">
+                                                        <span class="font-weight-medium">{{ item.display_title }}</span>
+                                                        <span v-if="item.description" class="text-body-2 text-medium-emphasis">
+                                                                {{ item.description }}
+                                                        </span>
+                                                </div>
+                                        </template>
+                                        <template #item.applies_display="{ item }">
+                                                <div class="d-flex flex-column">
+                                                        <span>{{ item.applies_display }}</span>
+                                                        <span v-if="item.conditions_display" class="text-caption text-medium-emphasis">
+                                                                {{ item.conditions_display }}
+                                                        </span>
+                                                </div>
+                                        </template>
+                                        <template #item.benefit_display="{ item }">
+                                                <div class="d-flex align-center">
+                                                        <v-chip
+                                                                v-if="item.is_free_item_rule"
+                                                                size="x-small"
+                                                                color="success"
+                                                                class="mr-2"
+                                                                variant="tonal"
+                                                        >
+                                                                {{ __("Free") }}
+                                                        </v-chip>
+                                                        <span>{{ item.benefit_display }}</span>
+                                                </div>
+                                        </template>
+                                        <template #item.actions="{ item }">
+                                                <v-btn
+                                                        v-if="!item.applied"
+                                                        size="small"
+                                                        color="primary"
+                                                        variant="tonal"
+                                                        :disabled="item.is_free_item_rule && !item.free_item"
+                                                        @click="handleApply(item)"
+                                                >
+                                                        {{ __("Apply") }}
+                                                </v-btn>
+                                                <v-btn
+                                                        v-else
+                                                        size="small"
+                                                        color="red"
+                                                        variant="tonal"
+                                                        @click="handleRemove(item)"
+                                                >
+                                                        {{ __("Remove") }}
+                                                </v-btn>
+                                        </template>
+                                </v-data-table>
+                        </div>
+                </v-card>
+
+                <v-card flat style="max-height: 11vh; height: 11vh" class="cards mb-0 mt-3 py-0">
+                        <v-row align="start" no-gutters>
+                                <v-col cols="12">
+                                        <v-btn block class="pa-1" size="large" color="warning" theme="dark" @click="back_to_invoice">
+                                                {{ __("Back") }}
+                                        </v-btn>
+                                </v-col>
+                        </v-row>
+                </v-card>
+        </div>
+</template>
+
+<script>
+import format from "../../format";
+
+export default {
+        mixins: [format],
+        data: () => ({
+                pricing_rules: [],
+                itemsPerPage: 500,
+                items_headers: [
+                        { title: __("Name"), value: "display_title", align: "start" },
+                        { title: __("Applies On"), value: "applies_display", align: "start" },
+                        { title: __("Benefit"), value: "benefit_display", align: "start" },
+                        { title: __("Status"), value: "actions", align: "center", sortable: false },
+                ],
+        }),
+        computed: {
+                totalRules() {
+                        return Array.isArray(this.pricing_rules) ? this.pricing_rules.length : 0;
+                },
+                appliedRules() {
+                        return this.pricing_rules.filter((rule) => rule.applied).length;
+                },
+        },
+        watch: {
+                pricing_rules: {
+                        deep: true,
+                        handler() {
+                                this.updateCounters();
+                        },
+                },
+        },
+        methods: {
+                back_to_invoice() {
+                        this.eventBus.emit("show_pricing_rules", "false");
+                },
+                handleApply(rule) {
+                        if (!rule) {
+                                return;
+                        }
+                        const payload = this.preparePayload(rule);
+                        rule.applied = true;
+                        this.refreshRuleState(rule.name, true);
+                        this.eventBus.emit("toggle_pricing_rule", { rule: payload, applied: true });
+                        this.updateCounters();
+                },
+                handleRemove(rule) {
+                        if (!rule) {
+                                return;
+                        }
+                        const payload = this.preparePayload(rule);
+                        rule.applied = false;
+                        this.refreshRuleState(rule.name, false);
+                        this.eventBus.emit("toggle_pricing_rule", { rule: payload, applied: false });
+                        this.updateCounters();
+                },
+                preparePayload(rule) {
+                        const source = rule?.original_rule || rule;
+                        return JSON.parse(JSON.stringify(source));
+                },
+                refreshRuleState(name, applied) {
+                        this.pricing_rules = this.pricing_rules.map((entry) => {
+                                if (entry.name === name) {
+                                        return { ...entry, applied };
+                                }
+                                return entry;
+                        });
+                },
+                decorateRules(rules) {
+                        if (!Array.isArray(rules)) {
+                                return [];
+                        }
+                        return rules.map((rule) => this.decorateRule(rule));
+                },
+                decorateRule(rule) {
+                        const safeRule = { ...(rule || {}) };
+                        const applies = this.buildAppliesDisplay(safeRule);
+                        const benefit = this.buildBenefitDisplay(safeRule);
+                        const conditions = this.buildConditionsDisplay(safeRule);
+                        return {
+                                ...safeRule,
+                                original_rule: JSON.parse(JSON.stringify(safeRule)),
+                                display_title: safeRule.title || safeRule.name,
+                                applies_display: applies,
+                                benefit_display: benefit,
+                                conditions_display: conditions,
+                                applied: Boolean(safeRule.applied),
+                                is_free_item_rule: Boolean(safeRule.is_free_item_rule),
+                        };
+                },
+                buildAppliesDisplay(rule) {
+                        const segments = [];
+                        if (rule.apply_on) {
+                                segments.push(rule.apply_on);
+                        }
+                        if (rule.applicable_for) {
+                                segments.push(rule.applicable_for);
+                        }
+                        if (rule.customer) {
+                                segments.push(`${__("Customer")}: ${rule.customer}`);
+                        } else if (rule.customer_group) {
+                                segments.push(`${__("Customer Group")}: ${rule.customer_group}`);
+                        }
+                        if (rule.territory) {
+                                segments.push(`${__("Territory")}: ${rule.territory}`);
+                        }
+                        if (rule.item_code) {
+                                segments.push(`${__("Item")}: ${rule.item_code}`);
+                        } else if (rule.item_group) {
+                                segments.push(`${__("Item Group")}: ${rule.item_group}`);
+                        } else if (rule.brand) {
+                                segments.push(`${__("Brand")}: ${rule.brand}`);
+                        }
+                        if (rule.warehouse) {
+                                segments.push(`${__("Warehouse")}: ${rule.warehouse}`);
+                        }
+                        if (!segments.length) {
+                                segments.push(__("All"));
+                        }
+                        return segments.join(" • ");
+                },
+                buildBenefitDisplay(rule) {
+                        if (rule.is_free_item_rule) {
+                                const qty = this.flt(rule.free_qty || 0);
+                                const itemName = rule.free_item_name || rule.free_item || __("Free Item");
+                                if (qty) {
+                                        return __("{0} x {1}", [qty, itemName]);
+                                }
+                                return itemName;
+                        }
+                        if (rule.is_price_discount) {
+                                if (rule.discount_percentage) {
+                                        return __("{0}% off", [this.flt(rule.discount_percentage || 0)]);
+                                }
+                                if (rule.discount_amount) {
+                                        return __("Discount {0}", [this.formatCurrency(rule.discount_amount)]);
+                                }
+                                if (rule.rate) {
+                                        return __("Rate {0}", [this.formatCurrency(rule.rate)]);
+                                }
+                        }
+                        return __("Automatic adjustment");
+                },
+                buildConditionsDisplay(rule) {
+                        const segments = [];
+                        if (rule.min_qty) {
+                                segments.push(__("Min Qty: {0}", [this.flt(rule.min_qty)]));
+                        }
+                        if (rule.min_amt) {
+                                segments.push(__("Min Amount: {0}", [this.formatCurrency(rule.min_amt)]));
+                        }
+                        if (rule.valid_from || rule.valid_upto) {
+                                const from = rule.valid_from ? rule.valid_from : __("Any");
+                                const to = rule.valid_upto ? rule.valid_upto : __("Any");
+                                segments.push(__("Valid {0} → {1}", [from, to]));
+                        }
+                        return segments.join(" • ");
+                },
+                syncAppliedState(payload) {
+                        const applied = Array.isArray(payload?.applied) ? payload.applied : [];
+                        const appliedMap = new Map();
+                        applied.forEach((row) => {
+                                if (row?.name) {
+                                        appliedMap.set(row.name, true);
+                                }
+                        });
+                        this.pricing_rules = this.pricing_rules.map((rule) => ({
+                                ...rule,
+                                applied: appliedMap.has(rule.name),
+                        }));
+                        this.updateCounters();
+                },
+                updateCounters() {
+                        this.eventBus.emit("update_pricing_rules_counters", {
+                                pricingRulesCount: this.totalRules,
+                                appliedPricingRulesCount: this.appliedRules,
+                        });
+                },
+        },
+        created() {
+                this._handlers = {
+                        set: (rules) => {
+                                this.pricing_rules = this.decorateRules(rules);
+                                this.updateCounters();
+                        },
+                        sync: (payload) => {
+                                this.syncAppliedState(payload);
+                        },
+                };
+                this.eventBus.on("set_pricing_rules", this._handlers.set);
+                this.eventBus.on("sync_pricing_rules", this._handlers.sync);
+        },
+        beforeUnmount() {
+                if (this._handlers?.set) {
+                        this.eventBus.off("set_pricing_rules", this._handlers.set);
+                }
+                if (this._handlers?.sync) {
+                        this.eventBus.off("sync_pricing_rules", this._handlers.sync);
+                }
+        },
+};
+</script>
+
+<style scoped>
+.selection {
+        border-radius: 12px;
+}
+</style>

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -16,9 +16,12 @@ export default {
 			qty = storeValue;
 		} else {
 			qty = 0;
-			this.items.forEach((item) => {
-				qty += flt(item.qty);
-			});
+                        this.items.forEach((item) => {
+                                if (item.posa_pricing_rule_virtual) {
+                                        return;
+                                }
+                                qty += flt(item.qty);
+                        });
 		}
 
 		const result = this.flt(qty, this.float_precision);
@@ -36,12 +39,15 @@ export default {
 			sum = this.isReturnInvoice ? Math.abs(storeValue) : storeValue;
 		} else {
 			sum = 0;
-			this.items.forEach((item) => {
-				// For returns, use absolute value for correct calculation
-				const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
-				const rate = flt(item.rate);
-				sum += qty * rate;
-			});
+                        this.items.forEach((item) => {
+                                if (item.posa_pricing_rule_virtual) {
+                                        return;
+                                }
+                                // For returns, use absolute value for correct calculation
+                                const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
+                                const rate = flt(item.rate);
+                                sum += qty * rate;
+                        });
 		}
 
 		const result = this.flt(sum, this.currency_precision);
@@ -57,12 +63,15 @@ export default {
 		let sum = typeof storeValue === "number" && !Number.isNaN(storeValue) ? storeValue : 0;
 
 		if (!(typeof storeValue === "number" && !Number.isNaN(storeValue))) {
-			this.items.forEach((item) => {
-				// For returns, use absolute value for correct calculation
-				const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
-				const rate = flt(item.rate);
-				sum += qty * rate;
-			});
+                        this.items.forEach((item) => {
+                                if (item.posa_pricing_rule_virtual) {
+                                        return;
+                                }
+                                // For returns, use absolute value for correct calculation
+                                const qty = this.isReturnInvoice ? Math.abs(flt(item.qty)) : flt(item.qty);
+                                const rate = flt(item.rate);
+                                sum += qty * rate;
+                        });
 		} else if (this.isReturnInvoice) {
 			sum = Math.abs(sum);
 		}
@@ -94,11 +103,14 @@ export default {
 			sum = this.isReturnInvoice ? Math.abs(storeValue) : storeValue;
 		} else {
 			sum = 0;
-			this.items.forEach((item) => {
-				// For returns, use absolute value for correct calculation
-				if (this.isReturnInvoice) {
-					sum += Math.abs(flt(item.qty)) * flt(item.discount_amount);
-				} else {
+                        this.items.forEach((item) => {
+                                if (item.posa_pricing_rule_virtual) {
+                                        return;
+                                }
+                                // For returns, use absolute value for correct calculation
+                                if (this.isReturnInvoice) {
+                                        sum += Math.abs(flt(item.qty)) * flt(item.discount_amount);
+                                } else {
 					sum += flt(item.qty) * flt(item.discount_amount);
 				}
 			});

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1445,44 +1445,90 @@ export default {
 
                 const applyOn = (rule.apply_on || "").toLowerCase();
                 const applicableFor = (rule.applicable_for || "").toLowerCase();
-                const itemCode = rule.item_code || null;
-                const itemGroup = rule.item_group || null;
-                const brand = rule.brand || null;
+                const buildTargetSet = (sources = []) => {
+                        const set = new Set();
+                        const addValue = (value) => {
+                                if (value === undefined || value === null) {
+                                        return;
+                                }
+                                if (Array.isArray(value)) {
+                                        value.forEach(addValue);
+                                        return;
+                                }
+                                const normalized = `${value}`.trim();
+                                if (normalized) {
+                                        set.add(normalized);
+                                }
+                        };
+                        sources.forEach(addValue);
+                        return set;
+                };
+
+                const itemTargets = buildTargetSet([
+                        rule.target_items,
+                        rule.rule_data?.target_items,
+                        rule.item_code,
+                ]);
+                const groupTargets = buildTargetSet([
+                        rule.target_item_groups,
+                        rule.rule_data?.target_item_groups,
+                        rule.item_group,
+                ]);
+                const brandTargets = buildTargetSet([
+                        rule.target_brands,
+                        rule.rule_data?.target_brands,
+                        rule.brand,
+                ]);
 
                 const expectsSpecificTarget = ["item code", "item group", "brand"].includes(applyOn);
-                const hasSpecificTarget = Boolean(itemCode || itemGroup || brand);
+                const hasSpecificTarget = Boolean(
+                        itemTargets.size || groupTargets.size || brandTargets.size,
+                );
 
                 // Some ERPNext configurations use applicable_for to describe the same
                 // target semantics as apply_on. Account for that by falling back when
                 // apply_on is empty but applicable_for is populated with an item scope.
-                const derivedScope = (expectsSpecificTarget || hasSpecificTarget)
+                const derivedScope = expectsSpecificTarget
                         ? applyOn
                         : ["item code", "item group", "brand"].includes(applicableFor)
                                 ? applicableFor
                                 : "";
 
-                return (Array.isArray(this.items) ? this.items : []).filter((item) => {
+                if (!hasSpecificTarget && (expectsSpecificTarget || derivedScope)) {
+                        return [];
+                }
+
+                const items = Array.isArray(this.items) ? this.items : [];
+                return items.filter((item) => {
                         if (!item || item.posa_pricing_rule_virtual) {
                                 return false;
                         }
 
-                        if (itemCode && item.item_code !== itemCode) {
+                        const normalizedItemCode = item.item_code ? `${item.item_code}`.trim() : "";
+                        if (itemTargets.size && (!normalizedItemCode || !itemTargets.has(normalizedItemCode))) {
                                 return false;
                         }
 
-                        if ((applyOn === "item group" || derivedScope === "item group") && itemGroup && item.item_group !== itemGroup) {
-                                return false;
+                        const normalizedGroup = item.item_group ? `${item.item_group}`.trim() : "";
+                        const shouldMatchGroup = applyOn === "item group" || derivedScope === "item group";
+                        if (shouldMatchGroup) {
+                                if (!groupTargets.size) {
+                                        return false;
+                                }
+                                if (!normalizedGroup || !groupTargets.has(normalizedGroup)) {
+                                        return false;
+                                }
                         }
 
-                        if ((applyOn === "brand" || derivedScope === "brand") && brand && item.brand !== brand) {
-                                return false;
-                        }
-
-                        if (!hasSpecificTarget && (expectsSpecificTarget || derivedScope)) {
-                                // The rule expects a specific item, group, or brand but
-                                // no explicit target has been provided – treat as non-match
-                                // so the discount does not blanket every row.
-                                return false;
+                        const normalizedBrand = item.brand ? `${item.brand}`.trim() : "";
+                        const shouldMatchBrand = applyOn === "brand" || derivedScope === "brand";
+                        if (shouldMatchBrand) {
+                                if (!brandTargets.size) {
+                                        return false;
+                                }
+                                if (!normalizedBrand || !brandTargets.has(normalizedBrand)) {
+                                        return false;
+                                }
                         }
 
                         return true;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1213,17 +1213,13 @@ export default {
                         }
 
                         if (rule.is_free_item_rule) {
-                                const freeItemCode = rule.free_item || rule.item_code;
-                                if (!freeItemCode) {
-                                        this.eventBus.emit("show_message", {
-                                                title: __("Pricing rule {0} has no free item", [rule.title || rule.name]),
-                                                color: "warning",
-                                        });
+                                const evaluation = this._evaluateFreeItemPricingRule(rule);
+                                if (!evaluation) {
                                         return;
                                 }
 
-                                const qty = Math.abs(this.flt(rule.free_qty || 0)) || 1;
-                                const newItem = this._createVirtualPricingRuleItem(rule, freeItemCode, qty);
+                                const { freeItemCode, freeQty, multiplier, aggregated } = evaluation;
+                                const newItem = this._createVirtualPricingRuleItem(rule, freeItemCode, freeQty);
                                 if (!newItem) {
                                         return;
                                 }
@@ -1242,9 +1238,19 @@ export default {
                                         this.calc_stock_qty(newItem, newItem.qty);
                                 }
 
+                                const recordRuleData = {
+                                        ...rule,
+                                        posa_applied_multiplier: multiplier,
+                                        posa_applied_free_qty: freeQty,
+                                        posa_base_qty: aggregated?.qty ?? null,
+                                        posa_base_amount: aggregated?.amount ?? null,
+                                };
+
                                 this._registerPricingRuleRecord(rule, newItem, {
                                         type: "free_item",
-                                        rule_data: rule,
+                                        free_item: freeItemCode,
+                                        free_qty: freeQty,
+                                        rule_data: recordRuleData,
                                 });
                                 this.emitPricingRulesState();
                         } else if (rule.is_price_discount) {
@@ -1578,6 +1584,104 @@ export default {
                 };
         },
 
+        _evaluateFreeItemPricingRule(rule) {
+                if (!rule) {
+                        return null;
+                }
+
+                const matchingItems = this._findItemsMatchingPricingRule(rule);
+                if (!matchingItems.length) {
+                        this.eventBus.emit("show_message", {
+                                title: __("No items match pricing rule {0}", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return null;
+                }
+
+                const minQty = Math.abs(this.flt(rule.min_qty || 0));
+                const minAmt = Math.abs(this.flt(rule.min_amt || 0));
+                const allowMultiple = Boolean(rule.apply_multiple_pricing_rules);
+
+                const aggregated = matchingItems.reduce(
+                        (acc, item) => {
+                                const qty = Math.abs(this.flt(item.qty));
+                                const rateSource = item.price_list_rate || item.rate || 0;
+                                const amount = Math.abs(this.flt(rateSource * qty, this.currency_precision));
+                                return {
+                                        qty: acc.qty + qty,
+                                        amount: acc.amount + amount,
+                                };
+                        },
+                        { qty: 0, amount: 0 },
+                );
+
+                if (minQty && aggregated.qty < minQty) {
+                        this.eventBus.emit("show_message", {
+                                title: __("Minimum quantity not met for pricing rule {0}", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return null;
+                }
+
+                if (minAmt && aggregated.amount < minAmt) {
+                        this.eventBus.emit("show_message", {
+                                title: __("Minimum amount not met for pricing rule {0}", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return null;
+                }
+
+                let applications = 1;
+                if (allowMultiple) {
+                        const multipliers = [];
+                        if (minQty) {
+                                multipliers.push(Math.floor(aggregated.qty / minQty));
+                        }
+                        if (minAmt) {
+                                multipliers.push(Math.floor(aggregated.amount / minAmt));
+                        }
+                        if (multipliers.length) {
+                                applications = Math.max(Math.min(...multipliers), 0);
+                        }
+                        if (!applications || applications < 1) {
+                                applications = 1;
+                        }
+                }
+
+                const baseFreeQty = Math.abs(this.flt(rule.free_qty || 0));
+                const freeQtyPerApplication = baseFreeQty || 1;
+                const totalFreeQty = allowMultiple
+                        ? freeQtyPerApplication * applications
+                        : freeQtyPerApplication;
+
+                if (!totalFreeQty || totalFreeQty <= 0) {
+                        this.eventBus.emit("show_message", {
+                                title: __("Pricing rule {0} has no free quantity", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return null;
+                }
+
+                const resolvedFreeItemCode =
+                        rule.free_item || (rule.same_item ? matchingItems[0]?.item_code : rule.item_code);
+
+                if (!resolvedFreeItemCode) {
+                        this.eventBus.emit("show_message", {
+                                title: __("Pricing rule {0} has no free item", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return null;
+                }
+
+                return {
+                        freeItemCode: resolvedFreeItemCode,
+                        freeQty: totalFreeQty,
+                        multiplier: allowMultiple ? applications : 1,
+                        aggregated,
+                        matchingItems,
+                };
+        },
+
         _applyDiscountPricingRule(rule) {
                 const matchingItems = this._findItemsMatchingPricingRule(rule);
                 if (!matchingItems.length) {
@@ -1747,6 +1851,14 @@ export default {
                                   free_item: entry.free_item,
                                   free_qty: entry.free_qty,
                                   type: entry.type,
+                                  multiplier:
+                                          entry.rule_data?.posa_applied_multiplier !== undefined
+                                                  ? entry.rule_data?.posa_applied_multiplier
+                                                  : entry.type === "free_item"
+                                                          ? 1
+                                                          : null,
+                                  base_qty: entry.rule_data?.posa_base_qty ?? null,
+                                  base_amount: entry.rule_data?.posa_base_amount ?? null,
                           }))
                         : [];
                 this.eventBus.emit("sync_pricing_rules", { applied });
@@ -2987,8 +3099,9 @@ export default {
 		}
 	},
 
-	_applyItemDetailPayload(item, data, options = {}) {
-		const { forceUpdate = false } = options;
+        _applyItemDetailPayload(item, data, options = {}) {
+                const { forceUpdate = false } = options;
+                const isVirtualPricingRuleItem = Boolean(item?.posa_pricing_rule_virtual);
 
 		if (!item.warehouse) {
 			item.warehouse = this.pos_profile.warehouse;
@@ -3021,8 +3134,13 @@ export default {
 			item.uom = data.uom;
 		}
 
-		item.allow_change_warehouse = data.allow_change_warehouse;
-		item.locked_price = data.locked_price;
+                if (isVirtualPricingRuleItem) {
+                        item.allow_change_warehouse = false;
+                        item.locked_price = true;
+                } else {
+                        item.allow_change_warehouse = data.allow_change_warehouse;
+                        item.locked_price = data.locked_price;
+                }
 		item.description = data.description;
 		item.item_tax_template = data.item_tax_template;
 		item.discount_percentage = data.discount_percentage;
@@ -3090,7 +3208,7 @@ export default {
 			this.set_batch_qty(item, null, false);
 		}
 
-		if (!item.locked_price) {
+                if (!item.locked_price) {
 			if (forceUpdate || !item.base_rate) {
 				if (data.price_list_rate !== 0 || !item.base_price_list_rate) {
 					item.base_price_list_rate = data.price_list_rate;
@@ -3187,19 +3305,23 @@ export default {
                 item.has_serial_no = data.has_serial_no;
                 item.has_batch_no = data.has_batch_no;
 
-		item.amount = this.flt(item.qty * item.rate, this.currency_precision);
-		item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
+                item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
 
-		console.log(`Updated rates for ${item.item_code} on expand:`, {
-			base_rate: item.base_rate,
-			rate: item.rate,
-			base_price_list_rate: item.base_price_list_rate,
+                console.log(`Updated rates for ${item.item_code} on expand:`, {
+                        base_rate: item.base_rate,
+                        rate: item.rate,
+                        base_price_list_rate: item.base_price_list_rate,
 			price_list_rate: item.price_list_rate,
 			exchange_rate: this.exchange_rate,
 			selected_currency: this.selected_currency,
-			default_currency: this.pos_profile.currency,
-		});
-	},
+                        default_currency: this.pos_profile.currency,
+                });
+
+                if (isVirtualPricingRuleItem) {
+                        this._markVirtualFreeItem(item);
+                }
+        },
 	// Fetch customer details (info, price list, etc)
 	async fetch_customer_details() {
 		var vm = this;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -184,9 +184,31 @@ export default {
 		this.item_stock_cache = {};
 	},
         remove_item(item) {
-                if (item && item.pricing_rule && item.posa_pricing_rule_virtual) {
-                        this._removePricingRuleRecord(item.pricing_rule);
-                        this.emitPricingRulesState();
+                if (item && item.pricing_rule) {
+                        if (item.posa_pricing_rule_virtual) {
+                                this._removePricingRuleRecord(item.pricing_rule);
+                                this.emitPricingRulesState();
+                        } else {
+                                const recordIndex = Array.isArray(this.pos_pricing_rules)
+                                        ? this.pos_pricing_rules.findIndex((entry) => entry.name === item.pricing_rule)
+                                        : -1;
+                                if (recordIndex > -1) {
+                                        const record = this.pos_pricing_rules[recordIndex];
+                                        if (record.type === "discount") {
+                                                const updated = Array.isArray(record.affected_items)
+                                                        ? record.affected_items.filter((row) => row.row_id !== item.posa_row_id)
+                                                        : [];
+                                                this.pos_pricing_rules.splice(recordIndex, 1, {
+                                                        ...record,
+                                                        affected_items: updated,
+                                                });
+                                                if (!updated.length) {
+                                                        this._removePricingRuleRecord(item.pricing_rule);
+                                                }
+                                                this.emitPricingRulesState();
+                                        }
+                                }
+                        }
                 }
                 return removeItem(item, this);
         },
@@ -322,6 +344,12 @@ export default {
 
 	// Load an invoice (or return invoice) from data, set all fields accordingly
         async load_invoice(data = {}, options = {}) {
+                const previousPricingRules = Array.isArray(this.pos_pricing_rules)
+                        ? this.pos_pricing_rules.map((entry) => ({
+                                  name: entry.name,
+                                  rule_data: entry.rule_data || null,
+                          }))
+                        : [];
                 const { preserveAdditionalDiscountPercentage = false } = options || {};
                 const usePercentageDiscount = Boolean(this.pos_profile?.posa_use_percentage_discount);
                 const previousDiscountPercentage = usePercentageDiscount
@@ -409,16 +437,27 @@ export default {
                         }
 
                         this.posa_offers = data.posa_offers || [];
+                        const ruleDataMap = new Map(previousPricingRules.map((row) => [row.name, row.rule_data]));
                         this.pos_pricing_rules = Array.isArray(data.posa_pricing_rules)
-                                ? data.posa_pricing_rules.map((entry) => ({
-                                          name: entry.pricing_rule || entry.name,
-                                          label: entry.label || entry.pricing_rule || entry.name,
-                                          free_item: entry.free_item,
-                                          free_qty: entry.free_qty,
-                                          row_id: entry.row_id,
-                                  }))
+                                ? data.posa_pricing_rules.map((entry) => {
+                                          const name = entry.pricing_rule || entry.name;
+                                          return {
+                                                  name,
+                                                  label: entry.label || entry.pricing_rule || entry.name,
+                                                  free_item: entry.free_item,
+                                                  free_qty: entry.free_qty,
+                                                  row_id: entry.row_id,
+                                                  type:
+                                                          entry.free_item && entry.free_qty
+                                                                  ? "free_item"
+                                                                  : "discount",
+                                                  affected_items: [],
+                                                  rule_data: ruleDataMap.get(name) || null,
+                                          };
+                                  })
                                 : [];
                         this.emitPricingRulesState();
+                        await this._restoreVirtualPricingRuleItemsFromRecords();
                 } else {
                         console.log("Warning: No items in return invoice");
                         this.pos_pricing_rules = [];
@@ -1173,37 +1212,53 @@ export default {
                                 return;
                         }
 
-                        const freeItemCode = rule.free_item || rule.item_code;
-                        if (!freeItemCode) {
+                        if (rule.is_free_item_rule) {
+                                const freeItemCode = rule.free_item || rule.item_code;
+                                if (!freeItemCode) {
+                                        this.eventBus.emit("show_message", {
+                                                title: __("Pricing rule {0} has no free item", [rule.title || rule.name]),
+                                                color: "warning",
+                                        });
+                                        return;
+                                }
+
+                                const qty = Math.abs(this.flt(rule.free_qty || 0)) || 1;
+                                const newItem = this._createVirtualPricingRuleItem(rule, freeItemCode, qty);
+                                if (!newItem) {
+                                        return;
+                                }
+
+                                this.items.unshift(newItem);
+
+                                try {
+                                        await this.update_item_detail(newItem, true);
+                                } catch (error) {
+                                        console.warn("Unable to update virtual pricing rule item details", error);
+                                }
+
+                                this._markVirtualFreeItem(newItem);
+
+                                if (typeof this.calc_stock_qty === "function") {
+                                        this.calc_stock_qty(newItem, newItem.qty);
+                                }
+
+                                this._registerPricingRuleRecord(rule, newItem, {
+                                        type: "free_item",
+                                        rule_data: rule,
+                                });
+                                this.emitPricingRulesState();
+                        } else if (rule.is_price_discount) {
+                                const applied = this._applyDiscountPricingRule(rule);
+                                if (!applied) {
+                                        return;
+                                }
+                        } else {
                                 this.eventBus.emit("show_message", {
-                                        title: __("Pricing rule {0} has no free item", [rule.title || rule.name]),
+                                        title: __("Pricing rule {0} is not supported", [rule.title || rule.name]),
                                         color: "warning",
                                 });
                                 return;
                         }
-
-                        const qty = Math.abs(this.flt(rule.free_qty || 0)) || 1;
-                        const newItem = this._createVirtualPricingRuleItem(rule, freeItemCode, qty);
-                        if (!newItem) {
-                                return;
-                        }
-
-                        this.items.unshift(newItem);
-
-                        try {
-                                await this.update_item_detail(newItem, true);
-                        } catch (error) {
-                                console.warn("Unable to update virtual pricing rule item details", error);
-                        }
-
-                        this._markVirtualFreeItem(newItem);
-
-                        if (typeof this.calc_stock_qty === "function") {
-                                this.calc_stock_qty(newItem, newItem.qty);
-                        }
-
-                        this._registerPricingRuleRecord(rule, newItem);
-                        this.emitPricingRulesState();
 
                         if (typeof this.$forceUpdate === "function") {
                                 this.$forceUpdate();
@@ -1224,16 +1279,33 @@ export default {
 
                 const record = this.pos_pricing_rules.find((entry) => entry.name === ruleName);
                 if (record) {
-                        const item = this.items.find((it) => it.posa_row_id === record.row_id);
-                        if (item) {
-                                removeItem(item, this);
+                        if (record.type === "discount") {
+                                const affected = Array.isArray(record.affected_items) ? record.affected_items : [];
+                                affected.forEach((entry) => {
+                                        const target = this.items.find((it) => it.posa_row_id === entry.row_id);
+                                        if (!target) {
+                                                return;
+                                        }
+                                        this._restorePricingRuleSnapshot(target, entry.snapshot);
+                                        if (target.pricing_rule === ruleName && !entry.snapshot?.pricing_rule) {
+                                                delete target.pricing_rule;
+                                                delete target.pricing_rule_label;
+                                        }
+                                });
+                        } else {
+                                const item = this.items.find((it) => it.posa_row_id === record.row_id);
+                                if (item) {
+                                        removeItem(item, this);
+                                }
                         }
                 } else {
-                        const fallback = this.items.find(
-                                (it) => it.pricing_rule === ruleName && it.posa_pricing_rule_virtual,
-                        );
+                        const fallback = this.items.find((it) => it.pricing_rule === ruleName);
                         if (fallback) {
-                                removeItem(fallback, this);
+                                if (fallback.posa_pricing_rule_virtual) {
+                                        removeItem(fallback, this);
+                                } else {
+                                        this._resetItemPricingToDefault(fallback);
+                                }
                         }
                 }
 
@@ -1310,20 +1382,351 @@ export default {
                 item.disable_increment = true;
         },
 
-        _registerPricingRuleRecord(rule, item) {
-                if (!rule || !item) {
+        _findItemsMatchingPricingRule(rule) {
+                if (!rule) {
+                        return [];
+                }
+
+                const applyOn = (rule.apply_on || "").toLowerCase();
+                const itemCode = rule.item_code || null;
+                const itemGroup = rule.item_group || null;
+                const brand = rule.brand || null;
+
+                return (Array.isArray(this.items) ? this.items : []).filter((item) => {
+                        if (!item || item.posa_pricing_rule_virtual) {
+                                return false;
+                        }
+
+                        if (itemCode && item.item_code !== itemCode) {
+                                return false;
+                        }
+
+                        if (applyOn === "item group" && itemGroup && item.item_group !== itemGroup) {
+                                return false;
+                        }
+
+                        if (applyOn === "brand" && brand && item.brand !== brand) {
+                                return false;
+                        }
+
+                        return true;
+                });
+        },
+
+        _snapshotItemForPricingRule(item) {
+                if (!item) {
+                        return null;
+                }
+
+                return {
+                        rate: item.rate,
+                        base_rate: item.base_rate,
+                        discount_amount: item.discount_amount,
+                        base_discount_amount: item.base_discount_amount,
+                        discount_percentage: item.discount_percentage,
+                        amount: item.amount,
+                        base_amount: item.base_amount,
+                        pricing_rule: item.pricing_rule,
+                        pricing_rule_label: item.pricing_rule_label,
+                };
+        },
+
+        _restorePricingRuleSnapshot(item, snapshot) {
+                if (!item) {
                         return;
                 }
-                const entry = {
+
+                if (snapshot) {
+                        item.rate = snapshot.rate;
+                        item.base_rate = snapshot.base_rate;
+                        item.discount_amount = snapshot.discount_amount;
+                        item.base_discount_amount = snapshot.base_discount_amount;
+                        item.discount_percentage = snapshot.discount_percentage;
+                        item.pricing_rule = snapshot.pricing_rule;
+                        item.pricing_rule_label = snapshot.pricing_rule_label;
+                } else {
+                        this._resetItemPricingToDefault(item);
+                        return;
+                }
+
+                const qty = this.flt(item.qty);
+                item.amount = this.flt(qty * this.flt(item.rate), this.currency_precision);
+                item.base_amount = this.flt(qty * this.flt(item.base_rate), this.currency_precision);
+        },
+
+        _resetItemPricingToDefault(item) {
+                if (!item) {
+                        return;
+                }
+
+                const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+                const exchangeRate = this.exchange_rate || 1;
+
+                const resolvedBasePrice = this.flt(
+                        item.base_price_list_rate !== undefined && item.base_price_list_rate !== null
+                                ? item.base_price_list_rate
+                                : item.base_rate || 0,
+                        this.currency_precision,
+                );
+
+                const resolvedPrice = this.flt(
+                        item.price_list_rate !== undefined && item.price_list_rate !== null
+                                ? item.price_list_rate
+                                : this.selected_currency !== baseCurrency
+                                        ? resolvedBasePrice / exchangeRate
+                                        : resolvedBasePrice,
+                        this.currency_precision,
+                );
+
+                item.discount_amount = 0;
+                item.base_discount_amount = 0;
+                item.discount_percentage = 0;
+                item.rate = resolvedPrice;
+                item.base_rate = this.selected_currency !== baseCurrency
+                        ? this.flt(resolvedPrice * exchangeRate, this.currency_precision)
+                        : resolvedBasePrice;
+                item.amount = this.flt(this.flt(item.qty) * item.rate, this.currency_precision);
+                item.base_amount = this.flt(this.flt(item.qty) * item.base_rate, this.currency_precision);
+                delete item.pricing_rule;
+                delete item.pricing_rule_label;
+        },
+
+        _applyDiscountValuesToItem(item, rule) {
+                if (!item || !rule) {
+                        return null;
+                }
+
+                const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+                const exchangeRate = this.exchange_rate || 1;
+                const rateOrDiscount = (rule.rate_or_discount || "").toLowerCase();
+
+                const basePriceListRate = this.flt(
+                        item.base_price_list_rate !== undefined && item.base_price_list_rate !== null
+                                ? item.base_price_list_rate
+                                : this.selected_currency !== baseCurrency
+                                        ? this.flt((item.price_list_rate || item.rate || 0) * exchangeRate, this.currency_precision)
+                                        : item.price_list_rate || item.rate || 0,
+                        this.currency_precision,
+                );
+
+                const priceListRate = this.flt(
+                        item.price_list_rate !== undefined && item.price_list_rate !== null
+                                ? item.price_list_rate
+                                : this.selected_currency !== baseCurrency
+                                        ? basePriceListRate / exchangeRate
+                                        : basePriceListRate,
+                        this.currency_precision,
+                );
+
+                let discountPercentage = 0;
+                let discountAmount = 0;
+                let baseDiscountAmount = 0;
+
+                if (rateOrDiscount === "rate" && rule.rate) {
+                        const baseTargetRate = this.flt(rule.rate, this.currency_precision);
+                        const targetRate = this.selected_currency !== baseCurrency
+                                ? this.flt(baseTargetRate / exchangeRate, this.currency_precision)
+                                : baseTargetRate;
+                        discountAmount = this.flt(Math.max(0, priceListRate - targetRate), this.currency_precision);
+                        baseDiscountAmount = this.flt(
+                                Math.max(0, basePriceListRate - baseTargetRate),
+                                this.currency_precision,
+                        );
+                        discountPercentage = priceListRate
+                                ? this.flt((discountAmount / priceListRate) * 100, this.float_precision)
+                                : 0;
+                } else if (rateOrDiscount === "discount amount" && rule.discount_amount) {
+                        baseDiscountAmount = this.flt(
+                                Math.min(rule.discount_amount, basePriceListRate),
+                                this.currency_precision,
+                        );
+                        discountAmount = this.selected_currency !== baseCurrency
+                                ? this.flt(baseDiscountAmount / exchangeRate, this.currency_precision)
+                                : baseDiscountAmount;
+                        discountPercentage = priceListRate
+                                ? this.flt((discountAmount / priceListRate) * 100, this.float_precision)
+                                : 0;
+                } else {
+                        discountPercentage = this.flt(rule.discount_percentage || 0, this.float_precision);
+                        discountAmount = this.flt((priceListRate * discountPercentage) / 100, this.currency_precision);
+                        baseDiscountAmount = this.flt(
+                                (basePriceListRate * discountPercentage) / 100,
+                                this.currency_precision,
+                        );
+                }
+
+                discountPercentage = Math.min(Math.max(discountPercentage, 0), 100);
+                discountAmount = Math.min(discountAmount, priceListRate);
+                baseDiscountAmount = Math.min(baseDiscountAmount, basePriceListRate);
+
+                const resolvedRate = this.flt(priceListRate - discountAmount, this.currency_precision);
+                const resolvedBaseRate = this.flt(basePriceListRate - baseDiscountAmount, this.currency_precision);
+
+                item.discount_percentage = discountPercentage;
+                item.discount_amount = discountAmount;
+                item.base_discount_amount = baseDiscountAmount;
+                item.rate = resolvedRate;
+                item.base_rate = resolvedBaseRate;
+                item.amount = this.flt(this.flt(item.qty) * item.rate, this.currency_precision);
+                item.base_amount = this.flt(this.flt(item.qty) * item.base_rate, this.currency_precision);
+                item.pricing_rule = rule.name;
+                item.pricing_rule_label = rule.title || rule.name;
+
+                return {
+                        discountAmount,
+                        discountPercentage,
+                };
+        },
+
+        _applyDiscountPricingRule(rule) {
+                const matchingItems = this._findItemsMatchingPricingRule(rule);
+                if (!matchingItems.length) {
+                        this.eventBus.emit("show_message", {
+                                title: __("No items match pricing rule {0}", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return false;
+                }
+
+                const minQty = Math.abs(this.flt(rule.min_qty || 0));
+                const minAmt = Math.abs(this.flt(rule.min_amt || 0));
+
+                const aggregated = matchingItems.reduce(
+                        (acc, item) => {
+                                const qty = Math.abs(this.flt(item.qty));
+                                const amount = Math.abs(
+                                        this.flt((item.price_list_rate || item.rate || 0) * qty, this.currency_precision),
+                                );
+                                return {
+                                        qty: acc.qty + qty,
+                                        amount: acc.amount + amount,
+                                };
+                        },
+                        { qty: 0, amount: 0 },
+                );
+
+                if (minQty && aggregated.qty < minQty) {
+                        this.eventBus.emit("show_message", {
+                                title: __("Minimum quantity not met for pricing rule {0}", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return false;
+                }
+
+                if (minAmt && aggregated.amount < minAmt) {
+                        this.eventBus.emit("show_message", {
+                                title: __("Minimum amount not met for pricing rule {0}", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return false;
+                }
+
+                const affected = [];
+                matchingItems.forEach((item) => {
+                        const snapshot = this._snapshotItemForPricingRule(item);
+                        const result = this._applyDiscountValuesToItem(item, rule);
+                        if (result) {
+                                affected.push({
+                                        row_id: item.posa_row_id,
+                                        snapshot,
+                                });
+                        }
+                });
+
+                if (!affected.length) {
+                        this.eventBus.emit("show_message", {
+                                title: __("Unable to apply pricing rule {0}", [rule.title || rule.name]),
+                                color: "warning",
+                        });
+                        return false;
+                }
+
+                this._registerPricingRuleRecord(rule, null, {
+                        type: "discount",
+                        affected_items: affected,
+                        rule_data: rule,
+                });
+                this.emitPricingRulesState();
+                return true;
+        },
+
+        async _restoreVirtualPricingRuleItemsFromRecords() {
+                if (!Array.isArray(this.pos_pricing_rules) || !this.pos_pricing_rules.length) {
+                        return;
+                }
+
+                for (const record of this.pos_pricing_rules) {
+                        if (record.type !== "free_item" || !record.free_item) {
+                                continue;
+                        }
+
+                        const existing = this.items.find(
+                                (item) =>
+                                        item &&
+                                        item.posa_pricing_rule_virtual &&
+                                        item.pricing_rule === record.name,
+                        );
+                        if (existing) {
+                                if (record.row_id && existing.posa_row_id !== record.row_id) {
+                                        existing.posa_row_id = record.row_id;
+                                }
+                                this._markVirtualFreeItem(existing);
+                                continue;
+                        }
+
+                        const payloadRule = record.rule_data || {
+                                name: record.name,
+                                title: record.label || record.name,
+                                free_item: record.free_item,
+                                free_qty: record.free_qty,
+                        };
+                        const qty = Math.abs(this.flt(record.free_qty || payloadRule.free_qty || 0)) || 1;
+                        const virtual = this._createVirtualPricingRuleItem(payloadRule, record.free_item, qty);
+                        if (!virtual) {
+                                continue;
+                        }
+                        if (record.row_id) {
+                                virtual.posa_row_id = record.row_id;
+                        }
+                        this.items.unshift(virtual);
+                        try {
+                                await this.update_item_detail(virtual, true);
+                        } catch (error) {
+                                console.warn("Unable to refresh restored pricing rule item", error);
+                        }
+                        this._markVirtualFreeItem(virtual);
+                        if (typeof this.calc_stock_qty === "function") {
+                                this.calc_stock_qty(virtual, virtual.qty);
+                        }
+                }
+        },
+
+        _registerPricingRuleRecord(rule, item, options = {}) {
+                if (!rule) {
+                        return;
+                }
+
+                const payload = {
                         name: rule.name,
                         label: rule.title || rule.name,
-                        free_item: rule.free_item || item.item_code,
-                        free_qty: item.qty,
-                        row_id: item.posa_row_id,
+                        free_item: options.free_item !== undefined ? options.free_item : rule.free_item || item?.item_code || null,
+                        free_qty:
+                                options.free_qty !== undefined
+                                        ? options.free_qty
+                                        : item?.qty ?? rule.free_qty ?? 0,
+                        row_id: options.row_id !== undefined ? options.row_id : item?.posa_row_id || null,
+                        type: options.type || (item ? "free_item" : "discount"),
+                        affected_items: options.affected_items
+                                ? JSON.parse(JSON.stringify(options.affected_items))
+                                : [],
+                        rule_data: options.rule_data
+                                ? JSON.parse(JSON.stringify(options.rule_data))
+                                : JSON.parse(JSON.stringify(rule)),
                 };
+
                 this.pos_pricing_rules = Array.isArray(this.pos_pricing_rules)
-                        ? [...this.pos_pricing_rules.filter((row) => row.name !== entry.name), entry]
-                        : [entry];
+                        ? [...this.pos_pricing_rules.filter((row) => row.name !== payload.name), payload]
+                        : [payload];
         },
 
         _removePricingRuleRecord(ruleName) {
@@ -1343,6 +1746,7 @@ export default {
                                   row_id: entry.row_id,
                                   free_item: entry.free_item,
                                   free_qty: entry.free_qty,
+                                  type: entry.type,
                           }))
                         : [];
                 this.eventBus.emit("sync_pricing_rules", { applied });

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -184,6 +184,10 @@ export default {
 		this.item_stock_cache = {};
 	},
         remove_item(item) {
+                if (!item) {
+                        return removeItem(item, this);
+                }
+
                 if (item && item.pricing_rule) {
                         if (item.posa_pricing_rule_virtual) {
                                 this._removePricingRuleRecord(item.pricing_rule);
@@ -210,7 +214,62 @@ export default {
                                 }
                         }
                 }
-                return removeItem(item, this);
+
+                const impactedRuleNames = new Set();
+                if (!item.posa_pricing_rule_virtual) {
+                        const rowId = typeof item.posa_row_id === "string" ? item.posa_row_id : "";
+                        if (rowId) {
+                                const records = Array.isArray(this.pos_pricing_rules) ? [...this.pos_pricing_rules] : [];
+                                records.forEach((record) => {
+                                        if (
+                                                !record ||
+                                                record.type !== "free_item" ||
+                                                !Array.isArray(record.qualifying_rows) ||
+                                                !record.qualifying_rows.length
+                                        ) {
+                                                return;
+                                        }
+
+                                        if (!record.qualifying_rows.includes(rowId)) {
+                                                return;
+                                        }
+
+                                        const remaining = record.qualifying_rows
+                                                .map((value) => {
+                                                        if (typeof value === "string") {
+                                                                return value.trim();
+                                                        }
+                                                        if (value === null || value === undefined) {
+                                                                return "";
+                                                        }
+                                                        return `${value}`.trim();
+                                                })
+                                                .filter((value) => value && value !== rowId);
+
+                                        if (!remaining.length) {
+                                                impactedRuleNames.add(record.name);
+                                        } else {
+                                                this._refreshPricingRuleRecord(record.name, {
+                                                        matchingRowIds: remaining,
+                                                });
+                                        }
+                                });
+                        }
+                }
+
+                const response = removeItem(item, this);
+
+                impactedRuleNames.forEach((ruleName) => {
+                        if (ruleName) {
+                                this.removePricingRule(ruleName);
+                        }
+                });
+
+                if (!item.posa_pricing_rule_virtual && typeof this.schedulePricingRuleRefresh === "function") {
+                        this.schedulePricingRuleRefresh();
+                }
+
+                return response;
         },
 
 	async add_item(item, options = {}) {
@@ -1261,8 +1320,15 @@ export default {
                                         return false;
                                 }
 
-                                const { freeItemCode, freeQty, multiplier, aggregated, base_qty, base_amount } =
-                                        evaluationResult;
+                                const {
+                                        freeItemCode,
+                                        freeQty,
+                                        multiplier,
+                                        aggregated,
+                                        base_qty,
+                                        base_amount,
+                                        matchingItems,
+                                } = evaluationResult;
                                 const newItem = this._createVirtualPricingRuleItem(rule, freeItemCode, freeQty);
                                 if (!newItem) {
                                         return false;
@@ -1292,6 +1358,12 @@ export default {
                                         posa_cycle_amount: base_amount ?? null,
                                 };
 
+                                const matchingRowIds = Array.isArray(matchingItems)
+                                        ? matchingItems
+                                                  .map((entry) => entry?.posa_row_id)
+                                                  .filter((rowId) => typeof rowId === "string" && rowId)
+                                        : [];
+
                                 this._registerPricingRuleRecord(rule, newItem, {
                                         type: "free_item",
                                         free_item: freeItemCode,
@@ -1299,6 +1371,7 @@ export default {
                                         rule_data: recordRuleData,
                                         base_qty: base_qty,
                                         base_amount: base_amount,
+                                        qualifying_rows: matchingRowIds,
                                 });
                                 this.emitPricingRulesState();
                         } else if (rule.is_price_discount) {
@@ -2137,6 +2210,11 @@ export default {
 
                                 const desiredQty = Math.abs(flt(evaluation.freeQty || 0));
                                 const desiredMultiplier = evaluation.multiplier || null;
+                                const matchingRowIds = Array.isArray(evaluation.matchingItems)
+                                        ? evaluation.matchingItems
+                                                  .map((item) => item?.posa_row_id)
+                                                  .filter((rowId) => typeof rowId === "string" && rowId)
+                                        : [];
 
                                 if (!record) {
                                         await this.applyPricingRule(rule, {
@@ -2165,6 +2243,7 @@ export default {
                                                 aggregated: evaluation.aggregated,
                                                 baseQty: evaluation.base_qty,
                                                 baseAmount: evaluation.base_amount,
+                                                matchingRowIds,
                                         });
 
                                         if (!updated) {
@@ -2183,6 +2262,7 @@ export default {
                                         aggregated: evaluation.aggregated,
                                         baseQty: evaluation.base_qty,
                                         baseAmount: evaluation.base_amount,
+                                        matchingRowIds,
                                 });
                                 continue;
                         }
@@ -2291,6 +2371,19 @@ export default {
                 if (details.baseAmount !== undefined) {
                         updatedRecord.base_amount = details.baseAmount;
                 }
+                if (Array.isArray(details.matchingRowIds)) {
+                        updatedRecord.qualifying_rows = details.matchingRowIds
+                                .map((rowId) => {
+                                        if (typeof rowId === "string") {
+                                                return rowId.trim();
+                                        }
+                                        if (rowId === null || rowId === undefined) {
+                                                return "";
+                                        }
+                                        return `${rowId}`.trim();
+                                })
+                                .filter((rowId) => !!rowId);
+                }
 
                 this.pos_pricing_rules.splice(index, 1, updatedRecord);
                 this._pricingRuleRecordDirty = true;
@@ -2301,7 +2394,7 @@ export default {
                         return false;
                 }
 
-                const { freeQty, multiplier, aggregated } = details || {};
+                const { freeQty, multiplier, aggregated, matchingRowIds } = details || {};
                 if (freeQty === undefined || freeQty === null) {
                         return false;
                 }
@@ -2356,6 +2449,7 @@ export default {
                                 aggregated,
                                 baseQty: details.baseQty,
                                 baseAmount: details.baseAmount,
+                                matchingRowIds,
                         });
                         return true;
                 }
@@ -2374,6 +2468,7 @@ export default {
                         aggregated,
                         baseQty: details.baseQty,
                         baseAmount: details.baseAmount,
+                        matchingRowIds,
                 });
 
                 if (typeof this.$forceUpdate === "function") {
@@ -2502,6 +2597,22 @@ export default {
                                         desiredMultiplier = evaluation.multiplier || null;
                                         aggregated = evaluation.aggregated || null;
                                         desiredFreeItemCode = evaluation.freeItemCode || null;
+                                        if (Array.isArray(evaluation.matchingItems)) {
+                                                const matchingRowIds = evaluation.matchingItems
+                                                        .map((entry) => {
+                                                                if (entry?.posa_row_id && typeof entry.posa_row_id === "string") {
+                                                                        return entry.posa_row_id.trim();
+                                                                }
+                                                                if (entry?.posa_row_id !== undefined && entry?.posa_row_id !== null) {
+                                                                        return `${entry.posa_row_id}`.trim();
+                                                                }
+                                                                return "";
+                                                        })
+                                                        .filter((rowId) => !!rowId);
+                                                if (matchingRowIds.length) {
+                                                        updatedRecord.qualifying_rows = matchingRowIds;
+                                                }
+                                        }
                                         if (evaluation.base_qty !== undefined) {
                                                 slot.record.base_qty = evaluation.base_qty;
                                         }
@@ -2668,6 +2779,20 @@ export default {
                         base_qty: options.base_qty !== undefined ? options.base_qty : null,
                         base_amount: options.base_amount !== undefined ? options.base_amount : null,
                 };
+
+                if (Array.isArray(options.qualifying_rows)) {
+                        payload.qualifying_rows = options.qualifying_rows
+                                .map((rowId) => {
+                                        if (typeof rowId === "string") {
+                                                return rowId.trim();
+                                        }
+                                        if (rowId === null || rowId === undefined) {
+                                                return "";
+                                        }
+                                        return `${rowId}`.trim();
+                                })
+                                .filter((rowId) => !!rowId);
+                }
 
                 this.pos_pricing_rules = Array.isArray(this.pos_pricing_rules)
                         ? [...this.pos_pricing_rules.filter((row) => row.name !== payload.name), payload]

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1191,40 +1191,80 @@ export default {
                 }
 
                 if (applied) {
+                        this._releaseSuppressedPricingRule(ruleName);
                         this.applyPricingRule(rule);
                 } else {
+                        this._suppressPricingRule(ruleName);
                         this.removePricingRule(ruleName);
                 }
         },
 
-        async applyPricingRule(rule) {
+        _ensureSuppressedPricingRuleSet() {
+                if (!(this._manuallySuppressedPricingRules instanceof Set)) {
+                        this._manuallySuppressedPricingRules = new Set();
+                }
+        },
+
+        _suppressPricingRule(ruleName) {
+                if (!ruleName) {
+                        return;
+                }
+                this._ensureSuppressedPricingRuleSet();
+                this._manuallySuppressedPricingRules.add(ruleName);
+        },
+
+        _releaseSuppressedPricingRule(ruleName) {
+                if (!ruleName || !(this._manuallySuppressedPricingRules instanceof Set)) {
+                        return;
+                }
+                this._manuallySuppressedPricingRules.delete(ruleName);
+        },
+
+        _isPricingRuleSuppressed(ruleName) {
+                if (!ruleName || !(this._manuallySuppressedPricingRules instanceof Set)) {
+                        return false;
+                }
+                return this._manuallySuppressedPricingRules.has(ruleName);
+        },
+
+        async applyPricingRule(rule, options = {}) {
                 try {
                         if (!rule || !rule.name) {
-                                return;
+                                return false;
                         }
 
-                        if (this.pos_pricing_rules.some((entry) => entry.name === rule.name)) {
-                                return;
+                        const { silent = false, force = false, evaluation = null } = options || {};
+                        const existingIndex = Array.isArray(this.pos_pricing_rules)
+                                ? this.pos_pricing_rules.findIndex((entry) => entry.name === rule.name)
+                                : -1;
+
+                        if (existingIndex !== -1) {
+                                if (!force) {
+                                        return false;
+                                }
+                                this.removePricingRule(rule.name);
                         }
 
                         if (this.isReturnInvoice) {
-                                this.eventBus.emit("show_message", {
-                                        title: __("Pricing rules are not applied on return invoices"),
-                                        color: "warning",
-                                });
-                                return;
+                                if (!silent) {
+                                        this.eventBus.emit("show_message", {
+                                                title: __("Pricing rules are not applied on return invoices"),
+                                                color: "warning",
+                                        });
+                                }
+                                return false;
                         }
 
                         if (rule.is_free_item_rule) {
-                                const evaluation = this._evaluateFreeItemPricingRule(rule);
-                                if (!evaluation) {
-                                        return;
+                                const evaluationResult = evaluation || this._evaluateFreeItemPricingRule(rule, { silent });
+                                if (!evaluationResult) {
+                                        return false;
                                 }
 
-                                const { freeItemCode, freeQty, multiplier, aggregated } = evaluation;
+                                const { freeItemCode, freeQty, multiplier, aggregated } = evaluationResult;
                                 const newItem = this._createVirtualPricingRuleItem(rule, freeItemCode, freeQty);
                                 if (!newItem) {
-                                        return;
+                                        return false;
                                 }
 
                                 this.items.unshift(newItem);
@@ -1257,27 +1297,34 @@ export default {
                                 });
                                 this.emitPricingRulesState();
                         } else if (rule.is_price_discount) {
-                                const applied = this._applyDiscountPricingRule(rule);
+                                const applied = this._applyDiscountPricingRule(rule, {
+                                        silent,
+                                        evaluation,
+                                });
                                 if (!applied) {
-                                        return;
+                                        return false;
                                 }
                         } else {
-                                this.eventBus.emit("show_message", {
-                                        title: __("Pricing rule {0} is not supported", [rule.title || rule.name]),
-                                        color: "warning",
-                                });
-                                return;
+                                if (!silent) {
+                                        this.eventBus.emit("show_message", {
+                                                title: __("Pricing rule {0} is not supported", [rule.title || rule.name]),
+                                                color: "warning",
+                                        });
+                                }
+                                return false;
                         }
 
                         if (typeof this.$forceUpdate === "function") {
                                 this.$forceUpdate();
                         }
+                        return true;
                 } catch (error) {
                         console.error("Failed to apply pricing rule", error);
                         this.eventBus.emit("show_message", {
                                 title: __("Unable to apply pricing rule"),
                                 color: "error",
                         });
+                        return false;
                 }
         },
 
@@ -1607,17 +1654,20 @@ export default {
                 };
         },
 
-        _evaluateFreeItemPricingRule(rule) {
+        _evaluateFreeItemPricingRule(rule, options = {}) {
                 if (!rule) {
                         return null;
                 }
 
+                const { silent = false } = options || {};
                 const matchingItems = this._findItemsMatchingPricingRule(rule);
                 if (!matchingItems.length) {
-                        this.eventBus.emit("show_message", {
-                                title: __("No items match pricing rule {0}", [rule.title || rule.name]),
-                                color: "warning",
-                        });
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("No items match pricing rule {0}", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
                         return null;
                 }
 
@@ -1639,18 +1689,22 @@ export default {
                 );
 
                 if (minQty && aggregated.qty < minQty) {
-                        this.eventBus.emit("show_message", {
-                                title: __("Minimum quantity not met for pricing rule {0}", [rule.title || rule.name]),
-                                color: "warning",
-                        });
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Minimum quantity not met for pricing rule {0}", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
                         return null;
                 }
 
                 if (minAmt && aggregated.amount < minAmt) {
-                        this.eventBus.emit("show_message", {
-                                title: __("Minimum amount not met for pricing rule {0}", [rule.title || rule.name]),
-                                color: "warning",
-                        });
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Minimum amount not met for pricing rule {0}", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
                         return null;
                 }
 
@@ -1678,10 +1732,12 @@ export default {
                         : freeQtyPerApplication;
 
                 if (!totalFreeQty || totalFreeQty <= 0) {
-                        this.eventBus.emit("show_message", {
-                                title: __("Pricing rule {0} has no free quantity", [rule.title || rule.name]),
-                                color: "warning",
-                        });
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Pricing rule {0} has no free quantity", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
                         return null;
                 }
 
@@ -1689,10 +1745,12 @@ export default {
                         rule.free_item || (rule.same_item ? matchingItems[0]?.item_code : rule.item_code);
 
                 if (!resolvedFreeItemCode) {
-                        this.eventBus.emit("show_message", {
-                                title: __("Pricing rule {0} has no free item", [rule.title || rule.name]),
-                                color: "warning",
-                        });
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Pricing rule {0} has no free item", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
                         return null;
                 }
 
@@ -1705,14 +1763,21 @@ export default {
                 };
         },
 
-        _applyDiscountPricingRule(rule) {
+        _evaluateDiscountPricingRule(rule, options = {}) {
+                if (!rule) {
+                        return null;
+                }
+
+                const { silent = false } = options || {};
                 const matchingItems = this._findItemsMatchingPricingRule(rule);
                 if (!matchingItems.length) {
-                        this.eventBus.emit("show_message", {
-                                title: __("No items match pricing rule {0}", [rule.title || rule.name]),
-                                color: "warning",
-                        });
-                        return false;
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("No items match pricing rule {0}", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
+                        return null;
                 }
 
                 const minQty = Math.abs(this.flt(rule.min_qty || 0));
@@ -1733,21 +1798,36 @@ export default {
                 );
 
                 if (minQty && aggregated.qty < minQty) {
-                        this.eventBus.emit("show_message", {
-                                title: __("Minimum quantity not met for pricing rule {0}", [rule.title || rule.name]),
-                                color: "warning",
-                        });
-                        return false;
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Minimum quantity not met for pricing rule {0}", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
+                        return null;
                 }
 
                 if (minAmt && aggregated.amount < minAmt) {
-                        this.eventBus.emit("show_message", {
-                                title: __("Minimum amount not met for pricing rule {0}", [rule.title || rule.name]),
-                                color: "warning",
-                        });
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Minimum amount not met for pricing rule {0}", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
+                        return null;
+                }
+
+                return { matchingItems, aggregated };
+        },
+
+        _applyDiscountPricingRule(rule, options = {}) {
+                const { silent = false, evaluation = null } = options || {};
+                const context = evaluation || this._evaluateDiscountPricingRule(rule, { silent });
+                if (!context) {
                         return false;
                 }
 
+                const { matchingItems, aggregated } = context;
                 const affected = [];
                 matchingItems.forEach((item) => {
                         const snapshot = this._snapshotItemForPricingRule(item);
@@ -1761,20 +1841,269 @@ export default {
                 });
 
                 if (!affected.length) {
-                        this.eventBus.emit("show_message", {
-                                title: __("Unable to apply pricing rule {0}", [rule.title || rule.name]),
-                                color: "warning",
-                        });
+                        if (!silent) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Unable to apply pricing rule {0}", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                        }
                         return false;
                 }
+
+                const rulePayload = {
+                        ...rule,
+                        posa_base_qty: aggregated?.qty ?? null,
+                        posa_base_amount: aggregated?.amount ?? null,
+                };
 
                 this._registerPricingRuleRecord(rule, null, {
                         type: "discount",
                         affected_items: affected,
-                        rule_data: rule,
+                        rule_data: rulePayload,
                 });
                 this.emitPricingRulesState();
                 return true;
+        },
+
+        ingestPricingRuleCatalog(rules = []) {
+                const sanitized = Array.isArray(rules)
+                        ? rules
+                                  .filter((entry) => entry && entry.name)
+                                  .map((entry) => ({ ...entry }))
+                        : [];
+                this.pricing_rule_catalog = sanitized;
+                this.pricing_rule_catalog_ready = true;
+                this.schedulePricingRuleRefresh();
+        },
+
+        schedulePricingRuleRefresh(changedRowIds = []) {
+                this._pendingPricingRuleRows = this._pendingPricingRuleRows || new Set();
+                const rows = Array.isArray(changedRowIds) ? changedRowIds : [changedRowIds];
+                rows.forEach((rowId) => {
+                        if (rowId) {
+                                this._pendingPricingRuleRows.add(rowId);
+                        }
+                });
+
+                if (this._pricingRuleRefreshPending) {
+                        return;
+                }
+
+                this._pricingRuleRefreshPending = true;
+                const schedule =
+                        typeof window !== "undefined" && typeof window.requestAnimationFrame === "function"
+                                ? window.requestAnimationFrame.bind(window)
+                                : (cb) => setTimeout(cb, 16);
+
+                this._pricingRuleRefreshHandle = schedule(() => {
+                        this._pricingRuleRefreshHandle = null;
+                        this._pricingRuleRefreshPending = false;
+                        const affectedRows = this._pendingPricingRuleRows ? Array.from(this._pendingPricingRuleRows) : [];
+                        this._pendingPricingRuleRows = new Set();
+                        this._queueAutoApplyPricingRules({ affectedRows });
+                });
+        },
+
+        cancelScheduledPricingRuleRefresh() {
+                if (this._pricingRuleRefreshHandle != null) {
+                        if (typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+                                window.cancelAnimationFrame(this._pricingRuleRefreshHandle);
+                        } else {
+                                clearTimeout(this._pricingRuleRefreshHandle);
+                        }
+                        this._pricingRuleRefreshHandle = null;
+                }
+                this._pricingRuleRefreshPending = false;
+                this._pendingPricingRuleRows = new Set();
+        },
+
+        _queueAutoApplyPricingRules(context = {}) {
+                const run = () => this._autoApplyPricingRules(context);
+                this._pricingRuleEvaluationQueue = (this._pricingRuleEvaluationQueue || Promise.resolve())
+                        .then(run)
+                        .catch((error) => {
+                                console.error("Failed to auto-apply pricing rules", error);
+                        });
+                return this._pricingRuleEvaluationQueue;
+        },
+
+        async _autoApplyPricingRules(context = {}) {
+                const { affectedRows = [] } = context || {};
+                void affectedRows;
+                if (this.isReturnInvoice) {
+                        return;
+                }
+
+                if (!this.pricing_rule_catalog_ready) {
+                        return;
+                }
+
+                const catalog = Array.isArray(this.pricing_rule_catalog) ? this.pricing_rule_catalog : [];
+                if (!catalog.length) {
+                        return;
+                }
+
+                const epsilon = 0.000001;
+                const appliedRecords = Array.isArray(this.pos_pricing_rules) ? [...this.pos_pricing_rules] : [];
+                const appliedMap = new Map(appliedRecords.map((record) => [record.name, record]));
+                const catalogNames = new Set(catalog.map((rule) => rule.name).filter(Boolean));
+                this._pricingRuleRecordDirty = false;
+
+                for (const rule of catalog) {
+                        if (!rule || !rule.name) {
+                                continue;
+                        }
+
+                        if (this._isPricingRuleSuppressed(rule.name)) {
+                                continue;
+                        }
+
+                        if (rule.is_free_item_rule) {
+                                const evaluation = this._evaluateFreeItemPricingRule(rule, { silent: true });
+                                const record = appliedMap.get(rule.name);
+                                if (!evaluation) {
+                                        if (record) {
+                                                this.removePricingRule(rule.name);
+                                        }
+                                        this._releaseSuppressedPricingRule(rule.name);
+                                        continue;
+                                }
+
+                                const desiredQty = Math.abs(flt(evaluation.freeQty || 0));
+                                const desiredMultiplier = evaluation.multiplier || null;
+
+                                if (!record) {
+                                        await this.applyPricingRule(rule, {
+                                                silent: true,
+                                                evaluation,
+                                        });
+                                        continue;
+                                }
+
+                                const currentQty = Math.abs(
+                                        flt(
+                                                record.rule_data?.posa_applied_free_qty ??
+                                                        record.free_qty ??
+                                                        0,
+                                        ),
+                                );
+                                const currentMultiplier = record.rule_data?.posa_applied_multiplier ?? null;
+
+                                if (
+                                        Math.abs(currentQty - desiredQty) > epsilon ||
+                                        (desiredMultiplier && desiredMultiplier !== currentMultiplier)
+                                ) {
+                                        await this.applyPricingRule(rule, {
+                                                silent: true,
+                                                evaluation,
+                                                force: true,
+                                        });
+                                        continue;
+                                }
+
+                                this._refreshPricingRuleRecord(rule.name, {
+                                        freeQty: desiredQty,
+                                        multiplier: desiredMultiplier,
+                                        aggregated: evaluation.aggregated,
+                                });
+                                continue;
+                        }
+
+                        if (rule.is_price_discount) {
+                                const evaluation = this._evaluateDiscountPricingRule(rule, { silent: true });
+                                const record = appliedMap.get(rule.name);
+
+                                if (!evaluation) {
+                                        if (record) {
+                                                this.removePricingRule(rule.name);
+                                        }
+                                        this._releaseSuppressedPricingRule(rule.name);
+                                        continue;
+                                }
+
+                                const desiredQty = flt(evaluation.aggregated?.qty || 0);
+                                const desiredAmount = flt(evaluation.aggregated?.amount || 0);
+                                const currentQty = flt(record?.rule_data?.posa_base_qty ?? 0);
+                                const currentAmount = flt(record?.rule_data?.posa_base_amount ?? 0);
+
+                                const mismatch = evaluation.matchingItems.some(
+                                        (item) => item && item.pricing_rule !== rule.name,
+                                );
+
+                                if (
+                                        !record ||
+                                        Math.abs(currentQty - desiredQty) > epsilon ||
+                                        Math.abs(currentAmount - desiredAmount) > epsilon ||
+                                        mismatch
+                                ) {
+                                        await this.applyPricingRule(rule, {
+                                                silent: true,
+                                                evaluation,
+                                                force: Boolean(record),
+                                        });
+                                        continue;
+                                }
+
+                                this._refreshPricingRuleRecord(rule.name, {
+                                        aggregated: evaluation.aggregated,
+                                });
+                        }
+                }
+
+                for (const record of appliedRecords) {
+                        if (record?.name && !catalogNames.has(record.name)) {
+                                this.removePricingRule(record.name);
+                                this._releaseSuppressedPricingRule(record.name);
+                        }
+                }
+
+                if (this._pricingRuleRecordDirty) {
+                        this._pricingRuleRecordDirty = false;
+                        this.emitPricingRulesState();
+                }
+        },
+
+        _refreshPricingRuleRecord(ruleName, details = {}) {
+                if (!ruleName || !Array.isArray(this.pos_pricing_rules)) {
+                        return;
+                }
+
+                const index = this.pos_pricing_rules.findIndex((entry) => entry && entry.name === ruleName);
+                if (index === -1) {
+                        return;
+                }
+
+                const record = this.pos_pricing_rules[index];
+                const nextRuleData = {
+                        ...(record.rule_data || {}),
+                };
+
+                if (details.freeQty !== undefined) {
+                        nextRuleData.posa_applied_free_qty = details.freeQty;
+                }
+                if (details.multiplier !== undefined) {
+                        nextRuleData.posa_applied_multiplier = details.multiplier;
+                }
+                if (details.aggregated && typeof details.aggregated === "object") {
+                        if (details.aggregated.qty !== undefined) {
+                                nextRuleData.posa_base_qty = details.aggregated.qty;
+                        }
+                        if (details.aggregated.amount !== undefined) {
+                                nextRuleData.posa_base_amount = details.aggregated.amount;
+                        }
+                }
+
+                const updatedRecord = {
+                        ...record,
+                        rule_data: nextRuleData,
+                };
+
+                if (details.freeQty !== undefined) {
+                        updatedRecord.free_qty = details.freeQty;
+                }
+
+                this.pos_pricing_rules.splice(index, 1, updatedRecord);
+                this._pricingRuleRecordDirty = true;
         },
 
         _syncDocItemsWithPricingRuleRecords() {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -183,9 +183,13 @@ export default {
 	clearItemStockCache() {
 		this.item_stock_cache = {};
 	},
-	remove_item(item) {
-		return removeItem(item, this);
-	},
+        remove_item(item) {
+                if (item && item.pricing_rule && item.posa_pricing_rule_virtual) {
+                        this._removePricingRuleRecord(item.pricing_rule);
+                        this.emitPricingRulesState();
+                }
+                return removeItem(item, this);
+        },
 
 	async add_item(item, options = {}) {
 		const res = await addItem(item, this);
@@ -398,16 +402,28 @@ export default {
 
 			const manualSnapshots = this._snapshotManualValuesFromDocItems(this.items);
 
-			await this.update_items_details(this.items);
+                        await this.update_items_details(this.items);
 
-			if (manualSnapshots.length) {
-				this._restoreManualSnapshots(this.items, manualSnapshots);
-			}
+                        if (manualSnapshots.length) {
+                                this._restoreManualSnapshots(this.items, manualSnapshots);
+                        }
 
-			this.posa_offers = data.posa_offers || [];
-		} else {
-			console.log("Warning: No items in return invoice");
-		}
+                        this.posa_offers = data.posa_offers || [];
+                        this.pos_pricing_rules = Array.isArray(data.posa_pricing_rules)
+                                ? data.posa_pricing_rules.map((entry) => ({
+                                          name: entry.pricing_rule || entry.name,
+                                          label: entry.label || entry.pricing_rule || entry.name,
+                                          free_item: entry.free_item,
+                                          free_qty: entry.free_qty,
+                                          row_id: entry.row_id,
+                                  }))
+                                : [];
+                        this.emitPricingRulesState();
+                } else {
+                        console.log("Warning: No items in return invoice");
+                        this.pos_pricing_rules = [];
+                        this.emitPricingRulesState();
+                }
 
 		if (this.packed_items.length > 0) {
 			this.update_items_details(this.packed_items);
@@ -708,11 +724,19 @@ export default {
 		doc.is_return = isReturn ? 1 : 0;
 
 		// Calculate amounts in selected currency
-		const items = this.get_invoice_items();
-		doc.items = items;
-		doc.packed_items = (this.packed_items || []).map((pi) => ({
-			parent_item: pi.parent_item,
-			item_code: pi.item_code,
+                const items = this.get_invoice_items();
+                doc.items = items;
+                doc.posa_pricing_rules = Array.isArray(this.pos_pricing_rules)
+                        ? this.pos_pricing_rules.map((entry) => ({
+                                  pricing_rule: entry.name,
+                                  free_item: entry.free_item,
+                                  free_qty: entry.free_qty,
+                                  row_id: entry.row_id,
+                          }))
+                        : [];
+                doc.packed_items = (this.packed_items || []).map((pi) => ({
+                        parent_item: pi.parent_item,
+                        item_code: pi.item_code,
 			item_name: pi.item_name,
 			qty: flt(pi.qty),
 			uom: pi.uom,
@@ -989,13 +1013,16 @@ export default {
 	// Prepare items array for invoice doc
 	get_invoice_items() {
 		const items_list = [];
-		const isReturn = this.isReturnInvoice;
-		const usesPosInvoice = this.pos_profile.create_pos_invoice_instead_of_sales_invoice;
+                const isReturn = this.isReturnInvoice;
+                const usesPosInvoice = this.pos_profile.create_pos_invoice_instead_of_sales_invoice;
 
-		this.items.forEach((item) => {
-			const new_item = {
-				item_code: item.item_code,
-				// Retain the item name for offline invoices
+                this.items.forEach((item) => {
+                        if (item.posa_pricing_rule_virtual) {
+                                return;
+                        }
+                        const new_item = {
+                                item_code: item.item_code,
+                                // Retain the item name for offline invoices
 				// Fallback to item_code if item_name is not available
 				item_name: item.item_name || item.item_code,
 				name_overridden: item.name_overridden ? 1 : 0,
@@ -1077,12 +1104,15 @@ export default {
 	},
 
 	// Prepare items array for order doc
-	get_order_items() {
-		const items_list = [];
-		this.items.forEach((item) => {
-			const new_item = {
-				item_code: item.item_code,
-				// Retain item name to show on offline order documents
+        get_order_items() {
+                const items_list = [];
+                this.items.forEach((item) => {
+                        if (item.posa_pricing_rule_virtual) {
+                                return;
+                        }
+                        const new_item = {
+                                item_code: item.item_code,
+                                // Retain item name to show on offline order documents
 				// Use item_code if item_name is missing
 				item_name: item.item_name || item.item_code,
 				name_overridden: item.name_overridden ? 1 : 0,
@@ -1105,16 +1135,223 @@ export default {
 				posa_delivery_date: item.posa_delivery_date,
 				price_list_rate: item.price_list_rate,
 			};
-			items_list.push(new_item);
-		});
+                        items_list.push(new_item);
+                });
 
-		return items_list;
-	},
+                return items_list;
+        },
 
-	// Prepare payments array for invoice doc
-	get_payments() {
-		const payments = [];
-		// Use this.subtotal which is already in selected currency and includes all calculations
+        handleTogglePricingRule(payload = {}) {
+                const { rule, applied } = payload || {};
+                const ruleName = rule && rule.name;
+                if (!ruleName) {
+                        return;
+                }
+
+                if (applied) {
+                        this.applyPricingRule(rule);
+                } else {
+                        this.removePricingRule(ruleName);
+                }
+        },
+
+        async applyPricingRule(rule) {
+                try {
+                        if (!rule || !rule.name) {
+                                return;
+                        }
+
+                        if (this.pos_pricing_rules.some((entry) => entry.name === rule.name)) {
+                                return;
+                        }
+
+                        if (this.isReturnInvoice) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Pricing rules are not applied on return invoices"),
+                                        color: "warning",
+                                });
+                                return;
+                        }
+
+                        const freeItemCode = rule.free_item || rule.item_code;
+                        if (!freeItemCode) {
+                                this.eventBus.emit("show_message", {
+                                        title: __("Pricing rule {0} has no free item", [rule.title || rule.name]),
+                                        color: "warning",
+                                });
+                                return;
+                        }
+
+                        const qty = Math.abs(this.flt(rule.free_qty || 0)) || 1;
+                        const newItem = this._createVirtualPricingRuleItem(rule, freeItemCode, qty);
+                        if (!newItem) {
+                                return;
+                        }
+
+                        this.items.unshift(newItem);
+
+                        try {
+                                await this.update_item_detail(newItem, true);
+                        } catch (error) {
+                                console.warn("Unable to update virtual pricing rule item details", error);
+                        }
+
+                        this._markVirtualFreeItem(newItem);
+
+                        if (typeof this.calc_stock_qty === "function") {
+                                this.calc_stock_qty(newItem, newItem.qty);
+                        }
+
+                        this._registerPricingRuleRecord(rule, newItem);
+                        this.emitPricingRulesState();
+
+                        if (typeof this.$forceUpdate === "function") {
+                                this.$forceUpdate();
+                        }
+                } catch (error) {
+                        console.error("Failed to apply pricing rule", error);
+                        this.eventBus.emit("show_message", {
+                                title: __("Unable to apply pricing rule"),
+                                color: "error",
+                        });
+                }
+        },
+
+        removePricingRule(ruleName) {
+                if (!ruleName) {
+                        return;
+                }
+
+                const record = this.pos_pricing_rules.find((entry) => entry.name === ruleName);
+                if (record) {
+                        const item = this.items.find((it) => it.posa_row_id === record.row_id);
+                        if (item) {
+                                removeItem(item, this);
+                        }
+                } else {
+                        const fallback = this.items.find(
+                                (it) => it.pricing_rule === ruleName && it.posa_pricing_rule_virtual,
+                        );
+                        if (fallback) {
+                                removeItem(fallback, this);
+                        }
+                }
+
+                this._removePricingRuleRecord(ruleName);
+                this.emitPricingRulesState();
+
+                if (typeof this.$forceUpdate === "function") {
+                        this.$forceUpdate();
+                }
+        },
+
+        _createVirtualPricingRuleItem(rule, itemCode, qty) {
+                const label = rule.title || rule.name;
+                const baseItem = {
+                        item_code: itemCode,
+                        item_name: rule.free_item_name || rule.free_item || rule.item_name || itemCode,
+                        qty,
+                        rate: 0,
+                        price_list_rate: 0,
+                        base_rate: 0,
+                        base_price_list_rate: 0,
+                        discount_amount: 0,
+                        base_discount_amount: 0,
+                        stock_uom: rule.free_item_uom || rule.uom,
+                        uom: rule.free_item_uom || rule.uom,
+                        posa_is_offer: 1,
+                        posa_offer_applied: 1,
+                        posa_offers: JSON.stringify([]),
+                        allow_change_warehouse: 0,
+                        has_batch_no: 0,
+                        has_serial_no: 0,
+                };
+
+                const newItem = this.get_new_item(baseItem);
+                newItem.qty = qty;
+                newItem.stock_qty = qty;
+                newItem.is_free_item = 1;
+                newItem.posa_pricing_rule_virtual = 1;
+                newItem.pricing_rule = rule.name;
+                newItem.pricing_rule_label = label;
+                newItem.posa_offer_applied = 1;
+                newItem.allow_change_warehouse = false;
+                newItem.locked_price = true;
+                newItem.disable_increment = true;
+                newItem.discount_amount = 0;
+                newItem.base_discount_amount = 0;
+                newItem.rate = 0;
+                newItem.base_rate = 0;
+                newItem.price_list_rate = 0;
+                newItem.base_price_list_rate = 0;
+                newItem.amount = 0;
+                newItem.base_amount = 0;
+                newItem.posa_notes = label ? __("Applied via {0}", [label]) : "";
+                return newItem;
+        },
+
+        _markVirtualFreeItem(item) {
+                if (!item) {
+                        return;
+                }
+                item.is_free_item = 1;
+                item.posa_pricing_rule_virtual = 1;
+                item.posa_offer_applied = 1;
+                item.rate = 0;
+                item.base_rate = 0;
+                item.price_list_rate = 0;
+                item.base_price_list_rate = 0;
+                item.discount_amount = 0;
+                item.base_discount_amount = 0;
+                item.amount = 0;
+                item.base_amount = 0;
+                item.locked_price = true;
+                item.allow_change_warehouse = false;
+                item.disable_increment = true;
+        },
+
+        _registerPricingRuleRecord(rule, item) {
+                if (!rule || !item) {
+                        return;
+                }
+                const entry = {
+                        name: rule.name,
+                        label: rule.title || rule.name,
+                        free_item: rule.free_item || item.item_code,
+                        free_qty: item.qty,
+                        row_id: item.posa_row_id,
+                };
+                this.pos_pricing_rules = Array.isArray(this.pos_pricing_rules)
+                        ? [...this.pos_pricing_rules.filter((row) => row.name !== entry.name), entry]
+                        : [entry];
+        },
+
+        _removePricingRuleRecord(ruleName) {
+                if (!ruleName || !Array.isArray(this.pos_pricing_rules)) {
+                        return;
+                }
+                const filtered = this.pos_pricing_rules.filter((entry) => entry.name !== ruleName);
+                if (filtered.length !== this.pos_pricing_rules.length) {
+                        this.pos_pricing_rules = filtered;
+                }
+        },
+
+        emitPricingRulesState() {
+                const applied = Array.isArray(this.pos_pricing_rules)
+                        ? this.pos_pricing_rules.map((entry) => ({
+                                  name: entry.name,
+                                  row_id: entry.row_id,
+                                  free_item: entry.free_item,
+                                  free_qty: entry.free_qty,
+                          }))
+                        : [];
+                this.eventBus.emit("sync_pricing_rules", { applied });
+        },
+
+        // Prepare payments array for invoice doc
+        get_payments() {
+                const payments = [];
+                // Use this.subtotal which is already in selected currency and includes all calculations
 		const total_amount = this.subtotal;
 		let remaining_amount = total_amount;
 

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -456,8 +456,11 @@ export default {
                                           };
                                   })
                                 : [];
+
+                        this._syncDocItemsWithPricingRuleRecords();
                         this.emitPricingRulesState();
                         await this._restoreVirtualPricingRuleItemsFromRecords();
+                        this.emitPricingRulesState();
                 } else {
                         console.log("Warning: No items in return invoice");
                         this.pos_pricing_rules = [];
@@ -1394,9 +1397,22 @@ export default {
                 }
 
                 const applyOn = (rule.apply_on || "").toLowerCase();
+                const applicableFor = (rule.applicable_for || "").toLowerCase();
                 const itemCode = rule.item_code || null;
                 const itemGroup = rule.item_group || null;
                 const brand = rule.brand || null;
+
+                const expectsSpecificTarget = ["item code", "item group", "brand"].includes(applyOn);
+                const hasSpecificTarget = Boolean(itemCode || itemGroup || brand);
+
+                // Some ERPNext configurations use applicable_for to describe the same
+                // target semantics as apply_on. Account for that by falling back when
+                // apply_on is empty but applicable_for is populated with an item scope.
+                const derivedScope = (expectsSpecificTarget || hasSpecificTarget)
+                        ? applyOn
+                        : ["item code", "item group", "brand"].includes(applicableFor)
+                                ? applicableFor
+                                : "";
 
                 return (Array.isArray(this.items) ? this.items : []).filter((item) => {
                         if (!item || item.posa_pricing_rule_virtual) {
@@ -1407,11 +1423,18 @@ export default {
                                 return false;
                         }
 
-                        if (applyOn === "item group" && itemGroup && item.item_group !== itemGroup) {
+                        if ((applyOn === "item group" || derivedScope === "item group") && itemGroup && item.item_group !== itemGroup) {
                                 return false;
                         }
 
-                        if (applyOn === "brand" && brand && item.brand !== brand) {
+                        if ((applyOn === "brand" || derivedScope === "brand") && brand && item.brand !== brand) {
+                                return false;
+                        }
+
+                        if (!hasSpecificTarget && (expectsSpecificTarget || derivedScope)) {
+                                // The rule expects a specific item, group, or brand but
+                                // no explicit target has been provided – treat as non-match
+                                // so the discount does not blanket every row.
                                 return false;
                         }
 
@@ -1754,6 +1777,135 @@ export default {
                 return true;
         },
 
+        _syncDocItemsWithPricingRuleRecords() {
+                if (!Array.isArray(this.items) || !this.items.length) {
+                        return;
+                }
+
+                if (!Array.isArray(this.pos_pricing_rules) || !this.pos_pricing_rules.length) {
+                        return;
+                }
+
+                const freeRuleSlots = [];
+                this.pos_pricing_rules.forEach((record, index) => {
+                        if (record && record.type === "free_item") {
+                                freeRuleSlots.push({ record, index });
+                        }
+                });
+
+                if (!freeRuleSlots.length) {
+                        return;
+                }
+
+                const byName = new Map();
+                const byItemCode = new Map();
+
+                freeRuleSlots.forEach((slot) => {
+                        if (!slot || !slot.record) {
+                                return;
+                        }
+                        byName.set(slot.record.name, slot);
+                        const code = slot.record.free_item;
+                        if (code) {
+                                const existing = byItemCode.get(code) || [];
+                                existing.push(slot);
+                                byItemCode.set(code, existing);
+                        }
+                });
+
+                const toNumber = (value) => {
+                        if (typeof this.flt === "function") {
+                                const numeric = this.flt(value);
+                                return Number.isFinite(numeric) ? numeric : 0;
+                        }
+                        const parsed = parseFloat(value);
+                        return Number.isFinite(parsed) ? parsed : 0;
+                };
+
+                const ensureRowId = (item) => {
+                        if (!item.posa_row_id) {
+                                if (typeof this.makeid === "function") {
+                                        item.posa_row_id = this.makeid(20);
+                                } else {
+                                        item.posa_row_id = `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+                                }
+                        }
+                };
+
+                this.items.forEach((item) => {
+                        if (!item) {
+                                return;
+                        }
+
+                        const ruleName = item.pricing_rule || item.pricing_rule_name;
+                        let slot = ruleName ? byName.get(ruleName) : null;
+
+                        if (!slot && item.is_free_item) {
+                                const candidates = byItemCode.get(item.item_code) || [];
+                                if (candidates.length === 1) {
+                                        slot = candidates[0];
+                                } else if (candidates.length > 1) {
+                                        slot = candidates.find((entry) => entry.record?.row_id && entry.record.row_id === item.posa_row_id) ||
+                                                candidates.find((entry) => !entry.record?.row_id) ||
+                                                candidates[0];
+                                }
+                        }
+
+                        if (!slot || !slot.record) {
+                                return;
+                        }
+
+                        ensureRowId(item);
+
+                        const updatedRecord = { ...slot.record };
+                        const resolvedQty = Math.abs(
+                                toNumber(
+                                        updatedRecord.free_qty !== undefined && updatedRecord.free_qty !== null
+                                                ? updatedRecord.free_qty
+                                                : updatedRecord.rule_data?.posa_applied_free_qty ?? item.qty ?? 0,
+                                ),
+                        );
+
+                        if (resolvedQty > 0 && Math.abs(toNumber(item.qty)) !== resolvedQty) {
+                                item.qty = resolvedQty;
+                                item.stock_qty = resolvedQty;
+                        }
+
+                        if (resolvedQty > 0) {
+                                updatedRecord.free_qty = resolvedQty;
+                                if (updatedRecord.rule_data) {
+                                        updatedRecord.rule_data = {
+                                                ...updatedRecord.rule_data,
+                                                posa_applied_free_qty: resolvedQty,
+                                        };
+                                }
+                        }
+
+                        if (updatedRecord.row_id !== item.posa_row_id) {
+                                updatedRecord.row_id = item.posa_row_id;
+                        }
+
+                        slot.record = updatedRecord;
+                        this.pos_pricing_rules.splice(slot.index, 1, updatedRecord);
+                        byName.set(updatedRecord.name, slot);
+                        if (updatedRecord.free_item) {
+                                const existing = byItemCode.get(updatedRecord.free_item) || [];
+                                if (!existing.includes(slot)) {
+                                        existing.push(slot);
+                                        byItemCode.set(updatedRecord.free_item, existing);
+                                }
+                        }
+
+                        this._markVirtualFreeItem(item);
+                        item.pricing_rule = updatedRecord.name;
+                        item.pricing_rule_label = updatedRecord.label || updatedRecord.name;
+
+                        if (typeof this.calc_stock_qty === "function") {
+                                this.calc_stock_qty(item, item.qty);
+                        }
+                });
+        },
+
         async _restoreVirtualPricingRuleItemsFromRecords() {
                 if (!Array.isArray(this.pos_pricing_rules) || !this.pos_pricing_rules.length) {
                         return;
@@ -1774,7 +1926,22 @@ export default {
                                 if (record.row_id && existing.posa_row_id !== record.row_id) {
                                         existing.posa_row_id = record.row_id;
                                 }
+                                const resolvedQty = Math.abs(
+                                        this.flt(
+                                                record.rule_data?.posa_applied_free_qty ??
+                                                        record.free_qty ??
+                                                        record.rule_data?.free_qty ??
+                                                        0,
+                                        ) || 0,
+                                );
+                                if (resolvedQty > 0 && Math.abs(this.flt(existing.qty)) !== resolvedQty) {
+                                        existing.qty = resolvedQty;
+                                        existing.stock_qty = resolvedQty;
+                                }
                                 this._markVirtualFreeItem(existing);
+                                if (typeof this.calc_stock_qty === "function") {
+                                        this.calc_stock_qty(existing, existing.qty);
+                                }
                                 continue;
                         }
 
@@ -1784,7 +1951,12 @@ export default {
                                 free_item: record.free_item,
                                 free_qty: record.free_qty,
                         };
-                        const qty = Math.abs(this.flt(record.free_qty || payloadRule.free_qty || 0)) || 1;
+                        const rawQty =
+                                record.rule_data?.posa_applied_free_qty ??
+                                record.free_qty ??
+                                payloadRule.free_qty ??
+                                0;
+                        const qty = Math.abs(this.flt(rawQty)) || 1;
                         const virtual = this._createVirtualPricingRuleItem(payloadRule, record.free_item, qty);
                         if (!virtual) {
                                 continue;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -2043,11 +2043,19 @@ export default {
                                         Math.abs(currentQty - desiredQty) > epsilon ||
                                         (desiredMultiplier && desiredMultiplier !== currentMultiplier)
                                 ) {
-                                        await this.applyPricingRule(rule, {
-                                                silent: true,
-                                                evaluation,
-                                                force: true,
+                                        const updated = this._updateExistingVirtualPricingRuleItem(rule.name, {
+                                                freeQty: desiredQty,
+                                                multiplier: desiredMultiplier,
+                                                aggregated: evaluation.aggregated,
                                         });
+
+                                        if (!updated) {
+                                                await this.applyPricingRule(rule, {
+                                                        silent: true,
+                                                        evaluation,
+                                                        force: true,
+                                                });
+                                        }
                                         continue;
                                 }
 
@@ -2154,6 +2162,81 @@ export default {
 
                 this.pos_pricing_rules.splice(index, 1, updatedRecord);
                 this._pricingRuleRecordDirty = true;
+        },
+
+        _updateExistingVirtualPricingRuleItem(ruleName, details = {}) {
+                if (!ruleName || !Array.isArray(this.items) || !this.items.length) {
+                        return false;
+                }
+
+                const { freeQty, multiplier, aggregated } = details || {};
+                if (freeQty === undefined || freeQty === null) {
+                        return false;
+                }
+
+                const resolveNumber = (value, absolute = false) => {
+                        const parsed = typeof this.flt === "function" ? this.flt(value) : parseFloat(value);
+                        if (!Number.isFinite(parsed)) {
+                                return null;
+                        }
+                        return absolute ? Math.abs(parsed) : parsed;
+                };
+
+                const desiredQty = resolveNumber(freeQty, true);
+                if (desiredQty === null) {
+                        return false;
+                }
+
+                const record = Array.isArray(this.pos_pricing_rules)
+                        ? this.pos_pricing_rules.find((entry) => entry && entry.name === ruleName)
+                        : null;
+                if (!record) {
+                        return false;
+                }
+
+                const epsilon = 0.000001;
+                const target = (() => {
+                        if (record.row_id) {
+                                const matchByRow = this.items.find((item) => item && item.posa_row_id === record.row_id);
+                                if (matchByRow) {
+                                        return matchByRow;
+                                }
+                        }
+
+                        const matchByRule = this.items.find(
+                                (item) =>
+                                        item &&
+                                        item.posa_pricing_rule_virtual &&
+                                        item.pricing_rule === ruleName,
+                        );
+                        return matchByRule || null;
+                })();
+
+                if (!target) {
+                        return false;
+                }
+
+                const currentQty = resolveNumber(target.qty, true) || 0;
+                if (Math.abs(currentQty - desiredQty) <= epsilon) {
+                        this._refreshPricingRuleRecord(ruleName, { freeQty: desiredQty, multiplier, aggregated });
+                        return true;
+                }
+
+                target.qty = desiredQty;
+                target.stock_qty = desiredQty;
+                this._markVirtualFreeItem(target);
+
+                if (typeof this.calc_stock_qty === "function") {
+                        this.calc_stock_qty(target, target.qty);
+                }
+
+                this._refreshPricingRuleRecord(ruleName, { freeQty: desiredQty, multiplier, aggregated });
+
+                if (typeof this.$forceUpdate === "function") {
+                        this.$forceUpdate();
+                }
+
+                return true;
         },
 
         _syncDocItemsWithPricingRuleRecords() {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1261,7 +1261,8 @@ export default {
                                         return false;
                                 }
 
-                                const { freeItemCode, freeQty, multiplier, aggregated } = evaluationResult;
+                                const { freeItemCode, freeQty, multiplier, aggregated, base_qty, base_amount } =
+                                        evaluationResult;
                                 const newItem = this._createVirtualPricingRuleItem(rule, freeItemCode, freeQty);
                                 if (!newItem) {
                                         return false;
@@ -1287,6 +1288,8 @@ export default {
                                         posa_applied_free_qty: freeQty,
                                         posa_base_qty: aggregated?.qty ?? null,
                                         posa_base_amount: aggregated?.amount ?? null,
+                                        posa_cycle_qty: base_qty ?? null,
+                                        posa_cycle_amount: base_amount ?? null,
                                 };
 
                                 this._registerPricingRuleRecord(rule, newItem, {
@@ -1294,6 +1297,8 @@ export default {
                                         free_item: freeItemCode,
                                         free_qty: freeQty,
                                         rule_data: recordRuleData,
+                                        base_qty: base_qty,
+                                        base_amount: base_amount,
                                 });
                                 this.emitPricingRulesState();
                         } else if (rule.is_price_discount) {
@@ -1709,7 +1714,36 @@ export default {
                         return null;
                 }
 
-                const { silent = false } = options || {};
+                const { silent = false, record = null } = options || {};
+                const recordContext = (() => {
+                        if (record) {
+                                return record;
+                        }
+
+                        if (!rule || typeof rule !== "object") {
+                                return null;
+                        }
+
+                        const candidate = {};
+                        if (rule.rule_data && typeof rule.rule_data === "object") {
+                                candidate.rule_data = rule.rule_data;
+                        }
+                        if (rule.free_qty !== undefined) {
+                                candidate.free_qty = rule.free_qty;
+                        }
+                        if (rule.multiplier !== undefined) {
+                                candidate.multiplier = rule.multiplier;
+                        }
+                        if (rule.base_qty !== undefined) {
+                                candidate.base_qty = rule.base_qty;
+                        }
+                        if (rule.base_amount !== undefined) {
+                                candidate.base_amount = rule.base_amount;
+                        }
+
+                        return Object.keys(candidate).length ? candidate : null;
+                })();
+
                 const matchingItems = this._findItemsMatchingPricingRule(rule);
                 if (!matchingItems.length) {
                         if (!silent) {
@@ -1723,7 +1757,11 @@ export default {
 
                 const minQty = Math.abs(this.flt(rule.min_qty || 0));
                 const minAmt = Math.abs(this.flt(rule.min_amt || 0));
-                const allowMultiple = Boolean(rule.apply_multiple_pricing_rules);
+                const allowMultiple = Boolean(
+                        rule.apply_multiple_pricing_rules ||
+                                rule.rule_data?.apply_multiple_pricing_rules ||
+                                recordContext?.rule_data?.apply_multiple_pricing_rules,
+                );
 
                 const aggregated = matchingItems.reduce(
                         (acc, item) => {
@@ -1759,24 +1797,97 @@ export default {
                 }
 
                 let applications = 1;
+                let fallbackFreeQtyPerApplication = null;
+                let baseQtyPerApplication = minQty > 0 ? minQty : null;
+                let baseAmountPerApplication = minAmt > 0 ? minAmt : null;
                 if (allowMultiple) {
                         const multipliers = [];
                         if (minQty) {
                                 multipliers.push(Math.floor(aggregated.qty / minQty));
+                                baseQtyPerApplication = minQty;
                         }
                         if (minAmt) {
                                 multipliers.push(Math.floor(aggregated.amount / minAmt));
+                                baseAmountPerApplication = minAmt;
                         }
+
+                        if (!multipliers.length && recordContext) {
+                                const data =
+                                        recordContext.rule_data && typeof recordContext.rule_data === "object"
+                                                ? recordContext.rule_data
+                                                : {};
+                                const resolveNumber = (value) => Math.abs(this.flt(value || 0));
+                                const recordMultiplier = resolveNumber(
+                                        data.posa_applied_multiplier ??
+                                                data.multiplier ??
+                                                recordContext.multiplier ??
+                                                0,
+                                );
+                                const multiplierBaseline = recordMultiplier > 0 ? recordMultiplier : 1;
+
+                                const recordCycleQty = resolveNumber(
+                                        data.posa_cycle_qty ?? recordContext.base_qty ?? 0,
+                                );
+                                const recordCycleAmount = resolveNumber(
+                                        data.posa_cycle_amount ?? recordContext.base_amount ?? 0,
+                                );
+                                const recordAggregatedQty = resolveNumber(data.posa_base_qty ?? 0);
+                                const recordAggregatedAmount = resolveNumber(data.posa_base_amount ?? 0);
+                                const recordFreeQty = resolveNumber(
+                                        data.posa_applied_free_qty ??
+                                                recordContext.free_qty ??
+                                                rule.free_qty ??
+                                                0,
+                                );
+
+                                const derivedQtyPerApplication =
+                                        recordCycleQty && multiplierBaseline
+                                                ? recordCycleQty / multiplierBaseline
+                                                : recordAggregatedQty && multiplierBaseline
+                                                        ? recordAggregatedQty / multiplierBaseline
+                                                        : 0;
+                                const derivedAmountPerApplication =
+                                        recordCycleAmount && multiplierBaseline
+                                                ? recordCycleAmount / multiplierBaseline
+                                                : recordAggregatedAmount && multiplierBaseline
+                                                        ? recordAggregatedAmount / multiplierBaseline
+                                                        : 0;
+
+                                if (derivedQtyPerApplication > 0) {
+                                        multipliers.push(
+                                                Math.floor(aggregated.qty / derivedQtyPerApplication),
+                                        );
+                                        baseQtyPerApplication = derivedQtyPerApplication;
+                                }
+
+                                if (derivedAmountPerApplication > 0) {
+                                        multipliers.push(
+                                                Math.floor(aggregated.amount / derivedAmountPerApplication),
+                                        );
+                                        baseAmountPerApplication = derivedAmountPerApplication;
+                                }
+
+                                if (recordFreeQty > 0 && multiplierBaseline > 0) {
+                                        const computed = recordFreeQty / multiplierBaseline;
+                                        if (computed > 0) {
+                                                fallbackFreeQtyPerApplication = computed;
+                                        }
+                                }
+                        }
+
                         if (multipliers.length) {
                                 applications = Math.max(Math.min(...multipliers), 0);
-                        }
-                        if (!applications || applications < 1) {
-                                applications = 1;
+                                if (!applications || applications < 1) {
+                                        return null;
+                                }
                         }
                 }
 
                 const baseFreeQty = Math.abs(this.flt(rule.free_qty || 0));
-                const freeQtyPerApplication = baseFreeQty || 1;
+                const freeQtyPerApplication =
+                        fallbackFreeQtyPerApplication !== null
+                                ? fallbackFreeQtyPerApplication
+                                : baseFreeQty || 1;
                 const totalFreeQty = allowMultiple
                         ? freeQtyPerApplication * applications
                         : freeQtyPerApplication;
@@ -1808,6 +1919,8 @@ export default {
                         freeItemCode: resolvedFreeItemCode,
                         freeQty: totalFreeQty,
                         multiplier: allowMultiple ? applications : 1,
+                        base_qty: baseQtyPerApplication,
+                        base_amount: baseAmountPerApplication,
                         aggregated,
                         matchingItems,
                 };
@@ -2009,8 +2122,11 @@ export default {
                         }
 
                         if (rule.is_free_item_rule) {
-                                const evaluation = this._evaluateFreeItemPricingRule(rule, { silent: true });
                                 const record = appliedMap.get(rule.name);
+                                const evaluation = this._evaluateFreeItemPricingRule(rule, {
+                                        silent: true,
+                                        record,
+                                });
                                 if (!evaluation) {
                                         if (record) {
                                                 this.removePricingRule(rule.name);
@@ -2047,6 +2163,8 @@ export default {
                                                 freeQty: desiredQty,
                                                 multiplier: desiredMultiplier,
                                                 aggregated: evaluation.aggregated,
+                                                baseQty: evaluation.base_qty,
+                                                baseAmount: evaluation.base_amount,
                                         });
 
                                         if (!updated) {
@@ -2063,6 +2181,8 @@ export default {
                                         freeQty: desiredQty,
                                         multiplier: desiredMultiplier,
                                         aggregated: evaluation.aggregated,
+                                        baseQty: evaluation.base_qty,
+                                        baseAmount: evaluation.base_amount,
                                 });
                                 continue;
                         }
@@ -2150,6 +2270,12 @@ export default {
                                 nextRuleData.posa_base_amount = details.aggregated.amount;
                         }
                 }
+                if (details.baseQty !== undefined) {
+                        nextRuleData.posa_cycle_qty = details.baseQty;
+                }
+                if (details.baseAmount !== undefined) {
+                        nextRuleData.posa_cycle_amount = details.baseAmount;
+                }
 
                 const updatedRecord = {
                         ...record,
@@ -2158,6 +2284,12 @@ export default {
 
                 if (details.freeQty !== undefined) {
                         updatedRecord.free_qty = details.freeQty;
+                }
+                if (details.baseQty !== undefined) {
+                        updatedRecord.base_qty = details.baseQty;
+                }
+                if (details.baseAmount !== undefined) {
+                        updatedRecord.base_amount = details.baseAmount;
                 }
 
                 this.pos_pricing_rules.splice(index, 1, updatedRecord);
@@ -2218,7 +2350,13 @@ export default {
 
                 const currentQty = resolveNumber(target.qty, true) || 0;
                 if (Math.abs(currentQty - desiredQty) <= epsilon) {
-                        this._refreshPricingRuleRecord(ruleName, { freeQty: desiredQty, multiplier, aggregated });
+                        this._refreshPricingRuleRecord(ruleName, {
+                                freeQty: desiredQty,
+                                multiplier,
+                                aggregated,
+                                baseQty: details.baseQty,
+                                baseAmount: details.baseAmount,
+                        });
                         return true;
                 }
 
@@ -2230,7 +2368,13 @@ export default {
                         this.calc_stock_qty(target, target.qty);
                 }
 
-                this._refreshPricingRuleRecord(ruleName, { freeQty: desiredQty, multiplier, aggregated });
+                this._refreshPricingRuleRecord(ruleName, {
+                        freeQty: desiredQty,
+                        multiplier,
+                        aggregated,
+                        baseQty: details.baseQty,
+                        baseAmount: details.baseAmount,
+                });
 
                 if (typeof this.$forceUpdate === "function") {
                         this.$forceUpdate();
@@ -2349,12 +2493,21 @@ export default {
                         let desiredFreeItemCode = null;
 
                         if (ruleSource && typeof this._evaluateFreeItemPricingRule === "function") {
-                                const evaluation = this._evaluateFreeItemPricingRule(ruleSource, { silent: true });
+                                const evaluation = this._evaluateFreeItemPricingRule(ruleSource, {
+                                        silent: true,
+                                        record: slot.record,
+                                });
                                 if (evaluation) {
                                         desiredQty = Math.abs(toNumber(evaluation.freeQty));
                                         desiredMultiplier = evaluation.multiplier || null;
                                         aggregated = evaluation.aggregated || null;
                                         desiredFreeItemCode = evaluation.freeItemCode || null;
+                                        if (evaluation.base_qty !== undefined) {
+                                                slot.record.base_qty = evaluation.base_qty;
+                                        }
+                                        if (evaluation.base_amount !== undefined) {
+                                                slot.record.base_amount = evaluation.base_amount;
+                                        }
                                 }
                         }
 
@@ -2512,6 +2665,8 @@ export default {
                         rule_data: options.rule_data
                                 ? JSON.parse(JSON.stringify(options.rule_data))
                                 : JSON.parse(JSON.stringify(rule)),
+                        base_qty: options.base_qty !== undefined ? options.base_qty : null,
+                        base_amount: options.base_amount !== undefined ? options.base_amount : null,
                 };
 
                 this.pos_pricing_rules = Array.isArray(this.pos_pricing_rules)

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1504,6 +1504,10 @@ export default {
                                 return false;
                         }
 
+                        if (item.is_free_item) {
+                                return false;
+                        }
+
                         const normalizedItemCode = item.item_code ? `${item.item_code}`.trim() : "";
                         if (itemTargets.size && (!normalizedItemCode || !itemTargets.has(normalizedItemCode))) {
                                 return false;
@@ -2233,11 +2237,51 @@ export default {
                         ensureRowId(item);
 
                         const updatedRecord = { ...slot.record };
+
+                        const cloneRule = (source) => {
+                                if (!source) {
+                                        return null;
+                                }
+                                try {
+                                        return JSON.parse(JSON.stringify(source));
+                                } catch (error) {
+                                        console.warn("Failed to clone pricing rule data", error);
+                                        return { ...source };
+                                }
+                        };
+
+                        const ruleSource =
+                                cloneRule(updatedRecord.rule_data) ||
+                                cloneRule(
+                                        Array.isArray(this.pricing_rule_catalog)
+                                                ? this.pricing_rule_catalog.find(
+                                                          (entry) => entry && entry.name === updatedRecord.name,
+                                                  )
+                                                : null,
+                                );
+
+                        let desiredQty = null;
+                        let desiredMultiplier = null;
+                        let aggregated = null;
+                        let desiredFreeItemCode = null;
+
+                        if (ruleSource && typeof this._evaluateFreeItemPricingRule === "function") {
+                                const evaluation = this._evaluateFreeItemPricingRule(ruleSource, { silent: true });
+                                if (evaluation) {
+                                        desiredQty = Math.abs(toNumber(evaluation.freeQty));
+                                        desiredMultiplier = evaluation.multiplier || null;
+                                        aggregated = evaluation.aggregated || null;
+                                        desiredFreeItemCode = evaluation.freeItemCode || null;
+                                }
+                        }
+
                         const resolvedQty = Math.abs(
                                 toNumber(
-                                        updatedRecord.free_qty !== undefined && updatedRecord.free_qty !== null
-                                                ? updatedRecord.free_qty
-                                                : updatedRecord.rule_data?.posa_applied_free_qty ?? item.qty ?? 0,
+                                        desiredQty !== null && desiredQty !== undefined && !Number.isNaN(desiredQty)
+                                                ? desiredQty
+                                                : updatedRecord.free_qty !== undefined && updatedRecord.free_qty !== null
+                                                        ? updatedRecord.free_qty
+                                                        : updatedRecord.rule_data?.posa_applied_free_qty ?? item.qty ?? 0,
                                 ),
                         );
 
@@ -2248,12 +2292,24 @@ export default {
 
                         if (resolvedQty > 0) {
                                 updatedRecord.free_qty = resolvedQty;
-                                if (updatedRecord.rule_data) {
-                                        updatedRecord.rule_data = {
-                                                ...updatedRecord.rule_data,
-                                                posa_applied_free_qty: resolvedQty,
-                                        };
+                                const nextRuleData = cloneRule(updatedRecord.rule_data) || {};
+                                nextRuleData.posa_applied_free_qty = resolvedQty;
+                                if (desiredMultiplier !== null && desiredMultiplier !== undefined) {
+                                        nextRuleData.posa_applied_multiplier = desiredMultiplier;
                                 }
+                                if (aggregated && typeof aggregated === "object") {
+                                        if (aggregated.qty !== undefined) {
+                                                nextRuleData.posa_base_qty = aggregated.qty;
+                                        }
+                                        if (aggregated.amount !== undefined) {
+                                                nextRuleData.posa_base_amount = aggregated.amount;
+                                        }
+                                }
+                                updatedRecord.rule_data = nextRuleData;
+                        }
+
+                        if (desiredFreeItemCode) {
+                                updatedRecord.free_item = desiredFreeItemCode;
                         }
 
                         if (updatedRecord.row_id !== item.posa_row_id) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1966,15 +1966,15 @@ export default {
                                 );
 
                                 const derivedQtyPerApplication =
-                                        recordCycleQty && multiplierBaseline
-                                                ? recordCycleQty / multiplierBaseline
-                                                : recordAggregatedQty && multiplierBaseline
+                                        recordCycleQty && recordCycleQty > 0
+                                                ? recordCycleQty
+                                                : recordAggregatedQty && multiplierBaseline > 0
                                                         ? recordAggregatedQty / multiplierBaseline
                                                         : 0;
                                 const derivedAmountPerApplication =
-                                        recordCycleAmount && multiplierBaseline
-                                                ? recordCycleAmount / multiplierBaseline
-                                                : recordAggregatedAmount && multiplierBaseline
+                                        recordCycleAmount && recordCycleAmount > 0
+                                                ? recordCycleAmount
+                                                : recordAggregatedAmount && multiplierBaseline > 0
                                                         ? recordAggregatedAmount / multiplierBaseline
                                                         : 0;
 

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -1828,13 +1828,65 @@ export default {
                         return null;
                 }
 
+                const normalizeFlag = (value) => {
+                        if (value === undefined || value === null) {
+                                return null;
+                        }
+
+                        if (typeof value === "boolean") {
+                                return value;
+                        }
+
+                        if (typeof value === "number") {
+                                return value !== 0;
+                        }
+
+                        if (typeof value === "string") {
+                                const normalized = value.trim().toLowerCase();
+                                if (!normalized) {
+                                        return null;
+                                }
+
+                                if (["1", "true", "yes", "y", "on", "enable", "enabled"].includes(normalized)) {
+                                        return true;
+                                }
+
+                                if (["0", "false", "no", "n", "off", "disable", "disabled"].includes(normalized)) {
+                                        return false;
+                                }
+                        }
+
+                        return null;
+                };
+
+                const resolveFlag = (...candidates) => {
+                        for (const candidate of candidates) {
+                                const normalized = normalizeFlag(candidate);
+                                if (normalized !== null) {
+                                        return normalized;
+                                }
+                        }
+                        return false;
+                };
+
                 const minQty = Math.abs(this.flt(rule.min_qty || 0));
                 const minAmt = Math.abs(this.flt(rule.min_amt || 0));
-                const allowMultiple = Boolean(
-                        rule.apply_multiple_pricing_rules ||
-                                rule.rule_data?.apply_multiple_pricing_rules ||
-                                recordContext?.rule_data?.apply_multiple_pricing_rules,
+                let allowMultiple = resolveFlag(
+                        rule.apply_multiple_pricing_rules,
+                        rule.rule_data?.apply_multiple_pricing_rules,
+                        recordContext?.rule_data?.apply_multiple_pricing_rules,
+                        recordContext?.apply_multiple_pricing_rules,
+                        recordContext?.rule_data?.posa_apply_multiple_pricing_rules,
                 );
+
+                if (!allowMultiple) {
+                        const recordMultiplier = recordContext?.rule_data?.posa_applied_multiplier ??
+                                recordContext?.multiplier ??
+                                recordContext?.rule_data?.multiplier;
+                        if (recordMultiplier && Math.abs(this.flt(recordMultiplier)) > 1) {
+                                allowMultiple = true;
+                        }
+                }
 
                 const aggregated = matchingItems.reduce(
                         (acc, item) => {

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -133,10 +133,18 @@ export default {
 
                         if (!previous) {
                                 if (snapshot.order.length) {
-                                        this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                        const affected = [...new Set(snapshot.order)];
+                                        this.scheduleOfferRefresh(affected);
+                                        if (typeof this.schedulePricingRuleRefresh === "function") {
+                                                this.schedulePricingRuleRefresh(affected);
+                                        }
                                 }
                         } else if (changed.size) {
-                                this.scheduleOfferRefresh(Array.from(changed));
+                                const affected = Array.from(changed);
+                                this.scheduleOfferRefresh(affected);
+                                if (typeof this.schedulePricingRuleRefresh === "function") {
+                                        this.schedulePricingRuleRefresh(affected);
+                                }
                         }
 
                         if (typeof this.emitCartQuantities === "function") {
@@ -163,10 +171,18 @@ export default {
 
                         if (!previous) {
                                 if (snapshot.order.length) {
-                                        this.scheduleOfferRefresh([...new Set(snapshot.order)]);
+                                        const affected = [...new Set(snapshot.order)];
+                                        this.scheduleOfferRefresh(affected);
+                                        if (typeof this.schedulePricingRuleRefresh === "function") {
+                                                this.schedulePricingRuleRefresh(affected);
+                                        }
                                 }
                         } else if (changed.size) {
-                                this.scheduleOfferRefresh(Array.from(changed));
+                                const affected = Array.from(changed);
+                                this.scheduleOfferRefresh(affected);
+                                if (typeof this.schedulePricingRuleRefresh === "function") {
+                                        this.schedulePricingRuleRefresh(affected);
+                                }
                         }
 
                         if (typeof this.emitCartQuantities === "function") {

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -527,9 +527,13 @@ export function useItemAddition() {
                 if (typeof context.emitPricingRulesState === "function") {
                         context.emitPricingRulesState();
                 }
+                if (typeof context.cancelScheduledPricingRuleRefresh === "function") {
+                        context.cancelScheduledPricingRuleRefresh();
+                }
+                context._manuallySuppressedPricingRules = new Set();
                 context.invoice_doc = "";
-		context.return_doc = "";
-		context.discount_amount = 0;
+                context.return_doc = "";
+                context.discount_amount = 0;
 		context.additional_discount = 0;
 		context.additional_discount_percentage = 0;
 		context.delivery_charges_rate = 0;

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -519,11 +519,15 @@ export function useItemAddition() {
 	const clearInvoice = (context) => {
 		context.items = [];
 		context.packed_items = [];
-		context.posa_offers = [];
-		context.expanded = [];
-		context.eventBus.emit("set_pos_coupons", []);
-		context.posa_coupons = [];
-		context.invoice_doc = "";
+                context.posa_offers = [];
+                context.expanded = [];
+                context.eventBus.emit("set_pos_coupons", []);
+                context.posa_coupons = [];
+                context.pos_pricing_rules = [];
+                if (typeof context.emitPricingRulesState === "function") {
+                        context.emitPricingRulesState();
+                }
+                context.invoice_doc = "";
 		context.return_doc = "";
 		context.discount_amount = 0;
 		context.additional_discount = 0;

--- a/frontend/src/posapp/composables/usePricingRules.js
+++ b/frontend/src/posapp/composables/usePricingRules.js
@@ -1,0 +1,34 @@
+import { ref, getCurrentInstance } from "vue";
+
+export function usePricingRules() {
+        const { proxy } = getCurrentInstance();
+        const eventBus = proxy?.eventBus;
+        const pricingRules = ref([]);
+
+        function get_pricing_rules(profileName) {
+                if (!profileName) {
+                        pricingRules.value = [];
+                        eventBus?.emit("set_pricing_rules", []);
+                        return Promise.resolve([]);
+                }
+
+                return frappe
+                        .call("posawesome.posawesome.api.offers.get_pricing_rules", {
+                                profile: profileName,
+                        })
+                        .then((r) => {
+                                const rules = Array.isArray(r?.message) ? r.message : [];
+                                pricingRules.value = rules;
+                                eventBus?.emit("set_pricing_rules", rules);
+                                return rules;
+                        })
+                        .catch((error) => {
+                                console.error("Failed to fetch pricing rules:", error);
+                                pricingRules.value = [];
+                                eventBus?.emit("set_pricing_rules", []);
+                                return [];
+                        });
+        }
+
+        return { pricingRules, get_pricing_rules };
+}

--- a/posawesome/posawesome/api/offers.py
+++ b/posawesome/posawesome/api/offers.py
@@ -113,13 +113,16 @@ def get_pricing_rules(profile):
         )
         return []
 
+    rule_names = [rule.get("name") for rule in rules or [] if rule.get("name")]
+    child_targets = _load_pricing_rule_child_targets(rule_names)
+
     prepared = []
     for raw_rule in rules or []:
         rule = frappe._dict(raw_rule)
         if not _pricing_rule_matches_profile(rule, pos_profile, today):
             continue
 
-        serialized = _serialize_pricing_rule(rule, pos_profile)
+        serialized = _serialize_pricing_rule(rule, pos_profile, child_targets)
         if serialized:
             prepared.append(serialized)
 
@@ -437,7 +440,7 @@ def _pricing_rule_matches_profile(rule, pos_profile, today):
     return True
 
 
-def _serialize_pricing_rule(rule, pos_profile):
+def _serialize_pricing_rule(rule, pos_profile, child_targets=None):
     name = rule.get("name")
     if not name:
         return None
@@ -449,6 +452,11 @@ def _serialize_pricing_rule(rule, pos_profile):
     discount_amount = flt(rule.get("discount_amount") or 0)
     discount_percentage = flt(rule.get("discount_percentage") or 0)
     rate = flt(rule.get("rate") or 0)
+
+    child_targets = child_targets or {}
+    item_targets = child_targets.get("items", {}).get(name, [])
+    group_targets = child_targets.get("item_groups", {}).get(name, [])
+    brand_targets = child_targets.get("brands", {}).get(name, [])
 
     entry = {
         "name": name,
@@ -492,6 +500,12 @@ def _serialize_pricing_rule(rule, pos_profile):
         "rule_description": rule.get("rule_description") or "",
     }
 
+    entry["target_items"] = _deduplicate_targets([rule.get("item_code"), *item_targets])
+    entry["target_item_groups"] = _deduplicate_targets(
+        [rule.get("item_group"), *group_targets]
+    )
+    entry["target_brands"] = _deduplicate_targets([rule.get("brand"), *brand_targets])
+
     entry["is_product_discount"] = price_or_product_discount.lower() in {
         "product",
         "product discount",
@@ -505,3 +519,53 @@ def _serialize_pricing_rule(rule, pos_profile):
     entry["is_free_item_rule"] = bool(entry["free_item"] and entry["free_qty"])
 
     return entry
+
+
+def _load_pricing_rule_child_targets(rule_names):
+    if not rule_names:
+        return {"items": {}, "item_groups": {}, "brands": {}}
+
+    return {
+        "items": _group_pricing_rule_children(
+            "Pricing Rule Item Code", "item_code", rule_names
+        ),
+        "item_groups": _group_pricing_rule_children(
+            "Pricing Rule Item Group", "item_group", rule_names
+        ),
+        "brands": _group_pricing_rule_children(
+            "Pricing Rule Brand", "brand", rule_names
+        ),
+    }
+
+
+def _group_pricing_rule_children(doctype, fieldname, parents):
+    if not parents:
+        return {}
+
+    rows = frappe.get_all(
+        doctype,
+        filters={"parent": ("in", parents)},
+        fields=["parent", fieldname],
+    )
+
+    grouped = {}
+    for row in rows or []:
+        parent = row.get("parent")
+        value = row.get(fieldname)
+        if not parent or not value:
+            continue
+        grouped.setdefault(parent, []).append(value)
+
+    return grouped
+
+
+def _deduplicate_targets(candidates):
+    seen = set()
+    result = []
+    for value in candidates or []:
+        normalized = cstr(value).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result

--- a/posawesome/posawesome/api/offers.py
+++ b/posawesome/posawesome/api/offers.py
@@ -93,6 +93,40 @@ def get_offers(profile):
 
 
 @frappe.whitelist()
+def get_pricing_rules(profile):
+    pos_profile = frappe.get_doc("POS Profile", profile)
+    today = getdate(nowdate())
+
+    filters = {"selling": 1, "disable": 0}
+
+    try:
+        rules = frappe.get_all(
+            "Pricing Rule",
+            filters=filters,
+            fields=["*"],
+            order_by="priority desc, modified desc",
+        )
+    except Exception:
+        frappe.log_error(
+            frappe.get_traceback(),
+            "POS Awesome - Failed to fetch pricing rules",
+        )
+        return []
+
+    prepared = []
+    for raw_rule in rules or []:
+        rule = frappe._dict(raw_rule)
+        if not _pricing_rule_matches_profile(rule, pos_profile, today):
+            continue
+
+        serialized = _serialize_pricing_rule(rule, pos_profile)
+        if serialized:
+            prepared.append(serialized)
+
+    return prepared
+
+
+@frappe.whitelist()
 def get_applicable_delivery_charges(company, pos_profile, customer, shipping_address_name=None):
     return _get_applicable_delivery_charges(company, pos_profile, customer, shipping_address_name)
 
@@ -371,3 +405,103 @@ def _make_offer_identifier(*parts):
     if not cleaned:
         cleaned = [frappe.generate_hash(length=10)]
     return "ps-" + "-".join(cleaned)
+
+
+def _pricing_rule_matches_profile(rule, pos_profile, today):
+    company = rule.get("company")
+    if company and company != pos_profile.company:
+        return False
+
+    valid_from = rule.get("valid_from")
+    if valid_from and getdate(valid_from) > today:
+        return False
+
+    valid_upto = rule.get("valid_upto")
+    if valid_upto and getdate(valid_upto) < today:
+        return False
+
+    rule_pos_profile = rule.get("pos_profile")
+    if rule_pos_profile and rule_pos_profile != pos_profile.name:
+        return False
+
+    profile_price_list = getattr(pos_profile, "selling_price_list", None)
+    rule_price_list = rule.get("price_list") or rule.get("for_price_list")
+    if rule_price_list and profile_price_list and rule_price_list != profile_price_list:
+        return False
+
+    profile_warehouse = getattr(pos_profile, "warehouse", None)
+    rule_warehouse = rule.get("warehouse")
+    if rule_warehouse and profile_warehouse and rule_warehouse != profile_warehouse:
+        return False
+
+    return True
+
+
+def _serialize_pricing_rule(rule, pos_profile):
+    name = rule.get("name")
+    if not name:
+        return None
+
+    price_or_product_discount = (rule.get("price_or_product_discount") or "").strip()
+    rate_or_discount = (rule.get("rate_or_discount") or "").strip()
+
+    free_qty = flt(rule.get("free_qty") or 0)
+    discount_amount = flt(rule.get("discount_amount") or 0)
+    discount_percentage = flt(rule.get("discount_percentage") or 0)
+    rate = flt(rule.get("rate") or 0)
+
+    entry = {
+        "name": name,
+        "title": rule.get("pricing_rule_name")
+        or rule.get("title")
+        or rule.get("label")
+        or name,
+        "description": rule.get("description") or rule.get("rule_description") or "",
+        "company": rule.get("company"),
+        "pos_profile": pos_profile.name,
+        "price_or_product_discount": price_or_product_discount,
+        "apply_on": rule.get("apply_on"),
+        "applicable_for": rule.get("applicable_for"),
+        "customer": rule.get("customer"),
+        "customer_group": rule.get("customer_group"),
+        "territory": rule.get("territory"),
+        "sales_partner": rule.get("sales_partner"),
+        "item_code": rule.get("item_code"),
+        "item_group": rule.get("item_group"),
+        "brand": rule.get("brand"),
+        "warehouse": rule.get("warehouse"),
+        "valid_from": cstr(rule.get("valid_from")) if rule.get("valid_from") else None,
+        "valid_upto": cstr(rule.get("valid_upto")) if rule.get("valid_upto") else None,
+        "min_qty": flt(rule.get("min_qty") or 0),
+        "max_qty": flt(rule.get("max_qty") or 0),
+        "min_amt": flt(rule.get("min_amt") or 0),
+        "max_amt": flt(rule.get("max_amt") or 0),
+        "priority": rule.get("priority"),
+        "apply_discount_on": rule.get("apply_discount_on"),
+        "rate_or_discount": rate_or_discount,
+        "discount_percentage": discount_percentage,
+        "discount_amount": discount_amount,
+        "rate": rate,
+        "currency": rule.get("currency"),
+        "free_item": rule.get("free_item"),
+        "free_item_name": rule.get("free_item_name"),
+        "free_item_uom": rule.get("free_item_uom"),
+        "free_qty": free_qty,
+        "same_item": 1 if rule.get("same_item") else 0,
+        "apply_multiple_pricing_rules": 1 if rule.get("apply_multiple_pricing_rules") else 0,
+        "rule_description": rule.get("rule_description") or "",
+    }
+
+    entry["is_product_discount"] = price_or_product_discount.lower() in {
+        "product",
+        "product discount",
+        "free item",
+    }
+    entry["is_price_discount"] = price_or_product_discount.lower() in {
+        "price",
+        "price discount",
+        "discount",
+    }
+    entry["is_free_item_rule"] = bool(entry["free_item"] and entry["free_qty"])
+
+    return entry


### PR DESCRIPTION
## Summary
- add a backend endpoint and new POS components to surface pricing rules alongside offers and coupons
- allow operators to toggle pricing rules from a dedicated panel while keeping free-item giveaways virtual in the invoice payload
- update invoice handling, totals, and item table UX to tag free items and block editing of virtual giveaways

## Testing
- yarn --cwd frontend lint *(fails: Command "lint" not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8bf657a883268d0db8aef0edc976)