### PR TITLE
Fix pricing rule discounts when rate is missing

### DIFF
--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -409,7 +409,18 @@ def reconcile_line_prices(cart_payload: dict | str | None = None):
         price_list_rate = flt(details.get("price_list_rate") or args.price_list_rate)
         discount_amount = flt(details.get("discount_amount") or 0)
         discount_percentage = flt(details.get("discount_percentage") or 0)
-        rate = flt(details.get("rate") or (price_list_rate - discount_amount))
+
+        rate = flt(details.get("rate") or 0)
+        if not rate:
+            if discount_amount:
+                rate = price_list_rate - discount_amount
+            elif discount_percentage:
+                rate = price_list_rate * (1 - (discount_percentage / 100))
+            else:
+                rate = price_list_rate
+
+        if not discount_amount and discount_percentage:
+            discount_amount = price_list_rate - rate
 
         updates.append(
             {

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -299,7 +299,7 @@ def _build_doc_context(ctx: frappe._dict):
     return doc
 
 
-def _build_pricing_args(line: frappe._dict, ctx: frappe._dict) -> frappe._dict:
+def _extract_qty_context(line: frappe._dict) -> Tuple[float, float, float]:
     raw_qty = flt(line.qty or 0)
 
     stock_candidates = [
@@ -332,6 +332,17 @@ def _build_pricing_args(line: frappe._dict, ctx: frappe._dict) -> frappe._dict:
 
     qty = abs(raw_qty)
     effective_stock_qty = abs(stock_qty)
+    conversion_factor = 1
+    if qty:
+        conversion_factor = effective_stock_qty / qty
+
+    return qty, effective_stock_qty, conversion_factor
+
+
+def _build_pricing_args(
+    line: frappe._dict, ctx: frappe._dict, qty_context: Tuple[float, float, float] | None = None
+) -> frappe._dict:
+    qty, effective_stock_qty, _ = qty_context or _extract_qty_context(line)
 
     return frappe._dict(
         doctype="Sales Invoice Item",
@@ -399,18 +410,38 @@ def reconcile_line_prices(cart_payload: dict | str | None = None):
 
     for raw_line in lines:
         line = frappe._dict(raw_line)
-        args = _build_pricing_args(line, ctx)
+        qty_context = _extract_qty_context(line)
+        conversion_factor = qty_context[2]
+
+        args = _build_pricing_args(line, ctx, qty_context)
         details = get_pricing_rule_for_item(args, doc=doc)
 
         applied_rules = []
         if details.get("pricing_rules"):
             applied_rules = _as_list(frappe.parse_json(details.get("pricing_rules")))
 
-        price_list_rate = flt(details.get("price_list_rate") or args.price_list_rate)
-        discount_amount = flt(details.get("discount_amount") or 0)
+        raw_price_list_rate = flt(details.get("price_list_rate") or args.price_list_rate)
+        raw_discount_amount = flt(details.get("discount_amount") or 0)
         discount_percentage = flt(details.get("discount_percentage") or 0)
 
-        rate = flt(details.get("rate") or 0)
+        raw_rate = flt(details.get("rate") or 0)
+        price_list_rate = raw_price_list_rate
+        discount_amount = raw_discount_amount
+        rate = raw_rate
+
+        should_scale = (
+            conversion_factor not in (0, 1)
+            and args.price_list_rate
+            and raw_price_list_rate
+            and abs((args.price_list_rate / raw_price_list_rate) - conversion_factor)
+            <= 0.0001 * conversion_factor
+        )
+
+        if should_scale:
+            price_list_rate = args.price_list_rate
+            rate = raw_rate * conversion_factor if raw_rate else raw_rate
+            discount_amount = raw_discount_amount * conversion_factor if raw_discount_amount else raw_discount_amount
+
         if not rate:
             if discount_amount:
                 rate = price_list_rate - discount_amount

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -351,8 +351,8 @@ def _build_pricing_args(
         item_code=line.item_code,
         qty=qty,
         stock_qty=effective_stock_qty,
-        price_list_rate=flt(line.base_price_list_rate or line.price_list_rate or 0),
-        rate=flt(line.base_rate or line.rate or 0),
+        price_list_rate=flt(line.price_list_rate or line.base_price_list_rate or 0),
+        rate=flt(line.rate or line.base_rate or 0),
         currency=ctx.get("currency"),
         price_list=ctx.get("price_list"),
         transaction_date=ctx.get("date") or nowdate(),
@@ -435,7 +435,7 @@ def reconcile_line_prices(cart_payload: dict | str | None = None):
         discount_amount = raw_discount_amount
         rate = raw_rate
 
-        target_price_list_rate = flt(line.get("base_price_list_rate") or line.get("price_list_rate") or 0)
+        target_price_list_rate = flt(line.get("price_list_rate") or line.get("base_price_list_rate") or 0)
 
         should_scale = (
             conversion_factor not in (0, 1)

--- a/posawesome/posawesome/api/pricing_rules.py
+++ b/posawesome/posawesome/api/pricing_rules.py
@@ -342,7 +342,7 @@ def _extract_qty_context(line: frappe._dict) -> Tuple[float, float, float]:
 def _build_pricing_args(
     line: frappe._dict, ctx: frappe._dict, qty_context: Tuple[float, float, float] | None = None
 ) -> frappe._dict:
-    qty, effective_stock_qty, _ = qty_context or _extract_qty_context(line)
+    qty, effective_stock_qty, conversion_factor = qty_context or _extract_qty_context(line)
 
     return frappe._dict(
         doctype="Sales Invoice Item",
@@ -359,6 +359,8 @@ def _build_pricing_args(
         company=ctx.company,
         conversion_rate=flt(ctx.get("conversion_rate") or 1),
         plc_conversion_rate=flt(ctx.get("conversion_rate") or 1),
+        conversion_factor=conversion_factor,
+        uom_conversion_factor=conversion_factor,
         customer=ctx.get("customer"),
         customer_group=ctx.get("customer_group"),
         territory=ctx.get("territory"),
@@ -420,7 +422,11 @@ def reconcile_line_prices(cart_payload: dict | str | None = None):
         if details.get("pricing_rules"):
             applied_rules = _as_list(frappe.parse_json(details.get("pricing_rules")))
 
-        raw_price_list_rate = flt(details.get("price_list_rate") or args.price_list_rate)
+        raw_price_list_rate = flt(
+            details.get("price_list_rate")
+            or details.get("for_price_list_rate")
+            or args.price_list_rate
+        )
         raw_discount_amount = flt(details.get("discount_amount") or 0)
         discount_percentage = flt(details.get("discount_percentage") or 0)
 
@@ -429,18 +435,23 @@ def reconcile_line_prices(cart_payload: dict | str | None = None):
         discount_amount = raw_discount_amount
         rate = raw_rate
 
+        target_price_list_rate = flt(line.get("base_price_list_rate") or line.get("price_list_rate") or 0)
+
         should_scale = (
             conversion_factor not in (0, 1)
-            and args.price_list_rate
+            and target_price_list_rate
             and raw_price_list_rate
-            and abs((args.price_list_rate / raw_price_list_rate) - conversion_factor)
+            and abs((target_price_list_rate / raw_price_list_rate) - conversion_factor)
             <= 0.0001 * conversion_factor
         )
 
         if should_scale:
-            price_list_rate = args.price_list_rate
+            price_list_rate = target_price_list_rate
             rate = raw_rate * conversion_factor if raw_rate else raw_rate
             discount_amount = raw_discount_amount * conversion_factor if raw_discount_amount else raw_discount_amount
+
+        if not should_scale and conversion_factor not in (0, 1) and raw_price_list_rate and not target_price_list_rate:
+            price_list_rate = raw_price_list_rate * conversion_factor
 
         if not rate:
             if discount_amount:


### PR DESCRIPTION
## Summary
- derive line rates when pricing rules return only discount percentage or amount
- backfill discount amounts from calculated rates so UOM-based discounts apply consistently

## Testing
- Not run (not requested)
