### PR TITLE
Add customer invoice history dialog and last rate display

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -28,27 +28,27 @@
 					{{ __("Invoices saved as POS Invoices") }}
 				</v-alert>
                                 <!-- Top Row: Customer Selection and Invoice Type -->
-                                <v-row align="center" class="items px-3 py-2">
-                                        <v-col :cols="pos_profile.posa_allow_sales_order ? 7 : 9" class="pb-0 pr-0">
-                                                <!-- Customer selection component -->
-                                                <Customer ref="customerComponent" />
-                                        </v-col>
-                                        <v-col :cols="pos_profile.posa_allow_sales_order ? 2 : 3" class="pb-0">
-                                                <v-tooltip :text="__('Check previous invoices')" location="top">
-                                                        <template #activator="{ props }">
-                                                                <v-btn
-                                                                        v-bind="props"
-                                                                        color="primary"
-                                                                        variant="tonal"
-                                                                        size="small"
-                                                                        rounded="circle"
-                                                                        class="previous-invoices-btn"
-                                                                        icon="mdi-history"
-                                                                        @click="openInvoiceHistory"
-                                                                        :disabled="!customer"
-                                                                ></v-btn>
-                                                        </template>
-                                                </v-tooltip>
+                                <v-row align="center" class="items px-3 py-2 history-header" no-gutters>
+                                        <v-col :cols="pos_profile.posa_allow_sales_order ? 9 : 12" class="pb-0 pr-0">
+                                                <div class="d-flex align-center ga-2 flex-nowrap">
+                                                        <!-- Customer selection component -->
+                                                        <Customer ref="customerComponent" class="flex-grow-1" />
+                                                        <v-tooltip :text="__('Check previous invoices')" location="top">
+                                                                <template #activator="{ props }">
+                                                                        <v-btn
+                                                                                v-bind="props"
+                                                                                color="primary"
+                                                                                variant="tonal"
+                                                                                size="small"
+                                                                                rounded="circle"
+                                                                                class="previous-invoices-btn"
+                                                                                icon="mdi-history"
+                                                                                @click="openInvoiceHistory"
+                                                                                :disabled="!getActiveCustomerId()"
+                                                                        ></v-btn>
+                                                                </template>
+                                                        </v-tooltip>
+                                                </div>
                                         </v-col>
                                         <!-- Invoice Type Selection (Only shown if sales orders are allowed) -->
                                         <v-col v-if="pos_profile.posa_allow_sales_order" cols="3" class="pb-4">
@@ -749,7 +749,19 @@ export default {
                         this.eventBus.emit("focus_item_search");
                 },
 
+                getActiveCustomerId() {
+                        const candidate = this.customer || this.selectedCustomer;
+                        if (candidate && typeof candidate === "object") {
+                                return candidate.name || candidate.customer || "";
+                        }
+                        return candidate || "";
+                },
+
                 openInvoiceHistory() {
+                        const activeCustomer = this.getActiveCustomerId();
+                        if (activeCustomer && !this.customer) {
+                                this.customer = activeCustomer;
+                        }
                         this.show_invoice_history = true;
                         this.resetInvoiceHistory();
                         this.loadInvoiceHistory();
@@ -851,7 +863,8 @@ export default {
                 },
 
                 async loadInvoiceHistory(loadMore = false) {
-                        if (!this.customer) {
+                        const customerId = this.getActiveCustomerId();
+                        if (!customerId) {
                                 this.invoice_history_error = __("Select a customer to view history.");
                                 return;
                         }
@@ -880,7 +893,7 @@ export default {
                                 const res = await frappe.call({
                                         method: "posawesome.posawesome.api.invoices.get_customer_invoice_history",
                                         args: {
-                                                customer: this.customer,
+                                                customer: customerId,
                                                 company: this.pos_profile?.company,
                                                 from_date: this.invoice_history_filters.from_date || undefined,
                                                 to_date: this.invoice_history_filters.to_date || undefined,

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -34,16 +34,20 @@
                                                 <Customer ref="customerComponent" />
                                         </v-col>
                                         <v-col :cols="pos_profile.posa_allow_sales_order ? 2 : 3" class="pb-0">
-                                                <v-btn
-                                                        block
-                                                        color="primary"
-                                                        variant="tonal"
-                                                        prepend-icon="mdi-history"
-                                                        @click="openInvoiceHistory"
-                                                        :disabled="!customer"
-                                                >
-                                                        {{ __("Previous Invoices") }}
-                                                </v-btn>
+                                                <v-tooltip :text="__('Check previous invoices')" location="top">
+                                                        <template #activator="{ props }">
+                                                                <v-btn
+                                                                        v-bind="props"
+                                                                        block
+                                                                        color="primary"
+                                                                        variant="tonal"
+                                                                        density="comfortable"
+                                                                        icon="mdi-history"
+                                                                        @click="openInvoiceHistory"
+                                                                        :disabled="!customer"
+                                                                ></v-btn>
+                                                        </template>
+                                                </v-tooltip>
                                         </v-col>
                                         <!-- Invoice Type Selection (Only shown if sales orders are allowed) -->
                                         <v-col v-if="pos_profile.posa_allow_sales_order" cols="3" class="pb-4">
@@ -135,30 +139,40 @@
                                                                         :key="invoice.invoice"
                                                                         class="history-list-item"
                                                                 >
-                                                                        <v-list-item-title class="d-flex align-center justify-space-between">
-                                                                                <span class="font-weight-medium">{{ invoice.invoice }}</span>
-                                                                                <div class="d-flex align-center history-meta">
-                                                                                        <v-chip
-                                                                                                v-if="invoice.is_return"
-                                                                                                size="x-small"
-                                                                                                color="warning"
-                                                                                                variant="tonal"
-                                                                                        >
-                                                                                                {{ __("Return") }}
-                                                                                        </v-chip>
-                                                                                        <span class="text-caption">{{ formatHistoryDate(invoice.posting_date) }}</span>
+                                                                        <div class="d-flex flex-column ga-1">
+                                                                                <div class="d-flex align-center justify-space-between">
+                                                                                        <div class="d-flex align-center ga-2">
+                                                                                                <span class="text-caption text-medium-emphasis">{{ formatHistoryDate(invoice.posting_date) }}</span>
+                                                                                                <v-chip
+                                                                                                        v-if="invoice.is_return"
+                                                                                                        size="x-small"
+                                                                                                        color="warning"
+                                                                                                        variant="tonal"
+                                                                                                >
+                                                                                                        {{ __("Return") }}
+                                                                                                </v-chip>
+                                                                                        </div>
+                                                                                        <span class="font-weight-medium">{{ formatHistoryAmount(invoice) }}</span>
                                                                                 </div>
-                                                                        </v-list-item-title>
-                                                                        <v-list-item-subtitle class="d-flex align-center justify-space-between flex-wrap">
-                                                                                <span>{{ formatHistoryAmount(invoice) }}</span>
-                                                                                <span class="text-caption">
-                                                                                        {{ __("Outstanding:") }}
-                                                                                        {{ formatHistoryAmount({
-                                                                                                ...invoice,
-                                                                                                grand_total: invoice.outstanding_amount,
-                                                                                        }) }}
-                                                                                </span>
-                                                                        </v-list-item-subtitle>
+                                                                                <div class="d-flex align-center justify-space-between flex-wrap">
+                                                                                        <v-btn
+                                                                                                variant="text"
+                                                                                                color="primary"
+                                                                                                density="compact"
+                                                                                                class="pa-0 text-body-2"
+                                                                                                @click="openInvoiceRecord(invoice)"
+                                                                                        >
+                                                                                                {{ invoice.invoice }}
+                                                                                        </v-btn>
+                                                                                        <span class="text-caption">
+                                                                                                {{ __("Outstanding:") }}
+                                                                                                {{ formatHistoryAmount({
+                                                                                                        ...invoice,
+                                                                                                        grand_total: invoice.outstanding_amount,
+                                                                                                }) }}
+                                                                                        </span>
+                                                                                </div>
+                                                                        </div>
                                                                 </v-list-item>
                                                         </v-list>
                                                 </v-card-text>
@@ -175,6 +189,90 @@
                                                         >
                                                                 {{ __("Load More") }}
                                                         </v-btn>
+                                                </v-card-actions>
+                                        </v-card>
+                                </v-dialog>
+
+                                <v-dialog v-model="show_invoice_record" max-width="960px">
+                                        <v-card>
+                                                <v-card-title class="d-flex align-center">
+                                                        <div class="d-flex flex-column">
+                                                                <span class="text-subtitle-1">{{ selected_invoice_record?.invoice }}</span>
+                                                                <span class="text-caption text-medium-emphasis">
+                                                                        {{ formatHistoryDate(selected_invoice_record?.posting_date) }}
+                                                                </span>
+                                                        </div>
+                                                        <v-spacer></v-spacer>
+                                                        <v-btn
+                                                                icon="mdi-printer"
+                                                                variant="text"
+                                                                color="primary"
+                                                                :disabled="!selected_invoice_record"
+                                                                @click="printInvoiceRecord"
+                                                        ></v-btn>
+                                                        <v-btn icon="mdi-close" variant="text" density="compact" @click="closeInvoiceRecord"></v-btn>
+                                                </v-card-title>
+                                                <v-divider></v-divider>
+                                                <v-card-text>
+                                                        <v-alert
+                                                                v-if="invoice_record_error"
+                                                                type="error"
+                                                                density="compact"
+                                                                class="mb-3"
+                                                        >
+                                                                {{ invoice_record_error }}
+                                                        </v-alert>
+                                                        <v-progress-linear
+                                                                v-if="invoice_record_loading"
+                                                                indeterminate
+                                                                color="primary"
+                                                                class="mb-3"
+                                                        ></v-progress-linear>
+
+                                                        <div v-if="invoice_record && !invoice_record_loading">
+                                                                <div class="d-flex flex-wrap ga-6 mb-4">
+                                                                        <div>
+                                                                                <div class="text-caption text-medium-emphasis">{{ __('Customer') }}</div>
+                                                                                <div class="text-body-2">{{ invoice_record.customer_name || invoice_record.customer }}</div>
+                                                                        </div>
+                                                                        <div>
+                                                                                <div class="text-caption text-medium-emphasis">{{ __('Invoice Total') }}</div>
+                                                                                <div class="text-body-2">{{ formatHistoryAmount({
+                                                                                        grand_total: invoice_record.grand_total,
+                                                                                        currency: invoice_record.currency,
+                                                                                }) }}</div>
+                                                                        </div>
+                                                                        <div>
+                                                                                <div class="text-caption text-medium-emphasis">{{ __('Outstanding') }}</div>
+                                                                                <div class="text-body-2">{{ formatHistoryAmount({
+                                                                                        grand_total: invoice_record.outstanding_amount,
+                                                                                        currency: invoice_record.currency,
+                                                                                }) }}</div>
+                                                                        </div>
+                                                                </div>
+
+                                                                <v-table density="compact" class="mb-4">
+                                                                        <thead>
+                                                                                <tr>
+                                                                                        <th class="text-left">{{ __('Item') }}</th>
+                                                                                        <th class="text-left">{{ __('Qty') }}</th>
+                                                                                        <th class="text-left">{{ __('Rate') }}</th>
+                                                                                        <th class="text-left">{{ __('Amount') }}</th>
+                                                                                </tr>
+                                                                        </thead>
+                                                                        <tbody>
+                                                                                <tr v-for="row in invoice_record.items || []" :key="row.name">
+                                                                                        <td>{{ row.item_name || row.item_code }}</td>
+                                                                                        <td>{{ formatFloat(row.qty) }}</td>
+                                                                                        <td>{{ formatHistoryAmount({ grand_total: row.rate, currency: invoice_record.currency }) }}</td>
+                                                                                        <td>{{ formatHistoryAmount({ grand_total: row.amount, currency: invoice_record.currency }) }}</td>
+                                                                                </tr>
+                                                                        </tbody>
+                                                                </v-table>
+                                                        </div>
+                                                </v-card-text>
+                                                <v-card-actions class="justify-end">
+                                                        <v-btn variant="text" @click="closeInvoiceRecord">{{ __('Close') }}</v-btn>
                                                 </v-card-actions>
                                         </v-card>
                                 </v-dialog>
@@ -576,6 +674,11 @@ export default {
                                 { title: __("Returns"), value: "return" },
                         ],
                         invoice_history_pagination: { start: 0, limit: 20, has_more: false },
+                        show_invoice_record: false,
+                        selected_invoice_record: null,
+                        invoice_record: null,
+                        invoice_record_loading: false,
+                        invoice_record_error: "",
                         _shortcutHandlers: {},
                         selected_columns: [], // Selected columns for items table
                         temp_selected_columns: [], // Temporary array for column selection
@@ -666,6 +769,64 @@ export default {
                                 this.resetInvoiceHistory();
                                 this.loadInvoiceHistory();
                         }
+                },
+
+                async openInvoiceRecord(invoice) {
+                        if (!invoice) {
+                                return;
+                        }
+
+                        this.selected_invoice_record = invoice;
+                        this.invoice_record = null;
+                        this.invoice_record_error = "";
+                        this.show_invoice_record = true;
+                        await this.fetchInvoiceRecord();
+                },
+
+                closeInvoiceRecord() {
+                        this.show_invoice_record = false;
+                        this.selected_invoice_record = null;
+                        this.invoice_record = null;
+                        this.invoice_record_error = "";
+                },
+
+                async fetchInvoiceRecord() {
+                        if (!this.selected_invoice_record) {
+                                return;
+                        }
+
+                        if (isOffline()) {
+                                this.invoice_record_error = __("Invoice details are unavailable offline.");
+                                return;
+                        }
+
+                        this.invoice_record_loading = true;
+                        this.invoice_record_error = "";
+
+                        try {
+                                const res = await frappe.call({
+                                        method: "frappe.client.get",
+                                        args: {
+                                                doctype: this.selected_invoice_record.doctype || "Sales Invoice",
+                                                name: this.selected_invoice_record.invoice,
+                                        },
+                                });
+
+                                this.invoice_record = res?.message || null;
+                        } catch (error) {
+                                console.error("Failed to fetch invoice record", error);
+                                this.invoice_record_error = __("Unable to load invoice details.");
+                        } finally {
+                                this.invoice_record_loading = false;
+                        }
+                },
+
+                printInvoiceRecord() {
+                        if (!this.selected_invoice_record) {
+                                return;
+                        }
+
+                        this.load_print_page(this.selected_invoice_record.invoice);
                 },
 
                 formatHistoryAmount(invoice) {

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -38,10 +38,11 @@
                                                         <template #activator="{ props }">
                                                                 <v-btn
                                                                         v-bind="props"
-                                                                        block
                                                                         color="primary"
                                                                         variant="tonal"
-                                                                        density="comfortable"
+                                                                        size="small"
+                                                                        rounded="circle"
+                                                                        class="previous-invoices-btn"
                                                                         icon="mdi-history"
                                                                         @click="openInvoiceHistory"
                                                                         :disabled="!customer"
@@ -2191,11 +2192,11 @@ export default {
 		}
 	},
 	// Register global keyboard shortcuts when component is created
-	created() {
-		this.invoiceStore.clear();
-		this.$watch(
-			() => this.selectedCustomer,
-			(newCustomer) => {
+                created() {
+                        this.invoiceStore.clear();
+                        this.$watch(
+                                () => this.selectedCustomer,
+                                (newCustomer) => {
 				if (newCustomer) {
 					if (this.customer !== newCustomer) {
 						this.customer = newCustomer;
@@ -2211,10 +2212,26 @@ export default {
 			() => {
 				if (this.customer) {
 					this.fetch_customer_details();
-				}
-			},
-		);
-		this._shortcutHandlers = this._shortcutHandlers || {};
+                                }
+                        },
+                );
+                this.$watch(
+                        () => this.customer,
+                        (newCustomer) => {
+                                if (!this.show_invoice_history) {
+                                        return;
+                                }
+
+                                this.resetInvoiceHistory();
+
+                                if (newCustomer) {
+                                        this.loadInvoiceHistory();
+                                } else {
+                                        this.invoice_history_error = __("Select a customer to view history.");
+                                }
+                        },
+                );
+                this._shortcutHandlers = this._shortcutHandlers || {};
 
 		this._shortcutHandlers.shortOpenPayment = this.shortOpenPayment.bind(this);
 		this._shortcutHandlers.shortDeleteFirstItem = this.shortDeleteFirstItem.bind(this);
@@ -2424,6 +2441,12 @@ export default {
 :deep(.column-switch .v-label) {
         opacity: 0.9;
         font-size: 0.95rem;
+}
+
+.previous-invoices-btn {
+        min-width: 40px;
+        height: 40px;
+        border-radius: 50%;
 }
 
 .history-list {

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -756,15 +756,20 @@ export default {
                                 this.invoice_doc?.customer,
                                 this.invoiceStore?.invoiceDoc?.customer,
                                 this.customer_info?.customer,
+                                this.customer_info?.customer_name,
                         ];
 
                         for (const candidate of candidates) {
                                 if (!candidate) continue;
 
                                 if (typeof candidate === "object") {
-                                        const id = candidate.name || candidate.customer;
+                                        const id =
+                                                candidate.name ||
+                                                candidate.customer ||
+                                                candidate.value ||
+                                                candidate.customer_name;
                                         if (id) {
-                                                return id;
+                                                return `${id}`.trim();
                                         }
                                         continue;
                                 }

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -27,32 +27,162 @@
 				>
 					{{ __("Invoices saved as POS Invoices") }}
 				</v-alert>
-				<!-- Top Row: Customer Selection and Invoice Type -->
-				<v-row align="center" class="items px-3 py-2">
-					<v-col :cols="pos_profile.posa_allow_sales_order ? 9 : 12" class="pb-0 pr-0">
-						<!-- Customer selection component -->
-						<Customer ref="customerComponent" />
-					</v-col>
-					<!-- Invoice Type Selection (Only shown if sales orders are allowed) -->
-					<v-col v-if="pos_profile.posa_allow_sales_order" cols="3" class="pb-4">
-						<v-select
-							density="compact"
-							hide-details
-							variant="solo"
+                                <!-- Top Row: Customer Selection and Invoice Type -->
+                                <v-row align="center" class="items px-3 py-2">
+                                        <v-col :cols="pos_profile.posa_allow_sales_order ? 7 : 9" class="pb-0 pr-0">
+                                                <!-- Customer selection component -->
+                                                <Customer ref="customerComponent" />
+                                        </v-col>
+                                        <v-col :cols="pos_profile.posa_allow_sales_order ? 2 : 3" class="pb-0">
+                                                <v-btn
+                                                        block
+                                                        color="primary"
+                                                        variant="tonal"
+                                                        prepend-icon="mdi-history"
+                                                        @click="openInvoiceHistory"
+                                                        :disabled="!customer"
+                                                >
+                                                        {{ __("Previous Invoices") }}
+                                                </v-btn>
+                                        </v-col>
+                                        <!-- Invoice Type Selection (Only shown if sales orders are allowed) -->
+                                        <v-col v-if="pos_profile.posa_allow_sales_order" cols="3" class="pb-4">
+                                                <v-select
+                                                        density="compact"
+                                                        hide-details
+                                                        variant="solo"
 							color="primary"
 							class="sleek-field pos-themed-input"
 							:items="invoiceTypes"
 							:label="frappe._('Type')"
 							v-model="invoiceType"
-							:disabled="invoiceType == 'Return'"
-						></v-select>
-					</v-col>
-				</v-row>
+                                                        :disabled="invoiceType == 'Return'"
+                                                ></v-select>
+                                        </v-col>
+                                </v-row>
 
-				<!-- Delivery Charges Section (Only if enabled in POS profile) -->
-				<DeliveryCharges
-					:pos_profile="pos_profile"
-					:delivery_charges="delivery_charges"
+                                <v-dialog v-model="show_invoice_history" max-width="900px">
+                                        <v-card>
+                                                <v-card-title class="d-flex align-center">
+                                                        <span>{{ __("Previous Invoices") }}</span>
+                                                        <v-spacer></v-spacer>
+                                                        <v-btn
+                                                                icon="mdi-close"
+                                                                variant="text"
+                                                                density="compact"
+                                                                @click="show_invoice_history = false"
+                                                        ></v-btn>
+                                                </v-card-title>
+                                                <v-divider></v-divider>
+                                                <v-card-text>
+                                                        <v-row dense class="mb-2">
+                                                                <v-col cols="12" md="4">
+                                                                        <v-select
+                                                                                density="compact"
+                                                                                variant="outlined"
+                                                                                hide-details
+                                                                                :items="invoice_history_type_options"
+                                                                                item-title="title"
+                                                                                item-value="value"
+                                                                                v-model="invoice_history_filters.type"
+                                                                                :label="__('Type')"
+                                                                                @update:model-value="refreshInvoiceHistory"
+                                                                        ></v-select>
+                                                                </v-col>
+                                                                <v-col cols="12" md="4">
+                                                                        <v-text-field
+                                                                                type="date"
+                                                                                density="compact"
+                                                                                variant="outlined"
+                                                                                color="primary"
+                                                                                hide-details
+                                                                                :label="__('From Date')"
+                                                                                v-model="invoice_history_filters.from_date"
+                                                                                @change="refreshInvoiceHistory"
+                                                                        ></v-text-field>
+                                                                </v-col>
+                                                                <v-col cols="12" md="4">
+                                                                        <v-text-field
+                                                                                type="date"
+                                                                                density="compact"
+                                                                                variant="outlined"
+                                                                                color="primary"
+                                                                                hide-details
+                                                                                :label="__('To Date')"
+                                                                                v-model="invoice_history_filters.to_date"
+                                                                                @change="refreshInvoiceHistory"
+                                                                        ></v-text-field>
+                                                                </v-col>
+                                                        </v-row>
+                                                        <v-alert v-if="invoice_history_error" type="error" density="compact" class="mb-3">
+                                                                {{ invoice_history_error }}
+                                                        </v-alert>
+                                                        <v-progress-linear
+                                                                v-if="invoice_history_loading && !invoice_history.length"
+                                                                indeterminate
+                                                                color="primary"
+                                                                class="mb-3"
+                                                        ></v-progress-linear>
+                                                        <div
+                                                                v-if="!invoice_history_loading && !invoice_history.length && !invoice_history_error"
+                                                                class="text-body-2 text-medium-emphasis"
+                                                        >
+                                                                {{ __("No invoices found for this customer.") }}
+                                                        </div>
+                                                        <v-list v-if="invoice_history.length" density="compact" class="history-list">
+                                                                <v-list-item
+                                                                        v-for="invoice in invoice_history"
+                                                                        :key="invoice.invoice"
+                                                                        class="history-list-item"
+                                                                >
+                                                                        <v-list-item-title class="d-flex align-center justify-space-between">
+                                                                                <span class="font-weight-medium">{{ invoice.invoice }}</span>
+                                                                                <div class="d-flex align-center history-meta">
+                                                                                        <v-chip
+                                                                                                v-if="invoice.is_return"
+                                                                                                size="x-small"
+                                                                                                color="warning"
+                                                                                                variant="tonal"
+                                                                                        >
+                                                                                                {{ __("Return") }}
+                                                                                        </v-chip>
+                                                                                        <span class="text-caption">{{ formatHistoryDate(invoice.posting_date) }}</span>
+                                                                                </div>
+                                                                        </v-list-item-title>
+                                                                        <v-list-item-subtitle class="d-flex align-center justify-space-between flex-wrap">
+                                                                                <span>{{ formatHistoryAmount(invoice) }}</span>
+                                                                                <span class="text-caption">
+                                                                                        {{ __("Outstanding:") }}
+                                                                                        {{ formatHistoryAmount({
+                                                                                                ...invoice,
+                                                                                                grand_total: invoice.outstanding_amount,
+                                                                                        }) }}
+                                                                                </span>
+                                                                        </v-list-item-subtitle>
+                                                                </v-list-item>
+                                                        </v-list>
+                                                </v-card-text>
+                                                <v-card-actions class="justify-end">
+                                                        <v-btn variant="text" @click="show_invoice_history = false">
+                                                                {{ __("Close") }}
+                                                        </v-btn>
+                                                        <v-btn
+                                                                v-if="invoice_history_pagination.has_more"
+                                                                :loading="invoice_history_loading"
+                                                                color="primary"
+                                                                variant="tonal"
+                                                                @click="loadInvoiceHistory(true)"
+                                                        >
+                                                                {{ __("Load More") }}
+                                                        </v-btn>
+                                                </v-card-actions>
+                                        </v-card>
+                                </v-dialog>
+
+                                <!-- Delivery Charges Section (Only if enabled in POS profile) -->
+                                <DeliveryCharges
+                                        :pos_profile="pos_profile"
+                                        :delivery_charges="delivery_charges"
 					:selected_delivery_charge="selected_delivery_charge"
 					:delivery_charges_rate="delivery_charges_rate"
 					:deliveryChargesFilter="deliveryChargesFilter"
@@ -431,13 +561,24 @@ export default {
 			conversion_rate: 1, // Currency to company rate
 			exchange_rate_date: frappe.datetime.nowdate(), // Date of fetched exchange rate
 			company: null, // Company doc with default currency
-			available_currencies: [], // List of available currencies
-			price_lists: [], // Available selling price lists
-			selected_price_list: "", // Currently selected price list
-			price_list_currency: "", // Currency of the selected price list
-			_shortcutHandlers: {},
-			selected_columns: [], // Selected columns for items table
-			temp_selected_columns: [], // Temporary array for column selection
+                        available_currencies: [], // List of available currencies
+                        price_lists: [], // Available selling price lists
+                        selected_price_list: "", // Currently selected price list
+                        price_list_currency: "", // Currency of the selected price list
+                        show_invoice_history: false,
+                        invoice_history: [],
+                        invoice_history_loading: false,
+                        invoice_history_error: "",
+                        invoice_history_filters: { type: "all", from_date: "", to_date: "" },
+                        invoice_history_type_options: [
+                                { title: __("All Types"), value: "all" },
+                                { title: __("Invoices"), value: "invoice" },
+                                { title: __("Returns"), value: "return" },
+                        ],
+                        invoice_history_pagination: { start: 0, limit: 20, has_more: false },
+                        _shortcutHandlers: {},
+                        selected_columns: [], // Selected columns for items table
+                        temp_selected_columns: [], // Temporary array for column selection
 			available_columns: [], // All available columns
 			show_column_selector: false, // Column selector dialog visibility
 			invoiceHeight: null,
@@ -500,13 +641,119 @@ export default {
 			}
 		},
 
-		focusItemSearchField() {
-			this.eventBus.emit("focus_item_search");
-		},
+                focusItemSearchField() {
+                        this.eventBus.emit("focus_item_search");
+                },
 
-		initializeItemsHeaders() {
-			// Define all available columns
-			this.available_columns = [
+                openInvoiceHistory() {
+                        this.show_invoice_history = true;
+                        this.resetInvoiceHistory();
+                        this.loadInvoiceHistory();
+                },
+
+                resetInvoiceHistory() {
+                        this.invoice_history = [];
+                        this.invoice_history_error = "";
+                        this.invoice_history_pagination = {
+                                ...this.invoice_history_pagination,
+                                start: 0,
+                                has_more: false,
+                        };
+                },
+
+                refreshInvoiceHistory() {
+                        if (this.show_invoice_history) {
+                                this.resetInvoiceHistory();
+                                this.loadInvoiceHistory();
+                        }
+                },
+
+                formatHistoryAmount(invoice) {
+                        const currency = invoice?.currency || this.pos_profile?.currency;
+                        return `${this.currencySymbol(currency)} ${this.format_currency(
+                                invoice?.grand_total || 0,
+                                currency,
+                                this.currency_precision,
+                        )}`;
+                },
+
+                formatHistoryDate(date) {
+                        if (!date) {
+                                return "";
+                        }
+                        try {
+                                return frappe.datetime.str_to_user(date);
+                        } catch (error) {
+                                return date;
+                        }
+                },
+
+                async loadInvoiceHistory(loadMore = false) {
+                        if (!this.customer) {
+                                this.invoice_history_error = __("Select a customer to view history.");
+                                return;
+                        }
+
+                        if (isOffline()) {
+                                this.invoice_history_error = __("Invoice history is unavailable offline.");
+                                return;
+                        }
+
+                        if (this.invoice_history_loading) {
+                                return;
+                        }
+
+                        const start = loadMore
+                                ? this.invoice_history_pagination.start + this.invoice_history_pagination.limit
+                                : 0;
+
+                        this.invoice_history_loading = true;
+                        this.invoice_history_error = "";
+
+                        if (!loadMore) {
+                                this.invoice_history = [];
+                        }
+
+                        try {
+                                const res = await frappe.call({
+                                        method: "posawesome.posawesome.api.invoices.get_customer_invoice_history",
+                                        args: {
+                                                customer: this.customer,
+                                                company: this.pos_profile?.company,
+                                                from_date: this.invoice_history_filters.from_date || undefined,
+                                                to_date: this.invoice_history_filters.to_date || undefined,
+                                                invoice_type:
+                                                        this.invoice_history_filters.type === "all"
+                                                                ? undefined
+                                                                : this.invoice_history_filters.type,
+                                                limit: this.invoice_history_pagination.limit,
+                                                offset: start,
+                                        },
+                                });
+
+                                const message = (res && res.message) || {};
+                                const records = message.invoices || [];
+
+                                this.invoice_history = loadMore
+                                        ? [...this.invoice_history, ...records]
+                                        : records;
+
+                                this.invoice_history_pagination = {
+                                        ...this.invoice_history_pagination,
+                                        start,
+                                        has_more: Boolean(message.has_more),
+                                };
+                        } catch (error) {
+                                console.error("Failed to fetch invoice history", error);
+                                this.invoice_history_error = __("Unable to load invoice history.");
+                        } finally {
+                                this.invoice_history_loading = false;
+                        }
+                },
+
+                initializeItemsHeaders() {
+                        // Define all available columns
+                        this.available_columns = [
 				{ title: __("Name"), align: "start", sortable: true, key: "item_name", required: true },
 				{ title: __("QTY"), key: "qty", align: "center", required: true },
 				{ title: __("UOM"), key: "uom", align: "center", required: false },
@@ -2014,7 +2261,20 @@ export default {
 }
 
 :deep(.column-switch .v-label) {
-	opacity: 0.9;
-	font-size: 0.95rem;
+        opacity: 0.9;
+        font-size: 0.95rem;
+}
+
+.history-list {
+        max-height: 420px;
+        overflow-y: auto;
+}
+
+.history-list-item + .history-list-item {
+        border-top: 1px solid var(--field-border);
+}
+
+.history-meta {
+        gap: 8px;
 }
 </style>

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -754,8 +754,10 @@ export default {
                                 this.customer,
                                 this.selectedCustomer,
                                 this.invoice_doc?.customer,
+                                this.invoice_doc?.customer_name,
                                 this.invoiceStore?.invoiceDoc?.customer,
                                 this.customer_info?.customer,
+                                this.customer_info?.name,
                                 this.customer_info?.customer_name,
                         ];
 

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -750,11 +750,31 @@ export default {
                 },
 
                 getActiveCustomerId() {
-                        const candidate = this.customer || this.selectedCustomer;
-                        if (candidate && typeof candidate === "object") {
-                                return candidate.name || candidate.customer || "";
+                        const candidates = [
+                                this.customer,
+                                this.selectedCustomer,
+                                this.invoice_doc?.customer,
+                                this.invoiceStore?.invoiceDoc?.customer,
+                                this.customer_info?.customer,
+                        ];
+
+                        for (const candidate of candidates) {
+                                if (!candidate) continue;
+
+                                if (typeof candidate === "object") {
+                                        const id = candidate.name || candidate.customer;
+                                        if (id) {
+                                                return id;
+                                        }
+                                        continue;
+                                }
+
+                                if (typeof candidate === "string" && candidate.trim()) {
+                                        return candidate.trim();
+                                }
                         }
-                        return candidate || "";
+
+                        return "";
                 },
 
                 openInvoiceHistory() {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -297,30 +297,50 @@
 															}}
 														</span>
 													</div>
-													<div
-														v-if="
-															pos_profile.posa_allow_multi_currency &&
-															selected_currency !== pos_profile.currency
-														"
-														class="secondary-price"
-													>
-														<span class="currency-symbol">
-															{{ currencySymbol(selected_currency) }}
-														</span>
-														<span class="price-amount">
-															{{
-																format_currency(
-																	item.rate,
-																	selected_currency,
-																	ratePrecision(item.rate),
-																)
-															}}
-														</span>
-													</div>
-												</div>
-												<div class="card-item-stock">
-													<v-icon size="small" class="stock-icon">
-														mdi-package-variant
+                                                                                                        <div
+                                                                                                                v-if="
+                                                                                                                        pos_profile.posa_allow_multi_currency &&
+                                                                                                                        selected_currency !== pos_profile.currency
+                                                                                                                "
+                                                                                                                class="secondary-price"
+                                                                                                        >
+                                                                                                                <span class="currency-symbol">
+                                                                                                                        {{ currencySymbol(selected_currency) }}
+                                                                                                                </span>
+                                                                                                                <span class="price-amount">
+                                                                                                                        {{
+                                                                                                                               format_currency(
+                                                                                                                                       item.rate,
+                                                                                                                                       selected_currency,
+                                                                                                                                       ratePrecision(item.rate),
+                                                                                                                               )
+                                                                                                                        }}
+                                                                                                                </span>
+                                                                                                        </div>
+                                                                                                <div v-if="getLastInvoiceRate(item)" class="last-rate-chip">
+                                                                                                        <v-icon size="14" class="mr-1" color="secondary">mdi-history</v-icon>
+                                                                                                        <span class="last-rate-label">{{ __("Last") }}:</span>
+                                                                                                        <span class="last-rate-value">
+                                                                                                                {{
+                                                                                                                        currencySymbol(
+                                                                                                                                getLastInvoiceRate(item).currency ||
+                                                                                                                                        pos_profile.currency,
+                                                                                                                        )
+                                                                                                                }}
+                                                                                                                {{
+                                                                                                                        format_currency(
+                                                                                                                                getLastInvoiceRate(item).rate,
+                                                                                                                                getLastInvoiceRate(item).currency ||
+                                                                                                                                        pos_profile.currency,
+                                                                                                                                ratePrecision(getLastInvoiceRate(item).rate || 0),
+                                                                                                                        )
+                                                                                                                }}
+                                                                                                        </span>
+                                                                                                </div>
+                                                                                                </div>
+                                                                                                <div class="card-item-stock">
+                                                                                                        <v-icon size="small" class="stock-icon">
+                                                                                                                mdi-package-variant
 													</v-icon>
 													<span
 														class="stock-amount"
@@ -363,20 +383,43 @@
 											{{
 												currencySymbol(item.original_currency || pos_profile.currency)
 											}}
-											{{
-												format_currency(
-													item.base_price_list_rate ?? item.rate ?? 0,
-													item.original_currency || pos_profile.currency,
-													ratePrecision(
-														item.base_price_list_rate ?? item.rate ?? 0,
-													),
-												)
-											}}
-										</div>
-										<div
-											v-if="
-												pos_profile.posa_allow_multi_currency &&
-												selected_currency !== pos_profile.currency
+                                                                                        {{
+                                                                                                format_currency(
+                                                                                                        item.base_price_list_rate ?? item.rate ?? 0,
+                                                                                                        item.original_currency || pos_profile.currency,
+                                                                                                        ratePrecision(
+                                                                                                                item.base_price_list_rate ?? item.rate ?? 0,
+                                                                                                        ),
+                                                                                                )
+                                                                                        }}
+                                                                                </div>
+                                                                                <div
+                                                                                        v-if="getLastInvoiceRate(item)"
+                                                                                        class="text-caption d-flex align-center last-rate-inline"
+                                                                                >
+                                                                                        <v-icon size="14" class="mr-1" color="secondary">mdi-history</v-icon>
+                                                                                        <span class="mr-1">{{ __("Last") }}:</span>
+                                                                                        <span class="font-weight-medium">
+                                                                                                {{
+                                                                                                        currencySymbol(
+                                                                                                                getLastInvoiceRate(item).currency ||
+                                                                                                                        pos_profile.currency,
+                                                                                                        )
+                                                                                                }}
+                                                                                                {{
+                                                                                                        format_currency(
+                                                                                                                getLastInvoiceRate(item).rate,
+                                                                                                                getLastInvoiceRate(item).currency ||
+                                                                                                                        pos_profile.currency,
+                                                                                                                ratePrecision(getLastInvoiceRate(item).rate || 0),
+                                                                                                        )
+                                                                                                }}
+                                                                                        </span>
+                                                                                </div>
+                                                                                <div
+                                                                                        v-if="
+                                                                                                pos_profile.posa_allow_multi_currency &&
+                                                                                                selected_currency !== pos_profile.currency
 											"
 											class="text-success"
 										>
@@ -583,23 +626,27 @@ export default {
 		itemDetailsRetryTimeout: null,
 		selected_currency: "",
 		exchange_rate: 1,
-		prePopulateInProgress: false,
-		itemWorker: null,
-		flyConfig: { speed: 0.6, easing: "ease-in-out" },
+                prePopulateInProgress: false,
+                itemWorker: null,
+                flyConfig: { speed: 0.6, easing: "ease-in-out" },
 		storageAvailable: true,
 		localStorageAvailable: true,
 		stockUnsubscribe: null,
-		items_request_token: 0,
-		pendingGetItems: null,
-		lastGetItemsKey: "",
-		show_item_settings: false,
-		hide_qty_decimals: false,
-		temp_hide_qty_decimals: false,
-		hide_zero_rate_items: false,
-		temp_hide_zero_rate_items: false,
-		isDragging: false,
-		// Items per page configuration
-		enable_custom_items_per_page: false,
+                items_request_token: 0,
+                pendingGetItems: null,
+                lastGetItemsKey: "",
+                show_item_settings: false,
+                hide_qty_decimals: false,
+                temp_hide_qty_decimals: false,
+                hide_zero_rate_items: false,
+                temp_hide_zero_rate_items: false,
+                lastInvoiceRateCache: new Map(),
+                lastInvoiceRates: {},
+                lastInvoiceRateScheduler: null,
+                lastInvoiceRateLoading: false,
+                isDragging: false,
+                // Items per page configuration
+                enable_custom_items_per_page: false,
 		temp_enable_custom_items_per_page: false,
 		items_per_page: 50,
 		temp_items_per_page: 50,
@@ -666,10 +713,11 @@ export default {
 			this.search_onchange();
 		},
 		customer: _.debounce(function () {
-			if (this.pos_profile.posa_force_reload_items) {
-				if (this.pos_profile.posa_smart_reload_mode) {
-					// When limit search is enabled there may be no items yet.
-					// Fallback to full reload if nothing is loaded
+                        if (this.pos_profile.posa_force_reload_items) {
+                                this.scheduleLastInvoiceRateRefresh();
+                                if (this.pos_profile.posa_smart_reload_mode) {
+                                        // When limit search is enabled there may be no items yet.
+                                        // Fallback to full reload if nothing is loaded
 					if (!this.itemsLoaded || !this.displayedItems.length) {
 						if (!isOffline()) {
 							this.get_items(true);
@@ -703,21 +751,23 @@ export default {
 					}
 				}
 				return;
-			}
-			// When the customer changes, avoid reloading all items.
-			// Simply refresh prices for visible items only
-			if (this.itemsLoaded && this.displayedItems && this.displayedItems.length > 0) {
-				this.$nextTick(() => this.refreshPricesForVisibleItems());
-			} else {
-				if (this.pos_profile && (!this.pos_profile.posa_local_storage || !this.storageAvailable)) {
-					this.get_items(true);
-				} else {
-					this.get_items();
-				}
-			}
-		}, 300),
-		customer_price_list: _.debounce(async function () {
-			if (this.pos_profile.posa_force_reload_items) {
+                        }
+                        // When the customer changes, avoid reloading all items.
+                        // Simply refresh prices for visible items only
+                        if (this.itemsLoaded && this.displayedItems && this.displayedItems.length > 0) {
+                                this.$nextTick(() => this.refreshPricesForVisibleItems());
+                                this.scheduleLastInvoiceRateRefresh();
+                        } else {
+                                if (this.pos_profile && (!this.pos_profile.posa_local_storage || !this.storageAvailable)) {
+                                        this.get_items(true);
+                                } else {
+                                        this.get_items();
+                                }
+                                this.scheduleLastInvoiceRateRefresh();
+                        }
+                }, 300),
+                customer_price_list: _.debounce(async function () {
+                        if (this.pos_profile.posa_force_reload_items) {
 				if (this.pos_profile.posa_smart_reload_mode) {
 					// When limit search is enabled there may be no items yet.
 					// Fallback to full reload if nothing is loaded
@@ -796,15 +846,16 @@ export default {
 			}
 		},
 		displayedItems(new_value, old_value) {
-			// Update item details if items changed
-			if (!this.usesLimitSearch && new_value.length !== old_value.length) {
-				this.update_items_details(new_value);
-			}
-			this.$nextTick(() => {
-				this.checkItemContainerOverflow();
-				this.scheduleCardMetricsUpdate();
-			});
-		},
+                        // Update item details if items changed
+                        if (!this.usesLimitSearch && new_value.length !== old_value.length) {
+                                this.update_items_details(new_value);
+                        }
+                        this.$nextTick(() => {
+                                this.checkItemContainerOverflow();
+                                this.scheduleCardMetricsUpdate();
+                        });
+                        this.scheduleLastInvoiceRateRefresh();
+                },
 		// Automatically search when the query has at least 3 characters
 		first_search: _.debounce(function (val, oldVal) {
 			if (this.clearingSearch) {
@@ -1319,9 +1370,9 @@ export default {
 				this.itemDetailsRequestCache.result = null;
 			}
 		},
-		async refreshPricesForVisibleItems() {
-			const vm = this;
-			if (!vm.displayedItems || vm.displayedItems.length === 0) return;
+                async refreshPricesForVisibleItems() {
+                        const vm = this;
+                        if (!vm.displayedItems || vm.displayedItems.length === 0) return;
 
 			if (vm.refreshInFlight) {
 				return;
@@ -1438,13 +1489,98 @@ export default {
 					releaseLoading();
 				}
 			} finally {
-				vm.refreshInFlight = false;
-				releaseLoading();
-			}
-		},
+                                vm.refreshInFlight = false;
+                                releaseLoading();
+                        }
+                },
 
-		show_offers() {
-			this.eventBus.emit("show_offers", "true");
+                scheduleLastInvoiceRateRefresh() {
+                        if (!this.lastInvoiceRateScheduler) {
+                                this.lastInvoiceRateScheduler = _.debounce(() => {
+                                        this.refreshLastInvoiceRatesForVisibleItems();
+                                }, 200);
+                        }
+
+                        this.lastInvoiceRateScheduler();
+                },
+
+                async refreshLastInvoiceRatesForVisibleItems() {
+                        if (!this.displayedItems || !this.displayedItems.length) {
+                                this.lastInvoiceRates = {};
+                                return this.lastInvoiceRates;
+                        }
+
+                        const itemCodes = this.displayedItems.map((it) => it.item_code).filter(Boolean);
+                        return this.fetchLastInvoiceRates(itemCodes);
+                },
+
+                async fetchLastInvoiceRates(itemCodes = []) {
+                        const customer = this.customer || this.selectedCustomer;
+
+                        if (!customer) {
+                                this.lastInvoiceRates = {};
+                                return {};
+                        }
+
+                        const normalizedCodes = Array.from(new Set(itemCodes.filter(Boolean)));
+                        const cachedForCustomer = this.lastInvoiceRateCache.get(customer) || new Map();
+                        this.lastInvoiceRates = Object.fromEntries(cachedForCustomer);
+
+                        const missingCodes = normalizedCodes.filter((code) => !cachedForCustomer.has(code));
+                        if (!missingCodes.length) {
+                                return this.lastInvoiceRates;
+                        }
+
+                        if (isOffline()) {
+                                return this.lastInvoiceRates;
+                        }
+
+                        this.lastInvoiceRateLoading = true;
+                        try {
+                                const res = await frappe.call({
+                                        method: "posawesome.posawesome.api.invoices.get_last_invoice_rates",
+                                        args: {
+                                                customer,
+                                                item_codes: missingCodes,
+                                                company: this.pos_profile?.company,
+                                        },
+                                });
+
+                                const rows = (res && res.message) || [];
+                                const updatedCache = new Map(cachedForCustomer);
+                                rows.forEach((row) => {
+                                        if (row && row.item_code) {
+                                                updatedCache.set(row.item_code, {
+                                                        rate: row.rate,
+                                                        currency: row.currency,
+                                                        invoice: row.invoice,
+                                                        posting_date: row.posting_date,
+                                                });
+                                        }
+                                });
+
+                                this.lastInvoiceRateCache.set(customer, updatedCache);
+                                this.lastInvoiceRates = Object.fromEntries(updatedCache);
+                                return this.lastInvoiceRates;
+                        } catch (error) {
+                                console.error("Failed to fetch last invoice rates", error);
+                                this.lastInvoiceRates = Object.fromEntries(cachedForCustomer);
+                                return this.lastInvoiceRates;
+                        } finally {
+                                this.lastInvoiceRateLoading = false;
+                        }
+                },
+
+                getLastInvoiceRate(item) {
+                        if (!item || !item.item_code) {
+                                return null;
+                        }
+
+                        return this.lastInvoiceRates[item.item_code] || null;
+                },
+
+                show_offers() {
+                        this.eventBus.emit("show_offers", "true");
 		},
 		show_coupons() {
 			this.eventBus.emit("show_coupons", "true");
@@ -4748,19 +4884,46 @@ export default {
 }
 
 .secondary-price {
-	display: flex;
-	align-items: center;
-	gap: 2px;
-	font-weight: 500;
-	color: #4caf50;
-	font-size: 0.875rem;
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        font-weight: 500;
+        color: #4caf50;
+        font-size: 0.875rem;
+}
+
+.last-rate-chip {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        font-size: 0.85rem;
+        color: rgba(0, 0, 0, 0.65);
+}
+
+.last-rate-label {
+        font-weight: 600;
+        opacity: 0.8;
+}
+
+.last-rate-value {
+        font-weight: 700;
+        color: var(--primary-color, #1976d2);
+}
+
+.last-rate-inline {
+        color: rgba(0, 0, 0, 0.6);
+}
+
+:deep(.v-theme--dark) .last-rate-chip,
+:deep(.v-theme--dark) .last-rate-inline {
+        color: rgba(255, 255, 255, 0.75);
 }
 
 .currency-symbol {
-	opacity: 0.8;
-	font-size: 0.85em;
-	font-family:
-		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
+        opacity: 0.8;
+        font-size: 0.85em;
+        font-family:
+                "SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
 		sans-serif;
 }
 

--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -12,7 +12,9 @@ from .customers import (
     set_customer_info,
 )
 from .invoices import (
+    get_customer_invoice_history,
     delete_invoice,
+    get_last_invoice_rates,
     get_draft_invoices,
     search_invoices_for_return,
     submit_invoice,

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1034,6 +1034,93 @@ def delete_invoice(invoice):
 
 
 @frappe.whitelist()
+def get_customer_invoice_history(
+    customer,
+    company=None,
+    from_date=None,
+    to_date=None,
+    invoice_type=None,
+    limit=20,
+    offset=0,
+):
+    """Return a paginated list of invoices for a customer ordered by date."""
+
+    if not customer:
+        return {"invoices": [], "has_more": False}
+
+    limit_value = max(cint(limit or 20), 1)
+    offset_value = max(cint(offset or 0), 0)
+
+    params = {
+        "customer": customer,
+        "limit": limit_value + 1,
+        "offset": offset_value,
+    }
+
+    base_filters = ["docstatus = 1", "customer = %(customer)s"]
+    if company:
+        params["company"] = company
+        base_filters.append("company = %(company)s")
+    if from_date:
+        params["from_date"] = from_date
+        base_filters.append("posting_date >= %(from_date)s")
+    if to_date:
+        params["to_date"] = to_date
+        base_filters.append("posting_date <= %(to_date)s")
+
+    if invoice_type == "invoice":
+        base_filters.append("is_return = 0")
+    elif invoice_type == "return":
+        base_filters.append("is_return = 1")
+
+    filters = " and ".join(base_filters)
+
+    sales_invoice_query = f"""
+        select
+            'Sales Invoice' as doctype,
+            name as invoice,
+            posting_date,
+            grand_total,
+            currency,
+            customer,
+            is_return,
+            company,
+            outstanding_amount,
+            creation
+        from `tabSales Invoice`
+        where {filters}
+    """
+
+    pos_invoice_query = f"""
+        select
+            'POS Invoice' as doctype,
+            name as invoice,
+            posting_date,
+            grand_total,
+            currency,
+            customer,
+            is_return,
+            company,
+            outstanding_amount,
+            creation
+        from `tabPOS Invoice`
+        where {filters}
+    """
+
+    query = (
+        f"{sales_invoice_query}\nUNION ALL\n{pos_invoice_query}\n"
+        "order by posting_date desc, creation desc\n"
+        "limit %(limit)s offset %(offset)s"
+    )
+
+    rows = frappe.db.sql(query, params, as_dict=True)
+    has_more = len(rows) > limit_value
+    invoices = rows[:limit_value]
+
+    return {"invoices": invoices, "has_more": has_more}
+
+
+@frappe.whitelist()
 def get_draft_invoices(pos_opening_shift, doctype="Sales Invoice"):
     filters = {
         "posa_pos_opening_shift": pos_opening_shift,
@@ -1284,6 +1371,102 @@ def update_invoice_from_order(data):
     _deduplicate_free_items(invoice_doc)
     invoice_doc.save()
     return invoice_doc
+
+
+def _normalize_item_codes(item_codes):
+    """Return a de-duplicated list of item codes from various input formats."""
+
+    if not item_codes:
+        return []
+
+    parsed_codes = []
+
+    if isinstance(item_codes, str):
+        raw_value = item_codes.strip()
+        if not raw_value:
+            return []
+
+        try:
+            decoded = json.loads(raw_value)
+            if isinstance(decoded, (list, tuple, set)):
+                parsed_codes = list(decoded)
+            elif isinstance(decoded, str):
+                parsed_codes = [code.strip() for code in decoded.split(",") if code.strip()]
+        except Exception:
+            parsed_codes = [code.strip() for code in raw_value.split(",") if code.strip()]
+    elif isinstance(item_codes, (list, tuple, set)):
+        parsed_codes = list(item_codes)
+
+    return [c for c in parsed_codes if c]
+
+
+@frappe.whitelist()
+def get_last_invoice_rates(customer, item_codes=None, company=None, limit_per_item=1):
+    """Return the most recent invoice rate for each requested item for a customer."""
+
+    normalized_codes = _normalize_item_codes(item_codes)
+    if not customer or not normalized_codes:
+        return []
+
+    params = {
+        "customer": customer,
+        "item_codes": normalized_codes,
+        "limit": max(len(normalized_codes) * cint(limit_per_item or 1), 10),
+    }
+
+    filters = ["si.docstatus = 1", "sii.item_code in %(item_codes)s", "si.customer = %(customer)s"]
+    pos_filters = ["pi.docstatus = 1", "pii.item_code in %(item_codes)s", "pi.customer = %(customer)s"]
+
+    if company:
+        params["company"] = company
+        filters.append("si.company = %(company)s")
+        pos_filters.append("pi.company = %(company)s")
+
+    sales_invoice_query = f"""
+        select
+            'Sales Invoice' as doctype,
+            sii.item_code,
+            sii.rate,
+            si.currency,
+            si.name as invoice,
+            si.posting_date,
+            si.creation
+        from `tabSales Invoice Item` sii
+        inner join `tabSales Invoice` si on sii.parent = si.name
+        where {' and '.join(filters)}
+    """
+
+    pos_invoice_query = f"""
+        select
+            'POS Invoice' as doctype,
+            pii.item_code,
+            pii.rate,
+            pi.currency,
+            pi.name as invoice,
+            pi.posting_date,
+            pi.creation
+        from `tabPOS Invoice Item` pii
+        inner join `tabPOS Invoice` pi on pii.parent = pi.name
+        where {' and '.join(pos_filters)}
+    """
+
+    query = (
+        f"{sales_invoice_query}\nUNION ALL\n{pos_invoice_query}\n"
+        "order by posting_date desc, creation desc\n"
+        "limit %(limit)s"
+    )
+
+    rows = frappe.db.sql(query, params, as_dict=True)
+    results = {}
+    for row in rows:
+        code = row.get("item_code")
+        if code and code not in results:
+            results[code] = row
+
+        if len(results) == len(normalized_codes):
+            break
+
+    return list(results.values())
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1057,7 +1057,9 @@ def get_customer_invoice_history(
         "offset": offset_value,
     }
 
-    base_filters = ["docstatus = 1", "customer = %(customer)s"]
+    # Match either the customer DocType name or the stored display name so results
+    # still appear when the caller provides a customer display string.
+    base_filters = ["docstatus = 1", "(customer = %(customer)s or customer_name = %(customer)s)"]
     if company:
         params["company"] = company
         base_filters.append("company = %(company)s")

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1051,15 +1051,32 @@ def get_customer_invoice_history(
     limit_value = max(cint(limit or 20), 1)
     offset_value = max(cint(offset or 0), 0)
 
+    resolved_customer_id = _resolve_customer_identifier(customer)
+
+    # Build candidate identifiers to match both the resolved ID and any display labels
+    candidates = []
+    for value in {customer, resolved_customer_id}:
+        if not value:
+            continue
+        candidates.append(value)
+        candidates.append(cstr(value).strip())
+
     params = {
-        "customer": customer,
         "limit": limit_value + 1,
         "offset": offset_value,
     }
 
-    # Match either the customer DocType name or the stored display name so results
-    # still appear when the caller provides a customer display string.
-    base_filters = ["docstatus = 1", "(customer = %(customer)s or customer_name = %(customer)s)"]
+    candidate_params = []
+    for idx, candidate in enumerate(dict.fromkeys(candidates)):
+        key = f"customer_{idx}"
+        params[key] = candidate
+        candidate_params.append(f"customer = %({key})s or customer_name = %({key})s")
+
+    # When no candidate rows were added, fail fast with empty results
+    if not candidate_params:
+        return {"invoices": [], "has_more": False}
+
+    base_filters = ["docstatus = 1", f"({' or '.join(candidate_params)})"]
     if company:
         params["company"] = company
         base_filters.append("company = %(company)s")
@@ -1120,6 +1137,38 @@ def get_customer_invoice_history(
     invoices = rows[:limit_value]
 
     return {"invoices": invoices, "has_more": has_more}
+
+
+def _resolve_customer_identifier(customer: str | None):
+    """Return a best-effort customer ID from various display formats."""
+
+    if not customer:
+        return ""
+
+    # Direct name match
+    if frappe.db.exists("Customer", customer):
+        return customer
+
+    # Common display strings may embed a delimiter (e.g. "CUST-0001 - John Doe")
+    if " - " in customer:
+        code, _, suffix = customer.partition(" - ")
+        if frappe.db.exists("Customer", code.strip()):
+            return code.strip()
+        if frappe.db.exists("Customer", suffix.strip()):
+            return suffix.strip()
+
+    # Match by exact display name
+    exact_match = frappe.db.get_value(
+        "Customer", {"customer_name": customer}, "name", cache=True
+    )
+    if exact_match:
+        return exact_match
+
+    # Relaxed contains search as a final fallback
+    fuzzy_match = frappe.db.get_value(
+        "Customer", {"customer_name": ["like", f"%{customer}%"]}, "name", cache=True
+    )
+    return fuzzy_match or ""
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1062,22 +1062,42 @@ def get_customer_invoice_history(
         candidates.append(cstr(value))
         candidates.append(cstr(value).strip())
 
+    # Attempt to fetch the canonical customer name for the provided identifier
+    # (this covers cases where the UI passes a display label that differs from the
+    # stored link field value)
+    if resolved_customer_id:
+        display_name = frappe.db.get_value(
+            "Customer", resolved_customer_id, "customer_name", cache=True
+        )
+        if display_name:
+            candidates.append(display_name)
+
     params = {
         "limit": limit_value + 1,
         "offset": offset_value,
+        "customer_like": f"%{raw_customer}%",
     }
 
     candidate_params = []
     for idx, candidate in enumerate(dict.fromkeys(candidates)):
         key = f"customer_{idx}"
         params[key] = candidate
-        candidate_params.append(f"customer = %({key})s or customer_name = %({key})s")
+        candidate_params.append(
+            f"customer = %({key})s or customer_name = %({key})s or customer like %({key})s or customer_name like %({key})s"
+        )
 
-    # When no candidate rows were added, fail fast with empty results
-    if not candidate_params:
-        return {"invoices": [], "has_more": False}
+    # When no candidate rows were added, use only the broad LIKE filter
+    if candidate_params:
+        base_filters = ["docstatus = 1", f"({' or '.join(candidate_params)})"]
+    else:
+        base_filters = [
+            "docstatus = 1",
+            "(customer like %(customer_like)s or customer_name like %(customer_like)s)",
+        ]
 
-    base_filters = ["docstatus = 1", f"({' or '.join(candidate_params)})"]
+    # Always keep a broad LIKE match in the filter to catch display-name-only values
+    base_filters.append("(customer like %(customer_like)s or customer_name like %(customer_like)s)")
+
     if company:
         params["company"] = company
         base_filters.append("company = %(company)s")
@@ -1093,7 +1113,7 @@ def get_customer_invoice_history(
     elif invoice_type == "return":
         base_filters.append("is_return = 1")
 
-    filters = " and ".join(base_filters)
+    filters = " and ".join(dict.fromkeys(base_filters))
 
     sales_invoice_query = f"""
         select
@@ -1135,63 +1155,6 @@ def get_customer_invoice_history(
 
     rows = frappe.db.sql(query, params, as_dict=True)
 
-    # Fallback: when direct matches fail, attempt a fuzzy match on the customer name
-    if not rows:
-        fuzzy_params = {
-            **params,
-            "customer_like": f"%{raw_customer}%",
-        }
-
-        fuzzy_filters = ["docstatus = 1", "(customer like %(customer_like)s or customer_name like %(customer_like)s)"]
-        if company:
-            fuzzy_filters.append("company = %(company)s")
-        if from_date:
-            fuzzy_filters.append("posting_date >= %(from_date)s")
-        if to_date:
-            fuzzy_filters.append("posting_date <= %(to_date)s")
-
-        if invoice_type == "invoice":
-            fuzzy_filters.append("is_return = 0")
-        elif invoice_type == "return":
-            fuzzy_filters.append("is_return = 1")
-
-        fallback_filters = " and ".join(fuzzy_filters)
-
-        fallback_query = (
-            f"""
-            select
-                'Sales Invoice' as doctype,
-                name as invoice,
-                posting_date,
-                grand_total,
-                currency,
-                customer,
-                is_return,
-                company,
-                outstanding_amount,
-                creation
-            from `tabSales Invoice`
-            where {fallback_filters}
-            union all
-            select
-                'POS Invoice' as doctype,
-                name as invoice,
-                posting_date,
-                grand_total,
-                currency,
-                customer,
-                is_return,
-                company,
-                outstanding_amount,
-                creation
-            from `tabPOS Invoice`
-            where {fallback_filters}
-            order by posting_date desc, creation desc
-            limit %(limit)s offset %(offset)s
-            """
-        )
-
-        rows = frappe.db.sql(fallback_query, fuzzy_params, as_dict=True)
     has_more = len(rows) > limit_value
     invoices = rows[:limit_value]
 

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1051,14 +1051,15 @@ def get_customer_invoice_history(
     limit_value = max(cint(limit or 20), 1)
     offset_value = max(cint(offset or 0), 0)
 
-    resolved_customer_id = _resolve_customer_identifier(customer)
+    raw_customer = cstr(customer)
+    resolved_customer_id = _resolve_customer_identifier(raw_customer)
 
     # Build candidate identifiers to match both the resolved ID and any display labels
     candidates = []
-    for value in {customer, resolved_customer_id}:
+    for value in {raw_customer, resolved_customer_id}:
         if not value:
             continue
-        candidates.append(value)
+        candidates.append(cstr(value))
         candidates.append(cstr(value).strip())
 
     params = {
@@ -1133,6 +1134,64 @@ def get_customer_invoice_history(
     )
 
     rows = frappe.db.sql(query, params, as_dict=True)
+
+    # Fallback: when direct matches fail, attempt a fuzzy match on the customer name
+    if not rows:
+        fuzzy_params = {
+            **params,
+            "customer_like": f"%{raw_customer}%",
+        }
+
+        fuzzy_filters = ["docstatus = 1", "(customer like %(customer_like)s or customer_name like %(customer_like)s)"]
+        if company:
+            fuzzy_filters.append("company = %(company)s")
+        if from_date:
+            fuzzy_filters.append("posting_date >= %(from_date)s")
+        if to_date:
+            fuzzy_filters.append("posting_date <= %(to_date)s")
+
+        if invoice_type == "invoice":
+            fuzzy_filters.append("is_return = 0")
+        elif invoice_type == "return":
+            fuzzy_filters.append("is_return = 1")
+
+        fallback_filters = " and ".join(fuzzy_filters)
+
+        fallback_query = (
+            f"""
+            select
+                'Sales Invoice' as doctype,
+                name as invoice,
+                posting_date,
+                grand_total,
+                currency,
+                customer,
+                is_return,
+                company,
+                outstanding_amount,
+                creation
+            from `tabSales Invoice`
+            where {fallback_filters}
+            union all
+            select
+                'POS Invoice' as doctype,
+                name as invoice,
+                posting_date,
+                grand_total,
+                currency,
+                customer,
+                is_return,
+                company,
+                outstanding_amount,
+                creation
+            from `tabPOS Invoice`
+            where {fallback_filters}
+            order by posting_date desc, creation desc
+            limit %(limit)s offset %(offset)s
+            """
+        )
+
+        rows = frappe.db.sql(fallback_query, fuzzy_params, as_dict=True)
     has_more = len(rows) > limit_value
     invoices = rows[:limit_value]
 


### PR DESCRIPTION
## Summary
- add backend APIs to fetch customer invoice history and last invoice rates
- display customer-specific last invoice pricing in the item selector list and card views
- add a previous invoices dialog and trigger button to the invoice header with date/type filters

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e7ebdc9a48326a81afc70008a2dd5)