### PR TITLE
Add menu shortcut for changing servers and translate setup text

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { app, BrowserWindow, ipcMain, net, shell } = require("electron");
+const { app, BrowserWindow, ipcMain, net, shell, Menu } = require("electron");
 
 const DEFAULT_PATH = "/app/posapp";
 
@@ -119,6 +119,8 @@ function createWindow() {
 	} else {
 		loadSetup();
 	}
+
+	buildAppMenu();
 }
 
 function loadSetup() {
@@ -143,6 +145,36 @@ function loadServer(serverUrl) {
 
 	store.set("serverUrl", normalized);
 	mainWindow.loadURL(normalized);
+}
+
+function buildAppMenu() {
+	const template = [
+		{
+			label: "POS Awesome",
+			submenu: [
+				{
+					label: "Change server",
+					accelerator: "CmdOrCtrl+Shift+C",
+					click: () => {
+						if (mainWindow) {
+							loadSetup();
+							mainWindow.focus();
+						}
+					},
+				},
+				{ type: "separator" },
+				{ role: "reload" },
+				{ role: "toggleDevTools" },
+				{ type: "separator" },
+				process.platform === "darwin" ? { role: "close" } : { role: "quit" },
+			].filter(Boolean),
+		},
+		{ role: "editMenu" },
+		{ role: "viewMenu" },
+	];
+
+	const menu = Menu.buildFromTemplate(template);
+	Menu.setApplicationMenu(menu);
 }
 
 async function probeServer() {

--- a/electron/renderer/offline.html
+++ b/electron/renderer/offline.html
@@ -101,7 +101,7 @@
 		<div class="card">
 			<div class="icon">📡</div>
 			<h1>Offline Mode</h1>
-			<p>Network ya server tak pohanch nahi ho rahi. Local cache available hai, lekin sync ke liye server ki zaroorat hai.</p>
+			<p>We can't reach the network or your server right now. Your local cache is available, but syncing requires the server.</p>
 			<p id="server-label" class="small"></p>
 			<div class="actions">
 				<button id="retry" class="primary" type="button">Retry connection</button>
@@ -111,13 +111,13 @@
 		<script>
 			const serverLabel = document.getElementById("server-label");
 			window.electronAPI.getServerUrl().then((saved) => {
-				serverLabel.textContent = saved ? `Last saved server: ${saved}` : "Server URL set nahi hai.";
+				serverLabel.textContent = saved ? `Last saved server: ${saved}` : "No server URL is set.";
 			});
 
 			document.getElementById("retry").addEventListener("click", async () => {
 				const result = await window.electronAPI.retryLoad();
 				if (!result?.launched) {
-					serverLabel.textContent = "Server URL set nahi hai.";
+					serverLabel.textContent = "No server URL is set.";
 				}
 			});
 

--- a/electron/renderer/setup.html
+++ b/electron/renderer/setup.html
@@ -159,9 +159,9 @@
 		<div class="card">
 			<h1>POS Awesome Desktop</h1>
 			<p class="description">
-				App start hone par server URL ki zaroorat hoti hai. Neeche apna ERPNext / POS Awesome server URL
-				daalen, hum <code>/app/posapp</code> path automatically set kar denge aur URL ko locally save kar
-				lenge.
+				POS Awesome Desktop needs your server URL to launch. Enter your ERPNext / POS Awesome server URL below;
+				we will automatically add the <code>/app/posapp</code> path and save the URL locally for the next
+				startup.
 			</p>
 
 			<form id="server-form">
@@ -179,8 +179,8 @@
 			<div class="hint">
 				<ul>
 					<li>Example: <strong>https://yourdomain.com</strong> (we will append <code>/app/posapp</code>).</li>
-					<li>Saved URL offline cache ke liye IndexedDB + disk par likh diya jaata hai.</li>
-					<li>Settings dubara kholne ke liye window se <em>Change server</em> button use karein.</li>
+					<li>The saved URL is stored in IndexedDB plus disk for offline caching.</li>
+					<li>Open settings again using the <em>Change server</em> option in the app menu.</li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- add an application menu entry to reopen the server setup screen after a URL is saved
- translate the desktop setup and offline pages to English and update guidance to use the menu option

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943d623c18c83268e9fe866685e3782)