### PR TITLE
Ensure pricing rules persist after refreshing item details

### DIFF
--- a/frontend/src/lib/pricingEngine.js
+++ b/frontend/src/lib/pricingEngine.js
@@ -131,6 +131,11 @@ export const ruleSort = (a, b) => {
         return String(a.name || "").localeCompare(String(b.name || ""));
 };
 
+const normaliseQuantity = (value) => {
+        const numeric = Number.parseFloat(value);
+        return Number.isFinite(numeric) ? Math.abs(numeric) : 0;
+};
+
 const selectSlab = (rule, qty) => {
         if (!Array.isArray(rule.slabs) || !rule.slabs.length) {
                 return null;
@@ -229,8 +234,25 @@ const applyOneRule = (currentRate, rule, qty, baseRate) => {
 
 const isFreeRule = (rule) => rule && (rule.is_free_item_rule || (rule.price_or_discount || "").toLowerCase() === "product");
 
-export const applyLocalPricingRules = ({ item, qty, baseRate, ctx, indexes }) => {
-        const absoluteQty = Math.max(0, Number.parseFloat(qty || 0));
+export const applyLocalPricingRules = ({ item, qty, stockQty, baseRate, ctx, indexes }) => {
+        const saleQty = normaliseQuantity(qty);
+        let stockQtyValue = normaliseQuantity(stockQty);
+        if (!stockQtyValue) {
+                const conversion = Number.parseFloat(item?.conversion_factor || 1);
+                if (Number.isFinite(conversion)) {
+                        stockQtyValue = normaliseQuantity(saleQty * conversion);
+                }
+        }
+        if (!stockQtyValue) {
+                stockQtyValue = saleQty;
+        }
+
+        const resolveRuleQuantity = (rule) => (rule?.min_qty_as_per_stock_uom ? stockQtyValue : saleQty);
+        const minimumForRule = (rule) => {
+                const minimum = Number.parseFloat(rule?.min_qty ?? 0);
+                return Number.isFinite(minimum) ? minimum : 0;
+        };
+
         const effectiveBase = Number.isFinite(baseRate) ? baseRate : Number.parseFloat(item?.base_price_list_rate || item?.price_list_rate || item?.rate || 0);
         const startRate = Number.isFinite(effectiveBase) ? effectiveBase : 0;
 
@@ -240,10 +262,7 @@ export const applyLocalPricingRules = ({ item, qty, baseRate, ctx, indexes }) =>
                 .filter((rule) => inDateRange(ctx?.date, rule.valid_from, rule.valid_upto))
                 .filter((rule) => matchParty(rule, ctx?.customer, ctx?.customer_group, ctx?.territory))
                 .filter((rule) => matchPriceListAndCurrency(rule, ctx?.price_list, ctx?.currency))
-                .filter((rule) => {
-                        const minimum = Number.parseFloat(rule.min_qty || 0);
-                        return absoluteQty >= minimum;
-                })
+                .filter((rule) => resolveRuleQuantity(rule) >= minimumForRule(rule))
                 .sort(ruleSort);
 
         if (!filtered.length) {
@@ -254,7 +273,8 @@ export const applyLocalPricingRules = ({ item, qty, baseRate, ctx, indexes }) =>
         let rate = startRate;
 
         for (const rule of filtered) {
-                const { newRate, discount, detail } = applyOneRule(rate, rule, absoluteQty, startRate);
+                const basisQty = resolveRuleQuantity(rule);
+                const { newRate, discount, detail } = applyOneRule(rate, rule, basisQty, startRate);
                 rate = newRate;
                 if (detail) {
                         applied.push(detail);
@@ -274,31 +294,50 @@ export const applyLocalPricingRules = ({ item, qty, baseRate, ctx, indexes }) =>
         };
 };
 
-const computeThresholdInfo = (rule, qty) => {
+const computeThresholdInfo = (rule, saleQty, stockQty) => {
         const minimum = Number.parseFloat(rule.min_qty || rule.recurse_for || 1) || 1;
+        const basisQtyRaw = rule?.min_qty_as_per_stock_uom ? stockQty : saleQty;
+        const basisQty = Number.isFinite(basisQtyRaw) ? Math.max(0, basisQtyRaw) : 0;
+
         let multiplier = 0;
 
         if (rule.apply_per_threshold || rule.is_recursive || rule.recurse_for) {
                 const divisor = Number.parseFloat(rule.recurse_for || rule.min_qty || 1) || 1;
-                multiplier = Math.floor(qty / divisor);
+                const safeDivisor = divisor > 0 ? divisor : 1;
+                multiplier = Math.floor(basisQty / safeDivisor);
         } else {
-                multiplier = qty >= minimum ? 1 : 0;
+                multiplier = basisQty >= minimum ? 1 : 0;
         }
 
-        return { minimum, multiplier };
+        return { minimum, multiplier, basisQty };
 };
 
-export const computeFreeItems = ({ item, qty, ctx, indexes }) => {
-        const absoluteQty = Math.max(0, Number.parseFloat(qty || 0));
+export const computeFreeItems = ({ item, qty, stockQty, ctx, indexes }) => {
+        const saleQty = normaliseQuantity(qty);
+        let stockQtyValue = normaliseQuantity(stockQty);
+        if (!stockQtyValue) {
+                const conversion = Number.parseFloat(item?.conversion_factor || 1);
+                if (Number.isFinite(conversion)) {
+                        stockQtyValue = normaliseQuantity(saleQty * conversion);
+                }
+        }
+        if (!stockQtyValue) {
+                stockQtyValue = saleQty;
+        }
+
+        const resolveRuleQuantity = (rule) => (rule?.min_qty_as_per_stock_uom ? stockQtyValue : saleQty);
+        const minimumForRule = (rule) => {
+                const fallback = rule?.min_qty ?? rule?.recurse_for ?? 1;
+                const numeric = Number.parseFloat(fallback);
+                return Number.isFinite(numeric) ? (numeric || 1) : 1;
+        };
+
         const candidates = collectCandidates(item, indexes)
                 .filter((rule) => isFreeRule(rule))
                 .filter((rule) => inDateRange(ctx?.date, rule.valid_from, rule.valid_upto))
                 .filter((rule) => matchParty(rule, ctx?.customer, ctx?.customer_group, ctx?.territory))
                 .filter((rule) => matchPriceListAndCurrency(rule, ctx?.price_list, ctx?.currency))
-                .filter((rule) => {
-                        const minimum = Number.parseFloat(rule.min_qty || rule.recurse_for || 1) || 1;
-                        return absoluteQty >= minimum;
-                })
+                .filter((rule) => resolveRuleQuantity(rule) >= minimumForRule(rule))
                 .sort(ruleSort);
 
         if (!candidates.length) {
@@ -308,17 +347,17 @@ export const computeFreeItems = ({ item, qty, ctx, indexes }) => {
         const freebies = [];
 
         for (const rule of candidates) {
-        const { minimum, multiplier } = computeThresholdInfo(rule, absoluteQty);
-        let freeQty = 0;
-        const thresholdQty = minimum;
-        const freePerThreshold = rule.free_qty_per_unit
-                ? Number.parseFloat(rule.free_qty_per_unit || 0) || 0
-                : Number.parseFloat(rule.free_qty || 0) || 0;
+                const { minimum, multiplier, basisQty } = computeThresholdInfo(rule, saleQty, stockQtyValue);
+                let freeQty = 0;
+                const thresholdQty = minimum;
+                const freePerThreshold = rule.free_qty_per_unit
+                        ? Number.parseFloat(rule.free_qty_per_unit || 0) || 0
+                        : Number.parseFloat(rule.free_qty || 0) || 0;
 
                 if (rule.apply_per_threshold || rule.is_recursive || rule.recurse_for) {
                         freeQty = multiplier * freePerThreshold;
                 } else if (rule.free_qty_per_unit) {
-                        freeQty = absoluteQty * Number.parseFloat(rule.free_qty_per_unit || 0);
+                        freeQty = basisQty * Number.parseFloat(rule.free_qty_per_unit || 0);
                 } else {
                         freeQty = Number.parseFloat(rule.free_qty || 0) || 0;
                 }

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -151,17 +151,16 @@
 			<!-- Discount percentage column -->
                         <template v-slot:item.discount_value="{ item }">
                                 <div class="currency-display right-aligned">
-                                        <span class="amount-value">
-                                                {{
-                                                        formatFloat(
-                                                                Math.abs(
-                                                                        item.discount_percentage ||
-                                                                                (item.price_list_rate
-                                                                                        ? (item.discount_amount / item.price_list_rate) * 100
-                                                                                        : 0),
-                                                                ),
-                                                        )
-                                                }}%
+                                        <span
+                                                class="amount-value"
+                                                :class="{ 'preview-value': isPreviewDiscount(item) }"
+                                                :title="
+                                                        isPreviewDiscount(item)
+                                                                ? __('Pending pricing rule discount')
+                                                                : null
+                                                "
+                                        >
+                                                {{ formatFloat(getDisplayedDiscountPercentage(item)) }}%
                                         </span>
                                 </div>
                         </template>
@@ -170,7 +169,17 @@
 			<template v-slot:item.discount_amount="{ item }">
 				<div class="currency-display right-aligned">
 					<span class="currency-symbol">{{ currencySymbol(displayCurrency) }}</span>
-                                        <span class="amount-value">{{ formatCurrency(Math.abs(item.discount_amount || 0)) }}</span>
+                                        <span
+                                                class="amount-value"
+                                                :class="{ 'preview-value': isPreviewDiscount(item) }"
+                                                :title="
+                                                        isPreviewDiscount(item)
+                                                                ? __('Pending pricing rule discount')
+                                                                : null
+                                                "
+                                        >
+                                                {{ formatCurrency(getDisplayedDiscountAmount(item)) }}
+                                        </span>
                                 </div>
                         </template>
 
@@ -932,11 +941,79 @@ export default {
 			return this._rtlComputed;
 		},
 	},
-	methods: {
-		customItemFilter(value, search, item) {
-			if (search == null) {
-				return true;
-			}
+        methods: {
+                getDisplayedDiscountPercentage(item) {
+                        if (!item) {
+                                return 0;
+                        }
+
+                        const explicitPercentage = Number.parseFloat(item.discount_percentage ?? 0);
+                        if (Number.isFinite(explicitPercentage) && Math.abs(explicitPercentage) > 0) {
+                                return Math.abs(explicitPercentage);
+                        }
+
+                        const previewPercentage = Number.parseFloat(item?.posa_pricing_preview?.discount_percentage ?? 0);
+                        if (Number.isFinite(previewPercentage) && Math.abs(previewPercentage) > 0) {
+                                return Math.abs(previewPercentage);
+                        }
+
+                        const priceListRate = Number.parseFloat(item?.price_list_rate ?? 0);
+                        if (Number.isFinite(priceListRate) && Math.abs(priceListRate) > 0) {
+                                const discountAmount = Math.abs(Number.parseFloat(item?.discount_amount ?? 0));
+                                if (discountAmount > 0) {
+                                        const derived = (discountAmount / Math.abs(priceListRate)) * 100;
+                                        if (Number.isFinite(derived) && derived > 0) {
+                                                return derived;
+                                        }
+                                }
+                        }
+
+                        return 0;
+                },
+                getDisplayedDiscountAmount(item) {
+                        if (!item) {
+                                return 0;
+                        }
+
+                        const explicitAmount = Math.abs(Number.parseFloat(item.discount_amount ?? 0));
+                        if (Number.isFinite(explicitAmount) && explicitAmount > 0) {
+                                return explicitAmount;
+                        }
+
+                        const previewAmount = Math.abs(Number.parseFloat(item?.posa_pricing_preview?.discount_amount ?? 0));
+                        if (Number.isFinite(previewAmount) && previewAmount > 0) {
+                                return previewAmount;
+                        }
+
+                        return 0;
+                },
+                isPreviewDiscount(item) {
+                        if (!item) {
+                                return false;
+                        }
+
+                        const explicitAmount = Math.abs(Number.parseFloat(item.discount_amount ?? 0));
+                        const explicitPercentage = Math.abs(Number.parseFloat(item.discount_percentage ?? 0));
+                        if ((Number.isFinite(explicitAmount) && explicitAmount > 0) || (Number.isFinite(explicitPercentage) && explicitPercentage > 0)) {
+                                return false;
+                        }
+
+                        const preview = item.posa_pricing_preview || null;
+                        if (!preview) {
+                                return false;
+                        }
+
+                        const previewAmount = Math.abs(Number.parseFloat(preview.discount_amount ?? 0));
+                        const previewPercentage = Math.abs(Number.parseFloat(preview.discount_percentage ?? 0));
+                        return (
+                                (Number.isFinite(previewAmount) && previewAmount > 0) ||
+                                (Number.isFinite(previewPercentage) && previewPercentage > 0)
+                        );
+                },
+                customItemFilter(value, search, item) {
+                        if (search == null) {
+                                return true;
+                        }
 
 			const normalized = String(search).toLowerCase().trim();
 			if (!normalized) {
@@ -1315,15 +1392,20 @@ export default {
 /* Table wrapper styling */
 .pos-table :deep(.v-data-table__wrapper),
 .pos-table :deep(.v-table__wrapper) {
-	border-radius: 0;
-	height: 100%;
-	width: 100%;
-	max-width: 100%;
+        border-radius: 0;
+        height: 100%;
+        width: 100%;
+        max-width: 100%;
 	overflow-y: auto;
 	scrollbar-width: thin;
 	margin: 0;
 	padding: 0;
 	border: none;
+}
+
+.preview-value {
+        opacity: 0.75;
+        font-style: italic;
 }
 
 /* Enhanced table header styling with global theme support */

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -176,8 +176,21 @@ export default {
                 const allowRateUpdate = !item.locked_price && !item.posa_offer_applied && !item._manual_rate_set;
                 const signedQty = Number.parseFloat(item.qty || 0) || 0;
                 const qty = Math.abs(signedQty);
+                const rawStockQty = Number.parseFloat(item.stock_qty);
+                let stockQty = Number.isFinite(rawStockQty) ? Math.abs(rawStockQty) : NaN;
+                if (!Number.isFinite(stockQty) || stockQty === 0) {
+                        const conversion = Number.parseFloat(item.conversion_factor || 1) || 1;
+                        const computedStock = signedQty * conversion;
+                        const normalizedStock = Number.isFinite(computedStock)
+                                ? Math.abs(computedStock)
+                                : 0;
+                        stockQty = normalizedStock || qty;
+                }
+                if (!Number.isFinite(stockQty) || stockQty === 0) {
+                        stockQty = qty;
+                }
                 const baseRate = this._resolveBaseRate(item);
-                const pricing = applyLocalPricingRules({ item, qty, baseRate, ctx, indexes });
+                const pricing = applyLocalPricingRules({ item, qty, stockQty, baseRate, ctx, indexes });
 
                 this._updatePricingBadge(item, pricing.applied);
 
@@ -228,7 +241,7 @@ export default {
                                 : baseAmount;
                 }
 
-                const freebies = computeFreeItems({ item, qty, ctx, indexes });
+                const freebies = computeFreeItems({ item, qty, stockQty, ctx, indexes });
                 if (Array.isArray(freebies)) {
                         freebies.forEach((entry) => {
                                 const key = `${entry.rule}::${entry.item_code}::${item.posa_row_id}`;

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -195,6 +195,7 @@ export default {
                 this._updatePricingBadge(item, pricing.applied);
 
                 if (allowRateUpdate) {
+                        item.posa_pricing_preview = null;
                         const proposedRate = Number.isFinite(pricing.rate) ? pricing.rate : baseRate;
                         const proposedDiscount = Number.isFinite(pricing.discountPerUnit)
                                 ? pricing.discountPerUnit
@@ -239,6 +240,40 @@ export default {
                         item.base_amount = this.flt
                                 ? this.flt(baseAmount, this.currency_precision)
                                 : baseAmount;
+                } else {
+                        const baseDiscount = Math.abs(Number.parseFloat(pricing.discountPerUnit || 0)) || 0;
+                        if (baseDiscount > 0 && Number.isFinite(baseRate) && baseRate > 0) {
+                                const convertedDiscount = this._fromBaseCurrency(baseDiscount);
+                                const previewRateBase = Number.isFinite(pricing.rate) ? pricing.rate : baseRate;
+                                const previewRate = this._fromBaseCurrency(previewRateBase);
+                                const rawPercentage = baseRate ? (baseDiscount / baseRate) * 100 : 0;
+
+                                const normalizedBaseDiscount = this.flt
+                                        ? this.flt(baseDiscount, this.currency_precision)
+                                        : baseDiscount;
+                                const normalizedDiscount = this.flt
+                                        ? this.flt(Math.abs(convertedDiscount), this.currency_precision)
+                                        : Math.abs(convertedDiscount);
+                                const normalizedPercentage = this.flt
+                                        ? this.flt(Math.abs(rawPercentage), this.float_precision)
+                                        : Math.abs(rawPercentage);
+                                const normalizedPreviewRate = this.flt
+                                        ? this.flt(previewRate, this.currency_precision)
+                                        : previewRate;
+                                const normalizedPreviewBaseRate = this.flt
+                                        ? this.flt(previewRateBase, this.currency_precision)
+                                        : previewRateBase;
+
+                                item.posa_pricing_preview = {
+                                        discount_amount: normalizedDiscount,
+                                        base_discount_amount: normalizedBaseDiscount,
+                                        discount_percentage: normalizedPercentage,
+                                        rate: normalizedPreviewRate,
+                                        base_rate: normalizedPreviewBaseRate,
+                                };
+                        } else {
+                                item.posa_pricing_preview = null;
+                        }
                 }
 
                 const freebies = computeFreeItems({ item, qty, stockQty, ctx, indexes });

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -2673,11 +2673,16 @@ export default {
                                                 item.currency = resolvedCurrency;
                                         }
                                 });
+
+                                // Reapply pricing rules after server updates so that any
+                                // discounts based on quantity remain in effect even if the
+                                // refreshed price list rate differs from the discounted rate.
+                                await this.applyPricingRulesForCart();
                         }
                 } catch (error) {
-			console.error("Error updating items:", error);
-			this.eventBus.emit("show_message", {
-				title: __("Error updating item details"),
+                        console.error("Error updating items:", error);
+                        this.eventBus.emit("show_message", {
+                                title: __("Error updating item details"),
 				color: "error",
 			});
 		}

--- a/frontend/tests/invoiceItemMethods.spec.js
+++ b/frontend/tests/invoiceItemMethods.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/posapp/utils/stockCoordinator.js", () => ({
         default: {
@@ -175,6 +175,8 @@ describe("invoiceItemMethods._applyPricingToLine", () => {
                         base_price_list_rate: 100,
                         rate: 100,
                         base_rate: 100,
+                        stock_qty: 12,
+                        conversion_factor: 12,
                         locked_price: 0,
                         posa_offer_applied: 0,
                         _manual_rate_set: false,
@@ -187,6 +189,14 @@ describe("invoiceItemMethods._applyPricingToLine", () => {
                 });
 
                 invoiceItemMethods._applyPricingToLine.call(context, item, {}, {}, new Map());
+
+                const pricingArgs = applyLocalPricingRules.mock.calls[0][0];
+                expect(pricingArgs.qty).toBeCloseTo(1);
+                expect(pricingArgs.stockQty).toBeCloseTo(12);
+
+                const freebiesArgs = computeFreeItems.mock.calls[0][0];
+                expect(freebiesArgs.qty).toBeCloseTo(1);
+                expect(freebiesArgs.stockQty).toBeCloseTo(12);
 
                 expect(item.base_rate).toBeCloseTo(90);
                 expect(item.rate).toBeCloseTo(90);

--- a/frontend/tests/invoiceItemMethods.spec.js
+++ b/frontend/tests/invoiceItemMethods.spec.js
@@ -205,5 +205,51 @@ describe("invoiceItemMethods._applyPricingToLine", () => {
                 expect(item.base_discount_amount).toBeCloseTo(10);
                 expect(item.amount).toBeCloseTo(90);
                 expect(item.base_amount).toBeCloseTo(90);
+                expect(item.posa_pricing_preview).toBeNull();
+        });
+
+        it("stores a pricing preview when the rate is locked", () => {
+                const context = {
+                        ...createContext(),
+                        _fromBaseCurrency: invoiceItemMethods._fromBaseCurrency,
+                        _resolveBaseRate: invoiceItemMethods._resolveBaseRate,
+                        _updatePricingBadge: vi.fn(),
+                };
+
+                const item = {
+                        item_code: "ITEM-PREVIEW",
+                        qty: 2,
+                        price_list_rate: 200,
+                        base_price_list_rate: 200,
+                        rate: 200,
+                        base_rate: 200,
+                        discount_amount: 0,
+                        base_discount_amount: 0,
+                        stock_qty: 2,
+                        conversion_factor: 1,
+                        locked_price: 0,
+                        posa_offer_applied: 0,
+                        _manual_rate_set: true,
+                };
+
+                applyLocalPricingRules.mockReturnValue({
+                        rate: 150,
+                        discountPerUnit: 50,
+                        applied: [{ name: "RULE-PREVIEW" }],
+                });
+
+                invoiceItemMethods._applyPricingToLine.call(context, item, {}, {}, new Map());
+
+                expect(item.rate).toBe(200);
+                expect(item.base_rate).toBe(200);
+                expect(item.discount_amount).toBe(0);
+                expect(item.base_discount_amount).toBe(0);
+                expect(item.posa_pricing_preview).toMatchObject({
+                        discount_amount: 50,
+                        base_discount_amount: 50,
+                        discount_percentage: 25,
+                        rate: 150,
+                        base_rate: 150,
+                });
         });
 });

--- a/frontend/tests/pricingEngine.spec.js
+++ b/frontend/tests/pricingEngine.spec.js
@@ -152,6 +152,39 @@ describe("pricingEngine - applyLocalPricingRules", () => {
                 expect(result.rate).toBeCloseTo(90);
         });
 
+        it("uses stock quantity when min qty is defined per stock uom", () => {
+                const rule = {
+                        name: "STOCK-THRESH",
+                        price_or_discount: "Discount",
+                        discount_type: "Rate",
+                        rate_or_discount: 10,
+                        min_qty: 10,
+                        min_qty_as_per_stock_uom: 1,
+                        specificity: 3,
+                        priority: 5,
+                };
+                const indexes = buildIndexes({ items: { "ITEM-STOCK": [rule] } });
+                const discounted = applyLocalPricingRules({
+                        item: { item_code: "ITEM-STOCK", conversion_factor: 12 },
+                        qty: 1,
+                        stockQty: 12,
+                        baseRate: 100,
+                        ctx: {},
+                        indexes,
+                });
+                expect(discounted.rate).toBeCloseTo(90);
+
+                const notDiscounted = applyLocalPricingRules({
+                        item: { item_code: "ITEM-STOCK", conversion_factor: 12 },
+                        qty: 1,
+                        stockQty: 6,
+                        baseRate: 100,
+                        ctx: {},
+                        indexes,
+                });
+                expect(notDiscounted.rate).toBeCloseTo(100);
+        });
+
         it("filters by customer and price list", () => {
                 const rule = {
                         name: "CUSTOM-RULE",
@@ -328,6 +361,38 @@ describe("pricingEngine - computeFreeItems", () => {
                         indexes,
                 });
                 expect(freebies).toHaveLength(0);
+        });
+
+        it("qualifies freebies using stock quantity when requested", () => {
+                const rule = {
+                        name: "FREE-STOCK",
+                        is_free_item_rule: 1,
+                        min_qty: 10,
+                        min_qty_as_per_stock_uom: 1,
+                        free_qty: 1,
+                        specificity: 3,
+                        priority: 5,
+                        same_item: 1,
+                };
+                const indexes = buildIndexes({ items: { "ITEM-STOCK": [rule] } });
+                const freebies = computeFreeItems({
+                        item: { item_code: "ITEM-STOCK", conversion_factor: 12 },
+                        qty: 1,
+                        stockQty: 12,
+                        ctx: {},
+                        indexes,
+                });
+                expect(freebies).toHaveLength(1);
+                expect(freebies[0].qty).toBe(1);
+
+                const none = computeFreeItems({
+                        item: { item_code: "ITEM-STOCK", conversion_factor: 12 },
+                        qty: 1,
+                        stockQty: 6,
+                        ctx: {},
+                        indexes,
+                });
+                expect(none).toHaveLength(0);
         });
 });
 


### PR DESCRIPTION
## Summary
- reapply pricing rules after refreshing invoice item details so quantity-based discounts keep their adjusted rate

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910d2fd49c48326ba1d94fc0fc2f455)