### PR TITLE
Add cash change return control and journal entry

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -490,11 +490,11 @@
 				<v-divider></v-divider>
 
 				<!-- Switches for Write Off and Credit Sale -->
-				<v-row class="pa-1" align="start" no-gutters>
-					<v-col
-						cols="6"
-						v-if="
-							invoice_doc &&
+                                <v-row class="pa-1" align="start" no-gutters>
+                                        <v-col
+                                                cols="6"
+                                                v-if="
+                                                        invoice_doc &&
 							pos_profile.posa_allow_write_off_change &&
 							credit_change > 0 &&
 							!invoice_doc.is_return
@@ -504,20 +504,38 @@
 							v-model="is_write_off_change"
 							flat
 							:label="frappe._('Write Off Difference Amount')"
-							class="my-0 pa-1"
-						></v-switch>
-					</v-col>
-					<v-col
-						cols="6"
+                                                        class="my-0 pa-1"
+                                                ></v-switch>
+                                        </v-col>
+                                        <v-col
+                                                cols="6"
 						v-if="invoice_doc && pos_profile.posa_allow_credit_sale && !invoice_doc.is_return"
 					>
-						<v-switch v-model="is_credit_sale" :label="frappe._('Credit Sale?')"></v-switch>
-					</v-col>
-					<v-col cols="6" v-if="invoice_doc && invoice_doc.is_return && pos_profile.use_cashback">
-						<v-switch
-							v-model="is_cashback"
-							flat
-							:label="frappe._('Cashback?')"
+                                                <v-switch v-model="is_credit_sale" :label="frappe._('Credit Sale?')"></v-switch>
+                                        </v-col>
+                                        <v-col
+                                                cols="12"
+                                                v-if="invoice_doc && !invoice_doc.is_return && change_due > 0"
+                                        >
+                                                <v-radio-group
+                                                        v-model="change_return_from_cash"
+                                                        inline
+                                                        hide-details
+                                                        :label="frappe._('Overpayment Change Return')"
+                                                        class="my-0 pa-1"
+                                                >
+                                                        <v-radio :label="frappe._('Return from Cash')" :value="true"></v-radio>
+                                                        <v-radio
+                                                                :label="frappe._('Do Not Return from Cash')"
+                                                                :value="false"
+                                                        ></v-radio>
+                                                </v-radio-group>
+                                        </v-col>
+                                        <v-col cols="6" v-if="invoice_doc && invoice_doc.is_return && pos_profile.use_cashback">
+                                                <v-switch
+                                                        v-model="is_cashback"
+                                                        flat
+                                                        :label="frappe._('Cashback?')"
 							class="my-0 pa-1"
 						></v-switch>
 					</v-col>
@@ -805,14 +823,15 @@ export default {
 			is_return: false, // Is this a return invoice?
 			loyalty_amount: 0, // Loyalty points to redeem
 			redeemed_customer_credit: 0, // Customer credit to redeem
-			credit_change: 0, // Change to be given as credit
-			paid_change: 0, // Change to be given as paid
-			is_credit_sale: false, // Is this a credit sale?
-			is_write_off_change: false, // Write-off for change enabled
-			is_cashback: true, // Cashback enabled
-			is_credit_return: false, // Is this a credit return?
-			redeem_customer_credit: false, // Redeem customer credit?
-			customer_credit_dict: [], // List of available customer credits
+                        credit_change: 0, // Change to be given as credit
+                        paid_change: 0, // Change to be given as paid
+                        is_credit_sale: false, // Is this a credit sale?
+                        is_write_off_change: false, // Write-off for change enabled
+                        change_return_from_cash: true, // Default overpayment change from cash
+                        is_cashback: true, // Cashback enabled
+                        is_credit_return: false, // Is this a credit return?
+                        redeem_customer_credit: false, // Redeem customer credit?
+                        customer_credit_dict: [], // List of available customer credits
 			paid_change_rules: [], // Validation rules for paid change
 			phone_dialog: false, // Show phone payment dialog
 			custom_days_dialog: false, // Show custom days dialog
@@ -965,6 +984,10 @@ export default {
                                 return false;
                         }
 
+                        if (this.change_return_from_cash) {
+                                return false;
+                        }
+
                         if (this.change_due <= 0) {
                                 return false;
                         }
@@ -1061,11 +1084,14 @@ export default {
                         }
 
                         const lastEditWasCash = this.last_payment_change_was_cash;
+                        const shouldAutoCreditChange =
+                                !this.change_return_from_cash &&
+                                (this.shouldAutoApplyCreditChange || lastEditWasCash === false);
 
                         if (newVal < 0) {
                                 const changeDue = -newVal;
 
-                                if (this.shouldAutoApplyCreditChange || lastEditWasCash === false) {
+                                if (shouldAutoCreditChange) {
                                         this.updateCreditChange(changeDue);
                                 } else {
                                         this.paid_change = changeDue;
@@ -1075,6 +1101,22 @@ export default {
                         }
 
                         this.last_payment_change_was_cash = null;
+                },
+                change_return_from_cash(newVal) {
+                        if (!this.invoice_doc || this.invoice_doc.is_return) {
+                                return;
+                        }
+
+                        const changeDue = Math.max(-this.diff_payment, 0);
+
+                        if (newVal) {
+                                this.paid_change = changeDue;
+                                this.credit_change = 0;
+                                this.invoice_doc.paid_change = changeDue;
+                                this.invoice_doc.credit_change = 0;
+                        } else if (changeDue > 0 && this.shouldAutoApplyCreditChange) {
+                                this.updateCreditChange(changeDue);
+                        }
                 },
                 // Watch paid_change to validate and update credit_change
                 paid_change(newVal) {
@@ -1506,14 +1548,15 @@ export default {
 				this.paid_change = paidChange;
 			}
 
-			let data = {
-				total_change: changeLimit,
-				paid_change: paidChange,
-				credit_change: creditChange,
-				redeemed_customer_credit: this.redeemed_customer_credit,
-				customer_credit_dict: this.customer_credit_dict,
-				is_cashback: this.is_cashback,
-			};
+                        let data = {
+                                total_change: changeLimit,
+                                paid_change: paidChange,
+                                credit_change: creditChange,
+                                redeemed_customer_credit: this.redeemed_customer_credit,
+                                customer_credit_dict: this.customer_credit_dict,
+                                is_cashback: this.is_cashback,
+                                change_return_from_cash: this.change_return_from_cash,
+                        };
 
 			if (isOffline()) {
 				try {
@@ -2274,11 +2317,12 @@ export default {
 	mounted() {
 		this.$nextTick(() => {
 			// Listen to various event bus events for POS actions
-			this.eventBus.on("send_invoice_doc_payment", (invoice_doc) => {
-				this.invoice_doc = invoice_doc;
-				const default_payment = this.invoice_doc.payments.find((payment) => payment.default === 1);
-				this.is_credit_sale = false;
-				this.is_write_off_change = false;
+                                this.eventBus.on("send_invoice_doc_payment", (invoice_doc) => {
+                                        this.invoice_doc = invoice_doc;
+                                        this.change_return_from_cash = true;
+                                        const default_payment = this.invoice_doc.payments.find((payment) => payment.default === 1);
+                                        this.is_credit_sale = false;
+                                        this.is_write_off_change = false;
 				if (invoice_doc.is_return) {
 					this.is_return = true;
 					this.is_credit_return = false;

--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -31,6 +31,7 @@ def before_submit(doc, method):
 
 def before_cancel(doc, method):
     update_coupon(doc, "cancelled")
+    cancel_change_return_payment_entries(doc)
 
 
 def on_cancel(doc, method):
@@ -69,6 +70,46 @@ def cancel_posawesome_credit_journal_entries(doc):
                 _(
                     "Unable to cancel Journal Entry {0} linked to this invoice. Please cancel it manually and try again."
                 ).format(journal_entry)
+            )
+
+
+def cancel_change_return_payment_entries(doc):
+    change_return_payments = frappe.get_all(
+        "Payment Entry",
+        filters={
+            "docstatus": 1,
+            "payment_type": "Pay",
+            "party_type": "Customer",
+            "reference_no": doc.name,
+        },
+        pluck="name",
+    )
+
+    if not change_return_payments:
+        return
+
+    for payment_name in change_return_payments:
+        payment_doc = frappe.get_doc("Payment Entry", payment_name)
+
+        has_reference = any(
+            ref.reference_doctype == doc.doctype and ref.reference_name == doc.name
+            for ref in payment_doc.get("references", [])
+        )
+
+        if not has_reference:
+            continue
+
+        try:
+            payment_doc.cancel()
+        except Exception:
+            frappe.log_error(
+                frappe.get_traceback(),
+                "POSAwesome Change Return Payment Cancellation Error",
+            )
+            frappe.throw(
+                _(
+                    "Unable to cancel Payment Entry {0} linked to this invoice. Please cancel it manually and try again."
+                ).format(payment_name)
             )
 
 

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -238,19 +238,26 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     pe.reference_no = invoice_doc.name
     pe.reference_date = pe.posting_date
 
+    invoice_outstanding = frappe.db.get_value(
+        invoice_doc.doctype, invoice_doc.name, "outstanding_amount"
+    )
+    invoice_outstanding = (
+        invoice_doc.get("outstanding_amount")
+        if invoice_outstanding is None
+        else invoice_outstanding
+    )
+    invoice_outstanding = max(flt(invoice_outstanding), 0)
+    allocated_amount = min(base_change_amount, invoice_outstanding)
+
     pe.append(
         "references",
         {
             "reference_doctype": invoice_doc.doctype,
             "reference_name": invoice_doc.name,
-            "allocated_amount": base_change_amount,
-            "total_amount": invoice_doc.get("outstanding_amount")
-            if invoice_doc.get("outstanding_amount") is not None
-            else invoice_doc.get("base_grand_total")
+            "allocated_amount": allocated_amount,
+            "total_amount": invoice_doc.get("base_grand_total")
             or invoice_doc.get("grand_total"),
-            "outstanding_amount": invoice_doc.get("outstanding_amount")
-            if invoice_doc.get("outstanding_amount") is not None
-            else base_change_amount,
+            "outstanding_amount": invoice_outstanding,
             "due_date": invoice_doc.get("due_date") or pe.posting_date,
         },
     )

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -226,11 +226,6 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     base_change_amount = flt(paid_change * conversion_rate)
 
     invoice_doc = frappe.get_doc(invoice_doc.doctype, invoice_doc.name)
-    invoice_outstanding = flt(
-        frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "outstanding_amount")
-        or invoice_doc.get("outstanding_amount")
-        or 0
-    )
 
     # Build a Payment Entry using ERPNext's helper to mirror the standard workflow
     try:
@@ -246,15 +241,8 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
         pe.append(
             "references",
             {
-                "reference_doctype": "Sales Invoice",
+                "reference_doctype": invoice_doc.doctype,
                 "reference_name": invoice_doc.name,
-                "outstanding_amount": invoice_outstanding,
-                "allocated_amount": 0,
-                "total_amount": invoice_doc.get("base_grand_total")
-                or invoice_doc.get("grand_total"),
-                "due_date": invoice_doc.get("due_date")
-                or invoice_doc.get("posting_date")
-                or nowdate(),
             },
         )
 
@@ -274,14 +262,8 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
 
     pe.setup_party_account_field()
     pe.set_missing_values()
-    pe.set_missing_ref_details()
 
-    # Align references with the invoice and cap allocation by the latest outstanding
-    latest_outstanding = flt(
-        frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "outstanding_amount")
-    )
-    allocated_amount = 0
-
+    # Keep a single Sales Invoice reference with only type and name, let helper fill the rest
     target_reference = None
     for ref in pe.get("references", []):
         if ref.reference_doctype == invoice_doc.doctype and ref.reference_name == invoice_doc.name:
@@ -298,21 +280,20 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
         )
         target_reference = pe.references[-1]
 
-    if latest_outstanding:
-        allocated_amount = min(base_change_amount, abs(latest_outstanding))
-
     target_reference.reference_doctype = invoice_doc.doctype
     target_reference.reference_name = invoice_doc.name
-    target_reference.outstanding_amount = latest_outstanding
-    target_reference.allocated_amount = allocated_amount
-    target_reference.total_amount = (
-        invoice_doc.get("base_grand_total") or invoice_doc.get("grand_total")
-    )
-    target_reference.due_date = (
-        invoice_doc.get("due_date") or invoice_doc.get("posting_date") or nowdate()
-    )
+    target_reference.allocated_amount = 0
+    target_reference.outstanding_amount = None
+    target_reference.total_amount = None
+    target_reference.due_date = None
 
     pe.set_missing_ref_details(force=True)
+
+    latest_outstanding = flt(target_reference.outstanding_amount)
+    if latest_outstanding > 0:
+        target_reference.allocated_amount = min(base_change_amount, latest_outstanding)
+    else:
+        target_reference.allocated_amount = 0
 
     ensure_child_doctype(pe, "references", "Payment Entry Reference")
     pe.flags.ignore_permissions = True

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -234,7 +234,13 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
 
     # Build a Payment Entry using ERPNext's helper to mirror the standard workflow
     try:
-        pe = get_payment_entry(invoice_doc.doctype, invoice_doc.name, bank_account=cash_account_name)
+        pe = get_payment_entry(
+            invoice_doc.doctype,
+            invoice_doc.name,
+            bank_account=cash_account_name,
+            payment_type="Pay",
+            party_amount=paid_change,
+        )
     except Exception:
         pe = frappe.new_doc("Payment Entry")
         pe.set("references", [])
@@ -272,39 +278,30 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     pe.set_missing_ref_details()
 
     # Align references with the invoice and cap allocation by outstanding
-    total_allocation = 0
-    for ref in pe.get("references", []):
-        ref.reference_doctype = invoice_doc.doctype
-        ref.reference_name = invoice_doc.name
-        if invoice_outstanding or invoice_outstanding == 0:
-            ref.outstanding_amount = invoice_outstanding
-        ref.total_amount = ref.total_amount or invoice_doc.get("base_grand_total") or invoice_doc.get("grand_total")
-        ref.due_date = ref.due_date or invoice_doc.get("due_date") or invoice_doc.get("posting_date") or nowdate()
+    latest_outstanding = flt(
+        frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "outstanding_amount")
+    )
+    allocated_amount = max(0, min(base_change_amount, latest_outstanding))
 
-        allowed = min(base_change_amount, flt(ref.outstanding_amount or 0))
-        if allowed < 0:
-            allowed = 0
-        ref.allocated_amount = allowed
-        total_allocation += allowed
+    # Rebuild the reference rows after helper calculations to ensure they persist
+    pe.set("references", [])
+    pe.append(
+        "references",
+        {
+            "reference_doctype": invoice_doc.doctype,
+            "reference_name": invoice_doc.name,
+            "outstanding_amount": latest_outstanding,
+            "allocated_amount": allocated_amount,
+            "total_amount": invoice_doc.get("base_grand_total")
+            or invoice_doc.get("grand_total"),
+            "due_date": invoice_doc.get("due_date")
+            or invoice_doc.get("posting_date")
+            or nowdate(),
+        },
+    )
 
-    if not pe.get("references"):
-        pe.append(
-            "references",
-            {
-                "reference_doctype": invoice_doc.doctype,
-                "reference_name": invoice_doc.name,
-                "outstanding_amount": invoice_outstanding,
-                "allocated_amount": min(base_change_amount, invoice_outstanding),
-                "total_amount": invoice_doc.get("base_grand_total")
-                or invoice_doc.get("grand_total"),
-                "due_date": invoice_doc.get("due_date")
-                or invoice_doc.get("posting_date")
-                or nowdate(),
-            },
-        )
-        total_allocation = min(base_change_amount, invoice_outstanding)
-
-    pe.unallocated_amount = max(0, base_change_amount - total_allocation)
+    pe.set_missing_ref_details(force=True)
+    pe.unallocated_amount = max(0, base_change_amount - allocated_amount)
 
     ensure_child_doctype(pe, "references", "Payment Entry Reference")
     pe.flags.ignore_permissions = True

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -246,8 +246,13 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
         if invoice_outstanding is None
         else invoice_outstanding
     )
-    invoice_outstanding = max(flt(invoice_outstanding), 0)
-    allocated_amount = min(base_change_amount, invoice_outstanding)
+    invoice_outstanding = flt(invoice_outstanding)
+    absolute_outstanding = abs(invoice_outstanding)
+    allocated_amount = (
+        base_change_amount
+        if not absolute_outstanding
+        else min(base_change_amount, absolute_outstanding)
+    )
 
     pe.append(
         "references",

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -224,19 +224,7 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     conversion_rate = invoice_doc.conversion_rate or 1
     base_change_amount = flt(paid_change * conversion_rate)
 
-    pe = frappe.new_doc("Payment Entry")
-    pe.payment_type = "Pay"
-    pe.company = invoice_doc.company
-    pe.mode_of_payment = selected_mode_of_payment
-    pe.party_type = "Customer"
-    pe.party = invoice_doc.get("customer")
-    pe.posting_date = invoice_doc.get("posting_date") or nowdate()
-    pe.paid_from = cash_account_name
-    pe.paid_to = party_account
-    pe.reference_no = invoice_doc.name
-    pe.reference_date = pe.posting_date
-
-    invoice_doc.reload()
+    invoice_doc = frappe.get_doc(invoice_doc.doctype, invoice_doc.name)
     invoice_outstanding = frappe.db.get_value(
         invoice_doc.doctype, invoice_doc.name, "outstanding_amount"
     )
@@ -250,40 +238,63 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     if invoice_outstanding > 0:
         allocated_amount = min(base_change_amount, invoice_outstanding)
 
-    pe.append(
-        "references",
+    pe = frappe.get_doc(
         {
-            "reference_doctype": invoice_doc.doctype,
-            "reference_name": invoice_doc.name,
-            "allocated_amount": allocated_amount,
-            "total_amount": invoice_doc.get("base_grand_total")
-            or invoice_doc.get("grand_total"),
-            "outstanding_amount": invoice_outstanding,
-            "due_date": invoice_doc.get("due_date") or pe.posting_date,
-        },
+            "doctype": "Payment Entry",
+            "payment_type": "Pay",
+            "company": invoice_doc.company,
+            "mode_of_payment": selected_mode_of_payment,
+            "party_type": "Customer",
+            "party": invoice_doc.get("customer"),
+            "posting_date": invoice_doc.get("posting_date") or nowdate(),
+            "paid_from": cash_account_name,
+            "paid_to": party_account,
+            "reference_no": invoice_doc.name,
+            "reference_date": invoice_doc.get("posting_date") or nowdate(),
+            "paid_amount": base_change_amount,
+            "received_amount": base_change_amount,
+            "references": [
+                {
+                    "reference_doctype": invoice_doc.doctype,
+                    "reference_name": invoice_doc.name,
+                    "allocated_amount": allocated_amount,
+                    "total_amount": invoice_doc.get("base_grand_total")
+                    or invoice_doc.get("grand_total"),
+                    "outstanding_amount": invoice_outstanding,
+                    "due_date": invoice_doc.get("due_date")
+                    or invoice_doc.get("posting_date")
+                    or nowdate(),
+                }
+            ],
+        }
     )
 
     pe.remarks = _("Change return for {0}").format(invoice_doc.name)
 
-    pe.setup_party_account_field()
-    pe.set_missing_values()
+    ensure_child_doctype(pe, "references", "Payment Entry Reference")
+    pe.flags.ignore_permissions = True
+    frappe.flags.ignore_account_permission = True
 
     try:
+        pe.setup_party_account_field()
+        pe.set_missing_values()
         pe.set_missing_ref_details()
-    except Exception:
-        pass
-
-    try:
         pe.allocate_payment_amounts()
+        # Re-assert the explicit reference to avoid any helper cleanup
+        if pe.references:
+            ref_row = pe.references[0]
+            ref_row.reference_doctype = invoice_doc.doctype
+            ref_row.reference_name = invoice_doc.name
+            ref_row.allocated_amount = allocated_amount
+            ref_row.total_amount = (
+                invoice_doc.get("base_grand_total") or invoice_doc.get("grand_total")
+            )
+            ref_row.outstanding_amount = invoice_outstanding
+            ref_row.due_date = invoice_doc.get("due_date") or ref_row.due_date
     except Exception:
         pass
 
     pe.set_amounts()
-    pe.paid_amount = allocated_amount or base_change_amount
-    pe.received_amount = allocated_amount or base_change_amount
-
-    pe.flags.ignore_permissions = True
-    frappe.flags.ignore_account_permission = True
     pe.save()
     pe.submit()
 

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -238,6 +238,9 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     pe.reference_no = invoice_doc.name
     pe.reference_date = pe.posting_date
 
+    if not invoice_doc.get("outstanding_amount"):
+        invoice_doc.reload()
+
     invoice_outstanding = frappe.db.get_value(
         invoice_doc.doctype, invoice_doc.name, "outstanding_amount"
     )
@@ -247,11 +250,9 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
         else invoice_outstanding
     )
     invoice_outstanding = flt(invoice_outstanding)
-    allocated_amount = (
-        min(base_change_amount, invoice_outstanding)
-        if invoice_outstanding > 0
-        else 0
-    )
+    allocated_amount = 0
+    if invoice_outstanding > 0:
+        allocated_amount = min(base_change_amount, invoice_outstanding)
 
     pe.append(
         "references",
@@ -265,6 +266,8 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
             "due_date": invoice_doc.get("due_date") or pe.posting_date,
         },
     )
+
+    pe.remarks = _("Change return for {0}").format(invoice_doc.name)
 
     pe.setup_party_account_field()
     pe.set_missing_values()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -238,7 +238,6 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
             invoice_doc.doctype,
             invoice_doc.name,
             bank_account=cash_account_name,
-            payment_type="Pay",
             party_amount=paid_change,
         )
     except Exception:
@@ -277,31 +276,43 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     pe.set_missing_values()
     pe.set_missing_ref_details()
 
-    # Align references with the invoice and cap allocation by outstanding
+    # Align references with the invoice and cap allocation by the latest outstanding
     latest_outstanding = flt(
         frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "outstanding_amount")
     )
-    allocated_amount = max(0, min(base_change_amount, latest_outstanding))
+    allocated_amount = 0
 
-    # Rebuild the reference rows after helper calculations to ensure they persist
-    pe.set("references", [])
-    pe.append(
-        "references",
-        {
-            "reference_doctype": invoice_doc.doctype,
-            "reference_name": invoice_doc.name,
-            "outstanding_amount": latest_outstanding,
-            "allocated_amount": allocated_amount,
-            "total_amount": invoice_doc.get("base_grand_total")
-            or invoice_doc.get("grand_total"),
-            "due_date": invoice_doc.get("due_date")
-            or invoice_doc.get("posting_date")
-            or nowdate(),
-        },
+    target_reference = None
+    for ref in pe.get("references", []):
+        if ref.reference_doctype == invoice_doc.doctype and ref.reference_name == invoice_doc.name:
+            target_reference = ref
+            break
+
+    if not target_reference:
+        pe.append(
+            "references",
+            {
+                "reference_doctype": invoice_doc.doctype,
+                "reference_name": invoice_doc.name,
+            },
+        )
+        target_reference = pe.references[-1]
+
+    if latest_outstanding:
+        allocated_amount = min(base_change_amount, abs(latest_outstanding))
+
+    target_reference.reference_doctype = invoice_doc.doctype
+    target_reference.reference_name = invoice_doc.name
+    target_reference.outstanding_amount = latest_outstanding
+    target_reference.allocated_amount = allocated_amount
+    target_reference.total_amount = (
+        invoice_doc.get("base_grand_total") or invoice_doc.get("grand_total")
+    )
+    target_reference.due_date = (
+        invoice_doc.get("due_date") or invoice_doc.get("posting_date") or nowdate()
     )
 
     pe.set_missing_ref_details(force=True)
-    pe.unallocated_amount = max(0, base_change_amount - allocated_amount)
 
     ensure_child_doctype(pe, "references", "Payment Entry Reference")
     pe.flags.ignore_permissions = True

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -4,7 +4,10 @@
 import json
 
 import frappe
-from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+from erpnext.accounts.doctype.payment_entry.payment_entry import (
+    get_outstanding_reference_amount,
+    get_payment_entry,
+)
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 from erpnext.accounts.party import get_party_account
 from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
@@ -280,18 +283,18 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
         )
         target_reference = pe.references[-1]
 
-    target_reference.reference_doctype = invoice_doc.doctype
-    target_reference.reference_name = invoice_doc.name
-    target_reference.allocated_amount = 0
-    target_reference.outstanding_amount = None
-    target_reference.total_amount = None
-    target_reference.due_date = None
-
     pe.set_missing_ref_details(force=True)
 
-    latest_outstanding = flt(target_reference.outstanding_amount)
-    if latest_outstanding > 0:
-        target_reference.allocated_amount = min(base_change_amount, latest_outstanding)
+    latest_outstanding = get_outstanding_reference_amount(
+        target_reference.reference_doctype,
+        target_reference.reference_name,
+        pe.company,
+        pe.party_type,
+        pe.party,
+    )
+
+    if latest_outstanding and latest_outstanding > 0:
+        target_reference.allocated_amount = min(base_change_amount, flt(latest_outstanding))
     else:
         target_reference.allocated_amount = 0
 

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -4,10 +4,7 @@
 import json
 
 import frappe
-from erpnext.accounts.doctype.payment_entry.payment_entry import (
-    get_outstanding_reference_amount,
-    get_payment_entry,
-)
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 from erpnext.accounts.party import get_party_account
 from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
@@ -285,16 +282,16 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
 
     pe.set_missing_ref_details(force=True)
 
-    latest_outstanding = get_outstanding_reference_amount(
-        target_reference.reference_doctype,
-        target_reference.reference_name,
-        pe.company,
-        pe.party_type,
-        pe.party,
+    latest_outstanding = flt(
+        invoice_doc.get("outstanding_amount")
+        or frappe.db.get_value(
+            invoice_doc.doctype, invoice_doc.name, "outstanding_amount"
+        )
+        or 0
     )
 
-    if latest_outstanding and latest_outstanding > 0:
-        target_reference.allocated_amount = min(base_change_amount, flt(latest_outstanding))
+    if latest_outstanding > 0:
+        target_reference.allocated_amount = min(base_change_amount, latest_outstanding)
     else:
         target_reference.allocated_amount = 0
 

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -82,22 +82,35 @@ def _get_payment_account(payment, company):
 
 
 def create_change_return_journal_entry(invoice_doc, data, cash_account=None, cash_mode_of_payment=None):
-    change_return_enabled = True if data is None else data.get("change_return_from_cash", True)
-    if not change_return_enabled or not data:
+    payload = data or {}
+
+    change_return_enabled = payload.get("change_return_from_cash", True)
+    if not change_return_enabled:
         return
 
-    paid_change = flt(data.get("paid_change") or 0)
+    paid_change = flt(payload.get("paid_change") or invoice_doc.get("paid_change") or 0)
     if paid_change <= 0 or invoice_doc.is_return:
         return
 
     cash_account_name = _get_account_name(cash_account)
+    fallback_cash_mop = cash_mode_of_payment
+
+    if not cash_account_name and invoice_doc.get("pos_profile"):
+        fallback_cash_mop = fallback_cash_mop or frappe.db.get_value(
+            "POS Profile", invoice_doc.pos_profile, "posa_cash_mode_of_payment"
+        )
+
+    if not cash_account_name and fallback_cash_mop:
+        cash_account = get_bank_cash_account(fallback_cash_mop, invoice_doc.company)
+        cash_account_name = _get_account_name(cash_account)
+
     if not cash_account_name:
         return
 
     conversion_rate = invoice_doc.conversion_rate or 1
     base_change_amount = flt(paid_change * conversion_rate)
 
-    cash_mode_lower = cstr(cash_mode_of_payment).lower()
+    cash_mode_lower = cstr(fallback_cash_mop).lower()
 
     non_cash_payments = []
     for payment in invoice_doc.payments:

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -233,14 +233,10 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     pe.posting_date = invoice_doc.get("posting_date") or nowdate()
     pe.paid_from = cash_account_name
     pe.paid_to = party_account
-    pe.paid_amount = base_change_amount
-    pe.received_amount = base_change_amount
     pe.reference_no = invoice_doc.name
     pe.reference_date = pe.posting_date
 
-    if not invoice_doc.get("outstanding_amount"):
-        invoice_doc.reload()
-
+    invoice_doc.reload()
     invoice_outstanding = frappe.db.get_value(
         invoice_doc.doctype, invoice_doc.name, "outstanding_amount"
     )
@@ -271,9 +267,20 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
 
     pe.setup_party_account_field()
     pe.set_missing_values()
+
+    try:
+        pe.set_missing_ref_details()
+    except Exception:
+        pass
+
+    try:
+        pe.allocate_payment_amounts()
+    except Exception:
+        pass
+
     pe.set_amounts()
-    pe.paid_amount = base_change_amount
-    pe.received_amount = base_change_amount
+    pe.paid_amount = allocated_amount or base_change_amount
+    pe.received_amount = allocated_amount or base_change_amount
 
     pe.flags.ignore_permissions = True
     frappe.flags.ignore_account_permission = True

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -185,6 +185,88 @@ def create_change_return_journal_entry(invoice_doc, data, cash_account=None, cas
     je_doc.submit()
 
 
+def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cash_mode_of_payment=None):
+    payload = data or {}
+
+    change_return_enabled = payload.get("change_return_from_cash", True)
+    if not change_return_enabled:
+        return
+
+    paid_change = flt(payload.get("paid_change") or invoice_doc.get("paid_change") or 0)
+    if paid_change <= 0 or invoice_doc.is_return:
+        return
+
+    cash_account_name = _get_account_name(cash_account)
+    fallback_cash_mop = cash_mode_of_payment
+
+    if not cash_account_name and invoice_doc.get("pos_profile"):
+        fallback_cash_mop = fallback_cash_mop or frappe.db.get_value(
+            "POS Profile", invoice_doc.pos_profile, "posa_cash_mode_of_payment"
+        )
+
+    if not cash_account_name and fallback_cash_mop:
+        cash_account = get_bank_cash_account(fallback_cash_mop, invoice_doc.company)
+        cash_account_name = _get_account_name(cash_account)
+
+    if not cash_account_name:
+        return
+
+    party_account = invoice_doc.get("debit_to")
+    if not party_account and invoice_doc.get("customer"):
+        party_account = get_party_account(
+            "Customer", invoice_doc.get("customer"), invoice_doc.get("company")
+        )
+
+    if not party_account:
+        return
+
+    selected_mode_of_payment = fallback_cash_mop or cash_mode_of_payment or "Cash"
+    conversion_rate = invoice_doc.conversion_rate or 1
+    base_change_amount = flt(paid_change * conversion_rate)
+
+    pe = frappe.new_doc("Payment Entry")
+    pe.payment_type = "Pay"
+    pe.company = invoice_doc.company
+    pe.mode_of_payment = selected_mode_of_payment
+    pe.party_type = "Customer"
+    pe.party = invoice_doc.get("customer")
+    pe.posting_date = invoice_doc.get("posting_date") or nowdate()
+    pe.paid_from = cash_account_name
+    pe.paid_to = party_account
+    pe.paid_amount = base_change_amount
+    pe.received_amount = base_change_amount
+    pe.reference_no = invoice_doc.name
+    pe.reference_date = pe.posting_date
+
+    pe.append(
+        "references",
+        {
+            "reference_doctype": invoice_doc.doctype,
+            "reference_name": invoice_doc.name,
+            "allocated_amount": base_change_amount,
+            "total_amount": invoice_doc.get("outstanding_amount")
+            if invoice_doc.get("outstanding_amount") is not None
+            else invoice_doc.get("base_grand_total")
+            or invoice_doc.get("grand_total"),
+            "outstanding_amount": invoice_doc.get("outstanding_amount")
+            if invoice_doc.get("outstanding_amount") is not None
+            else base_change_amount,
+            "due_date": invoice_doc.get("due_date") or pe.posting_date,
+        },
+    )
+
+    pe.setup_party_account_field()
+    pe.set_missing_values()
+    pe.set_amounts()
+    pe.paid_amount = base_change_amount
+    pe.received_amount = base_change_amount
+
+    pe.flags.ignore_permissions = True
+    frappe.flags.ignore_account_permission = True
+    pe.save()
+    pe.submit()
+
+
 def _get_available_stock(item):
     """Return available stock qty for an item row."""
     warehouse = item.get("warehouse")
@@ -906,6 +988,12 @@ def submit_invoice(invoice, data):
             cash_account=cash_account,
             cash_mode_of_payment=cash_mode_of_payment,
         )
+        create_change_return_payment_entry(
+            invoice_doc,
+            data,
+            cash_account=cash_account,
+            cash_mode_of_payment=cash_mode_of_payment,
+        )
         redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, cash_account, payments)
 
     return {"name": invoice_doc.name, "status": invoice_doc.docstatus}
@@ -939,6 +1027,12 @@ def submit_in_background_job(kwargs):
 
     invoice_doc.submit()
     create_change_return_journal_entry(
+        invoice_doc,
+        data,
+        cash_account=cash_account,
+        cash_mode_of_payment=cash_mode_of_payment,
+    )
+    create_change_return_payment_entry(
         invoice_doc,
         data,
         cash_account=cash_account,

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -59,6 +59,119 @@ def _apply_item_name_overrides(invoice_doc, overrides=None):
             item.name_overridden = 0
 
 
+def _get_account_name(account_details):
+    if isinstance(account_details, (dict, frappe._dict)):
+        return account_details.get("account")
+
+    return account_details
+
+
+def _get_base_payment_amount(payment, conversion_rate):
+    if payment.get("base_amount") is not None:
+        return flt(payment.get("base_amount"))
+
+    return flt(payment.get("amount") or 0) * flt(conversion_rate or 1)
+
+
+def _get_payment_account(payment, company):
+    if payment.get("account"):
+        return payment.get("account")
+
+    account_details = get_bank_cash_account(payment.get("mode_of_payment"), company)
+    return _get_account_name(account_details)
+
+
+def create_change_return_journal_entry(invoice_doc, data, cash_account=None, cash_mode_of_payment=None):
+    change_return_enabled = True if data is None else data.get("change_return_from_cash", True)
+    if not change_return_enabled or not data:
+        return
+
+    paid_change = flt(data.get("paid_change") or 0)
+    if paid_change <= 0 or invoice_doc.is_return:
+        return
+
+    cash_account_name = _get_account_name(cash_account)
+    if not cash_account_name:
+        return
+
+    conversion_rate = invoice_doc.conversion_rate or 1
+    base_change_amount = flt(paid_change * conversion_rate)
+
+    cash_mode_lower = cstr(cash_mode_of_payment).lower()
+
+    non_cash_payments = []
+    for payment in invoice_doc.payments:
+        if not payment.get("mode_of_payment"):
+            continue
+
+        if cash_mode_lower and cstr(payment.mode_of_payment).lower() == cash_mode_lower:
+            continue
+
+        if cstr(payment.get("type")).lower() == "cash":
+            continue
+
+        base_amount = _get_base_payment_amount(payment, conversion_rate)
+        if base_amount <= 0:
+            continue
+
+        payment_account = _get_payment_account(payment, invoice_doc.company)
+        if not payment_account:
+            continue
+
+        non_cash_payments.append({"account": payment_account, "base_amount": base_amount})
+
+    total_base = sum(row["base_amount"] for row in non_cash_payments)
+    if not total_base:
+        return
+
+    precision = frappe.get_precision("Journal Entry Account", "debit_in_account_currency") or 2
+    je_doc = frappe.new_doc("Journal Entry")
+    je_doc.voucher_type = "Journal Entry"
+    je_doc.posting_date = invoice_doc.get("posting_date") or nowdate()
+    je_doc.company = invoice_doc.company
+    je_doc.user_remark = _("Change returned from cash for {0}").format(invoice_doc.name)
+
+    remaining = base_change_amount
+    for idx, row in enumerate(non_cash_payments):
+        amount = base_change_amount * (row["base_amount"] / total_base)
+        if idx == len(non_cash_payments) - 1:
+            amount = remaining
+
+        amount = flt(amount, precision)
+        remaining = flt(remaining - amount, precision)
+
+        if amount <= 0:
+            continue
+
+        debit_row = je_doc.append("accounts", {})
+        debit_row.update(
+            {
+                "account": row["account"],
+                "debit_in_account_currency": amount,
+                "reference_type": invoice_doc.doctype,
+                "reference_name": invoice_doc.name,
+            }
+        )
+
+        credit_row = je_doc.append("accounts", {})
+        credit_row.update(
+            {
+                "account": cash_account_name,
+                "credit_in_account_currency": amount,
+                "reference_type": invoice_doc.doctype,
+                "reference_name": invoice_doc.name,
+            }
+        )
+
+    ensure_child_doctype(je_doc, "accounts", "Journal Entry Account")
+
+    je_doc.flags.ignore_permissions = True
+    frappe.flags.ignore_account_permission = True
+    je_doc.set_missing_values()
+    je_doc.save()
+    je_doc.submit()
+
+
 def _get_available_stock(item):
     """Return available stock qty for an item row."""
     warehouse = item.get("warehouse")
@@ -601,10 +714,20 @@ def submit_invoice(invoice, data):
         for i in invoice_doc.payments
         if "cash" in i.mode_of_payment.lower() and i.type == "Cash"
     ]
+    cash_mode_of_payment = None
     if len(mop_cash_list) > 0:
-        cash_account = get_bank_cash_account(mop_cash_list[0], invoice_doc.company)
+        cash_mode_of_payment = mop_cash_list[0]
+        cash_account = get_bank_cash_account(cash_mode_of_payment, invoice_doc.company)
     else:
-        cash_account = {"account": frappe.get_value("Company", invoice_doc.company, "default_cash_account")}
+        cash_mode_of_payment = (
+            frappe.db.get_value("POS Profile", pos_profile, "posa_cash_mode_of_payment")
+            or "Cash"
+        )
+        cash_account = get_bank_cash_account(cash_mode_of_payment, invoice_doc.company)
+        if not cash_account:
+            cash_account = {
+                "account": frappe.get_value("Company", invoice_doc.company, "default_cash_account")
+            }
 
     # Update remarks with items details
     items = []
@@ -758,11 +881,18 @@ def submit_invoice(invoice, data):
                     "is_payment_entry": is_payment_entry,
                     "total_cash": total_cash,
                     "cash_account": cash_account,
+                    "cash_mode_of_payment": cash_mode_of_payment,
                     "payments": payments,
                 },
             )
     else:
         invoice_doc.submit()
+        create_change_return_journal_entry(
+            invoice_doc,
+            data,
+            cash_account=cash_account,
+            cash_mode_of_payment=cash_mode_of_payment,
+        )
         redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, cash_account, payments)
 
     return {"name": invoice_doc.name, "status": invoice_doc.docstatus}
@@ -775,6 +905,7 @@ def submit_in_background_job(kwargs):
     is_payment_entry = kwargs.get("is_payment_entry")
     total_cash = kwargs.get("total_cash")
     cash_account = kwargs.get("cash_account")
+    cash_mode_of_payment = kwargs.get("cash_mode_of_payment")
     payments = kwargs.get("payments")
 
     invoice_doc = frappe.get_doc(doctype, invoice)
@@ -794,6 +925,12 @@ def submit_in_background_job(kwargs):
     invoice_doc.save()
 
     invoice_doc.submit()
+    create_change_return_journal_entry(
+        invoice_doc,
+        data,
+        cash_account=cash_account,
+        cash_mode_of_payment=cash_mode_of_payment,
+    )
     redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, cash_account, payments)
 
 

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -4,6 +4,7 @@
 import json
 
 import frappe
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import get_bank_cash_account
 from erpnext.accounts.party import get_party_account
 from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
@@ -225,20 +226,33 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     base_change_amount = flt(paid_change * conversion_rate)
 
     invoice_doc = frappe.get_doc(invoice_doc.doctype, invoice_doc.name)
-    invoice_outstanding = frappe.db.get_value(
-        invoice_doc.doctype, invoice_doc.name, "outstanding_amount"
+    invoice_outstanding = flt(
+        frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "outstanding_amount")
+        or invoice_doc.get("outstanding_amount")
+        or 0
     )
-    invoice_outstanding = (
-        invoice_doc.get("outstanding_amount")
-        if invoice_outstanding is None
-        else invoice_outstanding
-    )
-    invoice_outstanding = flt(invoice_outstanding)
-    allocated_amount = 0
-    if invoice_outstanding > 0:
-        allocated_amount = min(base_change_amount, invoice_outstanding)
 
-    pe = frappe.new_doc("Payment Entry")
+    # Build a Payment Entry using ERPNext's helper to mirror the standard workflow
+    try:
+        pe = get_payment_entry(invoice_doc.doctype, invoice_doc.name, bank_account=cash_account_name)
+    except Exception:
+        pe = frappe.new_doc("Payment Entry")
+        pe.set("references", [])
+        pe.append(
+            "references",
+            {
+                "reference_doctype": "Sales Invoice",
+                "reference_name": invoice_doc.name,
+                "outstanding_amount": invoice_outstanding,
+                "allocated_amount": 0,
+                "total_amount": invoice_doc.get("base_grand_total")
+                or invoice_doc.get("grand_total"),
+                "due_date": invoice_doc.get("due_date")
+                or invoice_doc.get("posting_date")
+                or nowdate(),
+            },
+        )
+
     pe.payment_type = "Pay"
     pe.company = invoice_doc.company
     pe.mode_of_payment = selected_mode_of_payment
@@ -251,41 +265,50 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     pe.reference_date = invoice_doc.get("posting_date") or nowdate()
     pe.paid_amount = base_change_amount
     pe.received_amount = base_change_amount
-
-    reference_row = {
-        "reference_doctype": "Sales Invoice",
-        "reference_name": invoice_doc.name,
-        "allocated_amount": allocated_amount,
-        "total_amount": invoice_doc.get("base_grand_total")
-        or invoice_doc.get("grand_total"),
-        "outstanding_amount": invoice_outstanding,
-        "due_date": invoice_doc.get("due_date")
-        or invoice_doc.get("posting_date")
-        or nowdate(),
-    }
-
-    # Seed references explicitly so helper routines keep the linkage intact
-    pe.set("references", [])
-    pe.append("references", reference_row)
-
     pe.remarks = _("Change return for {0}").format(invoice_doc.name)
+
+    pe.setup_party_account_field()
+    pe.set_missing_values()
+    pe.set_missing_ref_details()
+
+    # Align references with the invoice and cap allocation by outstanding
+    total_allocation = 0
+    for ref in pe.get("references", []):
+        ref.reference_doctype = invoice_doc.doctype
+        ref.reference_name = invoice_doc.name
+        if invoice_outstanding or invoice_outstanding == 0:
+            ref.outstanding_amount = invoice_outstanding
+        ref.total_amount = ref.total_amount or invoice_doc.get("base_grand_total") or invoice_doc.get("grand_total")
+        ref.due_date = ref.due_date or invoice_doc.get("due_date") or invoice_doc.get("posting_date") or nowdate()
+
+        allowed = min(base_change_amount, flt(ref.outstanding_amount or 0))
+        if allowed < 0:
+            allowed = 0
+        ref.allocated_amount = allowed
+        total_allocation += allowed
+
+    if not pe.get("references"):
+        pe.append(
+            "references",
+            {
+                "reference_doctype": invoice_doc.doctype,
+                "reference_name": invoice_doc.name,
+                "outstanding_amount": invoice_outstanding,
+                "allocated_amount": min(base_change_amount, invoice_outstanding),
+                "total_amount": invoice_doc.get("base_grand_total")
+                or invoice_doc.get("grand_total"),
+                "due_date": invoice_doc.get("due_date")
+                or invoice_doc.get("posting_date")
+                or nowdate(),
+            },
+        )
+        total_allocation = min(base_change_amount, invoice_outstanding)
+
+    pe.unallocated_amount = max(0, base_change_amount - total_allocation)
 
     ensure_child_doctype(pe, "references", "Payment Entry Reference")
     pe.flags.ignore_permissions = True
     frappe.flags.ignore_account_permission = True
-
-    try:
-        pe.setup_party_account_field()
-        pe.set_missing_values()
-        pe.set_missing_ref_details()
-        pe.allocate_payment_amounts()
-    except Exception:
-        pass
-
-    # Force the reference row to remain attached with the intended invoice link
-    pe.set("references", [])
-    pe.append("references", reference_row)
-    ensure_child_doctype(pe, "references", "Payment Entry Reference")
 
     pe.set_amounts()
     pe.save()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -247,11 +247,10 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
         else invoice_outstanding
     )
     invoice_outstanding = flt(invoice_outstanding)
-    absolute_outstanding = abs(invoice_outstanding)
     allocated_amount = (
-        base_change_amount
-        if not absolute_outstanding
-        else min(base_change_amount, absolute_outstanding)
+        min(base_change_amount, invoice_outstanding)
+        if invoice_outstanding > 0
+        else 0
     )
 
     pe.append(

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -252,20 +252,21 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     pe.paid_amount = base_change_amount
     pe.received_amount = base_change_amount
 
-    pe.append(
-        "references",
-        {
-            "reference_doctype": invoice_doc.doctype,
-            "reference_name": invoice_doc.name,
-            "allocated_amount": allocated_amount,
-            "total_amount": invoice_doc.get("base_grand_total")
-            or invoice_doc.get("grand_total"),
-            "outstanding_amount": invoice_outstanding,
-            "due_date": invoice_doc.get("due_date")
-            or invoice_doc.get("posting_date")
-            or nowdate(),
-        },
-    )
+    reference_row = {
+        "reference_doctype": "Sales Invoice",
+        "reference_name": invoice_doc.name,
+        "allocated_amount": allocated_amount,
+        "total_amount": invoice_doc.get("base_grand_total")
+        or invoice_doc.get("grand_total"),
+        "outstanding_amount": invoice_outstanding,
+        "due_date": invoice_doc.get("due_date")
+        or invoice_doc.get("posting_date")
+        or nowdate(),
+    }
+
+    # Seed references explicitly so helper routines keep the linkage intact
+    pe.set("references", [])
+    pe.append("references", reference_row)
 
     pe.remarks = _("Change return for {0}").format(invoice_doc.name)
 
@@ -278,19 +279,13 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
         pe.set_missing_values()
         pe.set_missing_ref_details()
         pe.allocate_payment_amounts()
-        # Re-assert the explicit reference to avoid any helper cleanup
-        if pe.references:
-            ref_row = pe.references[0]
-            ref_row.reference_doctype = invoice_doc.doctype
-            ref_row.reference_name = invoice_doc.name
-            ref_row.allocated_amount = allocated_amount
-            ref_row.total_amount = (
-                invoice_doc.get("base_grand_total") or invoice_doc.get("grand_total")
-            )
-            ref_row.outstanding_amount = invoice_outstanding
-            ref_row.due_date = invoice_doc.get("due_date") or ref_row.due_date
     except Exception:
         pass
+
+    # Force the reference row to remain attached with the intended invoice link
+    pe.set("references", [])
+    pe.append("references", reference_row)
+    ensure_child_doctype(pe, "references", "Payment Entry Reference")
 
     pe.set_amounts()
     pe.save()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -238,35 +238,33 @@ def create_change_return_payment_entry(invoice_doc, data, cash_account=None, cas
     if invoice_outstanding > 0:
         allocated_amount = min(base_change_amount, invoice_outstanding)
 
-    pe = frappe.get_doc(
+    pe = frappe.new_doc("Payment Entry")
+    pe.payment_type = "Pay"
+    pe.company = invoice_doc.company
+    pe.mode_of_payment = selected_mode_of_payment
+    pe.party_type = "Customer"
+    pe.party = invoice_doc.get("customer")
+    pe.posting_date = invoice_doc.get("posting_date") or nowdate()
+    pe.paid_from = cash_account_name
+    pe.paid_to = party_account
+    pe.reference_no = invoice_doc.name
+    pe.reference_date = invoice_doc.get("posting_date") or nowdate()
+    pe.paid_amount = base_change_amount
+    pe.received_amount = base_change_amount
+
+    pe.append(
+        "references",
         {
-            "doctype": "Payment Entry",
-            "payment_type": "Pay",
-            "company": invoice_doc.company,
-            "mode_of_payment": selected_mode_of_payment,
-            "party_type": "Customer",
-            "party": invoice_doc.get("customer"),
-            "posting_date": invoice_doc.get("posting_date") or nowdate(),
-            "paid_from": cash_account_name,
-            "paid_to": party_account,
-            "reference_no": invoice_doc.name,
-            "reference_date": invoice_doc.get("posting_date") or nowdate(),
-            "paid_amount": base_change_amount,
-            "received_amount": base_change_amount,
-            "references": [
-                {
-                    "reference_doctype": invoice_doc.doctype,
-                    "reference_name": invoice_doc.name,
-                    "allocated_amount": allocated_amount,
-                    "total_amount": invoice_doc.get("base_grand_total")
-                    or invoice_doc.get("grand_total"),
-                    "outstanding_amount": invoice_outstanding,
-                    "due_date": invoice_doc.get("due_date")
-                    or invoice_doc.get("posting_date")
-                    or nowdate(),
-                }
-            ],
-        }
+            "reference_doctype": invoice_doc.doctype,
+            "reference_name": invoice_doc.name,
+            "allocated_amount": allocated_amount,
+            "total_amount": invoice_doc.get("base_grand_total")
+            or invoice_doc.get("grand_total"),
+            "outstanding_amount": invoice_outstanding,
+            "due_date": invoice_doc.get("due_date")
+            or invoice_doc.get("posting_date")
+            or nowdate(),
+        },
     )
 
     pe.remarks = _("Change return for {0}").format(invoice_doc.name)


### PR DESCRIPTION
## Summary
- add an overpayment change return radio option in the payment view with a cash-return default
- include the selected change return preference when submitting invoices
- create journal entries that reclassify cash change returned for non-cash payments using the POS profile cash mode of payment account

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197b86d9388326ba775c753f72f4dd)