### PR TITLE
Handle cash change refunds for non-cash overpayments

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -2196,12 +2196,20 @@ export default {
                                 return false;
                         }
 
+                        const configuredCashMOP = String(
+                                this.pos_profile?.posa_cash_mode_of_payment || "",
+                        ).toLowerCase();
+
                         const type = String(payment.type || "").toLowerCase();
                         if (type === "cash") {
                                 return true;
                         }
 
                         const mode = String(payment.mode_of_payment || "").toLowerCase();
+                        if (configuredCashMOP && mode === configuredCashMOP) {
+                                return true;
+                        }
+
                         return mode.includes("cash");
                 },
                 updateCreditChange(rawValue) {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1066,7 +1066,8 @@ export default {
                                 const changeDue = -newVal;
 
                                 if (this.shouldAutoApplyCreditChange || lastEditWasCash === false) {
-                                        this.updateCreditChange(changeDue);
+                                        this.paid_change = this.flt(changeDue, this.currency_precision);
+                                        this.credit_change = 0;
                                 } else {
                                         this.paid_change = changeDue;
                                 }

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -664,6 +664,15 @@ def submit_invoice(invoice, data):
         advance_payment_entry.reference_no = reference_no
         advance_payment_entry.reference_date = posting_date
 
+        advance_payment_entry.append(
+            "references",
+            {
+                "reference_doctype": invoice_doc.doctype,
+                "reference_name": invoice_doc.name,
+                "allocated_amount": amount,
+            },
+        )
+
         advance_payment_entry.setup_party_account_field()
         advance_payment_entry.set_missing_values()
         advance_payment_entry.set_amounts()
@@ -733,6 +742,15 @@ def submit_invoice(invoice, data):
         if reference_no:
             change_payment_entry.reference_no = reference_no
             change_payment_entry.reference_date = posting_date
+
+        change_payment_entry.append(
+            "references",
+            {
+                "reference_doctype": invoice_doc.doctype,
+                "reference_name": invoice_doc.name,
+                "allocated_amount": paid_change_amount,
+            },
+        )
 
         change_payment_entry.setup_party_account_field()
         change_payment_entry.set_missing_values()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -575,6 +575,11 @@ def _create_change_payment_entries(invoice_doc, data, pos_profile=None, cash_acc
     credit_change_amount = flt(data.get("credit_change"))
     paid_change_amount = flt(data.get("paid_change"))
 
+    def _invert_sign(amount):
+        """Flip the sign of the provided amount (positive->negative and vice-versa)."""
+
+        return -1 * flt(amount)
+
     if credit_change_amount <= 0 and paid_change_amount <= 0:
         return
 
@@ -644,7 +649,7 @@ def _create_change_payment_entries(invoice_doc, data, pos_profile=None, cash_acc
             {
                 "reference_doctype": invoice_doc.doctype,
                 "reference_name": invoice_doc.name,
-                "allocated_amount": credit_change_amount,
+                "allocated_amount": _invert_sign(credit_change_amount),
             },
         )
 
@@ -686,7 +691,7 @@ def _create_change_payment_entries(invoice_doc, data, pos_profile=None, cash_acc
             {
                 "reference_doctype": invoice_doc.doctype,
                 "reference_name": invoice_doc.name,
-                "allocated_amount": paid_change_amount,
+                "allocated_amount": _invert_sign(paid_change_amount),
             },
         )
 


### PR DESCRIPTION
## Summary
- prevent automatic crediting of change when overpayments are made with non-cash methods by keeping the change as paid cash
- create a refund payment entry using the POS profile cash mode to record change returned to the customer

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d085154483269954d4d24180ea4c)