### PR TITLE
Handle payment entry refunds in closing shift reconciliation

### DIFF
--- a/frontend/src/posapp/components/pos/ClosingDialog.vue
+++ b/frontend/src/posapp/components/pos/ClosingDialog.vue
@@ -277,188 +277,123 @@
 
                                                                         <v-row dense class="mt-4">
                                                                                 <v-col cols="12" md="6">
-                                                                                        <div class="table-section">
-                                                                                                <div class="table-header mb-2">
-                                                                                                        <h5 class="text-subtitle-1 text-grey-darken-2 mb-1">
-                                                                                                                {{ __("Change Returned") }}
-                                                                                                        </h5>
-                                                                                                        <p class="text-body-2 text-grey">
-                                                                                                                {{ __("Track how much cash was handed back to customers") }}
-                                                                                                        </p>
-                                                                                                </div>
-                                                                                                <div class="table-subsection">
-                                                                                                        <div class="table-header table-header--compact mb-2">
-                                                                                                                <h6 class="text-subtitle-2 text-grey-darken-1 mb-1">
-                                                                                                                        {{ __("Invoice Change") }}
-                                                                                                                </h6>
-                                                                                                                <p class="text-body-2 text-grey">
-                                                                                                                        {{ __("Change recorded on POS invoices") }}
-                                                                                                                </p>
-                                                                                                        </div>
-                                                                                                        <div
-                                                                                                                v-if="invoiceChangeReturnedByCurrency.length"
-                                                                                                                class="overview-table-wrapper"
-                                                                                                        >
-                                                                                                                <table class="overview-table">
-                                                                                                                        <thead>
-                                                                                                                                <tr>
-
-<th>{{ __("Currency") }}</th>
-
-<th class="text-end">
-
-        {{ __("Total Change") }}
-
-</th>
-                                                                                                                                </tr>
-                                                                                                                        </thead>
-                                                                                                                        <tbody>
-                                                                                                                                <tr
-
-v-for="row in invoiceChangeReturnedByCurrency"
-
-:key="`invoice-change-${row.currency}`"
-                                                                                                                                >
-
-<td>{{ row.currency }}</td>
-
-<td class="text-end">
-
-        <div class="amount-with-base">
-
-                <div class="amount-primary">
-
-                        <span class="overview-amount">
-
-                                {{ formatCurrencyWithSymbol(row.total || 0, row.currency || overviewCompanyCurrency) }}
-
-                        </span>
-
-                        <span
-
-                                v-if="shouldShowCompanyEquivalent(row, row.currency)"
-
-                                class="company-equivalent"
-
-                        >
-
-                                ({{ formatCurrencyWithSymbol(row.company_currency_total || 0, overviewCompanyCurrency) }})
-
-                        </span>
-
-                </div>
-
-                <div
-
-                        v-if="showExchangeRates(row, row.currency)"
-
-                        class="exchange-note"
-
-                >
-
-                        {{ formatExchangeRates(row.exchange_rates, row.currency || overviewCompanyCurrency, overviewCompanyCurrency) }}
-
-                </div>
-
-        </div>
-
-</td>
-                                                                                                                                </tr>
-                                                                                                                        </tbody>
-                                                                                                                </table>
-                                                                                                        </div>
-                                                                                                        <div v-else class="overview-empty text-body-2">
-                                                                                                                {{ __("No invoice change recorded for this shift.") }}
-                                                                                                        </div>
-                                                                                                </div>
-
-                                                                                                <div class="table-subsection mt-4">
-                                                                                                        <div class="table-header table-header--compact mb-2">
-                                                                                                                <h6 class="text-subtitle-2 text-grey-darken-1 mb-1">
-                                                                                                                        {{ __("Overpayment Change Return") }}
-                                                                                                                </h6>
-                                                                                                                <p class="text-body-2 text-grey">
-                                                                                                                        {{ __("Refund payouts captured via Payment Entries") }}
-                                                                                                                </p>
-                                                                                                        </div>
-                                                                                                        <div
-                                                                                                                v-if="overpaymentChangeReturnedByCurrency.length"
-                                                                                                                class="overview-table-wrapper"
-                                                                                                        >
-                                                                                                                <table class="overview-table">
-                                                                                                                        <thead>
-                                                                                                                                <tr>
-
-<th>{{ __("Currency") }}</th>
-
-<th class="text-end">
-
-        {{ __("Total Change") }}
-
-</th>
-                                                                                                                                </tr>
-                                                                                                                        </thead>
-                                                                                                                        <tbody>
-                                                                                                                                <tr
-
-v-for="row in overpaymentChangeReturnedByCurrency"
-
-:key="`overpayment-change-${row.currency}`"
-                                                                                                                                >
-
-<td>{{ row.currency }}</td>
-
-<td class="text-end">
-
-        <div class="amount-with-base">
-
-                <div class="amount-primary">
-
-                        <span class="overview-amount">
-
-                                {{ formatCurrencyWithSymbol(row.total || 0, row.currency || overviewCompanyCurrency) }}
-
-                        </span>
-
-                        <span
-
-                                v-if="shouldShowCompanyEquivalent(row, row.currency)"
-
-                                class="company-equivalent"
-
-                        >
-
-                                ({{ formatCurrencyWithSymbol(row.company_currency_total || 0, overviewCompanyCurrency) }})
-
-                        </span>
-
-                </div>
-
-                <div
-
-                        v-if="showExchangeRates(row, row.currency)"
-
-                        class="exchange-note"
-
-                >
-
-                        {{ formatExchangeRates(row.exchange_rates, row.currency || overviewCompanyCurrency, overviewCompanyCurrency) }}
-
-                </div>
-
-        </div>
-
-</td>
-                                                                                                                                </tr>
-                                                                                                                        </tbody>
-                                                                                                                </table>
-                                                                                                        </div>
-                                                                                                        <div v-else class="overview-empty text-body-2">
-                                                                                                                {{ __("No overpayment change recorded for this shift.") }}
-                                                                                                        </div>
-                                                                                                </div>
-                                                                                                </div>
-                                                                                                <!-- End: Change Returned -->
+                                                        
+                                <div class="table-section">
+                                        <div class="table-header mb-2">
+                                                <h5 class="text-subtitle-1 text-grey-darken-2 mb-1">
+                                                        {{ __("Change Returned") }}
+                                                </h5>
+                                                <p class="text-body-2 text-grey">
+                                                        {{ __("Track how much cash was handed back to customers") }}
+                                                </p>
+                                        </div>
+                                        <div
+                                                v-if="changeReturnedRows.length"
+                                                class="overview-table-wrapper"
+                                        >
+                                                <table class="overview-table">
+                                                        <thead>
+                                                                <tr>
+                                                                        <th>{{ __("Currency") }}</th>
+                                                                        <th class="text-end">{{ __("Invoice Change") }}</th>
+                                                                        <th class="text-end">{{ __("Overpayment Change") }}</th>
+                                                                        <th class="text-end">{{ __("Total Change") }}</th>
+                                                                </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                                <tr
+                                                                        v-for="row in changeReturnedRows"
+                                                                        :key="`change-returned-${row.currency}`"
+                                                                >
+                                                                        <td>{{ row.currency }}</td>
+                                                                        <td class="text-end">
+                                                                                <div class="amount-with-base">
+                                                                                        <div class="amount-primary">
+                                                                                                <span class="overview-amount">
+                                                                                                        {{ formatCurrencyWithSymbol(row.invoice_total, row.currency || overviewCompanyCurrency) }}
+                                                                                                </span>
+                                                                                                <span
+                                                                                                        v-if="shouldShowCompanyEquivalent(
+                                                                                                                {
+                                                                                                                        currency: row.currency,
+                                                                                                                        total: row.invoice_total,
+                                                                                                                        company_currency_total:
+                                                                                                                                row.invoice_company_currency_total,
+                                                                                                                },
+                                                                                                                row.currency,
+                                                                                                        )"
+                                                                                                        class="company-equivalent"
+                                                                                                >
+                                                                                                        ({{ formatCurrencyWithSymbol(row.invoice_company_currency_total, overviewCompanyCurrency) }})
+                                                                                                </span>
+                                                                                        </div>
+                                                                                        <div
+                                                                                                v-if="showExchangeRates(row, row.currency)"
+                                                                                                class="exchange-note"
+                                                                                        >
+                                                                                                {{ formatExchangeRates(row.exchange_rates, row.currency || overviewCompanyCurrency, overviewCompanyCurrency) }}
+                                                                                        </div>
+                                                                                </div>
+                                                                        </td>
+                                                                        <td class="text-end">
+                                                                                <div class="amount-with-base">
+                                                                                        <div class="amount-primary">
+                                                                                                <span class="overview-amount">
+                                                                                                        {{ formatCurrencyWithSymbol(row.overpayment_total, row.currency || overviewCompanyCurrency) }}
+                                                                                                </span>
+                                                                                                <span
+                                                                                                        v-if="shouldShowCompanyEquivalent(
+                                                                                                                {
+                                                                                                                        currency: row.currency,
+                                                                                                                        total: row.overpayment_total,
+                                                                                                                        company_currency_total:
+                                                                                                                                row.overpayment_company_currency_total,
+                                                                                                                },
+                                                                                                                row.currency,
+                                                                                                        )"
+                                                                                                        class="company-equivalent"
+                                                                                                >
+                                                                                                        ({{ formatCurrencyWithSymbol(row.overpayment_company_currency_total, overviewCompanyCurrency) }})
+                                                                                                </span>
+                                                                                        </div>
+                                                                                        <div
+                                                                                                v-if="showExchangeRates(row, row.currency)"
+                                                                                                class="exchange-note"
+                                                                                        >
+                                                                                                {{ formatExchangeRates(row.exchange_rates, row.currency || overviewCompanyCurrency, overviewCompanyCurrency) }}
+                                                                                        </div>
+                                                                                </div>
+                                                                        </td>
+                                                                        <td class="text-end">
+                                                                                <div class="amount-with-base">
+                                                                                        <div class="amount-primary">
+                                                                                                <span class="overview-amount">
+                                                                                                        {{ formatCurrencyWithSymbol(row.total, row.currency || overviewCompanyCurrency) }}
+                                                                                                </span>
+                                                                                                <span
+                                                                                                        v-if="shouldShowCompanyEquivalent(row.company_currency_total, row.currency)"
+                                                                                                        class="company-equivalent"
+                                                                                                >
+                                                                                                        ({{ formatCurrencyWithSymbol(row.company_currency_total, overviewCompanyCurrency) }})
+                                                                                                </span>
+                                                                                        </div>
+                                                                                        <div
+                                                                                                v-if="showExchangeRates(row, row.currency)"
+                                                                                                class="exchange-note"
+                                                                                        >
+                                                                                                {{ formatExchangeRates(row.exchange_rates, row.currency || overviewCompanyCurrency, overviewCompanyCurrency) }}
+                                                                                        </div>
+                                                                                </div>
+                                                                        </td>
+                                                                </tr>
+                                                        </tbody>
+                                                </table>
+                                        </div>
+                                        <div v-else class="overview-empty text-body-2">
+                                                {{ __("No change returned recorded for this shift.") }}
+                                        </div>
+                                </div>
+                                <!-- End: Change Returned -->
                                                                                         <div class="table-section">
                                                                                                 <div class="table-header mb-2">
                                                                                                         <h5 class="text-subtitle-1 text-grey-darken-2 mb-1">
@@ -1124,6 +1059,54 @@ export default {
                         return Array.isArray(this.overpaymentChangeReturnedSummary.by_currency)
                                 ? this.overpaymentChangeReturnedSummary.by_currency
                                 : [];
+                },
+                changeReturnedRows() {
+                        const rows = {};
+
+                        const accumulate = (items, type) => {
+                                (items || []).forEach((item) => {
+                                        const currency = item.currency || this.overviewCompanyCurrency || "";
+                                        const existing =
+                                                rows[currency] ||
+                                                {
+                                                        currency,
+                                                        invoice_total: 0,
+                                                        invoice_company_currency_total: 0,
+                                                        overpayment_total: 0,
+                                                        overpayment_company_currency_total: 0,
+                                                        total: 0,
+                                                        company_currency_total: 0,
+                                                        exchange_rates: new Set(),
+                                                };
+
+                                        const total = item.total || 0;
+                                        const companyTotal = item.company_currency_total || 0;
+                                        if (type === "invoice") {
+                                                existing.invoice_total += total;
+                                                existing.invoice_company_currency_total += companyTotal;
+                                        } else if (type === "overpayment") {
+                                                existing.overpayment_total += total;
+                                                existing.overpayment_company_currency_total += companyTotal;
+                                        }
+
+                                        (item.exchange_rates || []).forEach((rate) => existing.exchange_rates.add(rate));
+                                        rows[currency] = existing;
+                                });
+                        };
+
+                        accumulate(this.invoiceChangeReturnedByCurrency, "invoice");
+                        accumulate(this.overpaymentChangeReturnedByCurrency, "overpayment");
+
+                        return Object.values(rows)
+                                .map((row) => ({
+                                        ...row,
+                                        exchange_rates: Array.from(row.exchange_rates || []),
+                                        total: (row.invoice_total || 0) + (row.overpayment_total || 0),
+                                        company_currency_total:
+                                                (row.invoice_company_currency_total || 0) +
+                                                (row.overpayment_company_currency_total || 0),
+                                }))
+                                .sort((a, b) => (a.currency || "").localeCompare(b.currency || ""));
                 },
                 cashExpectedSummary() {
                         return this.overview?.cash_expected || {

--- a/frontend/src/posapp/components/pos/ClosingDialog.vue
+++ b/frontend/src/posapp/components/pos/ClosingDialog.vue
@@ -286,54 +286,178 @@
                                                                                                                 {{ __("Track how much cash was handed back to customers") }}
                                                                                                         </p>
                                                                                                 </div>
-                                                                                                <div v-if="changeReturnedByCurrency.length" class="overview-table-wrapper">
-                                                                                                        <table class="overview-table">
-                                                                                                                <thead>
-                                                                                                                        <tr>
-                                                                                                                                <th>{{ __("Currency") }}</th>
-                                                                                                                                <th class="text-end">
-                                                                                                                                        {{ __("Total Change") }}
-                                                                                                                                </th>
-                                                                                                                        </tr>
-                                                                                                                </thead>
-                                                                                                                <tbody>
-                                                                                                                        <tr
-                                                                                                                                v-for="row in changeReturnedByCurrency"
-                                                                                                                                :key="`change-${row.currency}`"
-                                                                                                                        >
-                                                                                                                                <td>{{ row.currency }}</td>
-                                                                                                                                <td class="text-end">
-                                                                                                                                        <div class="amount-with-base">
-                                                                                                                                                <div class="amount-primary">
-                                                                                                                                                        <span class="overview-amount">
-                                                                                                                                                                {{ formatCurrencyWithSymbol(row.total || 0, row.currency || overviewCompanyCurrency) }}
-                                                                                                                                                        </span>
-                                                                                                                                                        <span
-                                                                                                                                                                v-if="shouldShowCompanyEquivalent(row, row.currency)"
-                                                                                                                                                                class="company-equivalent"
-                                                                                                                                                        >
-                                                                                                                                                                ({{ formatCurrencyWithSymbol(row.company_currency_total || 0, overviewCompanyCurrency) }})
-                                                                                                                                                        </span>
-                                                                                                                                                </div>
-                                                                                                                                                <div
-                                                                                                                                                        v-if="showExchangeRates(row, row.currency)"
-                                                                                                                                                        class="exchange-note"
-                                                                                                                                                >
-                                                                                                                                                        {{ formatExchangeRates(row.exchange_rates, row.currency || overviewCompanyCurrency, overviewCompanyCurrency) }}
-                                                                                                                                                </div>
-                                                                                                                                        </div>
-                                                                                                                                </td>
-                                                                                                                        </tr>
-                                                                                                                </tbody>
-                                                                                                        </table>
+                                                                                                <div class="table-subsection">
+                                                                                                        <div class="table-header table-header--compact mb-2">
+                                                                                                                <h6 class="text-subtitle-2 text-grey-darken-1 mb-1">
+                                                                                                                        {{ __("Invoice Change") }}
+                                                                                                                </h6>
+                                                                                                                <p class="text-body-2 text-grey">
+                                                                                                                        {{ __("Change recorded on POS invoices") }}
+                                                                                                                </p>
+                                                                                                        </div>
+                                                                                                        <div
+                                                                                                                v-if="invoiceChangeReturnedByCurrency.length"
+                                                                                                                class="overview-table-wrapper"
+                                                                                                        >
+                                                                                                                <table class="overview-table">
+                                                                                                                        <thead>
+                                                                                                                                <tr>
+
+<th>{{ __("Currency") }}</th>
+
+<th class="text-end">
+
+        {{ __("Total Change") }}
+
+</th>
+                                                                                                                                </tr>
+                                                                                                                        </thead>
+                                                                                                                        <tbody>
+                                                                                                                                <tr
+
+v-for="row in invoiceChangeReturnedByCurrency"
+
+:key="`invoice-change-${row.currency}`"
+                                                                                                                                >
+
+<td>{{ row.currency }}</td>
+
+<td class="text-end">
+
+        <div class="amount-with-base">
+
+                <div class="amount-primary">
+
+                        <span class="overview-amount">
+
+                                {{ formatCurrencyWithSymbol(row.total || 0, row.currency || overviewCompanyCurrency) }}
+
+                        </span>
+
+                        <span
+
+                                v-if="shouldShowCompanyEquivalent(row, row.currency)"
+
+                                class="company-equivalent"
+
+                        >
+
+                                ({{ formatCurrencyWithSymbol(row.company_currency_total || 0, overviewCompanyCurrency) }})
+
+                        </span>
+
+                </div>
+
+                <div
+
+                        v-if="showExchangeRates(row, row.currency)"
+
+                        class="exchange-note"
+
+                >
+
+                        {{ formatExchangeRates(row.exchange_rates, row.currency || overviewCompanyCurrency, overviewCompanyCurrency) }}
+
+                </div>
+
+        </div>
+
+</td>
+                                                                                                                                </tr>
+                                                                                                                        </tbody>
+                                                                                                                </table>
+                                                                                                        </div>
+                                                                                                        <div v-else class="overview-empty text-body-2">
+                                                                                                                {{ __("No invoice change recorded for this shift.") }}
+                                                                                                        </div>
                                                                                                 </div>
-                                                                                                <div v-else class="overview-empty text-body-2">
-                                                                                                        {{ __("No change recorded for this shift.") }}
+
+                                                                                                <div class="table-subsection mt-4">
+                                                                                                        <div class="table-header table-header--compact mb-2">
+                                                                                                                <h6 class="text-subtitle-2 text-grey-darken-1 mb-1">
+                                                                                                                        {{ __("Overpayment Change Return") }}
+                                                                                                                </h6>
+                                                                                                                <p class="text-body-2 text-grey">
+                                                                                                                        {{ __("Refund payouts captured via Payment Entries") }}
+                                                                                                                </p>
+                                                                                                        </div>
+                                                                                                        <div
+                                                                                                                v-if="overpaymentChangeReturnedByCurrency.length"
+                                                                                                                class="overview-table-wrapper"
+                                                                                                        >
+                                                                                                                <table class="overview-table">
+                                                                                                                        <thead>
+                                                                                                                                <tr>
+
+<th>{{ __("Currency") }}</th>
+
+<th class="text-end">
+
+        {{ __("Total Change") }}
+
+</th>
+                                                                                                                                </tr>
+                                                                                                                        </thead>
+                                                                                                                        <tbody>
+                                                                                                                                <tr
+
+v-for="row in overpaymentChangeReturnedByCurrency"
+
+:key="`overpayment-change-${row.currency}`"
+                                                                                                                                >
+
+<td>{{ row.currency }}</td>
+
+<td class="text-end">
+
+        <div class="amount-with-base">
+
+                <div class="amount-primary">
+
+                        <span class="overview-amount">
+
+                                {{ formatCurrencyWithSymbol(row.total || 0, row.currency || overviewCompanyCurrency) }}
+
+                        </span>
+
+                        <span
+
+                                v-if="shouldShowCompanyEquivalent(row, row.currency)"
+
+                                class="company-equivalent"
+
+                        >
+
+                                ({{ formatCurrencyWithSymbol(row.company_currency_total || 0, overviewCompanyCurrency) }})
+
+                        </span>
+
+                </div>
+
+                <div
+
+                        v-if="showExchangeRates(row, row.currency)"
+
+                        class="exchange-note"
+
+                >
+
+                        {{ formatExchangeRates(row.exchange_rates, row.currency || overviewCompanyCurrency, overviewCompanyCurrency) }}
+
+                </div>
+
+        </div>
+
+</td>
+                                                                                                                                </tr>
+                                                                                                                        </tbody>
+                                                                                                                </table>
+                                                                                                        </div>
+                                                                                                        <div v-else class="overview-empty text-body-2">
+                                                                                                                {{ __("No overpayment change recorded for this shift.") }}
+                                                                                                        </div>
                                                                                                 </div>
-                                                                                        </div>
-                                                                                </v-col>
-                                                                                <v-col cols="12" md="6">
-                                                                                        <div class="table-section">
+                        <div class="table-section">
                                                                                                 <div class="table-header mb-2">
                                                                                                         <h5 class="text-subtitle-1 text-grey-darken-2 mb-1">
                                                                                                                 {{ __("Cash Drawer Snapshot") }}
@@ -715,6 +839,44 @@ export default {
                                 }),
                         });
 
+                        const normalizeChangeReturned = (change = {}) => {
+                                const normalizeBranch = (branch = {}) => ({
+                                        company_currency_total: toNumber(branch?.company_currency_total),
+                                        by_currency: normalizeCurrencyRows(branch?.by_currency, {
+                                                includeExchangeRates: true,
+                                        }),
+                                });
+
+                                const invoiceChange = normalizeBranch(
+                                        change?.invoice_change || change || {},
+                                );
+                                const overpaymentChange = normalizeBranch(
+                                        change?.overpayment_change || {},
+                                );
+
+                                const primaryByCurrency = normalizeCurrencyRows(
+                                        change?.by_currency,
+                                        { includeExchangeRates: true },
+                                );
+
+                                const totalCompanyCurrency = toNumber(
+                                        change?.company_currency_total,
+                                );
+
+                                return {
+                                        company_currency_total:
+                                                totalCompanyCurrency ||
+                                                invoiceChange.company_currency_total +
+                                                        overpaymentChange.company_currency_total,
+                                        by_currency:
+                                                primaryByCurrency.length
+                                                        ? primaryByCurrency
+                                                        : invoiceChange.by_currency,
+                                        invoice_change: invoiceChange,
+                                        overpayment_change: overpaymentChange,
+                                };
+                        };
+
                         const normalize = (payload = {}) => ({
                                 total_invoices: toNumber(payload.total_invoices),
                                 company_currency:
@@ -751,15 +913,9 @@ export default {
                                                 includeExchangeRates: true,
                                         }),
                                 },
-                                change_returned: {
-                                        company_currency_total: toNumber(
-                                                payload.change_returned?.company_currency_total,
-                                        ),
-                                        by_currency: normalizeCurrencyRows(
-                                                payload.change_returned?.by_currency,
-                                                { includeExchangeRates: true },
-                                        ),
-                                },
+                                change_returned: normalizeChangeReturned(
+                                        payload.change_returned,
+                                ),
                                 cash_expected: {
                                         mode_of_payment: payload.cash_expected?.mode_of_payment || "",
                                         company_currency_total: toNumber(
@@ -931,11 +1087,40 @@ export default {
                         return Array.isArray(this.returnsSummary.by_currency) ? this.returnsSummary.by_currency : [];
                 },
                 changeReturnedSummary() {
-                        return this.overview?.change_returned || { company_currency_total: 0, by_currency: [] };
+                        return (
+                                this.overview?.change_returned || {
+                                        company_currency_total: 0,
+                                        by_currency: [],
+                                        invoice_change: { company_currency_total: 0, by_currency: [] },
+                                        overpayment_change: { company_currency_total: 0, by_currency: [] },
+                                }
+                        );
+                },
+                invoiceChangeReturnedSummary() {
+                        return this.changeReturnedSummary?.invoice_change || {
+                                company_currency_total: 0,
+                                by_currency: [],
+                        };
                 },
                 changeReturnedByCurrency() {
                         return Array.isArray(this.changeReturnedSummary.by_currency)
                                 ? this.changeReturnedSummary.by_currency
+                                : [];
+                },
+                invoiceChangeReturnedByCurrency() {
+                        return Array.isArray(this.invoiceChangeReturnedSummary.by_currency)
+                                ? this.invoiceChangeReturnedSummary.by_currency
+                                : [];
+                },
+                overpaymentChangeReturnedSummary() {
+                        return this.changeReturnedSummary?.overpayment_change || {
+                                company_currency_total: 0,
+                                by_currency: [],
+                        };
+                },
+                overpaymentChangeReturnedByCurrency() {
+                        return Array.isArray(this.overpaymentChangeReturnedSummary.by_currency)
+                                ? this.overpaymentChangeReturnedSummary.by_currency
                                 : [];
                 },
                 cashExpectedSummary() {

--- a/frontend/src/posapp/components/pos/ClosingDialog.vue
+++ b/frontend/src/posapp/components/pos/ClosingDialog.vue
@@ -457,7 +457,9 @@ v-for="row in overpaymentChangeReturnedByCurrency"
                                                                                                                 {{ __("No overpayment change recorded for this shift.") }}
                                                                                                         </div>
                                                                                                 </div>
-                        <div class="table-section">
+                                                                                                </div>
+                                                                                                <!-- End: Change Returned -->
+                                                                                        <div class="table-section">
                                                                                                 <div class="table-header mb-2">
                                                                                                         <h5 class="text-subtitle-1 text-grey-darken-2 mb-1">
                                                                                                                 {{ __("Cash Drawer Snapshot") }}

--- a/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.js
+++ b/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.js
@@ -163,17 +163,20 @@ async function add_to_payments(d, frm, conversion_rate) {
 }
 
 function add_pos_payment_to_payments(p, frm) {
-	const payment = frm.doc.payment_reconciliation.find((pay) => pay.mode_of_payment === p.mode_of_payment);
-	if (payment) {
-		let amount = get_base_value(p, "paid_amount", "base_paid_amount");
-		payment.expected_amount += flt(amount);
-	} else {
-		frm.add_child("payment_reconciliation", {
-			mode_of_payment: p.mode_of_payment,
-			opening_amount: 0,
-			expected_amount: get_base_value(p, "paid_amount", "base_paid_amount"),
-		});
-	}
+        const payment = frm.doc.payment_reconciliation.find((pay) => pay.mode_of_payment === p.mode_of_payment);
+        if (payment) {
+                let amount = get_base_value(p, "paid_amount", "base_paid_amount");
+                const multiplier = p.payment_type === "Pay" ? -1 : 1;
+                payment.expected_amount += flt(multiplier * amount);
+        } else {
+                frm.add_child("payment_reconciliation", {
+                        mode_of_payment: p.mode_of_payment,
+                        opening_amount: 0,
+                        expected_amount:
+                                get_base_value(p, "paid_amount", "base_paid_amount") *
+                                (p.payment_type === "Pay" ? -1 : 1),
+                });
+        }
 }
 
 function add_to_taxes(d, frm, conversion_rate) {

--- a/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.js
+++ b/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.js
@@ -165,7 +165,7 @@ async function add_to_payments(d, frm, conversion_rate) {
 function add_pos_payment_to_payments(p, frm) {
         const payment = frm.doc.payment_reconciliation.find((pay) => pay.mode_of_payment === p.mode_of_payment);
         if (payment) {
-                let amount = get_base_value(p, "paid_amount", "base_paid_amount");
+                let amount = Math.abs(get_base_value(p, "paid_amount", "base_paid_amount"));
                 const multiplier = p.payment_type === "Pay" ? -1 : 1;
                 payment.expected_amount += flt(multiplier * amount);
         } else {
@@ -173,7 +173,7 @@ function add_pos_payment_to_payments(p, frm) {
                         mode_of_payment: p.mode_of_payment,
                         opening_amount: 0,
                         expected_amount:
-                                get_base_value(p, "paid_amount", "base_paid_amount") *
+                                Math.abs(get_base_value(p, "paid_amount", "base_paid_amount")) *
                                 (p.payment_type === "Pay" ? -1 : 1),
                 });
         }

--- a/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
@@ -642,7 +642,7 @@ def get_closing_shift_overview(pos_opening_shift):
                     reference_name,
                 )
 
-            if belongs_to_shift and reference_doctype == doctype:
+            if belongs_to_shift and reference_doctype in {"POS Invoice", "Sales Invoice"}:
                 overpayment_invoice_names.add(reference_name)
 
     def reference_base_amount(reference, fallback_rate=None):

--- a/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
@@ -908,6 +908,18 @@ def get_closing_shift_overview(pos_opening_shift):
                 if base_change:
                     row["company_currency_total"] -= flt(base_change)
 
+            overpayment_change_row = overpayment_change_totals_by_currency.get(
+                row["currency"]
+            )
+            if overpayment_change_row:
+                row["total"] -= flt(overpayment_change_row.get("total"))
+
+                base_overpayment_change = overpayment_change_row.get(
+                    "company_currency_total"
+                )
+                if base_overpayment_change:
+                    row["company_currency_total"] -= flt(base_overpayment_change)
+
     cash_expected_totals = []
     cash_expected_company_currency_total = 0
     if cash_mode_of_payment:
@@ -1012,7 +1024,7 @@ def get_closing_shift_overview(pos_opening_shift):
         "change_returned": {
             "company_currency_total": flt(
                 change_company_currency_total
-                + overpayment_change_company_currency_total
+                - overpayment_change_company_currency_total
             ),
             "by_currency": prepare_currency_rows(change_totals_by_currency),
             "invoice_change": {

--- a/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
@@ -960,14 +960,6 @@ def get_closing_shift_overview(pos_opening_shift):
             if row["mode_of_payment"] != cash_mode_of_payment:
                 continue
 
-            change_row = change_totals_by_currency.get(row["currency"])
-            if change_row:
-                row["total"] -= flt(change_row.get("total"))
-
-                base_change = change_row.get("company_currency_total")
-                if base_change:
-                    row["company_currency_total"] -= flt(base_change)
-
             overpayment_change_row = overpayment_change_totals_by_currency.get(
                 row["currency"]
             )

--- a/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/posawesome/posawesome/doctype/pos_closing_shift/pos_closing_shift.py
@@ -302,8 +302,8 @@ class POSClosingShift(Document):
                 or payment_doc.get("currency")
                 or company_currency
             )
-            base_amount = multiplier * flt(payment_doc.get("base_paid_amount") or 0)
-            paid_amount = multiplier * flt(payment_doc.get("paid_amount") or 0)
+            base_amount = multiplier * abs(flt(payment_doc.get("base_paid_amount") or 0))
+            paid_amount = multiplier * abs(flt(payment_doc.get("paid_amount") or 0))
             mode_of_payment = row.get("mode_of_payment") or payment_doc.get("mode_of_payment")
 
             update_payment_breakdown(mode_of_payment, base_amount, currency, paid_amount)
@@ -1121,18 +1121,16 @@ def make_closing_shift_from_opening(opening_shift):
         )
         existing_pay = [pay for pay in payments if pay.mode_of_payment == py.mode_of_payment]
         multiplier = -1 if py.payment_type == "Pay" else 1
+        signed_amount = multiplier * abs(get_base_value(py, "paid_amount", "base_paid_amount"))
         if existing_pay:
-            existing_pay[0].expected_amount += multiplier * get_base_value(
-                py, "paid_amount", "base_paid_amount"
-            )
+            existing_pay[0].expected_amount += signed_amount
         else:
             payments.append(
                 frappe._dict(
                     {
                         "mode_of_payment": py.mode_of_payment,
                         "opening_amount": 0,
-                        "expected_amount": multiplier
-                        * get_base_value(py, "paid_amount", "base_paid_amount"),
+                        "expected_amount": signed_amount,
                     }
                 )
             )


### PR DESCRIPTION
## Summary
- include `Pay` payment entries when loading closing shifts
- treat `Pay` payment entries as negative contributions to expected amounts in the form
- subtract refund payment entries in reconciliation details so cash expectations reflect change payouts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ac1a1bb1483269ab16e7175710a5a)