### PR TITLE
Respect item-level negative stock settings

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -358,6 +358,7 @@ import { useInvoiceStore } from "../../stores/invoiceStore.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
 import stockCoordinator from "../../utils/stockCoordinator.js";
+import { parseBooleanSetting } from "../../utils/stock.js";
 import { isOffline } from "../../../offline/index.js";
 
 export default {
@@ -1091,13 +1092,17 @@ export default {
 
 			const enforceStockLimits = this.shouldEnforceStockLimits(item);
 			// Enforce available stock limits
-			if (
-				enforceStockLimits &&
-				item.max_qty !== undefined &&
-				this.flt(item[field_name]) > this.flt(item.max_qty)
-			) {
-				const blockSale =
-					!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty;
+                        const allowNegativeStock =
+                                (parseBooleanSetting(this.stock_settings?.allow_negative_stock) ||
+                                        parseBooleanSetting(item?.allow_negative_stock)) &&
+                                !this.blockSaleBeyondAvailableQty;
+
+                        if (
+                                enforceStockLimits &&
+                                item.max_qty !== undefined &&
+                                this.flt(item[field_name]) > this.flt(item.max_qty)
+                        ) {
+                                const blockSale = this.blockSaleBeyondAvailableQty || !allowNegativeStock;
 				if (blockSale) {
 					item[field_name] = item.max_qty;
 					parsedValue = item.max_qty;
@@ -1517,18 +1522,22 @@ export default {
 		},
 
 		// Increase quantity of an item (handles return logic)
-		add_one(item) {
-			const enforceStockLimits = this.shouldEnforceStockLimits(item);
-			if (this.isReturnInvoice) {
-				// For returns, make quantity more negative
-				item.qty--;
-			} else {
-				const proposed = item.qty + 1;
-				const blockSale =
-					enforceStockLimits &&
-					(!this.stock_settings.allow_negative_stock || this.blockSaleBeyondAvailableQty);
-				const exceedsAvailable =
-					enforceStockLimits && item.max_qty !== undefined && proposed > item.max_qty;
+                add_one(item) {
+                        const enforceStockLimits = this.shouldEnforceStockLimits(item);
+                        const allowNegativeStock =
+                                (parseBooleanSetting(this.stock_settings?.allow_negative_stock) ||
+                                        parseBooleanSetting(item?.allow_negative_stock)) &&
+                                !this.blockSaleBeyondAvailableQty;
+                        if (this.isReturnInvoice) {
+                                // For returns, make quantity more negative
+                                item.qty--;
+                        } else {
+                                const proposed = item.qty + 1;
+                                const blockSale =
+                                        enforceStockLimits &&
+                                        (this.blockSaleBeyondAvailableQty || !allowNegativeStock);
+                                const exceedsAvailable =
+                                        enforceStockLimits && item.max_qty !== undefined && proposed > item.max_qty;
 				if (blockSale && exceedsAvailable) {
 					item.qty = item.max_qty;
 					this.calc_stock_qty(item, item.qty);

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3563,9 +3563,11 @@ export default {
 				const formattedRequested = this.format_number
 					? this.format_number(requestedQty, this.hide_qty_decimals ? 0 : this.float_precision)
 					: requestedQty;
-				const negativeStockEnabled = this.isNegativeStockEnabled();
-				const shouldBlock =
-					!negativeStockEnabled && (this.blockSaleBeyondAvailableQty || availableQty <= 0);
+                                const negativeStockEnabled = this.isNegativeStockEnabled(newItem);
+                                const exceedsAvailable = availableQty < requestedQty;
+                                const shouldBlock =
+                                        (this.blockSaleBeyondAvailableQty && exceedsAvailable) ||
+                                        (!negativeStockEnabled && exceedsAvailable);
 
 				if (shouldBlock) {
 					this.showScanError({
@@ -3629,8 +3631,10 @@ export default {
 				this.awaitingScanResult = false;
 			}
 		},
-		isNegativeStockEnabled() {
-			return parseBooleanSetting(this.stock_settings?.allow_negative_stock);
+                isNegativeStockEnabled(item = null) {
+                        const allowNegativeSetting = parseBooleanSetting(this.stock_settings?.allow_negative_stock);
+                        const allowNegativeItem = item ? parseBooleanSetting(item.allow_negative_stock) : false;
+                        return allowNegativeSetting || allowNegativeItem;
 		},
 		showMultipleItemsDialog(items, scannedCode) {
 			// Create a dialog to let user choose from multiple matches
@@ -3880,10 +3884,7 @@ export default {
 			return 500;
 		},
 		blockSaleBeyondAvailableQty() {
-			return (
-				Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty) &&
-				!this.isNegativeStockEnabled()
-			);
+                        return Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty);
 		},
 		headers() {
 			return this.getItemsHeaders();

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -934,11 +934,10 @@ export default {
 			};
 		},
 
-		blockSaleBeyondAvailableQty() {
-			if (["Order", "Quotation"].includes(this.invoiceType)) return false;
-			const allowNegative = parseBooleanSetting(this.stock_settings?.allow_negative_stock);
-			return !allowNegative && !!this.pos_profile?.posa_block_sale_beyond_available_qty;
-		},
+                blockSaleBeyondAvailableQty() {
+                        if (["Order", "Quotation"].includes(this.invoiceType)) return false;
+                        return !!this.pos_profile?.posa_block_sale_beyond_available_qty;
+                },
 
 		// Responsive headers based on container size
 		responsiveHeaders() {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -887,13 +887,12 @@ export default {
 		displayCurrency() {
 			return this.invoice_doc ? this.invoice_doc.currency : "";
 		},
-		blockSaleBeyondAvailableQty() {
-			if (["Order", "Quotation"].includes(this.invoiceType)) {
-				return false;
-			}
-			const allowNegative = parseBooleanSetting(this.stock_settings?.allow_negative_stock);
-			return !allowNegative && Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty);
-		},
+                blockSaleBeyondAvailableQty() {
+                        if (["Order", "Quotation"].includes(this.invoiceType)) {
+                                return false;
+                        }
+                        return Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty);
+                },
 		// Calculate total payments (all methods, loyalty, credit)
 		total_payments() {
 			let total = 0;

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -138,13 +138,12 @@ export default {
 	isReturnInvoice() {
 		return this.invoiceType === "Return" || (this.invoice_doc && this.invoice_doc.is_return);
 	},
-	blockSaleBeyondAvailableQty() {
-		if (["Order", "Quotation"].includes(this.invoiceType)) {
-			return false;
-		}
-		const allowNegative = parseBooleanSetting(this.stock_settings?.allow_negative_stock);
-		return !allowNegative && Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty);
-	},
+        blockSaleBeyondAvailableQty() {
+                if (["Order", "Quotation"].includes(this.invoiceType)) {
+                        return false;
+                }
+                return Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty);
+        },
 	// Table headers for item table (for another table if needed)
 	itemTableHeaders() {
 		return [

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -16,6 +16,7 @@ import { useBatchSerial } from "../../composables/useBatchSerial.js";
 import { useDiscounts } from "../../composables/useDiscounts.js";
 import { useItemAddition } from "../../composables/useItemAddition.js";
 import { useStockUtils } from "../../composables/useStockUtils.js";
+import { parseBooleanSetting } from "../../utils/stock.js";
 import stockCoordinator from "../../utils/stockCoordinator.js";
 import { useItemsStore } from "../../stores/itemsStore.js";
 import { usePricingRulesStore } from "../../stores/pricingRulesStore.js";
@@ -4270,12 +4271,13 @@ export default {
 			this.update_qty_limits(item);
 		}
 
-		const blockSale =
-			this.pos_profile?.posa_block_sale_beyond_available_qty || this.blockSaleBeyondAvailableQty;
-		const allowNegativeStock =
-			item.allow_negative_stock === 1 ||
-			item.allow_negative_stock === true ||
-			item.allow_negative_stock === "1";
+                const blockSale = Boolean(
+                        this.pos_profile?.posa_block_sale_beyond_available_qty || this.blockSaleBeyondAvailableQty,
+                );
+                const allowNegativeStock =
+                        !blockSale &&
+                        (parseBooleanSetting(this.stock_settings?.allow_negative_stock) ||
+                                parseBooleanSetting(item?.allow_negative_stock));
 		let clamped = false;
 		if (
 			blockSale &&
@@ -4319,23 +4321,25 @@ export default {
 			item.max_qty = flt(item._base_actual_qty / (item.conversion_factor || 1));
 
 			// Set increment disable flag based on stock limits
-			const blockSale =
-				this.pos_profile?.posa_block_sale_beyond_available_qty || this.blockSaleBeyondAvailableQty;
-			const allowNegativeStock =
-				item.allow_negative_stock === 1 ||
-				item.allow_negative_stock === true ||
-				item.allow_negative_stock === "1";
+                        const blockSale = Boolean(
+                                this.pos_profile?.posa_block_sale_beyond_available_qty || this.blockSaleBeyondAvailableQty,
+                        );
+                        const allowNegativeStock =
+                                !blockSale &&
+                                (parseBooleanSetting(this.stock_settings?.allow_negative_stock) ||
+                                        parseBooleanSetting(item?.allow_negative_stock));
 
-			if (allowNegativeStock) {
-				item.disable_increment = false;
-			} else if (blockSale) {
-				item.disable_increment = item.qty >= item.max_qty;
-			} else {
-				item.disable_increment =
-					!this.stock_settings.allow_negative_stock && item.qty >= item.max_qty;
-			}
-		}
-	},
+                        if (allowNegativeStock) {
+                                item.disable_increment = false;
+                        } else if (blockSale) {
+                                item.disable_increment = item.qty >= item.max_qty;
+                        } else {
+                                item.disable_increment =
+                                        !parseBooleanSetting(this.stock_settings?.allow_negative_stock) &&
+                                        item.qty >= item.max_qty;
+                        }
+                }
+        },
 
 	// Fetch available stock for an item and cache it
 	async fetch_available_qty(item) {

--- a/frontend/src/posapp/composables/useCartValidation.js
+++ b/frontend/src/posapp/composables/useCartValidation.js
@@ -70,7 +70,9 @@ export function useCartValidation() {
 				// Step 4: Client-side quantity validation (before server call)
 				// Allow negative stock items when Allow Negative Stock is enabled
 				// This overrides POS Profile's block setting when negative stock is explicitly allowed
-				const allowNegativeStock = parseBooleanSetting(stockSettings?.allow_negative_stock);
+                                const allowNegativeStock =
+                                        parseBooleanSetting(stockSettings?.allow_negative_stock) ||
+                                        parseBooleanSetting(item?.allow_negative_stock);
 				const exceedsAvailable =
 					typeof item.actual_qty === "number" && requestedQty > item.actual_qty;
 				const blockSale = !allowNegativeStock && exceedsAvailable;
@@ -198,7 +200,9 @@ export function useCartValidation() {
 
 		if (isStockItem) {
 			// Allow negative stock items when Allow Negative Stock is enabled
-			const allowNegativeStock = parseBooleanSetting(stockSettings?.allow_negative_stock);
+                        const allowNegativeStock =
+                                parseBooleanSetting(stockSettings?.allow_negative_stock) ||
+                                parseBooleanSetting(item?.allow_negative_stock);
 
 			// Simple negative stock check - only block if negative stock is not allowed
 			if (item.actual_qty < 0 && !allowNegativeStock) {

--- a/frontend/src/posapp/composables/useCartValidation.js
+++ b/frontend/src/posapp/composables/useCartValidation.js
@@ -71,8 +71,9 @@ export function useCartValidation() {
 				// Allow negative stock items when Allow Negative Stock is enabled
 				// This overrides POS Profile's block setting when negative stock is explicitly allowed
                                 const allowNegativeStock =
-                                        parseBooleanSetting(stockSettings?.allow_negative_stock) ||
-                                        parseBooleanSetting(item?.allow_negative_stock);
+                                        !blockSaleBeyondAvailableQty &&
+                                        (parseBooleanSetting(stockSettings?.allow_negative_stock) ||
+                                                parseBooleanSetting(item?.allow_negative_stock));
 				const exceedsAvailable =
 					typeof item.actual_qty === "number" && requestedQty > item.actual_qty;
 				const blockSale = !allowNegativeStock && exceedsAvailable;
@@ -201,8 +202,9 @@ export function useCartValidation() {
 		if (isStockItem) {
 			// Allow negative stock items when Allow Negative Stock is enabled
                         const allowNegativeStock =
-                                parseBooleanSetting(stockSettings?.allow_negative_stock) ||
-                                parseBooleanSetting(item?.allow_negative_stock);
+                                !blockSaleBeyondAvailableQty &&
+                                (parseBooleanSetting(stockSettings?.allow_negative_stock) ||
+                                        parseBooleanSetting(item?.allow_negative_stock));
 
 			// Simple negative stock check - only block if negative stock is not allowed
 			if (item.actual_qty < 0 && !allowNegativeStock) {

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -142,6 +142,20 @@ def _is_stock_item(item):
     return bool(cint(frappe.get_cached_value("Item", item_code, "is_stock_item") or 0))
 
 
+def _allow_negative_stock(item):
+    """Return True if negative stock is allowed globally or for the item."""
+
+    # Global setting overrides everything
+    if cint(frappe.db.get_single_value("Stock Settings", "allow_negative_stock") or 0):
+        return True
+
+    flag = item.get("allow_negative_stock")
+    if flag is None and item.get("item_code"):
+        flag = frappe.get_cached_value("Item", item.get("item_code"), "allow_negative_stock")
+
+    return bool(cint(flag or 0))
+
+
 def _collect_stock_errors(items):
     """Return list of items exceeding available stock."""
     errors = []
@@ -149,6 +163,8 @@ def _collect_stock_errors(items):
         if flt(d.get("qty")) < 0:
             continue
         if not _is_stock_item(d):
+            continue
+        if _allow_negative_stock(d):
             continue
         available = _get_available_stock(d)
         requested = flt(d.get("stock_qty") or (flt(d.get("qty")) * flt(d.get("conversion_factor") or 1)))


### PR DESCRIPTION
## Summary
- skip stock blocking for items that explicitly allow negative stock even when global setting is disabled
- include item-level negative stock allowance in cart validation to avoid blocking item additions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d842d028c8326afd66a606ff8fc01)