### PR TITLE
Slim invoice payload before printing

### DIFF
--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -1029,7 +1029,7 @@ export default {
 					frappe.throw(__("Please select an invoice"));
 				}
 
-				let selectedInvoices = this.selected_invoices.map((invoice) => ({ ...invoice }));
+                                let selectedInvoices = this.selected_invoices.map((invoice) => ({ ...invoice }));
 
 				if (hasNewPayments && selectedInvoices.length === 0) {
 					selectedInvoices = this.outstanding_invoices
@@ -1037,31 +1037,71 @@ export default {
 						.map((invoice) => ({ ...invoice }));
 				}
 
-				const totalSelectedInvoicesAmount = selectedInvoices.reduce(
-					(acc, invoice) => acc + flt(invoice?.outstanding_amount || 0),
-					0,
-				);
+                                const totalSelectedInvoicesAmount = selectedInvoices.reduce(
+                                        (acc, invoice) => acc + flt(invoice?.outstanding_amount || 0),
+                                        0,
+                                );
 
-				this.payment_methods.forEach((payment) => {
-					payment.amount = flt(payment.amount);
-				});
+                                this.payment_methods.forEach((payment) => {
+                                        payment.amount = flt(payment.amount);
+                                });
 
-				const payload = {
-					customer,
-					company: this.company,
-					currency: this.pos_profile.currency,
-					pos_opening_shift_name: this.pos_opening_shift.name,
-					pos_profile_name: this.pos_profile.name,
-					pos_profile: this.pos_profile,
-					payment_methods: this.payment_methods,
-					selected_invoices: selectedInvoices,
-					selected_payments: this.selected_payments,
-					total_selected_invoices: flt(totalSelectedInvoicesAmount),
-					selected_mpesa_payments: this.selected_mpesa_payments,
-					total_selected_payments: flt(this.total_selected_payments),
-					total_payment_methods: flt(this.total_payment_methods),
-					total_selected_mpesa_payments: flt(this.total_selected_mpesa_payments),
-				};
+                                const trimmedPaymentMethods = (this.payment_methods || [])
+                                        .filter((payment) => payment.amount)
+                                        .map((payment) => ({
+                                                mode_of_payment: payment.mode_of_payment,
+                                                amount: payment.amount,
+                                        }));
+
+                                const trimmedInvoices = selectedInvoices.map((invoice) => ({
+                                        voucher_no: invoice.voucher_no || invoice.name,
+                                        name: invoice.voucher_no || invoice.name,
+                                        outstanding_amount: flt(invoice?.outstanding_amount),
+                                        currency: invoice?.currency,
+                                }));
+
+                                const trimmedSelectedPayments = (this.selected_payments || []).map((payment) => ({
+                                        name: payment.name,
+                                        is_credit_note: payment.is_credit_note,
+                                        voucher_type: payment.voucher_type,
+                                        posting_date: payment.posting_date,
+                                        unallocated_amount: flt(payment.unallocated_amount),
+                                        mode_of_payment: payment.mode_of_payment,
+                                        currency: payment.currency,
+                                        reference_invoice: payment.reference_invoice,
+                                }));
+
+                                const trimmedMpesaPayments = (this.selected_mpesa_payments || []).map((payment) => ({
+                                        name: payment.name,
+                                }));
+
+                                const slimPosProfile = {
+                                        name: this.pos_profile.name,
+                                        currency: this.pos_profile.currency,
+                                        posa_use_pos_awesome_payments: this.pos_profile.posa_use_pos_awesome_payments,
+                                        posa_allow_make_new_payments: this.pos_profile.posa_allow_make_new_payments,
+                                        posa_allow_reconcile_payments: this.pos_profile.posa_allow_reconcile_payments,
+                                        posa_allow_mpesa_reconcile_payments: this.pos_profile
+                                                .posa_allow_mpesa_reconcile_payments,
+                                        cost_center: this.pos_profile.cost_center,
+                                };
+
+                                const payload = {
+                                        customer,
+                                        company: this.company,
+                                        currency: this.pos_profile.currency,
+                                        pos_opening_shift_name: this.pos_opening_shift.name,
+                                        pos_profile_name: this.pos_profile.name,
+                                        pos_profile: slimPosProfile,
+                                        payment_methods: trimmedPaymentMethods,
+                                        selected_invoices: trimmedInvoices,
+                                        selected_payments: trimmedSelectedPayments,
+                                        total_selected_invoices: flt(totalSelectedInvoicesAmount),
+                                        selected_mpesa_payments: trimmedMpesaPayments,
+                                        total_selected_payments: flt(this.total_selected_payments),
+                                        total_payment_methods: flt(this.total_payment_methods),
+                                        total_selected_mpesa_payments: flt(this.total_selected_mpesa_payments),
+                                };
 
 				if (isOffline()) {
 					try {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1495,28 +1495,151 @@ export default {
 				this.invoice_doc.credit_change = creditChange;
 			}
 
-			if (!this.invoice_doc.is_return) {
-				this.credit_change = creditChange ? -creditChange : 0;
-				this.paid_change = paidChange;
-			}
+                        if (!this.invoice_doc.is_return) {
+                                this.credit_change = creditChange ? -creditChange : 0;
+                                this.paid_change = paidChange;
+                        }
 
-			let data = {
-				total_change: changeLimit,
-				paid_change: paidChange,
-				credit_change: creditChange,
-				redeemed_customer_credit: this.redeemed_customer_credit,
-				customer_credit_dict: this.customer_credit_dict,
+                        const pickFields = (record, allowedFields) => {
+                                return allowedFields.reduce((acc, field) => {
+                                        if (record[field] !== undefined) {
+                                                acc[field] = record[field];
+                                        }
+                                        return acc;
+                                }, {});
+                        };
+
+                        const sanitizeItemsForSubmit = (items) => {
+                                const allowedItemFields = [
+                                        "name",
+                                        "doctype",
+                                        "idx",
+                                        "item_code",
+                                        "item_name",
+                                        "item_group",
+                                        "description",
+                                        "barcode",
+                                        "brand",
+                                        "uom",
+                                        "stock_uom",
+                                        "conversion_factor",
+                                        "qty",
+                                        "rate",
+                                        "price_list_rate",
+                                        "base_price_list_rate",
+                                        "amount",
+                                        "base_amount",
+                                        "net_rate",
+                                        "net_amount",
+                                        "base_net_rate",
+                                        "base_net_amount",
+                                        "discount_percentage",
+                                        "discount_amount",
+                                        "margin_rate_or_amount",
+                                        "margin_type",
+                                        "warehouse",
+                                        "batch_no",
+                                        "serial_no",
+                                        "income_account",
+                                        "expense_account",
+                                        "cost_center",
+                                        "is_free_item",
+                                        "auto_free_source",
+                                        "allow_zero_valuation_rate",
+                                        "delivery_date",
+                                        "pricing_rules",
+                                        "item_tax_template",
+                                        "tax_category",
+                                        "rate_with_margin",
+                                        "posa_row_id",
+                                ];
+
+                                return (items || []).map((item) => pickFields(item || {}, allowedItemFields));
+                        };
+
+                        const sanitizePaymentsForSubmit = (payments) => {
+                                const allowedPaymentFields = [
+                                        "name",
+                                        "doctype",
+                                        "idx",
+                                        "mode_of_payment",
+                                        "type",
+                                        "amount",
+                                        "base_amount",
+                                        "default",
+                                        "account",
+                                        "reference_no",
+                                        "reference_date",
+                                        "pos_profile",
+                                        "card_type",
+                                        "card_number",
+                                        "payer",
+                                        "payer_name",
+                                        "contact_email",
+                                        "mobile_no",
+                                        "clearance_date",
+                                        "exchange_rate",
+                                        "account_currency",
+                                ];
+
+                                return (payments || []).map((payment) => pickFields(payment || {}, allowedPaymentFields));
+                        };
+
+                        const sanitizeTaxesForSubmit = (taxes) => {
+                                const allowedTaxFields = [
+                                        "name",
+                                        "doctype",
+                                        "idx",
+                                        "charge_type",
+                                        "account_head",
+                                        "description",
+                                        "rate",
+                                        "tax_amount",
+                                        "base_tax_amount",
+                                        "tax_amount_after_discount_amount",
+                                        "base_tax_amount_after_discount_amount",
+                                        "total",
+                                        "tax_amount_for_current_item",
+                                        "base_total",
+                                        "base_tax_amount_for_current_item",
+                                        "account_currency",
+                                        "cost_center",
+                                ];
+
+                                return (taxes || []).map((tax) => pickFields(tax || {}, allowedTaxFields));
+                        };
+
+                        const sanitizedInvoice = {
+                                ...(this.invoice_doc || {}),
+                                items: sanitizeItemsForSubmit(this.invoice_doc?.items),
+                                payments: sanitizePaymentsForSubmit(this.invoice_doc?.payments),
+                        };
+
+                        if (Array.isArray(this.invoice_doc?.taxes)) {
+                                sanitizedInvoice.taxes = sanitizeTaxesForSubmit(this.invoice_doc.taxes);
+                        }
+
+                        ["__last_sync_on", "__onload", "_dirty", "__unsaved", "_edited"]
+                                .filter((key) => key in sanitizedInvoice)
+                                .forEach((key) => delete sanitizedInvoice[key]);
+
+                        let data = {
+                                total_change: changeLimit,
+                                paid_change: paidChange,
+                                credit_change: creditChange,
+                                redeemed_customer_credit: this.redeemed_customer_credit,
+                                customer_credit_dict: this.customer_credit_dict,
 				is_cashback: this.is_cashback,
-			};
+                        };
 
-			if (isOffline()) {
-				try {
-					saveOfflineInvoice({ data: data, invoice: this.invoice_doc });
-					this.eventBus.emit("pending_invoices_changed", getPendingOfflineInvoiceCount());
-					this.eventBus.emit("show_message", {
-						title: __("Invoice saved offline"),
-						color: "warning",
-					});
+                        if (isOffline()) {
+                                try {
+                                        saveOfflineInvoice({ data: data, invoice: sanitizedInvoice });
+                                        this.eventBus.emit("pending_invoices_changed", getPendingOfflineInvoiceCount());
+                                        this.eventBus.emit("show_message", {
+                                                title: __("Invoice saved offline"),
+                                                color: "warning",
+                                        });
 					if (print) {
 						this.print_offline_invoice(this.invoice_doc);
 					}
@@ -1535,19 +1658,19 @@ export default {
 			}
 
 			try {
-				const r = await frappe.call({
-					method:
-						this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
-							? "posawesome.posawesome.api.sales_orders.submit_sales_order"
-							: this.invoiceType === "Quotation"
-								? "posawesome.posawesome.api.quotations.submit_quotation"
-								: "posawesome.posawesome.api.invoices.submit_invoice",
-					args: {
-						data: data,
-						invoice: this.invoice_doc,
-						order: this.invoice_doc,
-					},
-				});
+                                const r = await frappe.call({
+                                        method:
+                                                this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
+                                                        ? "posawesome.posawesome.api.sales_orders.submit_sales_order"
+                                                        : this.invoiceType === "Quotation"
+                                                                ? "posawesome.posawesome.api.quotations.submit_quotation"
+                                                                : "posawesome.posawesome.api.invoices.submit_invoice",
+                                        args: {
+                                                data: data,
+                                                invoice: sanitizedInvoice,
+                                                order: sanitizedInvoice,
+                                        },
+                                });
 
 				if (!r.message) {
 					this.eventBus.emit("show_message", {


### PR DESCRIPTION
## Summary
- trim submitted invoice payloads to only needed item, payment, and tax fields before processing
- strip client-only metadata and reuse the sanitized invoice when saving offline
- pass the smaller invoice payload when submitting or printing to reduce time to the print view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2cebe1d88326bb17b4dd762d65dc)