### PR TITLE
fix: Stop duplicate item worker creation

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -977,6 +977,29 @@ export default {
 			this.scaleBarcodeSettingsLoaded = true;
 			return this.scaleBarcodeSettings;
 		},
+		startItemWorker() {
+			// Avoid spawning duplicate workers which doubles script downloads and background threads
+			if (this.itemWorker || typeof Worker === "undefined") {
+				return;
+			}
+
+			try {
+				// Use the plain URL so the service worker can match the cached file
+				// even when offline. Using a query string causes cache lookups to fail
+				// which results in "Failed to fetch a worker script" errors.
+				const workerUrl = "/assets/posawesome/dist/js/posapp/workers/itemWorker.js";
+				this.itemWorker = new Worker(workerUrl, { type: "classic" });
+				this.itemWorker.onerror = function (event) {
+					console.error("Worker error:", event);
+					console.error("Message:", event.message);
+					console.error("Filename:", event.filename);
+					console.error("Line number:", event.lineno);
+				};
+			} catch (e) {
+				console.error("Failed to start item worker", e);
+				this.itemWorker = null;
+			}
+		},
 		async ensureScaleBarcodeSettings(force = false) {
 			if (!force && this.scaleBarcodeSettingsLoaded) {
 				return this.scaleBarcodeSettings;
@@ -1240,25 +1263,8 @@ export default {
 				} else {
 					this.localStorageAvailable = true;
 				}
-				if (
-					this.pos_profile &&
-					this.pos_profile.posa_local_storage &&
-					typeof Worker !== "undefined" &&
-					!this.itemWorker
-				) {
-					try {
-						const workerUrl = "/assets/posawesome/dist/js/posapp/workers/itemWorker.js";
-						this.itemWorker = new Worker(workerUrl, { type: "classic" });
-						this.itemWorker.onerror = function (event) {
-							console.error("Worker error:", event);
-							console.error("Message:", event.message);
-							console.error("Filename:", event.filename);
-							console.error("Line number:", event.lineno);
-						};
-					} catch (e) {
-						console.error("Failed to start item worker", e);
-						this.itemWorker = null;
-					}
+				if (this.pos_profile && this.pos_profile.posa_local_storage) {
+					this.startItemWorker();
 				}
 			} else {
 				this.markStorageUnavailable();
@@ -4422,47 +4428,7 @@ export default {
 			}
 		});
 
-		if (typeof Worker !== "undefined") {
-			try {
-				// Use the plain URL so the service worker can match the cached file
-				// even when offline. Using a query string causes cache lookups to fail
-				// which results in "Failed to fetch a worker script" errors.
-				const workerUrl = "/assets/posawesome/dist/js/posapp/workers/itemWorker.js";
-				this.itemWorker = new Worker(workerUrl, { type: "classic" });
-
-				this.itemWorker.onerror = function (event) {
-					console.error("Worker error:", event);
-					console.error("Message:", event.message);
-					console.error("Filename:", event.filename);
-					console.error("Line number:", event.lineno);
-				};
-				console.log("Created worker");
-			} catch (e) {
-				console.error("Failed to start item worker", e);
-				this.itemWorker = null;
-			}
-		}
-
-		if (typeof Worker !== "undefined") {
-			try {
-				// Use the plain URL so the service worker can match the cached file
-				// even when offline. Using a query string causes cache lookups to fail
-				// which results in "Failed to fetch a worker script" errors.
-				const workerUrl = "/assets/posawesome/dist/js/posapp/workers/itemWorker.js";
-				this.itemWorker = new Worker(workerUrl, { type: "classic" });
-
-				this.itemWorker.onerror = function (event) {
-					console.error("Worker error:", event);
-					console.error("Message:", event.message);
-					console.error("Filename:", event.filename);
-					console.error("Line number:", event.lineno);
-				};
-				console.log("Created worker");
-			} catch (e) {
-				console.error("Failed to start item worker", e);
-				this.itemWorker = null;
-			}
-		}
+		this.startItemWorker();
 
 		// Setup auto-refresh for item quantities
 		// Trigger an immediate refresh once items are available


### PR DESCRIPTION
## 💡 What
- centralize item worker initialization behind a guard to prevent spawning multiple instances

## 🎯 Why
- duplicated worker creation in ItemsSelector started two background threads and downloaded the worker script twice on each mount, wasting CPU and memory

## 📊 Impact
- removes the redundant worker startup, eliminating the extra thread and script fetch per ItemsSelector mount (cuts worker boot overhead roughly in half)

## 🔬 Measurement
- manual verification: ensured only a single `startItemWorker` call remains in the created hook and a guarded helper prevents duplicate instantiation; `yarn test` currently fails due to existing mocks/IndexedDB issues noted in the test output


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944d74afc38832681bed30b208c16c9)