### PR TITLE
Filter serial numbers by batch

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -552,9 +552,9 @@
 								</div>
 								<div class="form-row">
 									<div class="form-field full-width">
-										<v-autocomplete
-											v-model="item.serial_no_selected"
-											:items="item.serial_no_data"
+                                                                                <v-autocomplete
+                                                                                        v-model="item.serial_no_selected"
+                                                                                        :items="getSerialOptions(item)"
 											item-title="serial_no"
 											item-value="serial_no"
 											variant="outlined"
@@ -959,8 +959,15 @@ export default {
 			return this._rtlComputed;
 		},
 	},
-	methods: {
-		customItemFilter(value, search, item) {
+        methods: {
+                getSerialOptions(item) {
+                        if (Array.isArray(item?.filtered_serial_no_data)) {
+                                return item.filtered_serial_no_data;
+                        }
+                        return Array.isArray(item?.serial_no_data) ? item.serial_no_data : [];
+                },
+
+                customItemFilter(value, search, item) {
 			if (search == null) {
 				return true;
 			}

--- a/frontend/src/posapp/composables/useBatchSerial.js
+++ b/frontend/src/posapp/composables/useBatchSerial.js
@@ -1,6 +1,28 @@
-import { ref } from "vue";
-
 export function useBatchSerial() {
+        const normalizeSerialSelection = (item) => {
+                if (!Array.isArray(item.serial_no_selected)) {
+                        item.serial_no_selected = [];
+                }
+                return item.serial_no_selected;
+        };
+
+        const applySerialBatchFilter = (item) => {
+                const serials = Array.isArray(item.serial_no_data) ? item.serial_no_data : [];
+                if (!item?.has_serial_no) {
+                        item.filtered_serial_no_data = serials;
+                        return serials;
+                }
+
+                if (!item.has_batch_no || !item.batch_no) {
+                        item.filtered_serial_no_data = serials;
+                        return serials;
+                }
+
+                const filtered = serials.filter((serial) => serial?.batch_no === item.batch_no);
+                item.filtered_serial_no_data = filtered;
+                return filtered;
+        };
+
         const isBatchExpired = (batch) => {
                 if (!batch || !batch.expiry_date) return false;
 
@@ -12,24 +34,28 @@ export function useBatchSerial() {
         };
 
         // Set serial numbers for an item (and update qty)
-        const setSerialNo = (item, forceUpdate) => {
-                console.log(item);
-                if (!item.has_serial_no) return;
-                item.serial_no = "";
-		item.serial_no_selected.forEach((element) => {
-			item.serial_no += element + "\n";
-		});
-		item.serial_no_selected_count = item.serial_no_selected.length;
-		if (item.serial_no_selected_count != item.stock_qty) {
-			item.qty = item.serial_no_selected_count;
-			// Note: calc_stock_qty would need to be passed as a parameter or imported
-			if (forceUpdate) forceUpdate();
-		}
-	};
+        const setSerialNo = (item, context) => {
+                if (!item?.has_serial_no) return;
+
+                const filteredSerials = applySerialBatchFilter(item);
+                const validSerials = new Set(filteredSerials.map((serial) => serial?.serial_no).filter(Boolean));
+
+                const currentSelection = normalizeSerialSelection(item);
+                const sanitizedSelection = currentSelection.filter((serial) => validSerials.has(serial));
+                if (sanitizedSelection.length !== currentSelection.length) {
+                        item.serial_no_selected = sanitizedSelection;
+                }
+
+                item.serial_no = item.serial_no_selected.join("\n");
+                item.serial_no_selected_count = item.serial_no_selected.length;
+                if (item.serial_no_selected_count != item.stock_qty) {
+                        item.qty = item.serial_no_selected_count;
+                        if (context?.forceUpdate) context.forceUpdate();
+                }
+        };
 
         // Set batch number for an item (and update batch data)
         const setBatchQty = (item, value, update = true, context) => {
-                console.log("Setting batch quantity:", item, value);
                 const existing_items = context.items.filter(
                         (element) => element.item_code == item.item_code && element.posa_row_id != item.posa_row_id,
                 );
@@ -169,12 +195,27 @@ export function useBatchSerial() {
                 // Update batch_no_data with the full list so the UI can show every batch
                 item.batch_no_data = normalized_batch_data;
 
-                // Force UI update
-                if (context.forceUpdate) context.forceUpdate();
-	};
+                if (item.has_serial_no) {
+                        const filteredSerials = applySerialBatchFilter(item);
+                        const validSerials = new Set(
+                                filteredSerials.map((serial) => serial?.serial_no).filter(Boolean),
+                        );
+                        const currentSelection = normalizeSerialSelection(item);
+                        const sanitizedSelection = currentSelection.filter((serial) => validSerials.has(serial));
+                        if (sanitizedSelection.length !== currentSelection.length) {
+                                item.serial_no_selected = sanitizedSelection;
+                        }
+                        setSerialNo(item, context);
+                } else {
+                        item.filtered_serial_no_data = Array.isArray(item.serial_no_data) ? item.serial_no_data : [];
+                }
 
-	return {
-		setSerialNo,
-		setBatchQty,
+                // Force UI update
+                if (context?.forceUpdate) context.forceUpdate();
+        };
+
+        return {
+                setSerialNo,
+                setBatchQty,
 	};
 }

--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -329,7 +329,7 @@ def _fetch_serials(warehouse: str, item_codes: Tuple[str, ...]):
         return []
     return frappe.get_all(
         "Serial No",
-        fields=["name as serial_no", "item_code"],
+        fields=["name as serial_no", "item_code", "batch_no"],
         filters={
             "item_code": ["in", item_codes],
             "warehouse": warehouse,
@@ -553,7 +553,9 @@ class ItemDetailAggregator:
 
         serial_map: Dict[str, List[Dict[str, object]]] = {}
         for row in serial_rows:
-            serial_map.setdefault(row.item_code, []).append({"serial_no": row.serial_no})
+            serial_map.setdefault(row.item_code, []).append(
+                {"serial_no": row.serial_no, "batch_no": row.batch_no}
+            )
 
         return ItemLookupData(
             price_map=price_map,

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -834,7 +834,7 @@ def get_item_detail(item, doc=None, warehouse=None, price_list=None, company=Non
                 "status": "Active",
                 "warehouse": warehouse,
             },
-            fields=["name as serial_no"],
+            fields=["name as serial_no", "batch_no"],
         )
 
     item["selling_price_list"] = price_list


### PR DESCRIPTION
## Summary
- include the selected batch number when returning serial numbers from the server so the UI knows which serials belong to which batch
- update the batch/serial composable to keep each item's serial options and selections in sync with the currently chosen batch
- limit the serial selector in the items table to the filtered list so the dropdown only shows serials that match the selected batch

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d87d61a488326a4a953156dd643b1)