### PR TITLE
Ensure GH token available for Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   build-windows:
     runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- set GH_TOKEN for the Windows build job so electron-builder can run in CI

## Testing
- not run (workflow change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b47de1c483269c0635fc20dce020)