### PR TITLE
Allow pricing rules on UOM-priced items

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -224,7 +224,9 @@ export default {
 			return;
 		}
 
-		const allowRateUpdate = !item.locked_price && !item.posa_offer_applied && !item._manual_rate_set;
+                const manualFromUom = item._manual_rate_set_from_uom === true;
+                const manualOverride = item._manual_rate_set === true && !manualFromUom;
+                const allowRateUpdate = !item.locked_price && !item.posa_offer_applied && !manualOverride;
 		const rawDocQty = Number.parseFloat(item.qty || 0);
 		const signedDocQty = Number.isFinite(rawDocQty) ? rawDocQty : 0;
 		const docQty = Math.abs(signedDocQty);
@@ -1078,7 +1080,8 @@ export default {
 			const discountPercentage =
 				Number.parseFloat(update.discount_percentage ?? item.discount_percentage ?? 0) || 0;
 
-			const manualOverride = item._manual_rate_set === true;
+                        const manualFromUom = item._manual_rate_set_from_uom === true;
+                        const manualOverride = item._manual_rate_set === true && !manualFromUom;
 			const priceLocked = item.locked_price === true;
 			const offerApplied =
 				item.posa_offer_applied === true ||
@@ -2801,11 +2804,12 @@ export default {
 	},
 
 	_assignManualOverrideValues(item, values = {}) {
-		if (!item || !values) {
-			return;
-		}
+                if (!item || !values) {
+                        return;
+                }
 
-		item._manual_rate_set = true;
+                item._manual_rate_set = true;
+                item._manual_rate_set_from_uom = false;
 
 		if (values.uom) {
 			item.uom = values.uom;
@@ -3477,7 +3481,9 @@ export default {
 							updated_item.price_list_currency ||
 							item.price_list_currency ||
 							this.selected_currency;
-						const manualLocked = item._manual_rate_set === true;
+                                                const manualLocked =
+                                                        item._manual_rate_set === true &&
+                                                        item._manual_rate_set_from_uom !== true;
 						const shouldOverrideRate =
 							!item.locked_price && !item.posa_offer_applied && !manualLocked;
 
@@ -4083,7 +4089,7 @@ export default {
 
 		const rate = Number.isFinite(Number(newRate)) ? Number(newRate) : 0;
 		const resolvedCurrency = priceCurrency || this.selected_currency;
-		const manualOverride = item._manual_rate_set === true;
+                const manualOverride = item._manual_rate_set === true && item._manual_rate_set_from_uom !== true;
 		const companyCurrency = this.pos_profile?.currency;
 
 		if (!item.original_currency) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -48,11 +48,12 @@ export function useDiscounts() {
 		const fieldId = $event.target.id;
 		let newValue = flt(value, context.currency_precision);
 
-		try {
-			// Flag to track manual rate changes
-			if (["rate", "discount_amount", "discount_percentage"].includes(fieldId)) {
-				item._manual_rate_set = true;
-			}
+                try {
+                        // Flag to track manual rate changes
+                        if (["rate", "discount_amount", "discount_percentage"].includes(fieldId)) {
+                                item._manual_rate_set = true;
+                                item._manual_rate_set_from_uom = false;
+                        }
 
 			// Handle negative values
 			if (newValue < 0) {

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -477,12 +477,13 @@ export function useItemAddition() {
 		if (!item.posa_is_offer) {
 			item.posa_is_offer = 0;
 		}
-		if (!item.posa_is_replace) {
-			item.posa_is_replace = "";
-		}
+                if (!item.posa_is_replace) {
+                        item.posa_is_replace = "";
+                }
 
-		// Initialize flag for tracking manual rate changes
-		new_item._manual_rate_set = false;
+                // Initialize flag for tracking manual rate changes
+                new_item._manual_rate_set = false;
+                new_item._manual_rate_set_from_uom = false;
 
 		// Set negative quantity for return invoices
 		if (context.isReturnInvoice && item.qty > 0) {

--- a/frontend/src/posapp/composables/useStockUtils.js
+++ b/frontend/src/posapp/composables/useStockUtils.js
@@ -71,8 +71,9 @@ export function useStockUtils() {
 			}
 		}
 
-		if (uomRate) {
-			item._manual_rate_set = true;
+                if (uomRate) {
+                        item._manual_rate_set = true;
+                        item._manual_rate_set_from_uom = true;
 
 			// default rates based on fetched UOM price
 			let base_price = uomRate;
@@ -146,8 +147,9 @@ export function useStockUtils() {
 		// lock the rate when the user selected a non-stock UOM so the
 		// backend refresh (triggered when opening payments) does not
 		// revert the displayed rate back to the single-unit price.
-		const shouldPreserveManualRate = value !== item.stock_uom || item.conversion_factor !== 1;
-		item._manual_rate_set = shouldPreserveManualRate;
+                const shouldPreserveManualRate = value !== item.stock_uom || item.conversion_factor !== 1;
+                item._manual_rate_set = shouldPreserveManualRate;
+                item._manual_rate_set_from_uom = shouldPreserveManualRate;
 
 		// Reset discount if not offer
 		if (!item.posa_offer_applied) {


### PR DESCRIPTION
## Summary
- track when manual pricing flags come from UOM selection instead of user overrides
- allow pricing rules and price list updates to adjust items even when a rate was set via UOM
- initialize and reset UOM manual flags so discounts and conversions stay in sync

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da67ba2b883268cb71aca0508d9cc)