### PR TITLE
Preserve offline invoice timestamps during sync

### DIFF
--- a/frontend/src/offline/sync.js
+++ b/frontend/src/offline/sync.js
@@ -6,25 +6,51 @@ import { updateLocalStock } from "./stock.js";
 // Flag to avoid concurrent invoice syncs which can cause duplicate submissions
 let invoiceSyncInProgress = false;
 
-export function saveOfflineInvoice(entry) {
-	// Validate that invoice has items before saving
-	if (!entry.invoice || !Array.isArray(entry.invoice.items) || !entry.invoice.items.length) {
-		throw new Error("Cart is empty. Add items before saving.");
-	}
+function getOfflineTimestamp(entry) {
+        const now = new Date();
+        const pad = (value) => String(value).padStart(2, "0");
+        const posting_date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+        const posting_time = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
 
-	const key = "offline_invoices";
-	const entries = memory.offline_invoices;
-	// Clone the entry before storing to strip Vue reactivity
-	// and other non-serializable properties. IndexedDB only
-	// supports structured cloneable data, so reactive proxies
-	// cause a DataCloneError without this step.
-	let cleanEntry;
-	try {
-		cleanEntry = JSON.parse(JSON.stringify(entry));
-	} catch (e) {
-		console.error("Failed to serialize offline invoice", e);
-		throw e;
-	}
+        return {
+                offline_created_at: entry?.offline_created_at || now.toISOString(),
+                posting_date: entry?.invoice?.posting_date || posting_date,
+                posting_time: entry?.invoice?.posting_time || posting_time,
+        };
+}
+
+export function saveOfflineInvoice(entry) {
+        // Validate that invoice has items before saving
+        if (!entry.invoice || !Array.isArray(entry.invoice.items) || !entry.invoice.items.length) {
+                throw new Error("Cart is empty. Add items before saving.");
+        }
+
+        const key = "offline_invoices";
+        const entries = memory.offline_invoices;
+        // Clone the entry before storing to strip Vue reactivity
+        // and other non-serializable properties. IndexedDB only
+        // supports structured cloneable data, so reactive proxies
+        // cause a DataCloneError without this step.
+        const { offline_created_at, posting_date, posting_time } = getOfflineTimestamp(entry);
+
+        let cleanEntry;
+        try {
+                cleanEntry = JSON.parse(
+                        JSON.stringify({
+                                ...entry,
+                                offline_created_at,
+                                invoice: {
+                                        ...entry.invoice,
+                                        posting_date,
+                                        posting_time,
+                                        set_posting_time: 1,
+                                },
+                        }),
+                );
+        } catch (e) {
+                console.error("Failed to serialize offline invoice", e);
+                throw e;
+        }
 
 	entries.push(cleanEntry);
 	if (entries.length > MAX_QUEUE_ITEMS) {
@@ -216,10 +242,17 @@ export async function syncOfflineInvoices() {
 
 		for (const inv of invoices) {
 			try {
+				const invoicePayload = {
+					...inv.invoice,
+					posting_date: inv.invoice?.posting_date || inv.offline_created_at,
+					posting_time: inv.invoice?.posting_time,
+					set_posting_time: 1,
+				};
+
 				await frappe.call({
 					method: "posawesome.posawesome.api.invoices.submit_invoice",
 					args: {
-						invoice: inv.invoice,
+						invoice: invoicePayload,
 						data: inv.data,
 					},
 				});


### PR DESCRIPTION
## Summary
- store offline creation metadata and posting date/time when saving invoices offline
- submit offline invoices with preserved posting information so server uses the original timestamps

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d00170c188326bd790640a55acae0)