### PR TITLE
Respect manual item rates when applying offers

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3164,7 +3164,8 @@ export default {
 							newItem.price_list_rate = price;
 							newItem.base_rate = price;
 							newItem.base_price_list_rate = price;
-							newItem._manual_rate_set = true;
+                                                        newItem._manual_rate_set = true;
+                                                        newItem._manual_rate_source = "system";
 							newItem.skip_force_update = true;
 						}
 					} catch (e) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -533,6 +533,7 @@ export default {
                         freeLine.is_free_item = 1;
                         freeLine.locked_price = true;
                         freeLine._manual_rate_set = true;
+                        freeLine._manual_rate_source = "system";
                         freeLine.source_rule = data.rule;
                         freeLine.auto_free_source = key;
                         freeLine.parent_row_id = data.parentRowId;
@@ -2329,7 +2330,8 @@ export default {
 			return;
 		}
 
-		item._manual_rate_set = true;
+                item._manual_rate_set = true;
+                item._manual_rate_source = "user";
 
 		if (values.uom) {
 			item.uom = values.uom;

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1170,21 +1170,56 @@ export default {
 		if (!offer) return;
 
 		const combined = [...this.items, ...this.packed_items];
-		combined.forEach((item) => {
-			// Check if offer.items exists and is valid
-			if (!item || !offer.items || !Array.isArray(offer.items)) return;
+                combined.forEach((item) => {
+                        // Check if offer.items exists and is valid
+                        if (!item || !offer.items || !Array.isArray(offer.items)) return;
 
-			if (offer.items.includes(item.posa_row_id)) {
-				// Ensure posa_offers is initialized and valid
-				const item_offers = item.posa_offers ? JSON.parse(item.posa_offers) : [];
-				if (!Array.isArray(item_offers)) return;
+                        if (offer.items.includes(item.posa_row_id)) {
+                                // Ensure posa_offers is initialized and valid
+                                const item_offers = item.posa_offers ? JSON.parse(item.posa_offers) : [];
+                                if (!Array.isArray(item_offers)) return;
 
-				if (!item_offers.includes(offer.row_id)) {
-					// Store original rates only if this is the first offer being applied
-					if (!item.posa_offer_applied) {
-						// Store original prices normalized to conversion factor 1
-						const cf = flt(item.conversion_factor || 1);
-						item.original_base_rate = item.base_rate / cf;
+                                if (!item_offers.includes(offer.row_id)) {
+                                        const manualOverride = item._manual_rate_set === true;
+
+                                        if (manualOverride) {
+                                                // Preserve manually entered prices but still mark offer usage
+                                                item.posa_offer_applied = 1;
+
+                                                const qty = Number(item.qty) || 0;
+                                                const rate = Number(item.rate) || 0;
+
+                                                item.amount = this.flt(qty * rate, this.currency_precision);
+
+                                                const baseRate = Number(item.base_rate);
+                                                if (Number.isFinite(baseRate)) {
+                                                        item.base_amount = this.flt(qty * baseRate, this.currency_precision);
+                                                } else {
+                                                        const baseCurrency =
+                                                                this.price_list_currency || this.pos_profile.currency;
+                                                        if (this.selected_currency !== baseCurrency) {
+                                                                const exchange = Number(this.exchange_rate) || 1;
+                                                                item.base_amount = this.flt(
+                                                                        exchange
+                                                                                ? item.amount / exchange
+                                                                                : item.amount,
+                                                                        this.currency_precision,
+                                                                );
+                                                        } else {
+                                                                item.base_amount = item.amount;
+                                                        }
+                                                }
+
+                                                this.$forceUpdate();
+
+                                                return;
+                                        }
+
+                                        // Store original rates only if this is the first offer being applied
+                                        if (!item.posa_offer_applied) {
+                                                // Store original prices normalized to conversion factor 1
+                                                const cf = flt(item.conversion_factor || 1);
+                                                item.original_base_rate = item.base_rate / cf;
 						item.original_base_price_list_rate = item.base_price_list_rate / cf;
 						item.original_rate = item.rate / cf;
 						item.original_price_list_rate = item.price_list_rate / cf;
@@ -1301,19 +1336,30 @@ export default {
 		if (!offer) return;
 
 		const combined = [...this.items, ...this.packed_items];
-		combined.forEach((item) => {
-			if (!item || !item.posa_offers) return;
+                combined.forEach((item) => {
+                        if (!item || !item.posa_offers) return;
 
-			try {
-				const item_offers = JSON.parse(item.posa_offers);
-				if (!Array.isArray(item_offers)) return;
+                        try {
+                                const item_offers = JSON.parse(item.posa_offers);
+                                if (!Array.isArray(item_offers)) return;
 
-				if (item_offers.includes(offer.row_id)) {
-					// Check if we have original rates stored
-					if (!item.original_base_rate) {
-						console.warn("Original rates not found, fetching from server");
-						this.update_item_detail(item);
-						return;
+                                if (item_offers.includes(offer.row_id)) {
+                                        const manualOverride = item._manual_rate_set === true;
+                                        if (manualOverride) {
+                                                const remaining_offers = item_offers.filter((id) => id !== offer.row_id);
+                                                item.posa_offers = JSON.stringify(remaining_offers);
+                                                if (remaining_offers.length === 0) {
+                                                        item.posa_offer_applied = 0;
+                                                }
+                                                this.$forceUpdate();
+                                                return;
+                                        }
+
+                                        // Check if we have original rates stored
+                                        if (!item.original_base_rate) {
+                                                console.warn("Original rates not found, fetching from server");
+                                                this.update_item_detail(item);
+                                                return;
 					}
 
 					// Get current conversion factor

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1180,7 +1180,9 @@ export default {
                                 if (!Array.isArray(item_offers)) return;
 
                                 if (!item_offers.includes(offer.row_id)) {
-                                        const manualOverride = item._manual_rate_set === true;
+                                        const manualOverride =
+                                                item._manual_rate_set === true &&
+                                                item._manual_rate_source === "user";
 
                                         if (manualOverride) {
                                                 // Preserve manually entered prices but still mark offer usage
@@ -1344,7 +1346,9 @@ export default {
                                 if (!Array.isArray(item_offers)) return;
 
                                 if (item_offers.includes(offer.row_id)) {
-                                        const manualOverride = item._manual_rate_set === true;
+                                        const manualOverride =
+                                                item._manual_rate_set === true &&
+                                                item._manual_rate_source === "user";
                                         if (manualOverride) {
                                                 const remaining_offers = item_offers.filter((id) => id !== offer.row_id);
                                                 item.posa_offers = JSON.stringify(remaining_offers);

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -54,8 +54,9 @@ export function useDiscounts() {
 
 		try {
 			// Flag to track manual rate changes
-			if (fieldId === "rate") {
-				item._manual_rate_set = true;
+                        if (fieldId === "rate") {
+                                item._manual_rate_set = true;
+                                item._manual_rate_source = "user";
 			}
 
 			// Handle negative values

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -449,8 +449,9 @@ export function useItemAddition() {
 			item.posa_is_replace = "";
 		}
 
-		// Initialize flag for tracking manual rate changes
-		new_item._manual_rate_set = false;
+                // Initialize flag for tracking manual rate changes
+                new_item._manual_rate_set = false;
+                new_item._manual_rate_source = null;
 
 		// Set negative quantity for return invoices
 		if (context.isReturnInvoice && item.qty > 0) {

--- a/frontend/src/posapp/composables/useStockUtils.js
+++ b/frontend/src/posapp/composables/useStockUtils.js
@@ -70,6 +70,7 @@ export function useStockUtils() {
 
                 if (uomRate) {
                         item._manual_rate_set = true;
+                        item._manual_rate_source = "system";
 
 			// default rates based on fetched UOM price
 			let base_price = uomRate;
@@ -146,6 +147,7 @@ export function useStockUtils() {
                 const shouldPreserveManualRate =
                         value !== item.stock_uom || item.conversion_factor !== 1;
                 item._manual_rate_set = shouldPreserveManualRate;
+                item._manual_rate_source = shouldPreserveManualRate ? "system" : null;
 
 		// Reset discount if not offer
                 if (!item.posa_offer_applied) {


### PR DESCRIPTION
## Summary
- prevent offer application from overwriting manually edited item rates while keeping offer metadata consistent
- keep manual overrides intact when offer removal is triggered by skipping automatic restoration logic

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69119a3317d88326a22d256717ae79dc)