### PR TITLE
Handle overpayment change with cash return

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -996,7 +996,7 @@ export default {
                         }
 
                         const creditChange = this.credit_change
-                                ? this.flt(this.credit_change, this.currency_precision)
+                                ? Math.abs(this.flt(this.credit_change, this.currency_precision))
                                 : 0;
                         const paidChange = this.paid_change ? this.flt(this.paid_change, this.currency_precision) : 0;
 

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -977,6 +977,38 @@ export default {
                         return change > 0 ? change : 0;
                 },
 
+                overpayment_amount() {
+                        if (!this.invoice_doc) {
+                                return 0;
+                        }
+
+                        let invoice_total;
+                        if (
+                                this.pos_profile.posa_allow_multi_currency &&
+                                this.invoice_doc.currency !== this.pos_profile.currency
+                        ) {
+                                invoice_total = this.flt(this.invoice_doc.grand_total, this.currency_precision);
+                        } else {
+                                invoice_total = this.flt(
+                                        this.invoice_doc.rounded_total || this.invoice_doc.grand_total,
+                                        this.currency_precision,
+                                );
+                        }
+
+                        const creditChange = this.credit_change
+                                ? this.flt(this.credit_change, this.currency_precision)
+                                : 0;
+                        const paidChange = this.paid_change ? this.flt(this.paid_change, this.currency_precision) : 0;
+
+                        const tenderedTotal = this.flt(
+                                this.total_payments - creditChange - paidChange,
+                                this.currency_precision,
+                        );
+
+                        const overpayment = this.flt(tenderedTotal - invoice_total, this.currency_precision);
+                        return overpayment > 0 ? overpayment : 0;
+                },
+
                 has_non_cash_payment() {
                         if (!this.invoice_doc || !Array.isArray(this.invoice_doc.payments)) {
                                 return false;
@@ -996,7 +1028,7 @@ export default {
                                 return false;
                         }
 
-                        if (this.change_due <= 0) {
+                        if (this.overpayment_amount <= 0) {
                                 return false;
                         }
 
@@ -1099,6 +1131,10 @@ export default {
 	watch: {
 		// Watch diff_payment to update paid_change
                 diff_payment(newVal) {
+                        if (this.return_change_from_cash) {
+                                return;
+                        }
+
                         if (this.is_user_editing_paid_change) {
                                 return;
                         }
@@ -1121,7 +1157,7 @@ export default {
                 },
                 // Watch paid_change to validate and update credit_change
                 paid_change(newVal) {
-                        const changeLimit = Math.max(-this.diff_payment, 0);
+                        const changeLimit = this.overpayment_amount;
                         if (newVal > changeLimit) {
                                 this.paid_change = changeLimit;
                                 this.credit_change = 0;
@@ -1145,7 +1181,7 @@ export default {
                         }
                 },
                 return_change_from_cash(enabled) {
-                        const changeLimit = Math.max(-this.diff_payment, 0);
+                        const changeLimit = this.overpayment_amount;
 
                         if (!enabled) {
                                 if (this.shouldAutoApplyCreditChange && changeLimit > 0) {
@@ -1448,7 +1484,7 @@ export default {
 					}
 				}
 				// Validate paid_change
-				const changeLimit = Math.max(-this.diff_payment, 0);
+                                const changeLimit = this.overpayment_amount;
 				if (this.paid_change > changeLimit) {
 					this.eventBus.emit("show_message", {
 						title: `Paid change cannot be greater than total change!`,
@@ -1559,7 +1595,7 @@ export default {
 					row.credit_to_redeem = this.flt(row.credit_to_redeem);
 				});
 			}
-			const changeLimit = !this.invoice_doc.is_return ? Math.max(-this.diff_payment, 0) : 0;
+                        const changeLimit = !this.invoice_doc.is_return ? this.overpayment_amount : 0;
 			const paidChange = !this.invoice_doc.is_return
 				? this.flt(Math.min(this.paid_change, changeLimit), this.currency_precision)
 				: 0;
@@ -2276,7 +2312,7 @@ export default {
                         return mode.includes("cash");
                 },
                 updateCreditChange(rawValue) {
-                        const changeLimit = Math.max(-this.diff_payment, 0);
+                        const changeLimit = !this.invoice_doc?.is_return ? this.overpayment_amount : 0;
                         let requestedCredit = this.flt(Math.abs(rawValue) || 0, this.currency_precision);
 
                         if (requestedCredit > changeLimit) {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -44,11 +44,11 @@
 						></v-text-field>
 					</v-col>
 
-					<!-- Paid Change (if applicable) -->
+                                        <!-- Paid Change (if applicable) -->
                                         <v-col cols="7" v-if="invoice_doc && change_due > 0 && !invoice_doc.is_return">
-						<v-text-field
-							variant="solo"
-							color="primary"
+                                                <v-text-field
+                                                        variant="solo"
+                                                        color="primary"
 							:label="frappe._('Paid Change')"
 							class="sleek-field pos-themed-input"
 							:model-value="formatCurrency(paid_change)"
@@ -57,11 +57,11 @@
 							density="compact"
 							readonly
 							type="text"
-							@click="showPaidChange"
-						></v-text-field>
-					</v-col>
+                                                        @click="showPaidChange"
+                                                ></v-text-field>
+                                        </v-col>
 
-					<!-- Credit Change (if applicable) -->
+                                        <!-- Credit Change (if applicable) -->
                                         <v-col cols="5" v-if="invoice_doc && change_due > 0 && !invoice_doc.is_return">
                                                 <v-text-field
                                                         variant="solo"
@@ -74,11 +74,27 @@
                                                         type="text"
                                                         @change="
                                                                 setFormatedCurrency(this, 'credit_change', null, false, $event);
-								updateCreditChange(this.credit_change);
-							"
-						></v-text-field>
-					</v-col>
-				</v-row>
+                                                                updateCreditChange(this.credit_change);
+                                                        "
+                                                ></v-text-field>
+                                        </v-col>
+
+                                        <!-- Overpayment return toggle -->
+                                        <v-col cols="12" v-if="show_cash_return_option">
+                                                <v-radio-group
+                                                        v-model="return_change_from_cash"
+                                                        hide-details
+                                                        color="primary"
+                                                        class="my-0"
+                                                >
+                                                        <v-radio
+                                                                :label="frappe._('Return overpayment from cash')"
+                                                                :value="true"
+                                                        ></v-radio>
+                                                        <v-radio :label="frappe._('Keep existing behavior')" :value="false"></v-radio>
+                                                </v-radio-group>
+                                        </v-col>
+                                </v-row>
 
 				<v-divider></v-divider>
 
@@ -823,13 +839,14 @@ export default {
 			credit_due_days: null, // Number of days until due
 			credit_due_presets: [7, 14, 30], // Preset options for due days
 			customer_info: "", // Customer info
-			mpesa_modes: [], // List of available M-Pesa modes
-			sales_persons: [], // List of sales persons
-			sales_person: "", // Selected sales person
-			addresses: [], // List of customer addresses
-			is_user_editing_paid_change: false, // User interaction flag
+                        mpesa_modes: [], // List of available M-Pesa modes
+                        sales_persons: [], // List of sales persons
+                        sales_person: "", // Selected sales person
+                        addresses: [], // List of customer addresses
+                        is_user_editing_paid_change: false, // User interaction flag
                         highlightSubmit: false, // Highlight state for submit button
                         last_payment_change_was_cash: null, // Track last edited payment type
+                        return_change_from_cash: false, // Flag to return overpayment from cash
                 };
         },
 	computed: {
@@ -958,6 +975,32 @@ export default {
 
                         // Ensure change is not negative
                         return change > 0 ? change : 0;
+                },
+
+                has_non_cash_payment() {
+                        if (!this.invoice_doc || !Array.isArray(this.invoice_doc.payments)) {
+                                return false;
+                        }
+
+                        return this.invoice_doc.payments.some((payment) => {
+                                return (
+                                        payment &&
+                                        this.flt(payment.amount || 0, this.currency_precision) > 0 &&
+                                        !this.isCashLikePayment(payment)
+                                );
+                        });
+                },
+
+                show_cash_return_option() {
+                        if (!this.invoice_doc || this.invoice_doc.is_return) {
+                                return false;
+                        }
+
+                        if (this.change_due <= 0) {
+                                return false;
+                        }
+
+                        return this.has_non_cash_payment;
                 },
 
                 shouldAutoApplyCreditChange() {
@@ -1096,11 +1139,39 @@ export default {
                                 this.invoice_doc.credit_change = creditAmount > 0 ? creditAmount : 0;
                         }
                 },
-		// Watch loyalty_amount to handle loyalty points redemption
-		loyalty_amount(value) {
-			if (!this.invoice_doc) {
-				return;
-			}
+                show_cash_return_option(isAvailable) {
+                        if (!isAvailable && this.return_change_from_cash) {
+                                this.return_change_from_cash = false;
+                        }
+                },
+                return_change_from_cash(enabled) {
+                        const changeLimit = Math.max(-this.diff_payment, 0);
+
+                        if (!enabled) {
+                                if (this.shouldAutoApplyCreditChange && changeLimit > 0) {
+                                        this.updateCreditChange(changeLimit);
+                                }
+                                return;
+                        }
+
+                        if (changeLimit <= 0) {
+                                this.return_change_from_cash = false;
+                                return;
+                        }
+
+                        this.paid_change = changeLimit;
+                        this.credit_change = 0;
+
+                        if (this.invoice_doc) {
+                                this.invoice_doc.paid_change = changeLimit;
+                                this.invoice_doc.credit_change = 0;
+                        }
+                },
+                // Watch loyalty_amount to handle loyalty points redemption
+                loyalty_amount(value) {
+                        if (!this.invoice_doc) {
+                                return;
+                        }
 			if (value > this.available_points_amount) {
 				this.invoice_doc.loyalty_amount = 0;
 				this.invoice_doc.redeem_loyalty_points = 0;
@@ -1506,14 +1577,15 @@ export default {
 				this.paid_change = paidChange;
 			}
 
-			let data = {
-				total_change: changeLimit,
-				paid_change: paidChange,
-				credit_change: creditChange,
-				redeemed_customer_credit: this.redeemed_customer_credit,
-				customer_credit_dict: this.customer_credit_dict,
-				is_cashback: this.is_cashback,
-			};
+                        let data = {
+                                total_change: changeLimit,
+                                paid_change: paidChange,
+                                credit_change: creditChange,
+                                redeemed_customer_credit: this.redeemed_customer_credit,
+                                customer_credit_dict: this.customer_credit_dict,
+                                is_cashback: this.is_cashback,
+                                return_change_from_cash: this.return_change_from_cash,
+                        };
 
 			if (isOffline()) {
 				try {

--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -8,7 +8,10 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.utils import add_days, flt
 
 from posawesome.posawesome.api.utilities import get_company_domain  # Updated import
-from posawesome.posawesome.api.payments import get_posawesome_credit_redeem_remark
+from posawesome.posawesome.api.payments import (
+    get_overpayment_cash_return_remark,
+    get_posawesome_credit_redeem_remark,
+)
 from posawesome.posawesome.doctype.delivery_charges.delivery_charges import (
     get_applicable_delivery_charges,
 )
@@ -35,6 +38,7 @@ def before_cancel(doc, method):
 
 def on_cancel(doc, method):
     cancel_posawesome_credit_journal_entries(doc)
+    cancel_overpayment_cash_return_entries(doc)
 
 
 def cancel_posawesome_credit_journal_entries(doc):
@@ -64,6 +68,33 @@ def cancel_posawesome_credit_journal_entries(doc):
             frappe.log_error(
                 frappe.get_traceback(),
                 "POSAwesome Credit Journal Cancellation Error",
+            )
+            frappe.throw(
+                _(
+                    "Unable to cancel Journal Entry {0} linked to this invoice. Please cancel it manually and try again."
+                ).format(journal_entry)
+            )
+
+
+def cancel_overpayment_cash_return_entries(doc):
+    remark = get_overpayment_cash_return_remark(doc.name)
+    linked_journal_entries = frappe.get_all(
+        "Journal Entry",
+        filters={"docstatus": 1, "user_remark": remark},
+        pluck="name",
+    )
+
+    for journal_entry in linked_journal_entries:
+        je_doc = frappe.get_doc("Journal Entry", journal_entry)
+
+        if je_doc.docstatus != 1:
+            continue
+
+        try:
+            je_doc.cancel()
+        except Exception:
+            frappe.log_error(
+                frappe.get_traceback(), "POSAwesome Overpayment Cash Return Cancellation Error"
             )
             frappe.throw(
                 _(

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -25,6 +25,7 @@ from frappe.utils import (
 from frappe.utils.background_jobs import enqueue
 
 from posawesome.posawesome.api.payments import (
+    get_overpayment_cash_return_remark,
     redeeming_customer_credit,
 )  # Updated import
 from posawesome.posawesome.api.utilities import (
@@ -88,6 +89,20 @@ def _is_stock_item(item):
     return bool(cint(frappe.get_cached_value("Item", item_code, "is_stock_item") or 0))
 
 
+def _is_cash_like_payment(payment):
+    """Identify cash-like payments based on mode or explicit type."""
+
+    if not payment:
+        return False
+
+    pay_type = cstr(payment.get("type") or "").lower()
+    if pay_type == "cash":
+        return True
+
+    mode_of_payment = cstr(payment.get("mode_of_payment") or "").lower()
+    return "cash" in mode_of_payment
+
+
 def _collect_stock_errors(items):
     """Return list of items exceeding available stock."""
     errors = []
@@ -108,6 +123,164 @@ def _collect_stock_errors(items):
                 }
             )
     return errors
+
+
+def _get_account_for_mode_of_payment(mode_of_payment, company):
+    """Return the linked account for a given mode of payment."""
+
+    if not mode_of_payment:
+        return None
+
+    account = get_bank_cash_account(mode_of_payment, company)
+    if not account:
+        return None
+
+    if isinstance(account, (dict, frappe._dict)):
+        return account.get("account")
+
+    return account
+
+
+def _get_base_change_amount(invoice_doc, data=None):
+    """Calculate overpayment in company currency."""
+
+    conversion_rate = flt(invoice_doc.conversion_rate) or 1
+    invoice_total_base = flt(
+        invoice_doc.base_rounded_total or invoice_doc.base_grand_total or 0,
+        invoice_doc.precision("base_grand_total"),
+    )
+
+    total_paid_base = 0
+    for payment in invoice_doc.get("payments", []):
+        if not payment:
+            continue
+
+        payment_amount = flt(payment.get("base_amount") or 0)
+        if not payment_amount:
+            payment_amount = flt(payment.get("amount") or 0) * conversion_rate
+
+        total_paid_base += payment_amount
+
+    change_base_amount = flt(max(total_paid_base - invoice_total_base, 0))
+
+    if data:
+        paid_change = flt(data.get("paid_change") or 0)
+        if paid_change:
+            paid_change_base = paid_change * conversion_rate
+            change_base_amount = min(change_base_amount, paid_change_base) or change_base_amount
+
+    return change_base_amount
+
+
+def _set_cash_change_on_invoice(invoice_doc, data):
+    """Store change amount on the invoice when cash is used for returns."""
+
+    if not data or invoice_doc.is_return:
+        return
+
+    change_amount = flt(data.get("paid_change") or 0)
+    conversion_rate = flt(invoice_doc.conversion_rate) or 1
+
+    if data.get("return_change_from_cash") and change_amount > 0:
+        invoice_doc.change_amount = change_amount
+        invoice_doc.base_change_amount = flt(
+            change_amount * conversion_rate, invoice_doc.precision("base_grand_total")
+        )
+        return
+
+    if data.get("return_change_from_cash") is not None:
+        invoice_doc.change_amount = 0
+        invoice_doc.base_change_amount = 0
+
+
+def _create_cash_return_journal_entry(invoice_doc, data):
+    """Create Journal Entry to move overpayment from non-cash to cash account."""
+
+    if not data or invoice_doc.is_return or not data.get("return_change_from_cash"):
+        return
+
+    change_base_amount = _get_base_change_amount(invoice_doc, data)
+    if change_base_amount <= 0:
+        return
+
+    payments = invoice_doc.get("payments", []) or []
+    non_cash_payment = None
+    for payment in payments:
+        if not payment or flt(payment.get("amount") or 0) <= 0:
+            continue
+        if not _is_cash_like_payment(payment):
+            non_cash_payment = payment
+            break
+
+    if not non_cash_payment:
+        return
+
+    cash_mode_of_payment = None
+    if invoice_doc.pos_profile:
+        cash_mode_of_payment = frappe.db.get_value(
+            "POS Profile", invoice_doc.pos_profile, "posa_cash_mode_of_payment"
+        )
+
+    if not cash_mode_of_payment:
+        return
+
+    source_account = _get_account_for_mode_of_payment(non_cash_payment.get("mode_of_payment"), invoice_doc.company)
+    target_account = _get_account_for_mode_of_payment(cash_mode_of_payment, invoice_doc.company)
+
+    if not source_account or not target_account or source_account == target_account:
+        return
+
+    remark = get_overpayment_cash_return_remark(invoice_doc.name)
+    already_exists = frappe.get_all(
+        "Journal Entry", filters={"docstatus": 1, "user_remark": remark}, pluck="name"
+    )
+    if already_exists:
+        return
+
+    jv_doc = frappe.get_doc(
+        {
+            "doctype": "Journal Entry",
+            "voucher_type": "Journal Entry",
+            "posting_date": invoice_doc.posting_date or nowdate(),
+            "company": invoice_doc.company,
+            "user_remark": remark,
+        }
+    )
+
+    debit_row = jv_doc.append("accounts", {})
+    debit_row.update(
+        {
+            "account": source_account,
+            "debit_in_account_currency": change_base_amount,
+            "reference_type": invoice_doc.doctype,
+            "reference_name": invoice_doc.name,
+            "cost_center": invoice_doc.get("cost_center") or None,
+        }
+    )
+
+    credit_row = jv_doc.append("accounts", {})
+    credit_row.update(
+        {
+            "account": target_account,
+            "credit_in_account_currency": change_base_amount,
+            "reference_type": invoice_doc.doctype,
+            "reference_name": invoice_doc.name,
+            "cost_center": invoice_doc.get("cost_center") or None,
+        }
+    )
+
+    ensure_child_doctype(jv_doc, "accounts", "Journal Entry Account")
+
+    jv_doc.flags.ignore_permissions = True
+    frappe.flags.ignore_account_permission = True
+    jv_doc.set_missing_values()
+
+    try:
+        jv_doc.save()
+        jv_doc.submit()
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "POSAwesome Overpayment Cash Return Error")
+        frappe.throw(_("Unable to create Journal Entry for overpayment cash return."))
 
 
 def _merge_duplicate_taxes(invoice_doc):
@@ -717,6 +890,8 @@ def submit_invoice(invoice, data):
 
     _validate_stock_on_invoice(invoice_doc)
 
+    _set_cash_change_on_invoice(invoice_doc, data)
+
     invoice_doc.flags.ignore_permissions = True
     frappe.flags.ignore_account_permission = True
     invoice_doc.posa_is_printed = 1
@@ -764,6 +939,7 @@ def submit_invoice(invoice, data):
     else:
         invoice_doc.submit()
         redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, cash_account, payments)
+        _create_cash_return_journal_entry(invoice_doc, data)
 
     return {"name": invoice_doc.name, "status": invoice_doc.docstatus}
 
@@ -795,6 +971,7 @@ def submit_in_background_job(kwargs):
 
     invoice_doc.submit()
     redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, cash_account, payments)
+    _create_cash_return_journal_entry(invoice_doc, data)
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/payments.py
+++ b/posawesome/posawesome/api/payments.py
@@ -19,6 +19,10 @@ def get_posawesome_credit_redeem_remark(invoice_name):
     return _("POS Awesome credit redemption for Sales Invoice {0}").format(invoice_name)
 
 
+def get_overpayment_cash_return_remark(invoice_name):
+    return _("POS Awesome overpayment cash return for Sales Invoice {0}").format(invoice_name)
+
+
 @frappe.whitelist()
 def create_payment_request(doc):
     doc = json.loads(doc)


### PR DESCRIPTION
## Summary
- add UI toggle to mark overpayments as returned from cash when non-cash payments exceed the invoice total
- store paid change amounts on the invoice payload and create cash return journal entries that move the overpayment from the non-cash account to the POS cash account
- cancel linked overpayment journal entries when the invoice is cancelled to keep accounting in sync

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c1e25b8883269b029682722026ba)