### PR TITLE
Disable unsupported electron publish provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "appId": "com.posawesome.desktop",
     "productName": "POS Awesome Desktop",
     "asar": true,
-    "publish": "never",
+    "publish": [],
     "directories": {
       "output": "dist-electron"
     },


### PR DESCRIPTION
## Summary
- stop using the unsupported "publish": "never" setting in electron-builder config by switching to an empty publish list to avoid missing provider errors during CI builds

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b13bb0e48326ae5df5881739f09b)