### PR TITLE
Improve cart quantity recalculation performance

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -444,6 +444,9 @@ export default {
 			paymentVisible: false, // Track current payment view state
 			_busHandlers: {},
 			pricing_reconcile_in_progress: false,
+			cartQuantitiesScheduleHandle: null,
+			cartQuantitiesSchedulePending: false,
+			cartQuantitiesScheduleDirty: false,
 		};
 	},
 
@@ -543,6 +546,47 @@ export default {
 
 			// Generate headers based on selected columns
 			this.updateHeadersFromSelection();
+		},
+		scheduleCartQuantitiesUpdate() {
+			this.cartQuantitiesScheduleDirty = true;
+			if (this.cartQuantitiesSchedulePending) {
+				return;
+			}
+			this.cartQuantitiesSchedulePending = true;
+
+			const scheduler =
+				typeof window !== "undefined" && typeof window.requestAnimationFrame === "function"
+					? window.requestAnimationFrame.bind(window)
+					: (cb) => setTimeout(cb, 16);
+
+			this.cartQuantitiesScheduleHandle = scheduler(() => {
+				this.cartQuantitiesScheduleHandle = null;
+				this.cartQuantitiesSchedulePending = false;
+
+				if (!this.cartQuantitiesScheduleDirty) {
+					return;
+				}
+
+				this.cartQuantitiesScheduleDirty = false;
+				this.emitCartQuantities();
+			});
+		},
+		cancelScheduledCartQuantitiesUpdate() {
+			if (!this.cartQuantitiesScheduleHandle) {
+				this.cartQuantitiesSchedulePending = false;
+				this.cartQuantitiesScheduleDirty = false;
+				return;
+			}
+
+			if (typeof window !== "undefined" && typeof window.cancelAnimationFrame === "function") {
+				window.cancelAnimationFrame(this.cartQuantitiesScheduleHandle);
+			} else {
+				clearTimeout(this.cartQuantitiesScheduleHandle);
+			}
+
+			this.cartQuantitiesScheduleHandle = null;
+			this.cartQuantitiesSchedulePending = false;
+			this.cartQuantitiesScheduleDirty = false;
 		},
 		emitCartQuantities() {
 			const totals = {};
@@ -1776,6 +1820,7 @@ export default {
 		if (typeof this.cancelScheduledOfferRefresh === "function") {
 			this.cancelScheduledOfferRefresh();
 		}
+		this.cancelScheduledCartQuantitiesUpdate();
 		if (this._suppressClosePaymentsTimer) {
 			clearTimeout(this._suppressClosePaymentsTimer);
 			this._suppressClosePaymentsTimer = null;

--- a/frontend/src/posapp/components/pos/invoiceWatchers.js
+++ b/frontend/src/posapp/components/pos/invoiceWatchers.js
@@ -168,8 +168,13 @@ export default {
 				this.scheduleOfferRefresh(Array.from(changed));
 			}
 
-			if (typeof this.emitCartQuantities === "function") {
-				this.emitCartQuantities();
+			const triggerCartUpdate =
+				typeof this.scheduleCartQuantitiesUpdate === "function"
+					? this.scheduleCartQuantitiesUpdate
+					: this.emitCartQuantities;
+
+			if (typeof triggerCartUpdate === "function") {
+				triggerCartUpdate();
 			}
 		},
 	},
@@ -198,8 +203,13 @@ export default {
 				this.scheduleOfferRefresh(Array.from(changed));
 			}
 
-			if (typeof this.emitCartQuantities === "function") {
-				this.emitCartQuantities();
+			const triggerCartUpdate =
+				typeof this.scheduleCartQuantitiesUpdate === "function"
+					? this.scheduleCartQuantitiesUpdate
+					: this.emitCartQuantities;
+
+			if (typeof triggerCartUpdate === "function") {
+				triggerCartUpdate();
 			}
 		},
 	},


### PR DESCRIPTION
## Summary
- batch cart quantity/reservation recalculations so large carts are processed once per frame instead of on every mutation
- update invoice watchers to use the new scheduler and clean up pending work on unmount

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69453c9c250483269f3f6209a7553593)