### PR TITLE
Normalize desktop app path and adjust Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-windows:
+  release:
     runs-on: windows-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -29,45 +29,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-
-      - name: Build frontend
-        run: yarn build
-
-      - name: Build Electron app (Windows)
-        run: yarn electron:build:win
-
-      - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: electron-windows
-          path: dist-electron/**/*.exe
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [build-windows]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build frontend
-        run: yarn build
-
-      - name: Download Windows artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: electron-windows
-          path: dist-electron
 
       - name: Release
         env:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Use the bundled Electron shell when you need an offline-friendly desktop build t
 
 Notes:
 
-- The app prompts for the server URL on first launch (the `/app/posawesome` path is added automatically) and saves it locally so you do not need to re-enter it.
+- The app prompts for the server URL on first launch (the `/app/posapp` path is added automatically) and saves it locally so you do not need to re-enter it.
 - If connectivity drops, an offline screen appears with options to retry or change the saved server.
 - Windows (`.exe`) builds require Wine/Mono when running `electron-builder` on Linux. By default, `yarn electron:build` targets the current platform and writes artifacts into `dist-electron/`.
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -60,8 +60,11 @@ function ensureUrl(rawUrl) {
 		return "";
 	}
 
-	if (!parsed.pathname || parsed.pathname === "/") {
+	const trimmedPath = parsed.pathname?.replace(/\/+$/, "") || "";
+	if (!trimmedPath || trimmedPath === "/") {
 		parsed.pathname = DEFAULT_PATH;
+	} else if (trimmedPath === "/app/posawesome" || trimmedPath.startsWith("/app/posawesome/")) {
+		parsed.pathname = trimmedPath.replace("/app/posawesome", DEFAULT_PATH);
 	}
 
 	return parsed.toString().replace(/\/$/, "");

--- a/electron/renderer/setup.html
+++ b/electron/renderer/setup.html
@@ -160,7 +160,7 @@
 			<h1>POS Awesome Desktop</h1>
 			<p class="description">
 				App start hone par server URL ki zaroorat hoti hai. Neeche apna ERPNext / POS Awesome server URL
-				daalen, hum <code>/app/posawesome</code> path automatically set kar denge aur URL ko locally save kar
+				daalen, hum <code>/app/posapp</code> path automatically set kar denge aur URL ko locally save kar
 				lenge.
 			</p>
 
@@ -178,7 +178,7 @@
 
 			<div class="hint">
 				<ul>
-					<li>Example: <strong>https://yourdomain.com</strong> (we will append <code>/app/posawesome</code>).</li>
+					<li>Example: <strong>https://yourdomain.com</strong> (we will append <code>/app/posapp</code>).</li>
 					<li>Saved URL offline cache ke liye IndexedDB + disk par likh diya jaata hai.</li>
 					<li>Settings dubara kholne ke liye window se <em>Change server</em> button use karein.</li>
 				</ul>

--- a/release.config.js
+++ b/release.config.js
@@ -76,7 +76,7 @@ module.exports = {
 		[
 			"@semantic-release/exec",
 			{
-				prepareCmd: "python scripts/update_version.py ${nextRelease.version}",
+				prepareCmd: "python scripts/update_version.py ${nextRelease.version} && yarn build && yarn electron:build:win",
 			},
 		],
 		[


### PR DESCRIPTION
## Summary
- normalize saved/entered server URLs to use `/app/posapp` (migrating old `/app/posawesome` paths) so the desktop app loads correctly
- update setup instructions to mention the correct `/app/posapp` path
- run the release workflow entirely on Windows so version updates happen before packaging and build artifacts within semantic-release

## Testing
- not run (workflow and configuration changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943c0b6fb708326861b80336e675d1c)