### PR TITLE
Limit releases to Windows artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,15 +63,6 @@ jobs:
       - name: Build frontend
         run: yarn build
 
-      - name: Build Electron app (Linux)
-        run: yarn electron:build:linux
-
-      - name: Upload Electron artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: electron-linux
-          path: dist-electron/**/*.AppImage
-
       - name: Download Windows artifacts
         uses: actions/download-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "linux": {
       "target": ["AppImage"],
       "artifactName": "POSAwesome-${version}.${ext}",
-      "category": "Office",
-      "publish": "never"
+      "category": "Office"
     },
     "protocols": [
       {

--- a/release.config.js
+++ b/release.config.js
@@ -90,7 +90,7 @@ module.exports = {
 		[
 			"@semantic-release/github",
 			{
-				assets: ["dist-electron/*.AppImage", "dist-electron/*.exe"],
+				assets: ["dist-electron/*.exe"],
 			},
 		],
 	],


### PR DESCRIPTION
## Summary
- stop building and uploading Linux AppImage artifacts in the release workflow
- restrict semantic-release attachments to Windows executables only

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943b8b892788326bc8acf68d23c22b4)