### PR TITLE
Enhance cache clearing to fully reset offline state

### DIFF
--- a/frontend/src/offline.js
+++ b/frontend/src/offline.js
@@ -1199,16 +1199,24 @@ export async function forceClearAllCache() {
 	memory.customer_storage = [];
 	memory.pos_opening_storage = null;
 	memory.opening_dialog_storage = null;
-	memory.sales_persons_storage = [];
-	memory.price_list_cache = {};
-	memory.item_details_cache = {};
-	memory.tax_template_cache = {};
-	memory.tax_inclusive = false;
-	memory.manual_offline = false;
+        memory.sales_persons_storage = [];
+        memory.price_list_cache = {};
+        memory.item_details_cache = {};
+        memory.tax_template_cache = {};
+        memory.tax_inclusive = false;
+        memory.manual_offline = false;
+        memory.translation_cache = {};
+        memory.pricing_rules_snapshot = [];
+        memory.pricing_rules_context = null;
+        memory.pricing_rules_last_sync = null;
+        memory.pricing_rules_stale_at = null;
+        memory.print_template = "";
+        memory.terms_and_conditions = "";
+        memory.cache_ready = false;
 
-	try {
-		await Dexie.delete("posawesome_offline");
-	} catch (e) {
-		console.error("Failed to clear IndexedDB cache", e);
-	}
+        try {
+                await Dexie.delete("posawesome_offline");
+        } catch (e) {
+                console.error("Failed to clear IndexedDB cache", e);
+        }
 }

--- a/frontend/src/offline/cache.js
+++ b/frontend/src/offline/cache.js
@@ -544,31 +544,40 @@ export async function clearAllCache() {
 	memory.pos_last_sync_totals = { pending: 0, synced: 0, drafted: 0 };
 	memory.uom_cache = {};
 	memory.offers_cache = [];
-	memory.coupons_cache = {};
-	memory.customer_balance_cache = {};
-	memory.local_stock_cache = {};
-	memory.stock_cache_ready = false;
-	memory.customer_storage = [];
-	memory.items_last_sync = null;
-	memory.customers_last_sync = null;
-	memory.pos_opening_storage = null;
-	memory.opening_dialog_storage = null;
-	memory.sales_persons_storage = [];
-	memory.item_details_cache = {};
-	memory.tax_template_cache = {};
-	memory.item_groups_cache = [];
-	memory.cache_version = CACHE_VERSION;
-	memory.tax_inclusive = false;
-	memory.manual_offline = false;
+        memory.coupons_cache = {};
+        memory.customer_balance_cache = {};
+        memory.local_stock_cache = {};
+        memory.stock_cache_ready = false;
+        memory.customer_storage = [];
+        memory.items_last_sync = null;
+        memory.customers_last_sync = null;
+        memory.pos_opening_storage = null;
+        memory.opening_dialog_storage = null;
+        memory.sales_persons_storage = [];
+        memory.item_details_cache = {};
+        memory.tax_template_cache = {};
+        memory.item_groups_cache = [];
+        memory.translation_cache = {};
+        memory.pricing_rules_snapshot = [];
+        memory.pricing_rules_context = null;
+        memory.pricing_rules_last_sync = null;
+        memory.pricing_rules_stale_at = null;
+        memory.print_template = "";
+        memory.terms_and_conditions = "";
+        memory.cache_version = CACHE_VERSION;
+        memory.tax_inclusive = false;
+        memory.manual_offline = false;
+        memory.cache_ready = false;
 
-	await clearPriceListCache();
+        await clearPriceListCache();
 
-	persist("cache_version", CACHE_VERSION);
+        persist("cache_version", CACHE_VERSION);
+        persist("cache_ready", false);
 }
 
 // Faster cache clearing without reopening the database
 export async function forceClearAllCache() {
-	terminatePersistWorker();
+        terminatePersistWorker();
 	if (typeof localStorage !== "undefined") {
 		Object.keys(localStorage).forEach((key) => {
 			if (key.startsWith("posa_")) {
@@ -592,30 +601,39 @@ export async function forceClearAllCache() {
 	memory.customers_last_sync = null;
 	memory.pos_opening_storage = null;
 	memory.opening_dialog_storage = null;
-	memory.sales_persons_storage = [];
-	memory.item_details_cache = {};
-	memory.tax_template_cache = {};
-	memory.item_groups_cache = [];
-	memory.cache_version = CACHE_VERSION;
-	memory.tax_inclusive = false;
-	memory.manual_offline = false;
+        memory.sales_persons_storage = [];
+        memory.item_details_cache = {};
+        memory.tax_template_cache = {};
+        memory.item_groups_cache = [];
+        memory.translation_cache = {};
+        memory.pricing_rules_snapshot = [];
+        memory.pricing_rules_context = null;
+        memory.pricing_rules_last_sync = null;
+        memory.pricing_rules_stale_at = null;
+        memory.print_template = "";
+        memory.terms_and_conditions = "";
+        memory.cache_version = CACHE_VERSION;
+        memory.tax_inclusive = false;
+        memory.manual_offline = false;
+        memory.cache_ready = false;
 
-	if (typeof localStorage !== "undefined") {
-		localStorage.setItem("posa_cache_version", CACHE_VERSION);
-	}
+        if (typeof localStorage !== "undefined") {
+                localStorage.setItem("posa_cache_version", CACHE_VERSION);
+        }
 
-	await clearPriceListCache();
+        await clearPriceListCache();
 
-	// Delete the IndexedDB database in the background
-	try {
-		await Dexie.delete("posawesome_offline");
-		await db.open();
-		initPersistWorker();
-	} catch (e) {
-		console.error("Failed to clear IndexedDB cache", e);
-	}
+        // Delete the IndexedDB database in the background
+        try {
+                await Dexie.delete("posawesome_offline");
+                await db.open();
+                initPersistWorker();
+        } catch (e) {
+                console.error("Failed to clear IndexedDB cache", e);
+        }
 
-	persist("cache_version", CACHE_VERSION);
+        persist("cache_version", CACHE_VERSION);
+        persist("cache_ready", false);
 }
 
 /**

--- a/frontend/src/utils/clearAllCaches.js
+++ b/frontend/src/utils/clearAllCaches.js
@@ -1,9 +1,15 @@
+const DEFAULT_INDEXED_DB_NAMES = ["posawesome_offline"];
+
+async function delay(ms) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function clearLocalStorage(keys = []) {
-	if (typeof localStorage === "undefined") return;
-	try {
-		if (keys.length) {
-			keys.forEach((k) => localStorage.removeItem(k));
-		} else {
+        if (typeof localStorage === "undefined") return;
+        try {
+                if (keys.length) {
+                        keys.forEach((k) => localStorage.removeItem(k));
+                } else {
 			Object.keys(localStorage).forEach((key) => localStorage.removeItem(key));
 		}
 		console.log("[ClearAllCaches] localStorage cleared", keys.length ? keys : "all");
@@ -29,28 +35,42 @@ export async function clearSessionStorage(keys = []) {
 }
 
 export async function clearIndexedDB(databases = []) {
-	if (typeof indexedDB === "undefined") return;
-	try {
-		if (!databases.length && indexedDB.databases) {
-			const infos = await indexedDB.databases();
-			databases = infos.map((d) => d.name).filter(Boolean);
-		}
-		await Promise.all(
-			databases.map(
-				(dbName) =>
-					new Promise((resolve, reject) => {
-						const req = indexedDB.deleteDatabase(dbName);
-						req.onsuccess = () => resolve();
-						req.onblocked = () => resolve();
-						req.onerror = () => reject(req.error);
-					}),
-			),
-		);
-		console.log("[ClearAllCaches] IndexedDB cleared", databases.length ? databases : "all");
-	} catch (e) {
-		console.error("[ClearAllCaches] Failed to clear IndexedDB", e);
-		throw e;
-	}
+        if (typeof indexedDB === "undefined") return;
+        try {
+                let targets = Array.isArray(databases) ? [...databases] : [];
+
+                if (!targets.length && indexedDB.databases) {
+                        try {
+                                const infos = await indexedDB.databases();
+                                targets = infos.map((d) => d && d.name).filter(Boolean);
+                        } catch (enumerationError) {
+                                console.warn("[ClearAllCaches] Failed to enumerate IndexedDB databases", enumerationError);
+                        }
+                }
+                if (!targets.length) {
+                        targets = [...DEFAULT_INDEXED_DB_NAMES];
+                }
+
+                targets = Array.from(new Set(targets.filter(Boolean)));
+
+                await Promise.all(
+                        targets.map(
+                                (dbName) =>
+                                        new Promise((resolve, reject) => {
+                                                const req = indexedDB.deleteDatabase(dbName);
+                                                req.onsuccess = () => resolve();
+                                                req.onblocked = () => resolve();
+                                                req.onerror = () => reject(req.error);
+                                        }),
+                        ),
+                );
+                if (targets.length) {
+                        console.log("[ClearAllCaches] IndexedDB cleared", targets);
+                }
+        } catch (e) {
+                console.error("[ClearAllCaches] Failed to clear IndexedDB", e);
+                throw e;
+        }
 }
 
 export async function clearCacheAPI(cacheNames = []) {
@@ -63,48 +83,152 @@ export async function clearCacheAPI(cacheNames = []) {
 		console.log("[ClearAllCaches] Cache API cleared", cacheNames.length ? cacheNames : "all");
 	} catch (e) {
 		console.error("[ClearAllCaches] Failed to clear Cache API", e);
-		throw e;
-	}
+                throw e;
+        }
+}
+
+export async function unregisterServiceWorkers(scopes = []) {
+        if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+                return;
+        }
+
+        const requestedScopes = Array.isArray(scopes) ? scopes.filter(Boolean) : [];
+
+        const unregister = async (registration) => {
+                if (!registration) return;
+                try {
+                        const scope = registration.scope;
+                        await registration.unregister();
+                        if (registration.active) {
+                                try {
+                                        registration.active.postMessage({ type: "CLIENT_FORCE_UNREGISTER" });
+                                } catch (postMessageError) {
+                                        console.warn(
+                                                `[ClearAllCaches] Failed to notify active service worker for scope ${scope}`,
+                                                postMessageError,
+                                        );
+                                }
+                        }
+                        if (registration.waiting) {
+                                try {
+                                        registration.waiting.postMessage({ type: "CLIENT_FORCE_UNREGISTER" });
+                                } catch (postMessageError) {
+                                        console.warn(
+                                                `[ClearAllCaches] Failed to notify waiting service worker for scope ${scope}`,
+                                                postMessageError,
+                                        );
+                                }
+                        }
+                        if (registration.installing) {
+                                try {
+                                        registration.installing.postMessage({ type: "CLIENT_FORCE_UNREGISTER" });
+                                } catch (postMessageError) {
+                                        console.warn(
+                                                `[ClearAllCaches] Failed to notify installing service worker for scope ${scope}`,
+                                                postMessageError,
+                                        );
+                                }
+                        }
+                        return scope;
+                } catch (error) {
+                        console.error("[ClearAllCaches] Failed to unregister service worker", error);
+                        throw error;
+                }
+        };
+
+        try {
+                let registrations = [];
+                if (navigator.serviceWorker.getRegistrations) {
+                        registrations = await navigator.serviceWorker.getRegistrations();
+                } else if (navigator.serviceWorker.getRegistration) {
+                        const single = await navigator.serviceWorker.getRegistration();
+                        if (single) {
+                                registrations = [single];
+                        }
+                }
+
+                if (requestedScopes.length) {
+                        registrations = registrations.filter((registration) =>
+                                requestedScopes.some((scope) => registration.scope.includes(scope)),
+                        );
+                        // For scopes that did not have an eager registration fetch, try fetching directly
+                        const missingScopes = requestedScopes.filter(
+                                (scope) => !registrations.some((registration) => registration.scope.includes(scope)),
+                        );
+                        if (missingScopes.length && navigator.serviceWorker.getRegistration) {
+                                const fetched = await Promise.all(
+                                        missingScopes.map((scope) => navigator.serviceWorker.getRegistration(scope).catch(() => null)),
+                                );
+                                registrations.push(...fetched.filter(Boolean));
+                        }
+                }
+
+                if (!registrations.length) {
+                        return;
+                }
+
+                const scopesCleared = (await Promise.all(registrations.map((registration) => unregister(registration)))).filter(
+                        Boolean,
+                );
+
+                if (scopesCleared.length) {
+                        console.log("[ClearAllCaches] Service workers unregistered", scopesCleared);
+                }
+
+                // Allow the browser a brief moment to detach controllers before subsequent cache removal
+                await delay(100);
+        } catch (error) {
+                console.error("[ClearAllCaches] Failed during service worker cleanup", error);
+                throw error;
+        }
 }
 
 export async function clearAllCaches(
-	options = {
-		confirmBeforeClear: true,
-		onSuccess: () => {},
-		onError: () => {},
-		specificKeys: [],
-		specificDatabases: [],
-		specificCaches: [],
-		skipStorage: [],
-	},
+        options = {
+                confirmBeforeClear: true,
+                onSuccess: () => {},
+                onError: () => {},
+                specificKeys: [],
+                specificDatabases: [],
+                specificCaches: [],
+                skipStorage: [],
+                skipServiceWorkers: false,
+                serviceWorkerScopes: [],
+        },
 ) {
-	const opts = Object.assign(
-		{
-			confirmBeforeClear: true,
-			onSuccess: () => {},
-			onError: () => {},
-			specificKeys: [],
-			specificDatabases: [],
-			specificCaches: [],
-			skipStorage: [],
-		},
-		options || {},
-	);
+        const opts = Object.assign(
+                {
+                        confirmBeforeClear: true,
+                        onSuccess: () => {},
+                        onError: () => {},
+                        specificKeys: [],
+                        specificDatabases: [],
+                        specificCaches: [],
+                        skipStorage: [],
+                        skipServiceWorkers: false,
+                        serviceWorkerScopes: [],
+                },
+                options || {},
+        );
 
-	try {
+        try {
 		if (opts.confirmBeforeClear && typeof window !== "undefined") {
 			const confirmMsg = "Are you sure you want to clear application cache?";
 			if (!window.confirm(confirmMsg)) {
-				return;
-			}
-		}
+                                return;
+                        }
+                }
 
-		const tasks = [];
-		if (!opts.skipStorage.includes("localStorage")) {
-			tasks.push(clearLocalStorage(opts.specificKeys));
-		}
-		if (!opts.skipStorage.includes("sessionStorage")) {
-			tasks.push(clearSessionStorage(opts.specificKeys));
+                if (!opts.skipServiceWorkers) {
+                        await unregisterServiceWorkers(opts.serviceWorkerScopes);
+                }
+
+                const tasks = [];
+                if (!opts.skipStorage.includes("localStorage")) {
+                        tasks.push(clearLocalStorage(opts.specificKeys));
+                }
+                if (!opts.skipStorage.includes("sessionStorage")) {
+                        tasks.push(clearSessionStorage(opts.specificKeys));
 		}
 		if (!opts.skipStorage.includes("indexedDB")) {
 			tasks.push(clearIndexedDB(opts.specificDatabases));


### PR DESCRIPTION
## Summary
- reset offline memory caches and flags when clearing so the next launch behaves like a first-time load
- extend the cache clearing helper to unregister service workers and provide a fallback for deleting IndexedDB data on browsers without `indexedDB.databases`
