### PR TITLE
Auto-fetch batch data before applying selection

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -607,19 +607,21 @@
 										></v-text-field>
 									</div>
 									<div class="form-field">
-										<v-autocomplete
-											v-model="item.batch_no"
-											:items="item.batch_no_data"
-											item-title="batch_no"
-											variant="outlined"
-											density="compact"
-											color="primary"
-											class="pos-themed-input"
-											:label="frappe._('Batch No')"
-											@update:model-value="setBatchQty(item, $event)"
-											hide-details
-											prepend-inner-icon="mdi-package-variant-closed"
-										>
+                                                                                <v-autocomplete
+                                                                                        v-model="item.batch_no"
+                                                                                        :items="item.batch_no_data"
+                                                                                        item-title="batch_no"
+                                                                                        item-value="batch_no"
+                                                                                        variant="outlined"
+                                                                                        density="compact"
+                                                                                        color="primary"
+                                                                                        class="pos-themed-input"
+                                                                                        :label="frappe._('Batch No')"
+                                                                                        @update:model-value="setBatchQty(item, $event)"
+                                                                                        @focus="setBatchQty(item, item.batch_no, false)"
+                                                                                        hide-details
+                                                                                        prepend-inner-icon="mdi-package-variant-closed"
+                                                                                >
                                                                                         <template v-slot:item="{ props, item }">
                                                                                                 <v-list-item v-bind="props">
                                                                                                         <v-list-item-title

--- a/frontend/src/posapp/composables/useBatchSerial.js
+++ b/frontend/src/posapp/composables/useBatchSerial.js
@@ -54,24 +54,29 @@ export function useBatchSerial() {
                 const existing_items = context.items.filter(
                         (element) => element.item_code == item.item_code && element.posa_row_id != item.posa_row_id,
                 );
-		const used_batches = {};
-		item.batch_no_data.forEach((batch) => {
-			used_batches[batch.batch_no] = {
-				...batch,
-				used_qty: 0,
-				remaining_qty: batch.batch_qty,
-			};
-			existing_items.forEach((element) => {
-				if (element.batch_no && element.batch_no == batch.batch_no) {
-					used_batches[batch.batch_no].used_qty += element.qty;
-					used_batches[batch.batch_no].remaining_qty -= element.qty;
-					used_batches[batch.batch_no].batch_qty -= element.qty;
-				}
-			});
-		});
+                const used_batches = {};
+                item.batch_no_data.forEach((batch) => {
+                        used_batches[batch.batch_no] = {
+                                ...batch,
+                                used_qty: 0,
+                                remaining_qty: batch.batch_qty,
+                        };
+                        existing_items.forEach((element) => {
+                                if (element.batch_no && element.batch_no == batch.batch_no) {
+                                        used_batches[batch.batch_no].used_qty += element.qty;
+                                        used_batches[batch.batch_no].remaining_qty -= element.qty;
+                                        used_batches[batch.batch_no].batch_qty -= element.qty;
+                                }
+                        });
+                });
 
                 const batch_no_data = Object.values(used_batches)
-                        .filter((batch) => batch.remaining_qty > 0)
+                        .map((batch) => ({
+                                ...batch,
+                                remaining_qty: Math.max(batch.remaining_qty, 0),
+                                is_expired: isBatchExpired(batch),
+                        }))
+                        .filter((batch) => batch.remaining_qty > 0 || batch.is_expired)
                         .sort((a, b) => {
                                 const aExpired = isBatchExpired(a);
                                 const bExpired = isBatchExpired(b);

--- a/frontend/src/posapp/composables/useBatchSerial.js
+++ b/frontend/src/posapp/composables/useBatchSerial.js
@@ -27,12 +27,33 @@ export function useBatchSerial() {
 		}
 	};
 
-	// Set batch number for an item (and update batch data)
-	const setBatchQty = (item, value, update = true, context) => {
-		console.log("Setting batch quantity:", item, value);
-		const existing_items = context.items.filter(
-			(element) => element.item_code == item.item_code && element.posa_row_id != item.posa_row_id,
-		);
+        // Set batch number for an item (and update batch data)
+        const setBatchQty = (item, value, update = true, context) => {
+                console.log("Setting batch quantity:", item, value);
+
+                const needsBatchFetch = !Array.isArray(item.batch_no_data) || item.batch_no_data.length === 0;
+
+                // If batch data isn't loaded yet, fetch fresh item details so the dropdown can populate
+                if (needsBatchFetch) {
+                        if (!item._batchDataLoading && context?.update_item_detail) {
+                                item._batchDataLoading = true;
+
+                                Promise.resolve(context.update_item_detail(item, true)).finally(() => {
+                                        item._batchDataLoading = false;
+
+                                        if (Array.isArray(item.batch_no_data) && item.batch_no_data.length > 0) {
+                                                setBatchQty(item, value, update, context);
+                                        }
+                                });
+                        }
+
+                        item.batch_no_data = Array.isArray(item.batch_no_data) ? item.batch_no_data : [];
+                        return;
+                }
+
+                const existing_items = context.items.filter(
+                        (element) => element.item_code == item.item_code && element.posa_row_id != item.posa_row_id,
+                );
 		const used_batches = {};
 		item.batch_no_data.forEach((batch) => {
 			used_batches[batch.batch_no] = {


### PR DESCRIPTION
## Summary
- trigger item detail refresh when batch dropdown is empty and wait for data to return
- re-run batch selection once data is loaded so available batches populate like ERPNext picker

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d4ecfef94832682b183b9690a87d0)