### PR TITLE
Fix manual rate overrides being reset by pricing rules

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -735,27 +735,32 @@ export default {
                         const discountPercentage =
                                 Number.parseFloat(update.discount_percentage ?? item.discount_percentage ?? 0) || 0;
 
-                        const convertedRate = fromBase(baseRate);
-                        const convertedPriceListRate = fromBase(basePriceListRate);
-                        const convertedDiscount = fromBase(baseDiscount);
+                        const manualOverride = item._manual_rate_set === true;
+                        const priceLocked = item.locked_price === true;
 
-                        item.base_rate = baseRate;
-                        item.base_price_list_rate = basePriceListRate;
-                        item.base_discount_amount = baseDiscount;
-                        item.discount_percentage = discountPercentage;
-                        item.rate = this.flt ? this.flt(convertedRate, precision) : convertedRate;
-                        item.price_list_rate = this.flt
-                                ? this.flt(convertedPriceListRate, precision)
-                                : convertedPriceListRate;
-                        item.discount_amount = this.flt
-                                ? this.flt(convertedDiscount, precision)
-                                : convertedDiscount;
-                        item.amount = this.flt
-                                ? this.flt(item.rate * item.qty, precision)
-                                : item.rate * item.qty;
-                        item.base_amount = this.flt
-                                ? this.flt(baseRate * item.qty, precision)
-                                : baseRate * item.qty;
+                        if (!manualOverride && !priceLocked) {
+                                const convertedRate = fromBase(baseRate);
+                                const convertedPriceListRate = fromBase(basePriceListRate);
+                                const convertedDiscount = fromBase(baseDiscount);
+
+                                item.base_rate = baseRate;
+                                item.base_price_list_rate = basePriceListRate;
+                                item.base_discount_amount = baseDiscount;
+                                item.discount_percentage = discountPercentage;
+                                item.rate = this.flt ? this.flt(convertedRate, precision) : convertedRate;
+                                item.price_list_rate = this.flt
+                                        ? this.flt(convertedPriceListRate, precision)
+                                        : convertedPriceListRate;
+                                item.discount_amount = this.flt
+                                        ? this.flt(convertedDiscount, precision)
+                                        : convertedDiscount;
+                                item.amount = this.flt
+                                        ? this.flt(item.rate * item.qty, precision)
+                                        : item.rate * item.qty;
+                                item.base_amount = this.flt
+                                        ? this.flt(baseRate * item.qty, precision)
+                                        : baseRate * item.qty;
+                        }
 
                         const rulesProvided = Object.prototype.hasOwnProperty.call(update, "pricing_rules");
                         const detailsProvided = Object.prototype.hasOwnProperty.call(update, "pricing_rule_details");

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -737,8 +737,12 @@ export default {
 
                         const manualOverride = item._manual_rate_set === true;
                         const priceLocked = item.locked_price === true;
+                        const offerApplied =
+                                item.posa_offer_applied === true ||
+                                item.posa_offer_applied === 1 ||
+                                item.posa_offer_applied === "1";
 
-                        if (!manualOverride && !priceLocked) {
+                        if (!manualOverride && !priceLocked && !offerApplied) {
                                 const convertedRate = fromBase(baseRate);
                                 const convertedPriceListRate = fromBase(basePriceListRate);
                                 const convertedDiscount = fromBase(baseDiscount);

--- a/frontend/tests/invoiceItemMethods.spec.js
+++ b/frontend/tests/invoiceItemMethods.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/posapp/utils/stockCoordinator.js", () => ({
         default: {
@@ -167,6 +167,7 @@ describe("invoiceItemMethods._applyPricingToLine", () => {
                         _resolveBaseRate: invoiceItemMethods._resolveBaseRate,
                         _updatePricingBadge: vi.fn(),
                 };
+                context._resolvePricingQty = invoiceItemMethods._resolvePricingQty;
 
                 const item = {
                         item_code: "ITEM-NEG",
@@ -195,5 +196,69 @@ describe("invoiceItemMethods._applyPricingToLine", () => {
                 expect(item.base_discount_amount).toBeCloseTo(10);
                 expect(item.amount).toBeCloseTo(90);
                 expect(item.base_amount).toBeCloseTo(90);
+        });
+});
+
+describe("invoiceItemMethods._applyServerPricingRules", () => {
+        it("does not override manual rate overrides from server responses", async () => {
+                const manualItem = {
+                        posa_row_id: "ROW-1",
+                        item_code: "ITEM-1",
+                        qty: 2,
+                        rate: 120,
+                        base_rate: 120,
+                        price_list_rate: 150,
+                        base_price_list_rate: 150,
+                        discount_amount: 60,
+                        base_discount_amount: 60,
+                        discount_percentage: 40,
+                        _manual_rate_set: true,
+                        locked_price: 0,
+                };
+
+                const context = {
+                        ...createContext(),
+                        items: [manualItem],
+                        _syncAutoFreeLines: vi.fn(),
+                        _updatePricingBadge: vi.fn(),
+                        $forceUpdate: vi.fn(),
+                };
+                context._fromBaseCurrency = invoiceItemMethods._fromBaseCurrency;
+                context._toBaseCurrency = invoiceItemMethods._toBaseCurrency;
+                context._resolvePricingQty = invoiceItemMethods._resolvePricingQty;
+
+                global.frappe = {
+                        call: vi.fn(async () => ({
+                                message: {
+                                        updates: [
+                                                {
+                                                        row_id: manualItem.posa_row_id,
+                                                        rate: 80,
+                                                        price_list_rate: 110,
+                                                        discount_amount: 30,
+                                                        discount_percentage: 27,
+                                                },
+                                        ],
+                                        free_lines: [],
+                                },
+                        })),
+                };
+
+                await invoiceItemMethods._applyServerPricingRules.call(context, {
+                        company: "Test Co",
+                        price_list: "Standard",
+                        currency: "USD",
+                });
+
+                expect(global.frappe.call).toHaveBeenCalledTimes(1);
+                expect(manualItem.rate).toBeCloseTo(120);
+                expect(manualItem.base_rate).toBeCloseTo(120);
+                expect(manualItem.price_list_rate).toBeCloseTo(150);
+                expect(manualItem.base_price_list_rate).toBeCloseTo(150);
+                expect(manualItem.discount_amount).toBeCloseTo(60);
+                expect(manualItem.base_discount_amount).toBeCloseTo(60);
+                expect(manualItem.discount_percentage).toBeCloseTo(40);
+
+                delete global.frappe;
         });
 });


### PR DESCRIPTION
## Summary
- stop server pricing rule reconciliation from overriding prices that were manually edited or locked in the cart
- extend the invoice item method tests to cover manual override preservation and provide missing helpers for pricing logic

## Testing
- cd frontend && yarn test --run invoiceItemMethods.spec.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911a0815270832697e52fe523ba074b)