### PR TITLE
Ensure offer rate persists after item detail refresh

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -607,6 +607,8 @@ export default {
                         if (typeof this.$forceUpdate === "function") {
                                 this.$forceUpdate();
                         }
+
+                        this.ensureOfferRatePersistence(item);
                 } catch (error) {
                         console.error("Failed to apply pricing rules locally", error);
                 }
@@ -3367,16 +3369,85 @@ export default {
 		item.amount = this.flt(item.qty * item.rate, this.currency_precision);
 		item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
 
-		console.log(`Updated rates for ${item.item_code} on expand:`, {
-			base_rate: item.base_rate,
-			rate: item.rate,
+                console.log(`Updated rates for ${item.item_code} on expand:`, {
+                        base_rate: item.base_rate,
+                        rate: item.rate,
 			base_price_list_rate: item.base_price_list_rate,
 			price_list_rate: item.price_list_rate,
 			exchange_rate: this.exchange_rate,
 			selected_currency: this.selected_currency,
 			default_currency: this.pos_profile.currency,
-		});
-	},
+                });
+        },
+        ensureOfferRatePersistence(item) {
+                if (typeof this.ApplyOnPrice !== "function") {
+                        return;
+                }
+
+                if (!item || !item.posa_offer_applied) {
+                        return;
+                }
+
+                let appliedOfferIds = [];
+                if (item.posa_offers) {
+                        try {
+                                const parsed = typeof item.posa_offers === "string" ? JSON.parse(item.posa_offers) : item.posa_offers;
+                                if (Array.isArray(parsed)) {
+                                        appliedOfferIds = parsed.filter((rowId) => !!rowId);
+                                }
+                        } catch (error) {
+                                console.warn("Failed to parse posa_offers for item", error);
+                        }
+                }
+
+                if (!appliedOfferIds.length) {
+                        return;
+                }
+
+                const invoiceOffers = Array.isArray(this.posa_offers) ? this.posa_offers : [];
+                const offerCatalog = Array.isArray(this.posOffers) ? this.posOffers : [];
+
+                appliedOfferIds.forEach((rowId) => {
+                        if (!rowId) {
+                                return;
+                        }
+
+                        const invoiceOffer = invoiceOffers.find((entry) => entry && entry.row_id === rowId);
+
+                        let resolvedOffer =
+                                offerCatalog.find((entry) => entry && entry.row_id === rowId) ||
+                                (invoiceOffer &&
+                                        invoiceOffer.offer_name
+                                                ? offerCatalog.find(
+                                                          (entry) => entry && entry.name === invoiceOffer.offer_name,
+                                                  )
+                                                : null);
+
+                        if (!resolvedOffer && invoiceOffer) {
+                                resolvedOffer = { ...invoiceOffer };
+                                if (typeof resolvedOffer.items === "string") {
+                                        try {
+                                                const parsedItems = JSON.parse(resolvedOffer.items);
+                                                if (Array.isArray(parsedItems)) {
+                                                        resolvedOffer.items = parsedItems;
+                                                }
+                                        } catch (error) {
+                                                console.warn("Failed to parse stored offer items", error);
+                                        }
+                                }
+                        }
+
+                        if (!resolvedOffer || resolvedOffer.offer !== "Item Price") {
+                                return;
+                        }
+
+                        if (!Array.isArray(resolvedOffer.items)) {
+                                return;
+                        }
+
+                        this.ApplyOnPrice(resolvedOffer, { reapplyExisting: true });
+                });
+        },
 	// Fetch customer details (info, price list, etc)
 	async fetch_customer_details() {
 		var vm = this;

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1289,11 +1289,47 @@ export default {
 
                         if (!alreadyApplied) {
                                 if (!item.posa_offer_applied) {
-                                        const cf = flt(item.conversion_factor || 1);
-                                        item.original_base_rate = item.base_rate / cf;
-                                        item.original_base_price_list_rate = item.base_price_list_rate / cf;
-                                        item.original_rate = item.rate / cf;
-                                        item.original_price_list_rate = item.price_list_rate / cf;
+                                        const cfRaw = flt(item.conversion_factor || 1);
+                                        const cf = cfRaw > 0 ? cfRaw : 1;
+                                        const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+                                        const isForeignCurrency =
+                                                baseCurrency &&
+                                                this.selected_currency &&
+                                                this.selected_currency !== baseCurrency &&
+                                                this.exchange_rate;
+
+                                        const resolveBaseValue = (baseValue, displayedValue) => {
+                                                if (baseValue !== undefined && baseValue !== null) {
+                                                        return baseValue;
+                                                }
+
+                                                if (displayedValue === undefined || displayedValue === null) {
+                                                        return 0;
+                                                }
+
+                                                if (isForeignCurrency) {
+                                                        return displayedValue / this.exchange_rate;
+                                                }
+
+                                                return displayedValue;
+                                        };
+
+                                        const baseRate = resolveBaseValue(item.base_rate, item.rate);
+                                        const basePriceListRate = resolveBaseValue(
+                                                item.base_price_list_rate,
+                                                item.price_list_rate,
+                                        );
+
+                                        item.original_base_rate = this.flt(baseRate / cf, this.currency_precision);
+                                        item.original_base_price_list_rate = this.flt(
+                                                basePriceListRate / cf,
+                                                this.currency_precision,
+                                        );
+                                        item.original_rate = this.flt((item.rate || 0) / cf, this.currency_precision);
+                                        item.original_price_list_rate = this.flt(
+                                                (item.price_list_rate || 0) / cf,
+                                                this.currency_precision,
+                                        );
                                 }
                         }
 

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1166,136 +1166,150 @@ export default {
 		return new_item;
 	},
 
-	ApplyOnPrice(offer) {
-		if (!offer) return;
+        ApplyOnPrice(offer, options = {}) {
+                if (!offer) return;
 
-		const combined = [...this.items, ...this.packed_items];
-		combined.forEach((item) => {
-			// Check if offer.items exists and is valid
-			if (!item || !offer.items || !Array.isArray(offer.items)) return;
+                const { reapplyExisting = false } = options;
+                const combined = [...this.items, ...this.packed_items];
 
-			if (offer.items.includes(item.posa_row_id)) {
-				// Ensure posa_offers is initialized and valid
-				const item_offers = item.posa_offers ? JSON.parse(item.posa_offers) : [];
-				if (!Array.isArray(item_offers)) return;
+                const applyRatesForItem = (item, conversion_factor) => {
+                        if (offer.discount_type === "Rate") {
+                                const base_offer_rate = flt(offer.rate * conversion_factor);
+                                const normalizedBasePrice =
+                                        item.original_base_price_list_rate ??
+                                        (item.base_price_list_rate && conversion_factor
+                                                ? item.base_price_list_rate / conversion_factor
+                                                : item.price_list_rate / conversion_factor);
 
-				if (!item_offers.includes(offer.row_id)) {
-					// Store original rates only if this is the first offer being applied
-					if (!item.posa_offer_applied) {
-						// Store original prices normalized to conversion factor 1
-						const cf = flt(item.conversion_factor || 1);
-						item.original_base_rate = item.base_rate / cf;
-						item.original_base_price_list_rate = item.base_price_list_rate / cf;
-						item.original_rate = item.rate / cf;
-						item.original_price_list_rate = item.price_list_rate / cf;
-					}
+                                const base_price = this.flt(
+                                        (normalizedBasePrice || 0) * conversion_factor,
+                                        this.currency_precision,
+                                );
 
-					const conversion_factor = flt(item.conversion_factor || 1);
+                                item.base_rate = base_offer_rate;
+                                item.base_price_list_rate = base_price;
 
-					if (offer.discount_type === "Rate") {
-						// offer.rate is always in base currency (e.g. PKR)
-						const base_offer_rate = flt(offer.rate * conversion_factor);
+                                const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+                                if (this.selected_currency !== baseCurrency) {
+                                        item.rate = this.flt(
+                                                base_offer_rate * this.exchange_rate,
+                                                this.currency_precision,
+                                        );
+                                        item.price_list_rate = this.flt(
+                                                base_price * this.exchange_rate,
+                                                this.currency_precision,
+                                        );
+                                        item.discount_amount = this.flt(
+                                                (base_price - base_offer_rate) * this.exchange_rate,
+                                                this.currency_precision,
+                                        );
+                                } else {
+                                        item.rate = base_offer_rate;
+                                        item.price_list_rate = base_price;
+                                        item.discount_amount = this.flt(
+                                                base_price - base_offer_rate,
+                                                this.currency_precision,
+                                        );
+                                }
 
-						// Determine original base price for reference
-						const base_price = this.flt(
-							(item.original_base_price_list_rate ??
-								item.base_price_list_rate / conversion_factor) * conversion_factor,
-							this.currency_precision,
-						);
+                                item.base_discount_amount = this.flt(
+                                        base_price - base_offer_rate,
+                                        this.currency_precision,
+                                );
+                                item.discount_percentage = base_price
+                                        ? this.flt(
+                                                        (item.base_discount_amount / base_price) * 100,
+                                                        this.currency_precision,
+                                                )
+                                        : 0;
+                        } else if (offer.discount_type === "Discount Percentage") {
+                                item.discount_percentage = offer.discount_percentage;
 
-						// Set base rates and keep original price list rate
-						item.base_rate = base_offer_rate;
-						item.base_price_list_rate = base_price;
+                                const normalizedBasePrice =
+                                        item.original_base_price_list_rate ??
+                                        (item.base_price_list_rate && conversion_factor
+                                                ? item.base_price_list_rate / conversion_factor
+                                                : item.price_list_rate / conversion_factor);
 
-						// Convert to selected currency if needed
-						const baseCurrency = this.price_list_currency || this.pos_profile.currency;
-						if (this.selected_currency !== baseCurrency) {
-							// If exchange rate is 285 PKR = 1 USD
-							// To convert PKR to USD multiply by exchange rate
-							item.rate = this.flt(
-								base_offer_rate * this.exchange_rate,
-								this.currency_precision,
-							);
-							item.price_list_rate = this.flt(
-								base_price * this.exchange_rate,
-								this.currency_precision,
-							);
-							item.discount_amount = this.flt(
-								(base_price - base_offer_rate) * this.exchange_rate,
-								this.currency_precision,
-							);
-						} else {
-							item.rate = base_offer_rate;
-							item.price_list_rate = base_price;
-							item.discount_amount = this.flt(
-								base_price - base_offer_rate,
-								this.currency_precision,
-							);
-						}
+                                const base_price = this.flt(
+                                        (normalizedBasePrice || 0) * conversion_factor,
+                                        this.currency_precision,
+                                );
+                                const base_discount = this.flt(
+                                        (base_price * offer.discount_percentage) / 100,
+                                        this.currency_precision,
+                                );
 
-						// Compute base discount amounts and percentage
-						item.base_discount_amount = this.flt(
-							base_price - base_offer_rate,
-							this.currency_precision,
-						);
-						item.discount_percentage = base_price
-							? this.flt(
-									(item.base_discount_amount / base_price) * 100,
-									this.currency_precision,
-								)
-							: 0;
-					} else if (offer.discount_type === "Discount Percentage") {
-						item.discount_percentage = offer.discount_percentage;
+                                item.base_discount_amount = base_discount;
+                                item.base_rate = this.flt(base_price - base_discount, this.currency_precision);
+                                item.base_price_list_rate = base_price;
 
-						// Calculate discount in base currency first
-						// Use normalized price * current conversion factor
-						const base_price = this.flt(
-							(item.original_base_price_list_rate ??
-								item.base_price_list_rate / conversion_factor) * conversion_factor,
-							this.currency_precision,
-						);
-						const base_discount = this.flt(
-							(base_price * offer.discount_percentage) / 100,
-							this.currency_precision,
-						);
-						item.base_discount_amount = base_discount;
-						item.base_rate = this.flt(base_price - base_discount, this.currency_precision);
+                                const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+                                if (this.selected_currency !== baseCurrency) {
+                                        item.rate = this.flt(
+                                                item.base_rate * this.exchange_rate,
+                                                this.currency_precision,
+                                        );
+                                        item.price_list_rate = this.flt(
+                                                base_price * this.exchange_rate,
+                                                this.currency_precision,
+                                        );
+                                        item.discount_amount = this.flt(
+                                                base_discount * this.exchange_rate,
+                                                this.currency_precision,
+                                        );
+                                } else {
+                                        item.rate = item.base_rate;
+                                        item.price_list_rate = base_price;
+                                        item.discount_amount = base_discount;
+                                }
+                        }
 
-						// Keep price list rate at original price
-						item.base_price_list_rate = base_price;
+                        item.amount = this.flt(item.qty * item.rate, this.currency_precision);
+                        item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
+                        item.posa_offer_applied = 1;
+                };
 
-						// Convert to selected currency if needed
-						const baseCurrency = this.price_list_currency || this.pos_profile.currency;
-						if (this.selected_currency !== baseCurrency) {
-							item.rate = this.flt(
-								item.base_rate * this.exchange_rate,
-								this.currency_precision,
-							);
-							item.price_list_rate = this.flt(
-								base_price * this.exchange_rate,
-								this.currency_precision,
-							);
-							item.discount_amount = this.flt(
-								base_discount * this.exchange_rate,
-								this.currency_precision,
-							);
-						} else {
-							item.rate = item.base_rate;
-							item.price_list_rate = base_price;
-							item.discount_amount = base_discount;
-						}
-					}
+                combined.forEach((item) => {
+                        if (!item || !offer.items || !Array.isArray(offer.items)) return;
 
-					// Calculate final amounts
-					item.amount = this.flt(item.qty * item.rate, this.currency_precision);
-					item.base_amount = this.flt(item.qty * item.base_rate, this.currency_precision);
+                        if (!offer.items.includes(item.posa_row_id)) {
+                                return;
+                        }
 
-					item.posa_offer_applied = 1;
-					this.$forceUpdate();
-				}
-			}
-		});
-	},
+                        let item_offers = item.posa_offers ? JSON.parse(item.posa_offers) : [];
+                        if (!Array.isArray(item_offers)) {
+                                item_offers = [];
+                        }
+
+                        const alreadyApplied = item_offers.includes(offer.row_id);
+                        if (alreadyApplied && !reapplyExisting) {
+                                return;
+                        }
+
+                        if (!alreadyApplied) {
+                                if (!item.posa_offer_applied) {
+                                        const cf = flt(item.conversion_factor || 1);
+                                        item.original_base_rate = item.base_rate / cf;
+                                        item.original_base_price_list_rate = item.base_price_list_rate / cf;
+                                        item.original_rate = item.rate / cf;
+                                        item.original_price_list_rate = item.price_list_rate / cf;
+                                }
+                        }
+
+                        const conversion_factor = flt(item.conversion_factor || 1);
+                        applyRatesForItem(item, conversion_factor);
+
+                        if (!alreadyApplied) {
+                                item_offers.push(offer.row_id);
+                                item.posa_offers = JSON.stringify(item_offers);
+                        }
+
+                        if (typeof this.$forceUpdate === "function") {
+                                this.$forceUpdate();
+                        }
+                });
+        },
 
 	RemoveOnPrice(offer) {
 		if (!offer) return;

--- a/frontend/tests/invoiceItemMethods.spec.js
+++ b/frontend/tests/invoiceItemMethods.spec.js
@@ -31,6 +31,11 @@ const createContext = () => ({
         set_batch_qty: vi.fn(),
         calc_stock_qty: vi.fn(),
         eventBus: { emit: vi.fn() },
+        items: [],
+        packed_items: [],
+        posOffers: [],
+        posa_offers: [],
+        ApplyOnPrice: vi.fn(),
         flt(value, precision = null) {
                 const prec = precision !== null ? precision : this.float_precision;
                 const num = Number(value);
@@ -150,6 +155,93 @@ describe("invoiceItemMethods._applyItemDetailPayload", () => {
                 expect(item.base_discount_amount).toBeCloseTo(5);
                 expect(item.rate).toBeCloseTo(95);
                 expect(item.base_rate).toBeCloseTo(95);
+        });
+
+        it("reapplies item price offers after item detail refresh", () => {
+                const context = createContext();
+
+                const item = {
+                        item_code: "ITEM-OFFER",
+                        posa_row_id: "ROW-1",
+                        qty: 1,
+                        conversion_factor: 1,
+                        price_list_rate: 120,
+                        base_price_list_rate: 120,
+                        rate: 120,
+                        base_rate: 120,
+                        posa_offer_applied: 1,
+                        posa_offers: JSON.stringify(["OFFER-1"]),
+                        amount: 120,
+                        base_amount: 120,
+                        has_batch_no: 0,
+                        has_serial_no: 0,
+                };
+
+                context.items = [item];
+                context.posOffers = [
+                        {
+                                row_id: "OFFER-1",
+                                name: "Test Offer",
+                                offer: "Item Price",
+                                discount_type: "Rate",
+                                rate: 80,
+                                items: ["ROW-1"],
+                        },
+                ];
+                context.posa_offers = [
+                        {
+                                row_id: "OFFER-1",
+                                offer_name: "Test Offer",
+                                offer: "Item Price",
+                                items: JSON.stringify(["ROW-1"]),
+                        },
+                ];
+
+                context.ApplyOnPrice = vi.fn((offer, options) => {
+                        if (options?.reapplyExisting) {
+                                item.base_rate = 80;
+                                item.rate = 80;
+                                item.amount = 80;
+                                item.base_amount = 80;
+                        }
+                });
+
+                const data = {
+                        price_list_currency: "USD",
+                        uom: "Nos",
+                        conversion_factor: 1,
+                        item_uoms: [],
+                        allow_change_warehouse: 1,
+                        locked_price: 0,
+                        description: "",
+                        item_tax_template: "",
+                        discount_percentage: 0,
+                        warehouse: "Main",
+                        has_batch_no: 0,
+                        has_serial_no: 0,
+                        serial_no: null,
+                        batch_no: null,
+                        is_stock_item: 1,
+                        is_fixed_asset: 0,
+                        allow_alternative_item: 0,
+                        actual_qty: 0,
+                        price_list_rate: 120,
+                        last_purchase_rate: 0,
+                        projected_qty: 0,
+                        reserved_qty: 0,
+                        stock_qty: 0,
+                        stock_uom: "Nos",
+                };
+
+                invoiceItemMethods._applyItemDetailPayload.call(context, item, data);
+
+                expect(context.ApplyOnPrice).toHaveBeenCalledWith(
+                        expect.objectContaining({ row_id: "OFFER-1" }),
+                        { reapplyExisting: true },
+                );
+                expect(item.rate).toBe(80);
+                expect(item.base_rate).toBe(80);
+                expect(item.amount).toBe(80);
         });
 });
 

--- a/frontend/tests/invoiceOfferMethods.spec.js
+++ b/frontend/tests/invoiceOfferMethods.spec.js
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import invoiceOfferMethods from "../src/posapp/components/pos/invoiceOfferMethods.js";
+
+const fltMock = (value, precision = 2) => {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+                return 0;
+        }
+        return Number(num.toFixed(precision));
+};
+
+describe("invoiceOfferMethods.ApplyOnPrice", () => {
+        beforeEach(() => {
+                global.flt = fltMock;
+        });
+
+        afterEach(() => {
+                delete global.flt;
+        });
+
+        const createContext = () => ({
+                ...invoiceOfferMethods,
+                items: [],
+                packed_items: [],
+                posOffers: [],
+                posa_offers: [],
+                pos_profile: { currency: "PKR" },
+                price_list_currency: "PKR",
+                selected_currency: "PKR",
+                exchange_rate: 1,
+                currency_precision: 2,
+                $forceUpdate: vi.fn(),
+                flt: fltMock,
+        });
+
+        it("stores original base rates even when base values are missing", () => {
+                const ctx = createContext();
+                const item = {
+                        posa_row_id: "ROW-1",
+                        qty: 1,
+                        conversion_factor: 1,
+                        rate: 100,
+                        price_list_rate: 120,
+                        posa_offer_applied: 0,
+                        posa_offers: JSON.stringify([]),
+                };
+
+                ctx.items = [item];
+
+                const offer = {
+                        row_id: "OFFER-1",
+                        discount_type: "Rate",
+                        rate: 90,
+                        items: ["ROW-1"],
+                };
+
+                ctx.ApplyOnPrice.call(ctx, offer);
+
+                expect(item.rate).toBeCloseTo(90);
+                expect(item.price_list_rate).toBeCloseTo(120);
+                expect(item.discount_amount).toBeCloseTo(30);
+                expect(item.original_base_rate).toBeCloseTo(100);
+                expect(item.original_base_price_list_rate).toBeCloseTo(120);
+                expect(item.original_rate).toBeCloseTo(100);
+                expect(item.original_price_list_rate).toBeCloseTo(120);
+        });
+});
+


### PR DESCRIPTION
## Summary
- allow price offers to be re-applied without resetting stored offer metadata
- ensure invoice item detail updates reapply existing offer pricing so discounted rates persist
- extend the invoice item methods spec to cover the new offer persistence behaviour

## Testing
- yarn install --frozen-lockfile *(fails: registry returned 502 for @vitest/spy)*
- yarn test invoiceItemMethods *(blocked because vitest binary is unavailable until install succeeds)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910edeb8fe48326aeb81623f6daf793)