### PR TITLE
chore: disable linux electron publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "linux": {
       "target": ["AppImage"],
       "artifactName": "POSAwesome-${version}.${ext}",
-      "category": "Office"
+      "category": "Office",
+      "publish": "never"
     },
     "protocols": [
       {


### PR DESCRIPTION
## Summary
- keep global publish config empty for non-linux builds
- explicitly set linux electron-builder publish to "never" to bypass GH_TOKEN requirement on Linux CI builds

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b66681208326b4dbb9a338274c62)