### PR TITLE
perf: streamline offer snapshot diff

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -34,6 +34,33 @@ const buildSnapshot = (items) => {
 	return snapshot;
 };
 
+const META_KEYS = [
+	"item_code",
+	"item_group",
+	"brand",
+	"uom",
+	"conversion_factor",
+	"price_list_rate",
+	"stock_qty",
+	"posa_is_offer",
+	"posa_is_replace",
+];
+
+// PERF: shallow-compare tracked fields instead of JSON stringifying whole meta blobs on every change.
+// This avoids repeated allocations during cart edits while still detecting meaningful differences.
+const metaChanged = (prevMeta, currMeta) => {
+	if (prevMeta === currMeta) return false;
+	if (!prevMeta || !currMeta) return true;
+
+	for (const key of META_KEYS) {
+		if (prevMeta[key] !== currMeta[key]) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
 const diffSnapshots = (previous, current) => {
 	const prevSnapshot = previous || { order: [], qty: {}, stockQty: {}, meta: {} };
 	const changed = new Set();
@@ -72,9 +99,7 @@ const diffSnapshots = (previous, current) => {
 
 		const prevMeta = prevSnapshot.meta ? prevSnapshot.meta[rowId] : undefined;
 		const currMeta = current.meta ? current.meta[rowId] : undefined;
-		if (JSON.stringify(prevMeta) !== JSON.stringify(currMeta)) {
-			changed.add(rowId);
-		}
+		if (metaChanged(prevMeta, currMeta)) changed.add(rowId);
 	});
 
 	return { changed, removedInfo };


### PR DESCRIPTION
## Summary
- replace per-item offer meta comparisons with shallow field checks to avoid JSON serialization churn
- retain change detection fidelity while reducing allocations during cart edits

## Testing
- `yarn test` *(fails: IndexedDB API unavailable in test environment; two tests currently fail due to missing mocks and global __ definition)*

## Details
- 💡 What: shallow compare tracked offer meta fields instead of stringifying entire objects on each watcher run
- 🎯 Why: JSON.stringify per item on every cart change was allocating and parsing unnecessarily during rapid edits
- 📊 Impact: reduces per-row comparison cost (no JSON parse/alloc) during item watcher runs; expect fewer GC pauses when cart updates frequently
- 🔬 Measurement: profile watcher hot path via browser devtools Performance tab while adding/removing items; observe reduced time in JSON.stringify and fewer minor GCs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944dc50bf4c832695f969c1cd5fdcff)