### PR TITLE
fix: cache asset build version lookups

### DIFF
--- a/posawesome/utils.py
+++ b/posawesome/utils.py
@@ -12,26 +12,65 @@ _BASE_DIR = Path(__file__).resolve().parent
 _VERSION_FILE = _BASE_DIR / "public" / "dist" / "js" / "version.json"
 _CSS_FILE = _BASE_DIR / "public" / "dist" / "js" / "posawesome.css"
 _FALLBACK_VERSION: str | None = None
+_VERSION_FILE_MTIME: float | None = None
+_CACHED_VERSION_FILE_VALUE: str | None = None
+_CSS_FILE_MTIME: float | None = None
+_CACHED_CSS_VERSION: str | None = None
 
 
 def _read_version_file() -> str | None:
-    if not _VERSION_FILE.exists():
+    global _VERSION_FILE_MTIME, _CACHED_VERSION_FILE_VALUE
+
+    try:
+        version_stat = _VERSION_FILE.stat()
+    except FileNotFoundError:
+        _VERSION_FILE_MTIME = None
+        _CACHED_VERSION_FILE_VALUE = None
         return None
+    except OSError:
+        return None
+
+    if _CACHED_VERSION_FILE_VALUE is not None and _VERSION_FILE_MTIME == version_stat.st_mtime:
+        # Avoid re-reading/parsing when the asset version file is unchanged.
+        return _CACHED_VERSION_FILE_VALUE
+
     try:
         data = json.loads(_VERSION_FILE.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError, ValueError):
         return None
     version = data.get("version") or data.get("buildVersion")
-    return str(version) if version else None
+    if not version:
+        return None
+
+    normalized = str(version)
+    _CACHED_VERSION_FILE_VALUE = normalized
+    _VERSION_FILE_MTIME = version_stat.st_mtime
+    return normalized
 
 
 def _css_mtime_version() -> str | None:
-    if not _CSS_FILE.exists():
-        return None
+    global _CSS_FILE_MTIME, _CACHED_CSS_VERSION
+
     try:
-        return str(int(_CSS_FILE.stat().st_mtime))
+        css_stat = _CSS_FILE.stat()
+    except FileNotFoundError:
+        _CSS_FILE_MTIME = None
+        _CACHED_CSS_VERSION = None
+        return None
     except OSError:
         return None
+
+    if _CACHED_CSS_VERSION is not None and _CSS_FILE_MTIME == css_stat.st_mtime:
+        # Avoid repeated stat conversions when the CSS asset is untouched.
+        return _CACHED_CSS_VERSION
+
+    try:
+        version = str(int(css_stat.st_mtime))
+    except OSError:
+        return None
+    _CACHED_CSS_VERSION = version
+    _CSS_FILE_MTIME = css_stat.st_mtime
+    return version
 
 
 def get_build_version() -> str:


### PR DESCRIPTION
## 💡 What
- Cache the parsed asset version file and CSS mtime to avoid re-reading unchanged files on every build version lookup.

## 🎯 Why
- `get_build_version` runs whenever asset versions are injected and in app info responses; previously each call performed disk I/O and JSON parsing even when files were unchanged.

## 📊 Impact
- Eliminates repeat filesystem reads for stable asset files; repeated `get_build_version` calls are now served from memory after the first read (1000 calls ~6.1ms → ~5.9ms in local benchmark).

## 🔬 Measurement
- `python - <<'PY' ... get_build_version() ... PY` (before/after) to compare 1000-call timing.

## 🧪 Testing
- `yarn test run` (fails: existing Vitest mocks missing `evaluatePricingRules` export and global `__` in invoiceItemMethods.spec.js; see console output).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944d9adfd848326859d191dd641dc2b)