### PR TITLE
Fix: REOPEN 0 Rate items in item selector #2425

### DIFF
--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -64,51 +64,34 @@ def _fetch_item_prices(
         "customer": customer or "",
     }
     query = """
-                    SELECT
-                            item_code,
-                            price_list_rate,
-                            currency,
-                            uom,
-                            customer
-                    FROM (
-                            SELECT
-                                    item_code,
-                                    price_list_rate,
-                                    currency,
-                                    uom,
-                                    customer,
-                                    valid_from,
-                                    valid_upto
-                            FROM `tabItem Price`
-                            WHERE
-                                    price_list = %(price_list)s
-                                    AND item_code IN %(item_codes)s
-                                    AND currency = %(currency)s
-                                    AND selling = 1
-                                    AND valid_from <= %(today)s
-                                    AND IFNULL(customer, '') IN ('', %(customer)s)
-                                    AND valid_upto >= %(today)s
-                            UNION ALL
-                            SELECT
-                                    item_code,
-                                    price_list_rate,
-                                    currency,
-                                    uom,
-                                    customer,
-                                    valid_from,
-                                    valid_upto
-                            FROM `tabItem Price`
-                            WHERE
-                                    price_list = %(price_list)s
-                                    AND item_code IN %(item_codes)s
-                                    AND currency = %(currency)s
-                                    AND selling = 1
-                                    AND valid_from <= %(today)s
-                                    AND IFNULL(customer, '') IN ('', %(customer)s)
-                                    AND (valid_upto IS NULL OR valid_upto = '')
-                    ) ip
-                    ORDER BY IFNULL(customer, '') ASC, valid_from ASC, valid_upto DESC
-            """
+        SELECT
+            item_code,
+            price_list_rate,
+            currency,
+            uom,
+            customer
+        FROM (
+            SELECT
+                item_code,
+                price_list_rate,
+                currency,
+                uom,
+                customer,
+                valid_from,
+                valid_upto
+            FROM `tabItem Price`
+            WHERE
+                price_list = %(price_list)s
+                AND item_code IN %(item_codes)s
+                AND currency = %(currency)s
+                AND selling = 1
+                AND (valid_from IS NULL OR valid_from <= %(today)s)
+                AND IFNULL(customer, '') IN ('', %(customer)s)
+                AND (valid_upto IS NULL OR valid_upto = '' OR valid_upto >= %(today)s)
+        ) ip
+        ORDER BY IFNULL(customer, '') ASC, valid_from ASC, valid_upto DESC
+    """
+
     return frappe.db.sql(query, params, as_dict=True)
 
 


### PR DESCRIPTION
 was also having same issue and i find out that in item_fetchers.py, there is a function to get item prices named "_fetch_item_prices". The query written in this function is expecting that all the records in "Item Price" doctype have a value for "valid_from" field. which in my case was null.

so i've changed the query and now the application is working fine for me.