### PR TITLE
Avoid closing payments while recomputing totals

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -4,13 +4,12 @@ import { perfMarkStart, perfMarkEnd } from "../../utils/perf.js";
 import { parseBooleanSetting } from "../../utils/stock.js";
 
 export default {
-	// Calculate total quantity of all items
-	total_qty() {
-		const mark = perfMarkStart("pos:totals-total_qty");
-		this.close_payments();
-		const store = this.invoiceStore;
-		const storeValue = store?.totalQty?.value ?? store?.totalQty;
-		let qty;
+        // Calculate total quantity of all items
+        total_qty() {
+                const mark = perfMarkStart("pos:totals-total_qty");
+                const store = this.invoiceStore;
+                const storeValue = store?.totalQty?.value ?? store?.totalQty;
+                let qty;
 
 		if (typeof storeValue === "number" && !Number.isNaN(storeValue)) {
 			qty = storeValue;
@@ -47,14 +46,13 @@ export default {
 		const result = this.flt(sum, this.currency_precision);
 		perfMarkEnd("pos:totals-gross", mark);
 		return result;
-	},
-	// Calculate subtotal after discounts and delivery charges
-	subtotal() {
-		const mark = perfMarkStart("pos:totals-subtotal");
-		this.close_payments();
-		const store = this.invoiceStore;
-		const storeValue = store?.grossTotal?.value ?? store?.grossTotal;
-		let sum = typeof storeValue === "number" && !Number.isNaN(storeValue) ? storeValue : 0;
+        },
+        // Calculate subtotal after discounts and delivery charges
+        subtotal() {
+                const mark = perfMarkStart("pos:totals-subtotal");
+                const store = this.invoiceStore;
+                const storeValue = store?.grossTotal?.value ?? store?.grossTotal;
+                let sum = typeof storeValue === "number" && !Number.isNaN(storeValue) ? storeValue : 0;
 
 		if (!(typeof storeValue === "number" && !Number.isNaN(storeValue))) {
 			this.items.forEach((item) => {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -882,26 +882,26 @@ export default {
 		const serverDiscountPercentage = Number.parseFloat(invoiceUpdates.additional_discount_percentage || 0);
 		const serverRules = invoiceUpdates.pricing_rules;
 
-		if (serverRules) {
-			// Rule applied by server
-			if (this.pos_profile?.posa_use_percentage_discount) {
-				if (serverDiscountPercentage > 0) {
-					this.additional_discount_percentage = serverDiscountPercentage;
+                if (serverRules) {
+                        // Rule applied by server
+                        if (this.pos_profile?.posa_use_percentage_discount) {
+                                if (serverDiscountPercentage > 0) {
+                                        this.additional_discount_percentage = serverDiscountPercentage;
 				} else if (serverDiscountAmount > 0 && this.Total > 0) {
 					this.additional_discount_percentage = (serverDiscountAmount / this.Total) * 100;
 				} else {
 					this.additional_discount_percentage = 0;
-				}
-				this.update_discount_umount();
-			} else {
-				this.additional_discount = serverDiscountAmount;
-				this.additional_discount_percentage = serverDiscountPercentage;
-				this.update_discount_umount();
-			}
-			if (this.invoice_doc) {
-				this.invoice_doc.pricing_rules = serverRules;
-			} else {
-				this.invoiceStore.mergeInvoiceDoc({ pricing_rules: serverRules });
+                                }
+                                this.update_discount_umount();
+                        } else {
+                                this.additional_discount = serverDiscountAmount;
+                                this.additional_discount_percentage = serverDiscountPercentage;
+                                this.discount_amount = this.additional_discount;
+                        }
+                        if (this.invoice_doc) {
+                                this.invoice_doc.pricing_rules = serverRules;
+                        } else {
+                                this.invoiceStore.mergeInvoiceDoc({ pricing_rules: serverRules });
 			}
 		} else if (this.invoice_doc?.pricing_rules) {
 			// No rules from server, but we had rules before. Clear them.

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -3077,10 +3077,27 @@ export default {
 				}
 			}
 
-			// Update invoice_doc with current currency info
-			invoice_doc.currency = this.selected_currency || this.pos_profile.currency;
-			invoice_doc.conversion_rate = this.conversion_rate || 1;
-			invoice_doc.plc_conversion_rate = this.exchange_rate || 1;
+                        // Update invoice_doc with current currency info
+                        invoice_doc.currency = this.selected_currency || this.pos_profile.currency;
+                        invoice_doc.conversion_rate = this.conversion_rate || 1;
+                        invoice_doc.plc_conversion_rate = this.exchange_rate || 1;
+
+                        // Sync additional discount values back to the UI so totals remain accurate
+                        // in the summary panel even after the invoice is refreshed from the server.
+                        if (invoice_doc.discount_amount !== undefined && invoice_doc.discount_amount !== null) {
+                                this.discount_amount = this.flt(invoice_doc.discount_amount, this.currency_precision);
+                                this.additional_discount = this.discount_amount;
+                        }
+
+                        if (
+                                invoice_doc.additional_discount_percentage !== undefined &&
+                                invoice_doc.additional_discount_percentage !== null
+                        ) {
+                                this.additional_discount_percentage = this.flt(
+                                        invoice_doc.additional_discount_percentage,
+                                        this.float_precision,
+                                );
+                        }
 
 			// Preserve totals calculated on the server to ensure taxes are included
 			// The process_invoice method already updates the invoice with taxes and

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -878,19 +878,28 @@ export default {
 		const serverFree = Array.isArray(message.free_lines) ? message.free_lines : [];
 		const invoiceUpdates = message.invoice_updates || {};
 
-		const serverDiscountAmount = Number.parseFloat(invoiceUpdates.discount_amount || 0);
-		const serverDiscountPercentage = Number.parseFloat(invoiceUpdates.additional_discount_percentage || 0);
-		const serverRules = invoiceUpdates.pricing_rules;
+                const hasDiscountUpdate =
+                        invoiceUpdates &&
+                        (Object.prototype.hasOwnProperty.call(invoiceUpdates, "discount_amount") ||
+                                Object.prototype.hasOwnProperty.call(
+                                        invoiceUpdates,
+                                        "additional_discount_percentage",
+                                ));
 
-                if (serverRules) {
-                        // Rule applied by server
+                const serverDiscountAmount = Number.parseFloat(invoiceUpdates.discount_amount || 0);
+                const serverDiscountPercentage = Number.parseFloat(
+                        invoiceUpdates.additional_discount_percentage || 0,
+                );
+                const serverRules = invoiceUpdates.pricing_rules;
+
+                if (hasDiscountUpdate) {
                         if (this.pos_profile?.posa_use_percentage_discount) {
                                 if (serverDiscountPercentage > 0) {
                                         this.additional_discount_percentage = serverDiscountPercentage;
-				} else if (serverDiscountAmount > 0 && this.Total > 0) {
-					this.additional_discount_percentage = (serverDiscountAmount / this.Total) * 100;
-				} else {
-					this.additional_discount_percentage = 0;
+                                } else if (serverDiscountAmount > 0 && this.Total > 0) {
+                                        this.additional_discount_percentage = (serverDiscountAmount / this.Total) * 100;
+                                } else {
+                                        this.additional_discount_percentage = 0;
                                 }
                                 this.update_discount_umount();
                         } else {
@@ -898,22 +907,15 @@ export default {
                                 this.additional_discount_percentage = serverDiscountPercentage;
                                 this.discount_amount = this.additional_discount;
                         }
+                }
+
+                if (serverRules !== undefined) {
                         if (this.invoice_doc) {
-                                this.invoice_doc.pricing_rules = serverRules;
+                                this.invoice_doc.pricing_rules = serverRules || null;
                         } else {
-                                this.invoiceStore.mergeInvoiceDoc({ pricing_rules: serverRules });
-			}
-		} else if (this.invoice_doc?.pricing_rules) {
-			// No rules from server, but we had rules before. Clear them.
-			this.additional_discount = 0;
-			this.additional_discount_percentage = 0;
-			this.update_discount_umount();
-			if (this.invoice_doc) {
-				this.invoice_doc.pricing_rules = null;
-			} else {
-				this.invoiceStore.mergeInvoiceDoc({ pricing_rules: null });
-			}
-		}
+                                this.invoiceStore.mergeInvoiceDoc({ pricing_rules: serverRules || null });
+                        }
+                }
 
 		serverFree.forEach((entry) => {
 			if (!entry || !entry.item_code) {


### PR DESCRIPTION
## Summary
- prevent the payment dialog from being closed when totals are recalculated
- keep payments open when editing values such as additional discounts before checkout

## Testing
- not run (not requested)
