### PR TITLE
Fix default POS app path in Electron desktop shell

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -2,7 +2,7 @@ const path = require("path");
 const { app, BrowserWindow, ipcMain, net, shell } = require("electron");
 const Store = require("electron-store");
 
-const DEFAULT_PATH = "/app/posawesome";
+const DEFAULT_PATH = "/app/posapp";
 const store = new Store({
 	name: "posawesome-desktop",
 	defaults: {


### PR DESCRIPTION
## Summary
- update the Electron desktop shell’s default server path to `/app/posapp` instead of `/app/posawesome`

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943933439ac8326a0a8b1c82bf02668)