### PR TITLE
Prevent electron-builder publish requirement for Windows build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "appId": "com.posawesome.desktop",
     "productName": "POS Awesome Desktop",
     "asar": true,
+    "publish": "never",
     "directories": {
       "output": "dist-electron"
     },


### PR DESCRIPTION
## Summary
- disable electron-builder auto-publishing by setting publish to "never"
- avoid GH_TOKEN requirement when running Windows build in CI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943afbe23b4832693af0b62f4eac554)