### PR TITLE
Show expired batches in POS item selector

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -607,10 +607,10 @@
 										></v-text-field>
 									</div>
 									<div class="form-field">
-										<v-autocomplete
-											v-model="item.batch_no"
-											:items="item.batch_no_data"
-											item-title="batch_no"
+                                                                                <v-autocomplete
+                                                                                        v-model="item.batch_no"
+                                                                                        :items="item.batch_no_data"
+                                                                                        item-title="batch_no"
 											variant="outlined"
 											density="compact"
 											color="primary"
@@ -626,11 +626,11 @@
                                                                                                                 v-html="item.raw.batch_no"
                                                                                                         ></v-list-item-title>
                                                                                                         <v-list-item-subtitle class="d-flex align-center">
-                                                                                                                <span
-                                                                                                                        v-html="
-                                                                                                                                `Available QTY  '${item.raw.batch_qty}' - Expiry Date ${item.raw.expiry_date}`
-                                                                                                                        "
-                                                                                                                ></span>
+                                                                                                <span
+                                                                                                        v-html="
+                                                                                                                `Available QTY  '${item.raw.available_qty ?? item.raw.batch_qty}' - Expiry Date ${item.raw.expiry_date}`
+                                                                                                        "
+                                                                                                ></span>
                                                                                                                 <v-chip
                                                                                                                         v-if="item.raw.is_expired"
                                                                                                                         color="error"

--- a/frontend/src/posapp/composables/useBatchSerial.js
+++ b/frontend/src/posapp/composables/useBatchSerial.js
@@ -28,32 +28,36 @@ export function useBatchSerial() {
 	};
 
 	// Set batch number for an item (and update batch data)
-	const setBatchQty = (item, value, update = true, context) => {
-		console.log("Setting batch quantity:", item, value);
-		const existing_items = context.items.filter(
-			(element) => element.item_code == item.item_code && element.posa_row_id != item.posa_row_id,
-		);
-		const used_batches = {};
-		item.batch_no_data.forEach((batch) => {
-			used_batches[batch.batch_no] = {
-				...batch,
-				used_qty: 0,
-				remaining_qty: batch.batch_qty,
-			};
-			existing_items.forEach((element) => {
-				if (element.batch_no && element.batch_no == batch.batch_no) {
-					used_batches[batch.batch_no].used_qty += element.qty;
-					used_batches[batch.batch_no].remaining_qty -= element.qty;
-					used_batches[batch.batch_no].batch_qty -= element.qty;
-				}
-			});
-		});
+        const setBatchQty = (item, value, update = true, context) => {
+                console.log("Setting batch quantity:", item, value);
+                const existing_items = context.items.filter(
+                        (element) => element.item_code == item.item_code && element.posa_row_id != item.posa_row_id,
+                );
+                const used_batches = {};
+                item.batch_no_data.forEach((batch) => {
+                        used_batches[batch.batch_no] = {
+                                ...batch,
+                                used_qty: 0,
+                                remaining_qty: batch.batch_qty,
+                        };
+                        existing_items.forEach((element) => {
+                                if (element.batch_no && element.batch_no == batch.batch_no) {
+                                        used_batches[batch.batch_no].used_qty += element.qty;
+                                        used_batches[batch.batch_no].remaining_qty -= element.qty;
+                                        used_batches[batch.batch_no].batch_qty -= element.qty;
+                                }
+                        });
+                });
 
-                const batch_no_data = Object.values(used_batches)
-                        .filter((batch) => batch.remaining_qty > 0)
+                const normalized_batch_data = Object.values(used_batches)
+                        .map((batch) => ({
+                                ...batch,
+                                is_expired:
+                                        typeof batch.is_expired === "boolean" ? batch.is_expired : isBatchExpired(batch),
+                        }))
                         .sort((a, b) => {
-                                const aExpired = isBatchExpired(a);
-                                const bExpired = isBatchExpired(b);
+                                const aExpired = a.is_expired;
+                                const bExpired = b.is_expired;
 
                                 if (aExpired !== bExpired) {
                                         return aExpired ? 1 : -1;
@@ -76,21 +80,24 @@ export function useBatchSerial() {
                                 }
                         });
 
-                        if (batch_no_data.length > 0) {
-                                let batch_to_use = null;
-                                if (value) {
-                                        batch_to_use = batch_no_data.find((batch) => batch.batch_no == value);
-                                }
-			if (!batch_to_use) {
-				batch_to_use = batch_no_data[0];
-			}
+                const selectable_batches = normalized_batch_data.filter((batch) => batch.remaining_qty > 0);
+                const selection_pool = selectable_batches.length > 0 ? selectable_batches : normalized_batch_data;
+
+                if (selection_pool.length > 0) {
+                        let batch_to_use = null;
+                        if (value) {
+                                batch_to_use = normalized_batch_data.find((batch) => batch.batch_no == value);
+                        }
+                        if (!batch_to_use) {
+                                batch_to_use = selection_pool[0];
+                        }
 
                         item.batch_no = batch_to_use.batch_no;
                         item.actual_batch_qty = batch_to_use.batch_qty;
                         item.batch_no_expiry_date = batch_to_use.expiry_date;
-                        item.batch_no_is_expired = isBatchExpired(batch_to_use);
+                        item.batch_no_is_expired = batch_to_use.is_expired;
 
-			if (batch_to_use.batch_price) {
+                        if (batch_to_use.batch_price) {
 				// Store batch price in base currency
 				item.base_batch_price = batch_to_use.batch_price;
 
@@ -148,11 +155,11 @@ export function useBatchSerial() {
                         item.base_batch_price = null;
                 }
 
-		// Update batch_no_data
-		item.batch_no_data = batch_no_data;
+                // Update batch_no_data with the full list so the UI can show every batch
+                item.batch_no_data = normalized_batch_data;
 
-		// Force UI update
-		if (context.forceUpdate) context.forceUpdate();
+                // Force UI update
+                if (context.forceUpdate) context.forceUpdate();
 	};
 
 	return {

--- a/frontend/src/posapp/composables/useBatchSerial.js
+++ b/frontend/src/posapp/composables/useBatchSerial.js
@@ -27,60 +27,71 @@ export function useBatchSerial() {
 		}
 	};
 
-	// Set batch number for an item (and update batch data)
+        // Set batch number for an item (and update batch data)
         const setBatchQty = (item, value, update = true, context) => {
                 console.log("Setting batch quantity:", item, value);
                 const existing_items = context.items.filter(
                         (element) => element.item_code == item.item_code && element.posa_row_id != item.posa_row_id,
                 );
-                const used_batches = {};
-                item.batch_no_data.forEach((batch) => {
-                        used_batches[batch.batch_no] = {
-                                ...batch,
-                                used_qty: 0,
-                                remaining_qty: batch.batch_qty,
-                        };
-                        existing_items.forEach((element) => {
-                                if (element.batch_no && element.batch_no == batch.batch_no) {
-                                        used_batches[batch.batch_no].used_qty += element.qty;
-                                        used_batches[batch.batch_no].remaining_qty -= element.qty;
-                                        used_batches[batch.batch_no].batch_qty -= element.qty;
-                                }
+                const source_batches = Array.isArray(item.batch_no_data) ? item.batch_no_data : [];
+                const normalized_batch_data = source_batches
+                        .map((batch, index) => {
+                                const baseQty = Number(batch.original_batch_qty ?? batch.batch_qty) || 0;
+                                return {
+                                        ...batch,
+                                        _original_index: index,
+                                        original_batch_qty: baseQty,
+                                        used_qty: 0,
+                                        remaining_qty: baseQty,
+                                        available_qty: baseQty,
+                                        is_expired:
+                                                typeof batch.is_expired === "boolean" ? batch.is_expired : isBatchExpired(batch),
+                                };
+                        })
+                        .sort((a, b) => a._original_index - b._original_index);
+
+                existing_items.forEach((element) => {
+                        if (!element.batch_no || !element.qty) return;
+                        let qtyToAllocate = Number(element.qty) || 0;
+                        normalized_batch_data.forEach((batch) => {
+                                if (qtyToAllocate <= 0) return;
+                                if (batch.batch_no !== element.batch_no) return;
+                                const available = Math.max(batch.remaining_qty, 0);
+                                if (available <= 0) return;
+                                const deduction = Math.min(available, qtyToAllocate);
+                                batch.used_qty += deduction;
+                                batch.remaining_qty -= deduction;
+                                batch.available_qty = Math.max(batch.remaining_qty, 0);
+                                qtyToAllocate -= deduction;
                         });
                 });
 
-                const normalized_batch_data = Object.values(used_batches)
-                        .map((batch) => ({
-                                ...batch,
-                                is_expired:
-                                        typeof batch.is_expired === "boolean" ? batch.is_expired : isBatchExpired(batch),
-                        }))
-                        .sort((a, b) => {
-                                const aExpired = a.is_expired;
-                                const bExpired = b.is_expired;
+                normalized_batch_data.sort((a, b) => {
+                        const aExpired = a.is_expired;
+                        const bExpired = b.is_expired;
 
-                                if (aExpired !== bExpired) {
-                                        return aExpired ? 1 : -1;
-                                }
+                        if (aExpired !== bExpired) {
+                                return aExpired ? 1 : -1;
+                        }
 
-                                if (a.expiry_date && b.expiry_date) {
-                                        return new Date(a.expiry_date) - new Date(b.expiry_date);
-                                } else if (a.expiry_date) {
-                                        return -1;
-                                } else if (b.expiry_date) {
-                                        return 1;
-                                } else if (a.manufacturing_date && b.manufacturing_date) {
-                                        return new Date(a.manufacturing_date) - new Date(b.manufacturing_date);
-                                } else if (a.manufacturing_date) {
-                                        return -1;
-                                } else if (b.manufacturing_date) {
-                                        return 1;
-                                } else {
-                                        return b.remaining_qty - a.remaining_qty;
-                                }
-                        });
+                        if (a.expiry_date && b.expiry_date) {
+                                return new Date(a.expiry_date) - new Date(b.expiry_date);
+                        } else if (a.expiry_date) {
+                                return -1;
+                        } else if (b.expiry_date) {
+                                return 1;
+                        } else if (a.manufacturing_date && b.manufacturing_date) {
+                                return new Date(a.manufacturing_date) - new Date(b.manufacturing_date);
+                        } else if (a.manufacturing_date) {
+                                return -1;
+                        } else if (b.manufacturing_date) {
+                                return 1;
+                        } else {
+                                return b.remaining_qty - a.remaining_qty;
+                        }
+                });
 
-                const selectable_batches = normalized_batch_data.filter((batch) => batch.remaining_qty > 0);
+                const selectable_batches = normalized_batch_data.filter((batch) => batch.available_qty > 0);
                 const selection_pool = selectable_batches.length > 0 ? selectable_batches : normalized_batch_data;
 
                 if (selection_pool.length > 0) {
@@ -93,7 +104,7 @@ export function useBatchSerial() {
                         }
 
                         item.batch_no = batch_to_use.batch_no;
-                        item.actual_batch_qty = batch_to_use.batch_qty;
+                        item.actual_batch_qty = batch_to_use.available_qty;
                         item.batch_no_expiry_date = batch_to_use.expiry_date;
                         item.batch_no_is_expired = batch_to_use.is_expired;
 

--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 
 import frappe
 from erpnext.setup.utils import get_exchange_rate
-from erpnext.stock.doctype.batch.batch import get_batch_qty
 from frappe.utils import flt, nowdate
 from frappe.utils.caching import redis_cache
 
@@ -201,28 +200,64 @@ def get_uoms(item_codes: Sequence[str], ttl: Optional[int] = None):
 
 
 def _fetch_batches(warehouse: str, item_codes: Tuple[str, ...]):
-    """Collect positive batch quantities per item for the given warehouse."""
+    """Collect batch information (including expired entries) for the given warehouse."""
 
     if not item_codes or not warehouse:
         return []
 
+    batch_docs = frappe.get_all(
+        "Batch",
+        filters={"item": ["in", item_codes], "disabled": 0},
+        fields=[
+            "name as batch_no",
+            "item as item_code",
+            "expiry_date",
+            "manufacturing_date",
+            "posa_batch_price",
+        ],
+        order_by="expiry_date asc, creation asc",
+    )
+    if not batch_docs:
+        return []
+
+    qty_rows = frappe.db.sql(
+        """
+        SELECT
+            item_code,
+            batch_no,
+            SUM(actual_qty) AS qty
+        FROM `tabStock Ledger Entry`
+        WHERE
+            warehouse = %(warehouse)s
+            AND item_code in %(item_codes)s
+            AND batch_no is not null
+            AND is_cancelled = 0
+        GROUP BY item_code, batch_no
+        """,
+        {"warehouse": warehouse, "item_codes": item_codes},
+        as_dict=True,
+    )
+
+    qty_map = {
+        (row.item_code, row.batch_no): flt(row.qty) for row in qty_rows if row.batch_no
+    }
+
     rows = []
-    for item_code in item_codes:
-        batch_list = get_batch_qty(item_code=item_code, warehouse=warehouse) or []
-        for batch in batch_list:
-            if batch.get("batch_no") and flt(batch.get("qty")) > 0:
-                rows.append(
-                    frappe._dict(
-                        {
-                            "item_code": item_code,
-                            "batch_no": batch.get("batch_no"),
-                            "batch_qty": batch.get("qty"),
-                            "expiry_date": batch.get("expiry_date"),
-                            "batch_price": batch.get("posa_batch_price"),
-                            "manufacturing_date": batch.get("manufacturing_date"),
-                        }
-                    )
-                )
+    for doc in batch_docs:
+        qty = qty_map.get((doc.item_code, doc.batch_no), 0)
+        rows.append(
+            frappe._dict(
+                {
+                    "item_code": doc.item_code,
+                    "batch_no": doc.batch_no,
+                    "batch_qty": qty,
+                    "expiry_date": doc.expiry_date,
+                    "batch_price": doc.posa_batch_price,
+                    "manufacturing_date": doc.manufacturing_date,
+                }
+            )
+        )
+
     return rows
 
 

--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -245,18 +245,20 @@ def _fetch_batches(warehouse: str, item_codes: Tuple[str, ...]):
     bundle_rows = frappe.db.sql(
         """
         SELECT
-            sbe.item_code,
+            sbb.item_code,
             sbe.batch_no,
             SUM(sbe.qty) AS qty
         FROM `tabSerial and Batch Entry` sbe
+        INNER JOIN `tabSerial and Batch Bundle` sbb
+            ON sbb.name = sbe.parent
         INNER JOIN `tabStock Ledger Entry` sle
-            ON sle.serial_and_batch_bundle = sbe.parent
+            ON sle.serial_and_batch_bundle = sbb.name
         WHERE
             sbe.batch_no IS NOT NULL
-            AND sbe.item_code IN %(item_codes)s
-            AND sbe.warehouse IN %(warehouses)s
+            AND sbb.item_code IN %(item_codes)s
+            AND sbb.warehouse IN %(warehouses)s
             AND sle.is_cancelled = 0
-        GROUP BY sbe.item_code, sbe.batch_no
+        GROUP BY sbb.item_code, sbe.batch_no
         """,
         {"item_codes": item_codes, "warehouses": warehouses},
         as_dict=True,

--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -205,6 +205,13 @@ def _fetch_batches(warehouse: str, item_codes: Tuple[str, ...]):
     if not item_codes or not warehouse:
         return []
 
+    warehouses: Tuple[str, ...] = (warehouse,)
+    if frappe.db.get_value("Warehouse", warehouse, "is_group"):
+        descendants = frappe.db.get_descendants("Warehouse", warehouse) or []
+        if not descendants:
+            return []
+        warehouses = tuple(descendants)
+
     batch_docs = frappe.get_all(
         "Batch",
         filters={"item": ["in", item_codes], "disabled": 0},
@@ -228,13 +235,13 @@ def _fetch_batches(warehouse: str, item_codes: Tuple[str, ...]):
             SUM(actual_qty) AS qty
         FROM `tabStock Ledger Entry`
         WHERE
-            warehouse = %(warehouse)s
+            warehouse IN %(warehouses)s
             AND item_code in %(item_codes)s
             AND batch_no is not null
             AND is_cancelled = 0
         GROUP BY item_code, batch_no
         """,
-        {"warehouse": warehouse, "item_codes": item_codes},
+        {"warehouses": warehouses, "item_codes": item_codes},
         as_dict=True,
     )
 

--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -199,18 +199,30 @@ def get_uoms(item_codes: Sequence[str], ttl: Optional[int] = None):
     return cached(tuple(item_codes))
 
 
+def _normalize_warehouses(warehouse: Optional[str]) -> Tuple[str, ...]:
+    """Return a tuple of concrete warehouses for the provided warehouse or group."""
+
+    if not warehouse:
+        return tuple()
+
+    if frappe.db.get_value("Warehouse", warehouse, "is_group"):
+        descendants = frappe.db.get_descendants("Warehouse", warehouse) or []
+        if not descendants:
+            return tuple()
+        return tuple(sorted({w for w in descendants if w}))
+
+    return (warehouse,)
+
+
 def _fetch_batches(warehouse: str, item_codes: Tuple[str, ...]):
     """Collect batch information (including expired entries) for the given warehouse."""
 
     if not item_codes or not warehouse:
         return []
 
-    warehouses: Tuple[str, ...] = (warehouse,)
-    if frappe.db.get_value("Warehouse", warehouse, "is_group"):
-        descendants = frappe.db.get_descendants("Warehouse", warehouse) or []
-        if not descendants:
-            return []
-        warehouses = tuple(descendants)
+    warehouses = _normalize_warehouses(warehouse)
+    if not warehouses:
+        return []
 
     batch_docs = frappe.get_all(
         "Batch",
@@ -227,7 +239,37 @@ def _fetch_batches(warehouse: str, item_codes: Tuple[str, ...]):
     if not batch_docs:
         return []
 
-    qty_rows = frappe.db.sql(
+    qty_map: Dict[Tuple[str, str], float] = {}
+
+    # Primary source of batch quantities: Serial and Batch Entry records linked to SLEs.
+    bundle_rows = frappe.db.sql(
+        """
+        SELECT
+            sbe.item_code,
+            sbe.batch_no,
+            SUM(sbe.qty) AS qty
+        FROM `tabSerial and Batch Entry` sbe
+        INNER JOIN `tabStock Ledger Entry` sle
+            ON sle.serial_and_batch_bundle = sbe.parent
+        WHERE
+            sbe.batch_no IS NOT NULL
+            AND sbe.item_code IN %(item_codes)s
+            AND sbe.warehouse IN %(warehouses)s
+            AND sle.is_cancelled = 0
+        GROUP BY sbe.item_code, sbe.batch_no
+        """,
+        {"item_codes": item_codes, "warehouses": warehouses},
+        as_dict=True,
+    )
+
+    for row in bundle_rows:
+        if not row.batch_no:
+            continue
+        key = (row.item_code, row.batch_no)
+        qty_map[key] = qty_map.get(key, 0) + flt(row.qty)
+
+    # Backward compatibility for ledgers created before Serial and Batch Bundle existed.
+    legacy_rows = frappe.db.sql(
         """
         SELECT
             item_code,
@@ -235,19 +277,22 @@ def _fetch_batches(warehouse: str, item_codes: Tuple[str, ...]):
             SUM(actual_qty) AS qty
         FROM `tabStock Ledger Entry`
         WHERE
-            warehouse IN %(warehouses)s
-            AND item_code in %(item_codes)s
-            AND batch_no is not null
+            serial_and_batch_bundle IS NULL
+            AND warehouse IN %(warehouses)s
+            AND item_code IN %(item_codes)s
+            AND batch_no IS NOT NULL
             AND is_cancelled = 0
         GROUP BY item_code, batch_no
         """,
-        {"warehouses": warehouses, "item_codes": item_codes},
+        {"item_codes": item_codes, "warehouses": warehouses},
         as_dict=True,
     )
 
-    qty_map = {
-        (row.item_code, row.batch_no): flt(row.qty) for row in qty_rows if row.batch_no
-    }
+    for row in legacy_rows:
+        if not row.batch_no:
+            continue
+        key = (row.item_code, row.batch_no)
+        qty_map[key] = qty_map.get(key, 0) + flt(row.qty)
 
     rows = []
     for doc in batch_docs:

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -17,7 +17,7 @@ from frappe.utils import cint, cstr, flt, get_datetime, nowdate
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.caching import redis_cache
 
-from .item_fetchers import ItemDetailAggregator
+from .item_fetchers import ItemDetailAggregator, get_batches
 from .utils import (
     HAS_VARIANTS_EXCLUSION,
     expand_item_groups,
@@ -810,25 +810,22 @@ def get_item_detail(item, doc=None, warehouse=None, price_list=None, company=Non
     batch_no_data = []
     serial_no_data = []
     if warehouse and item.get("has_batch_no"):
-        batch_list = get_batch_qty(warehouse=warehouse, item_code=item_code)
-        if batch_list:
-            for batch in batch_list:
-                if batch.qty > 0 and batch.batch_no:
-                    batch_doc = frappe.get_cached_doc("Batch", batch.batch_no)
-                    if batch_doc.disabled == 0:
-                        batch_no_data.append(
-                            {
-                                "batch_no": batch.batch_no,
-                                "batch_qty": batch.qty,
-                                "expiry_date": batch_doc.expiry_date,
-                                "batch_price": batch_doc.posa_batch_price,
-                                "manufacturing_date": batch_doc.manufacturing_date,
-                                "is_expired": bool(
-                                    batch_doc.expiry_date
-                                    and str(batch_doc.expiry_date) <= str(today)
-                                ),
-                            }
-                        )
+        batch_rows = get_batches(warehouse, (item_code,))
+        for row in batch_rows:
+            if not row.batch_no:
+                continue
+            batch_no_data.append(
+                {
+                    "batch_no": row.batch_no,
+                    "batch_qty": row.batch_qty,
+                    "expiry_date": row.expiry_date,
+                    "batch_price": row.batch_price,
+                    "manufacturing_date": row.manufacturing_date,
+                    "is_expired": bool(
+                        row.expiry_date and str(row.expiry_date) <= str(today)
+                    ),
+                }
+            )
     if warehouse and item.get("has_serial_no"):
         serial_no_data = frappe.get_all(
             "Serial No",


### PR DESCRIPTION
## Summary
- keep the complete batch list (including expired entries) available in the item expansion view
- update the batch selection logic so users can pick expired batches while still preferring in-stock options and surface the "Expired" tag when appropriate

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d6c670a848326a6304d3a42f138a4)