### PR TITLE
Add semantic-release automation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,21 @@ name: Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  release:
-    runs-on: ubuntu-latest
+  build-windows:
+    runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -18,6 +27,54 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Build frontend
+        run: yarn build
+
+      - name: Build Electron app (Windows)
+        run: yarn electron:build:win
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: electron-windows
+          path: dist-electron/**/*.exe
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-windows]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build frontend
+        run: yarn build
+
+      - name: Build Electron app (Linux)
+        run: yarn electron:build:linux
+
+      - name: Upload Electron artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: electron-linux
+          path: dist-electron/**/*.AppImage
+
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: electron-windows
+          path: dist-electron
 
       - name: Release
         env:

--- a/release.config.js
+++ b/release.config.js
@@ -87,6 +87,11 @@ module.exports = {
 					"Release: v${nextRelease.version} — ${new Date().toISOString().slice(0, 10)}\n\n${nextRelease.notes}\n",
 			},
 		],
-		"@semantic-release/github",
+		[
+			"@semantic-release/github",
+			{
+				assets: ["dist-electron/*.AppImage", "dist-electron/*.exe"],
+			},
+		],
 	],
 };


### PR DESCRIPTION
## Summary
- keep the release workflow manual-only but add a Windows build job that creates and uploads the NSIS installer
- download the Windows artifact during the Linux release job so semantic-release can publish both Windows and Linux installers
- include both AppImage and Windows exe artifacts in the GitHub Release assets

## Testing
- Not run (workflow and release config changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943a7d9cbe4832694d7f7421cd2c008)