### PR TITLE
Add notification bell for background invoice submission errors

### DIFF
--- a/frontend/src/posapp/components/Navbar.vue
+++ b/frontend/src/posapp/components/Navbar.vue
@@ -43,6 +43,15 @@
 				<DatabaseUsageGadget />
 			</template>
 
+			<template #notification-bell>
+				<NotificationBell
+					:notifications="notificationCenter.items"
+					:unread-count="notificationCenter.unread"
+					@mark-read="markBellNotificationsRead"
+					@clear="clearBellNotifications"
+				/>
+			</template>
+
 			<!-- Slot for menu -->
 			<template #menu>
 				<NavbarMenu
@@ -114,6 +123,7 @@ import { defineAsyncComponent } from "vue";
 import NavbarAppBar from "./navbar/NavbarAppBar.vue";
 import NavbarDrawer from "./navbar/NavbarDrawer.vue";
 import NavbarMenu from "./navbar/NavbarMenu.vue";
+import NotificationBell from "./navbar/NotificationBell.vue";
 import StatusIndicator from "./navbar/StatusIndicator.vue";
 import CacheUsageMeter from "./navbar/CacheUsageMeter.vue";
 import AboutDialog from "./navbar/AboutDialog.vue";
@@ -145,6 +155,7 @@ export default {
 		NavbarAppBar,
 		NavbarDrawer,
 		NavbarMenu,
+		NotificationBell,
 		StatusIndicator,
 		CacheUsageMeter,
 		AboutDialog,
@@ -225,6 +236,10 @@ export default {
 			initialCacheRefreshRequested: false,
 			notificationUpdateHandle: null,
 			notificationUpdateUsesTimeout: false,
+			notificationCenter: {
+				items: [],
+				unread: 0,
+			},
 		};
 	},
 	watch: {
@@ -271,6 +286,7 @@ export default {
 			this.eventBus.off("freeze", this.handleFreeze);
 			this.eventBus.off("unfreeze", this.handleUnfreeze);
 			this.eventBus.off("set_company", this.handleSetCompany);
+			this.eventBus.off("invoice_submission_failed", this.handleInvoiceSubmissionFailed);
 		}
 	},
 	methods: {
@@ -351,6 +367,7 @@ export default {
 				this.eventBus.on("freeze", this.handleFreeze);
 				this.eventBus.on("unfreeze", this.handleUnfreeze);
 				this.eventBus.on("set_company", this.handleSetCompany);
+				this.eventBus.on("invoice_submission_failed", this.handleInvoiceSubmissionFailed);
 			}
 		},
 		handleNavClick() {
@@ -431,6 +448,55 @@ export default {
 		},
 		updateAfterDelete() {
 			this.$emit("update-after-delete");
+		},
+		handleInvoiceSubmissionFailed(payload = {}) {
+			const invoiceNumber =
+				payload.invoice || payload.invoiceId || payload.invoice_name || payload.name || payload.reference;
+			const rawReason = (payload.reason || payload.error || payload.message || "").toString().trim();
+			const reasonText =
+				rawReason || this.__("The invoice stayed in draft. Please review and submit it manually.");
+			const title = invoiceNumber
+				? this.__("Invoice {0} submission failed", [invoiceNumber])
+				: this.__("Invoice submission failed");
+
+			this.addBellNotification({
+				title,
+				detail: this.__("Saved as draft because: {0}", [reasonText]),
+				color: "error",
+				timestamp: payload.timestamp || Date.now(),
+			});
+
+			this.showMessage({
+				title,
+				summary: title,
+				detail: reasonText,
+				color: "error",
+				groupId: "invoice-submission-failed",
+			});
+		},
+		addBellNotification(notification = {}) {
+			const title = notification.title || this.__("Notification");
+			const detail = notification.detail || "";
+			const color = notification.color || "info";
+			const timestamp = notification.timestamp || Date.now();
+
+			const entry = {
+				id: `${timestamp}-${Math.random().toString(36).slice(2, 8)}`,
+				title,
+				detail,
+				color,
+				timestamp,
+			};
+
+			this.notificationCenter.items = [entry, ...this.notificationCenter.items].slice(0, 20);
+			this.notificationCenter.unread += 1;
+		},
+		markBellNotificationsRead() {
+			this.notificationCenter.unread = 0;
+		},
+		clearBellNotifications() {
+			this.notificationCenter.items = [];
+			this.notificationCenter.unread = 0;
 		},
 		showMessage(data) {
 			const notification = this.normalizeNotification(data);

--- a/frontend/src/posapp/components/navbar/NavbarAppBar.vue
+++ b/frontend/src/posapp/components/navbar/NavbarAppBar.vue
@@ -81,6 +81,9 @@
 					</v-tooltip>
 				</v-btn>
 
+				<!-- Notification bell between offline invoices and menu -->
+				<slot name="notification-bell"></slot>
+
 				<!-- Mobile Menu - contains all other items -->
 				<slot name="menu"></slot>
 			</template>
@@ -159,6 +162,9 @@
 						{{ __("Offline Invoices") }} ({{ pendingInvoices }})
 					</v-tooltip>
 				</v-btn>
+
+				<!-- Notification bell between offline invoices and menu -->
+				<slot name="notification-bell"></slot>
 
 				<!-- Menu component slot -->
 				<slot name="menu"></slot>
@@ -407,12 +413,16 @@ export default {
 	order: 4;
 }
 
+.ltr-actions-section .notification-bell-btn {
+	order: 5;
+}
+
 /* Menu should be the last element */
 .ltr-actions-section> :last-child,
 /* menu slot */
 .ltr-actions-section .v-menu,
 .ltr-actions-section [role="menu"] {
-	order: 5 !important;
+	order: 6 !important;
 }
 
 /* RTL adjustments for gadgets - reverse the order */
@@ -426,6 +436,10 @@ export default {
 
 .rtl-actions-section .offline-invoices-btn {
 	order: 2;
+}
+
+.rtl-actions-section .notification-bell-btn {
+	order: 1;
 }
 
 /* RTL Menu should be first */

--- a/frontend/src/posapp/components/navbar/NotificationBell.vue
+++ b/frontend/src/posapp/components/navbar/NotificationBell.vue
@@ -1,0 +1,241 @@
+<template>
+	<div class="notification-bell-btn">
+		<v-menu v-model="open" :close-on-content-click="false" offset="[0, 8]" location="bottom end">
+			<template #activator="{ props }">
+				<v-btn
+					v-bind="props"
+					icon
+					variant="elevated"
+					size="small"
+					class="pos-themed-button notification-bell-trigger"
+					:aria-label="__('View notifications') + (unreadCount ? ` (${unreadCount})` : '')"
+				>
+					<v-badge
+						:model-value="unreadCount > 0"
+						:content="unreadCount"
+						color="error"
+						overlap
+						v-if="notifications.length"
+					>
+						<v-icon class="pos-text-primary">mdi-bell-outline</v-icon>
+					</v-badge>
+					<v-icon v-else class="pos-text-primary">mdi-bell-outline</v-icon>
+				</v-btn>
+			</template>
+
+			<v-card class="pos-themed-card notification-card" elevation="12">
+				<div class="notification-card__header">
+					<div class="header-text">
+						<div class="title">{{ __("Notifications") }}</div>
+						<div class="subtitle">
+							{{
+								notifications.length
+									? __("Recent updates about your invoices")
+									: __("You have no notifications right now")
+							}}
+						</div>
+					</div>
+					<v-btn
+						v-if="notifications.length"
+						variant="text"
+						size="small"
+						class="clear-btn"
+						@click="clearAll"
+					>
+						<v-icon start size="16">mdi-broom</v-icon>
+						{{ __("Clear All") }}
+					</v-btn>
+				</div>
+
+				<v-divider></v-divider>
+
+				<div class="notification-list">
+					<div v-if="!notifications.length" class="empty-state">
+						<v-icon size="36" class="empty-icon">mdi-bell-off-outline</v-icon>
+						<div class="empty-title">{{ __("No notifications yet") }}</div>
+						<div class="empty-subtitle">
+							{{ __("We'll let you know if an invoice fails to submit") }}
+						</div>
+					</div>
+					<v-list v-else density="compact" class="notification-items">
+						<v-list-item v-for="item in notifications" :key="item.id" class="notification-item">
+							<template #prepend>
+								<div class="notification-icon" :class="item.color || 'error'">
+									<v-icon size="18">mdi-bell-alert-outline</v-icon>
+								</div>
+							</template>
+							<div class="notification-content">
+								<div class="notification-title">{{ item.title }}</div>
+								<div v-if="item.detail" class="notification-detail">
+									{{ item.detail }}
+								</div>
+								<div class="notification-time">{{ formatTimestamp(item.timestamp) }}</div>
+							</div>
+						</v-list-item>
+					</v-list>
+				</div>
+			</v-card>
+		</v-menu>
+	</div>
+</template>
+
+<script>
+export default {
+	name: "NotificationBell",
+	props: {
+		notifications: {
+			type: Array,
+			default: () => [],
+		},
+		unreadCount: {
+			type: Number,
+			default: 0,
+		},
+	},
+	data() {
+		return {
+			open: false,
+		};
+	},
+	watch: {
+		open(val) {
+			if (val) {
+				this.$emit("mark-read");
+			}
+		},
+	},
+	methods: {
+		clearAll() {
+			this.$emit("clear");
+		},
+		formatTimestamp(ts) {
+			if (!ts) {
+				return "";
+			}
+			try {
+				const date = new Date(ts);
+				return date.toLocaleString();
+			} catch {
+				return ts;
+			}
+		},
+	},
+	emits: ["mark-read", "clear"],
+};
+</script>
+
+<style scoped>
+.notification-bell-btn {
+	display: flex;
+	align-items: center;
+}
+
+.notification-bell-trigger {
+	box-shadow: 0 4px 12px var(--pos-shadow, rgba(0, 0, 0, 0.18)) !important;
+}
+
+.notification-card {
+	min-width: 320px;
+	max-width: 400px;
+}
+
+.notification-card__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 16px;
+}
+
+.header-text .title {
+	font-weight: 700;
+	font-size: 1rem;
+}
+
+.header-text .subtitle {
+	font-size: 0.85rem;
+	color: var(--pos-text-secondary);
+}
+
+.clear-btn {
+	text-transform: none;
+	font-weight: 600;
+}
+
+.notification-list {
+	max-height: 360px;
+	overflow-y: auto;
+}
+
+.notification-items {
+	padding: 0;
+}
+
+.notification-item {
+	border-bottom: 1px solid var(--pos-border);
+}
+
+.notification-item:last-child {
+	border-bottom: none;
+}
+
+.notification-icon {
+	width: 36px;
+	height: 36px;
+	border-radius: 12px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: white;
+}
+
+.notification-icon.error {
+	background: linear-gradient(135deg, #e53935, #e57373);
+}
+
+.notification-content {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.notification-title {
+	font-weight: 700;
+	color: var(--pos-text-primary);
+}
+
+.notification-detail {
+	font-size: 0.9rem;
+	color: var(--pos-text-secondary);
+	white-space: pre-wrap;
+}
+
+.notification-time {
+	font-size: 0.75rem;
+	color: var(--pos-text-secondary);
+}
+
+.empty-state {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 24px 12px;
+	text-align: center;
+	color: var(--pos-text-secondary);
+}
+
+.empty-icon {
+	color: var(--pos-text-secondary);
+	margin-bottom: 8px;
+}
+
+.empty-title {
+	font-weight: 700;
+	color: var(--pos-text-primary);
+	margin-bottom: 4px;
+}
+
+.empty-subtitle {
+	font-size: 0.9rem;
+}
+</style>

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1332,15 +1332,23 @@ export default {
 			this.is_credit_return = false;
 		},
 	},
-	methods: {
-		// Go back to invoice view and reset customer readonly
-		back_to_invoice() {
-			this.eventBus.emit("show_payment", "false");
-			this.eventBus.emit("set_customer_readonly", false);
-			this.$nextTick(() => {
-				this.eventBus.emit("focus_item_search");
-			});
-		},
+		methods: {
+			// Go back to invoice view and reset customer readonly
+			back_to_invoice() {
+				this.eventBus.emit("show_payment", "false");
+				this.eventBus.emit("set_customer_readonly", false);
+				this.$nextTick(() => {
+					this.eventBus.emit("focus_item_search");
+				});
+			},
+			finishSubmissionNavigation(clearInvoice = false) {
+				this.back_to_invoice();
+				if (clearInvoice) {
+					this.addresses = [];
+					this.eventBus.emit("clear_invoice");
+					this.eventBus.emit("reset_posting_date");
+				}
+			},
 		// Highlight and focus the submit button when payment screen opens
 		handleShowPayment(data) {
 			if (data === "true") {
@@ -1703,6 +1711,7 @@ export default {
 							title: __("Invoice {0} stayed in draft", [responseInvoiceName || ""]),
 							color: "warning",
 						});
+						this.finishSubmissionNavigation(true);
 						return;
 					}
 
@@ -1738,11 +1747,7 @@ export default {
 						item_codes: submittedCodes,
 						timestamp: Date.now(),
 					});
-					this.addresses = [];
-					this.eventBus.emit("clear_invoice");
-					this.eventBus.emit("focus_item_search");
-					this.eventBus.emit("reset_posting_date");
-					this.back_to_invoice();
+					this.finishSubmissionNavigation(true);
 				} catch (exc) {
 					console.error("Error submitting invoice:", exc);
 					let errorMsg = this.extractSubmissionErrorMessage(exc);
@@ -1778,6 +1783,9 @@ export default {
 							title: __("Error submitting invoice: ") + errorMsg,
 							color: "error",
 						});
+						if (this.pos_profile?.posa_allow_submissions_in_background_job) {
+							this.finishSubmissionNavigation(true);
+						}
 					}
 				}
 			},

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -873,6 +873,28 @@ export default {
 			get() {
 				return this.invoiceStore.invoiceDoc;
 			},
+			extractSubmissionErrorMessage(exc) {
+				if (!exc) {
+					return __("Unknown error");
+				}
+				if (exc?._server_messages) {
+					try {
+						const parsed = JSON.parse(exc._server_messages);
+						if (Array.isArray(parsed) && parsed.length) {
+							const first = parsed[0];
+							if (typeof first === "string") {
+								return frappe.utils.strip_html(first);
+							}
+						}
+					} catch {
+						/* ignore parse issues */
+					}
+				}
+				if (exc?.message) {
+					return exc.message;
+				}
+				return exc.toString ? exc.toString() : __("Unknown error");
+			},
 			set(value) {
 				this.invoiceStore.setInvoiceDoc(value);
 			},
@@ -1640,99 +1662,125 @@ export default {
                                         },
                                 });
 
-				if (!r.message) {
-					if (
-						this.pos_profile?.posa_allow_submissions_in_background_job &&
-						this.eventBus &&
-						typeof this.eventBus.emit === "function"
-					) {
-						this.eventBus.emit("invoice_submission_failed", {
-							invoice: this.invoice_doc?.name,
-							reason: __("No response from server"),
+					if (!r.message) {
+						if (
+							this.pos_profile?.posa_allow_submissions_in_background_job &&
+							this.eventBus &&
+							typeof this.eventBus.emit === "function"
+						) {
+							this.eventBus.emit("invoice_submission_failed", {
+								invoice: this.invoice_doc?.name,
+								reason: __("No response from server"),
+							});
+						}
+						this.eventBus.emit("show_message", {
+							title: __("Error submitting invoice: No response from server"),
+							color: "error",
 						});
+						return;
 					}
-					this.eventBus.emit("show_message", {
-						title: __("Error submitting invoice: No response from server"),
-						color: "error",
-					});
-					return;
-				}
 
-				if (print) {
-					this.load_print_page();
-				}
-				this.customer_credit_dict = [];
-				this.redeem_customer_credit = false;
-				this.is_cashback = true;
-				this.is_credit_return = false;
-				this.sales_person = "";
-				this.eventBus.emit("set_last_invoice", this.invoice_doc.name);
-				this.eventBus.emit("show_message", {
-					title:
-						this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
-							? __("Sales Order {0} is Submitted", [r.message.name])
-							: this.invoiceType === "Quotation"
-								? __("Quotation {0} is Submitted", [r.message.name])
-								: __("Invoice {0} is Submitted", [r.message.name]),
-					color: "success",
-				});
-				frappe.utils.play_sound("submit");
-				const submittedItems = Array.isArray(this.invoice_doc.items) ? this.invoice_doc.items : [];
-				updateLocalStock(submittedItems);
-				stockCoordinator.applyInvoiceConsumption(submittedItems, {
-					source: "invoice",
-				});
-				const submittedCodes = submittedItems
-					.map((item) => (item ? item.item_code : null))
-					.filter((code) => code !== undefined && code !== null);
-				this.eventBus.emit("invoice_stock_adjusted", {
-					items: submittedItems,
-					item_codes: submittedCodes,
-					timestamp: Date.now(),
-				});
-				this.addresses = [];
-				this.eventBus.emit("clear_invoice");
-				this.eventBus.emit("focus_item_search");
-				this.eventBus.emit("reset_posting_date");
-				this.back_to_invoice();
-			} catch (exc) {
-				console.error("Error submitting invoice:", exc);
-				let errorMsg = exc.toString();
-				if (errorMsg.includes("Amount must be negative")) {
+					const wasSubmitted = r.message?.docstatus === 1 || r.message?.status === 1;
+					const responseInvoiceName = r.message?.name || this.invoice_doc?.name;
+
+					if (!wasSubmitted && this.pos_profile?.posa_allow_submissions_in_background_job) {
+						const backgroundReason =
+							r.message?.error ||
+							r.message?.exc ||
+							r.message?.exception ||
+							r.message?.message ||
+							__("Submission kept as draft while processing in background.");
+						if (this.eventBus && typeof this.eventBus.emit === "function") {
+							this.eventBus.emit("invoice_submission_failed", {
+								invoice: responseInvoiceName,
+								reason: backgroundReason,
+							});
+						}
+					}
+
+					if (!wasSubmitted) {
+						this.eventBus.emit("show_message", {
+							title: __("Invoice {0} stayed in draft", [responseInvoiceName || ""]),
+							color: "warning",
+						});
+						return;
+					}
+
+					if (print) {
+						this.load_print_page();
+					}
+					this.customer_credit_dict = [];
+					this.redeem_customer_credit = false;
+					this.is_cashback = true;
+					this.is_credit_return = false;
+					this.sales_person = "";
+					this.eventBus.emit("set_last_invoice", this.invoice_doc.name);
 					this.eventBus.emit("show_message", {
-						title: __("Fixing payment amounts for return invoice..."),
-						color: "warning",
+						title:
+							this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
+								? __("Sales Order {0} is Submitted", [r.message.name])
+								: this.invoiceType === "Quotation"
+									? __("Quotation {0} is Submitted", [r.message.name])
+									: __("Invoice {0} is Submitted", [r.message.name]),
+						color: "success",
 					});
-					this.invoice_doc.payments.forEach((payment) => {
-						if (payment.amount > 0) {
-							payment.amount = -Math.abs(payment.amount);
-						}
-						if (payment.base_amount > 0) {
-							payment.base_amount = -Math.abs(payment.base_amount);
-						}
+					frappe.utils.play_sound("submit");
+					const submittedItems = Array.isArray(this.invoice_doc.items) ? this.invoice_doc.items : [];
+					updateLocalStock(submittedItems);
+					stockCoordinator.applyInvoiceConsumption(submittedItems, {
+						source: "invoice",
 					});
-					console.log("Retrying submission with fixed payment amounts");
-					setTimeout(() => {
-						this.submit_invoice(print);
-					}, 500);
-				} else {
-					if (
-						this.pos_profile?.posa_allow_submissions_in_background_job &&
-						this.eventBus &&
-						typeof this.eventBus.emit === "function"
-					) {
-						this.eventBus.emit("invoice_submission_failed", {
-							invoice: this.invoice_doc?.name,
-							reason: errorMsg,
+					const submittedCodes = submittedItems
+						.map((item) => (item ? item.item_code : null))
+						.filter((code) => code !== undefined && code !== null);
+					this.eventBus.emit("invoice_stock_adjusted", {
+						items: submittedItems,
+						item_codes: submittedCodes,
+						timestamp: Date.now(),
+					});
+					this.addresses = [];
+					this.eventBus.emit("clear_invoice");
+					this.eventBus.emit("focus_item_search");
+					this.eventBus.emit("reset_posting_date");
+					this.back_to_invoice();
+				} catch (exc) {
+					console.error("Error submitting invoice:", exc);
+					let errorMsg = this.extractSubmissionErrorMessage(exc);
+					if (errorMsg.includes("Amount must be negative")) {
+						this.eventBus.emit("show_message", {
+							title: __("Fixing payment amounts for return invoice..."),
+							color: "warning",
+						});
+						this.invoice_doc.payments.forEach((payment) => {
+							if (payment.amount > 0) {
+								payment.amount = -Math.abs(payment.amount);
+							}
+							if (payment.base_amount > 0) {
+								payment.base_amount = -Math.abs(payment.base_amount);
+							}
+						});
+						console.log("Retrying submission with fixed payment amounts");
+						setTimeout(() => {
+							this.submit_invoice(print);
+						}, 500);
+					} else {
+						if (
+							this.pos_profile?.posa_allow_submissions_in_background_job &&
+							this.eventBus &&
+							typeof this.eventBus.emit === "function"
+						) {
+							this.eventBus.emit("invoice_submission_failed", {
+								invoice: this.invoice_doc?.name,
+								reason: errorMsg,
+							});
+						}
+						this.eventBus.emit("show_message", {
+							title: __("Error submitting invoice: ") + errorMsg,
+							color: "error",
 						});
 					}
-					this.eventBus.emit("show_message", {
-						title: __("Error submitting invoice: ") + errorMsg,
-						color: "error",
-					});
 				}
-			}
-		},
+			},
 		// Set full amount for a payment method (or negative for returns)
 		set_full_amount(idx) {
 			const isReturn = this.invoice_doc.is_return || this.invoiceType === "Return";

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1641,6 +1641,16 @@ export default {
                                 });
 
 				if (!r.message) {
+					if (
+						this.pos_profile?.posa_allow_submissions_in_background_job &&
+						this.eventBus &&
+						typeof this.eventBus.emit === "function"
+					) {
+						this.eventBus.emit("invoice_submission_failed", {
+							invoice: this.invoice_doc?.name,
+							reason: __("No response from server"),
+						});
+					}
 					this.eventBus.emit("show_message", {
 						title: __("Error submitting invoice: No response from server"),
 						color: "error",
@@ -1706,6 +1716,16 @@ export default {
 						this.submit_invoice(print);
 					}, 500);
 				} else {
+					if (
+						this.pos_profile?.posa_allow_submissions_in_background_job &&
+						this.eventBus &&
+						typeof this.eventBus.emit === "function"
+					) {
+						this.eventBus.emit("invoice_submission_failed", {
+							invoice: this.invoice_doc?.name,
+							reason: errorMsg,
+						});
+					}
 					this.eventBus.emit("show_message", {
 						title: __("Error submitting invoice: ") + errorMsg,
 						color: "error",

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1688,28 +1688,34 @@ export default {
 						return;
 					}
 
-					const wasSubmitted = r.message?.docstatus === 1 || r.message?.status === 1;
+					const docstatus = r.message?.docstatus;
+					const status = r.message?.status;
 					const responseInvoiceName = r.message?.name || this.invoice_doc?.name;
+					const backgroundReason =
+						r.message?.error ||
+						r.message?.exc ||
+						r.message?.exception ||
+						r.message?.message;
 
-					if (!wasSubmitted && this.pos_profile?.posa_allow_submissions_in_background_job) {
-						const backgroundReason =
-							r.message?.error ||
-							r.message?.exc ||
-							r.message?.exception ||
-							r.message?.message ||
-							__("Submission kept as draft while processing in background.");
-						if (this.eventBus && typeof this.eventBus.emit === "function") {
-							this.eventBus.emit("invoice_submission_failed", {
-								invoice: responseInvoiceName,
-								reason: backgroundReason,
-							});
-						}
-					}
+					const wasSubmitted =
+						docstatus === 1 ||
+						status === 1 ||
+						(docstatus === undefined && status === undefined);
 
 					if (!wasSubmitted) {
+						if (this.pos_profile?.posa_allow_submissions_in_background_job && backgroundReason) {
+							if (this.eventBus && typeof this.eventBus.emit === "function") {
+								this.eventBus.emit("invoice_submission_failed", {
+									invoice: responseInvoiceName,
+									reason: backgroundReason,
+								});
+							}
+						}
+
 						this.eventBus.emit("show_message", {
 							title: __("Invoice {0} stayed in draft", [responseInvoiceName || ""]),
 							color: "warning",
+							detail: backgroundReason,
 						});
 						this.finishSubmissionNavigation(true);
 						return;

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -831,11 +831,11 @@ export default {
 		return { invoiceStore, selectedCustomer, customerInfoFromStore: customerInfo };
 	},
 	data() {
-		return {
-			loading: false, // UI loading state
-			pos_profile: "", // POS profile settings
-			pos_settings: {}, // POS settings
-			stock_settings: "", // Stock settings
+			return {
+				loading: false, // UI loading state
+				pos_profile: "", // POS profile settings
+				pos_settings: {}, // POS settings
+				stock_settings: "", // Stock settings
 			invoiceType: "Invoice", // Type of invoice
 			is_return: false, // Is this a return invoice?
 			loyalty_amount: 0, // Loyalty points to redeem
@@ -862,12 +862,13 @@ export default {
 			mpesa_modes: [], // List of available M-Pesa modes
 			sales_persons: [], // List of sales persons
 			sales_person: "", // Selected sales person
-			addresses: [], // List of customer addresses
-			is_user_editing_paid_change: false, // User interaction flag
-			highlightSubmit: false, // Highlight state for submit button
-			last_payment_change_was_cash: null, // Track last edited payment type
-		};
-	},
+				addresses: [], // List of customer addresses
+				is_user_editing_paid_change: false, // User interaction flag
+				highlightSubmit: false, // Highlight state for submit button
+				last_payment_change_was_cash: null, // Track last edited payment type
+				backgroundStatusCheck: null,
+			};
+		},
 	computed: {
 		invoice_doc: {
 			get() {
@@ -1718,6 +1719,7 @@ export default {
 							detail: backgroundReason,
 						});
 						this.finishSubmissionNavigation(true);
+						this.scheduleBackgroundStatusCheck(responseInvoiceName, r.message?.doctype);
 						return;
 					}
 
@@ -1728,33 +1730,34 @@ export default {
 					this.redeem_customer_credit = false;
 					this.is_cashback = true;
 					this.is_credit_return = false;
-					this.sales_person = "";
-					this.eventBus.emit("set_last_invoice", this.invoice_doc.name);
-					this.eventBus.emit("show_message", {
-						title:
-							this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
-								? __("Sales Order {0} is Submitted", [r.message.name])
-								: this.invoiceType === "Quotation"
-									? __("Quotation {0} is Submitted", [r.message.name])
-									: __("Invoice {0} is Submitted", [r.message.name]),
-						color: "success",
-					});
-					frappe.utils.play_sound("submit");
-					const submittedItems = Array.isArray(this.invoice_doc.items) ? this.invoice_doc.items : [];
-					updateLocalStock(submittedItems);
-					stockCoordinator.applyInvoiceConsumption(submittedItems, {
-						source: "invoice",
-					});
-					const submittedCodes = submittedItems
-						.map((item) => (item ? item.item_code : null))
-						.filter((code) => code !== undefined && code !== null);
-					this.eventBus.emit("invoice_stock_adjusted", {
-						items: submittedItems,
-						item_codes: submittedCodes,
-						timestamp: Date.now(),
-					});
-					this.finishSubmissionNavigation(true);
-				} catch (exc) {
+				this.sales_person = "";
+				this.eventBus.emit("set_last_invoice", this.invoice_doc.name);
+				this.eventBus.emit("show_message", {
+					title:
+						this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
+							? __("Sales Order {0} is Submitted", [r.message.name])
+							: this.invoiceType === "Quotation"
+								? __("Quotation {0} is Submitted", [r.message.name])
+								: __("Invoice {0} is Submitted", [r.message.name]),
+					color: "success",
+				});
+				frappe.utils.play_sound("submit");
+				const submittedItems = Array.isArray(this.invoice_doc.items) ? this.invoice_doc.items : [];
+				updateLocalStock(submittedItems);
+				stockCoordinator.applyInvoiceConsumption(submittedItems, {
+					source: "invoice",
+				});
+				const submittedCodes = submittedItems
+					.map((item) => (item ? item.item_code : null))
+					.filter((code) => code !== undefined && code !== null);
+				this.eventBus.emit("invoice_stock_adjusted", {
+					items: submittedItems,
+					item_codes: submittedCodes,
+					timestamp: Date.now(),
+				});
+				this.finishSubmissionNavigation(true);
+				this.scheduleBackgroundStatusCheck(responseInvoiceName, r.message?.doctype);
+			} catch (exc) {
 					console.error("Error submitting invoice:", exc);
 					let errorMsg = this.extractSubmissionErrorMessage(exc);
 					if (errorMsg.includes("Amount must be negative")) {
@@ -1789,10 +1792,58 @@ export default {
 							title: __("Error submitting invoice: ") + errorMsg,
 							color: "error",
 						});
-						if (this.pos_profile?.posa_allow_submissions_in_background_job) {
+					if (this.pos_profile?.posa_allow_submissions_in_background_job) {
 							this.finishSubmissionNavigation(true);
+							this.scheduleBackgroundStatusCheck(this.invoice_doc?.name, this.invoice_doc?.doctype);
 						}
 					}
+				}
+			},
+			scheduleBackgroundStatusCheck(invoiceName, doctype) {
+				this.clearBackgroundStatusCheck();
+				if (!this.pos_profile?.posa_allow_submissions_in_background_job) {
+					return;
+				}
+				if (!invoiceName) {
+					return;
+				}
+				this.backgroundStatusCheck = setTimeout(async () => {
+					try {
+						const result = await frappe.call({
+							method: "frappe.client.get_value",
+							args: {
+								doctype: doctype || this.invoice_doc?.doctype || "Sales Invoice",
+								filters: { name: invoiceName },
+								fieldname: ["docstatus"],
+							},
+						});
+						const status = result?.message?.docstatus;
+						if (status === 1) {
+							return;
+						}
+						const reason = this.__("Invoice is still in draft after background submission.");
+						if (this.eventBus && typeof this.eventBus.emit === "function") {
+							this.eventBus.emit("invoice_submission_failed", {
+								invoice: invoiceName,
+								reason,
+							});
+						}
+						this.eventBus.emit("show_message", {
+							title: __("Error submitting invoice: {0}", [invoiceName]),
+							color: "error",
+							detail: reason,
+						});
+					} catch (err) {
+						console.error("Background status check failed", err);
+					} finally {
+						this.clearBackgroundStatusCheck();
+					}
+				}, 10000);
+			},
+			clearBackgroundStatusCheck() {
+				if (this.backgroundStatusCheck) {
+					clearTimeout(this.backgroundStatusCheck);
+					this.backgroundStatusCheck = null;
 				}
 			},
 		// Set full amount for a payment method (or negative for returns)
@@ -2681,13 +2732,14 @@ export default {
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("add_the_new_address");
 		this.eventBus.off("update_invoice_type");
-		this.eventBus.off("set_pos_settings");
-		this.eventBus.off("set_mpesa_payment");
-		this.eventBus.off("clear_invoice");
-		this.eventBus.off("network-online", this.syncPendingInvoices);
-		this.eventBus.off("server-online", this.syncPendingInvoices);
-		this.eventBus.off("show_payment", this.handleShowPayment);
-	},
+			this.eventBus.off("set_pos_settings");
+			this.eventBus.off("set_mpesa_payment");
+			this.eventBus.off("clear_invoice");
+			this.eventBus.off("network-online", this.syncPendingInvoices);
+			this.eventBus.off("server-online", this.syncPendingInvoices);
+			this.eventBus.off("show_payment", this.handleShowPayment);
+			this.clearBackgroundStatusCheck();
+		},
 	// Lifecycle hook: unmounted
 	unmounted() {
 		// Remove keyboard shortcut listener

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1702,8 +1702,8 @@ export default {
 						status === 1 ||
 						(docstatus === undefined && status === undefined);
 
-					if (!wasSubmitted) {
-						if (this.pos_profile?.posa_allow_submissions_in_background_job && backgroundReason) {
+					if (!wasSubmitted && backgroundReason) {
+						if (this.pos_profile?.posa_allow_submissions_in_background_job) {
 							if (this.eventBus && typeof this.eventBus.emit === "function") {
 								this.eventBus.emit("invoice_submission_failed", {
 									invoice: responseInvoiceName,
@@ -1713,8 +1713,8 @@ export default {
 						}
 
 						this.eventBus.emit("show_message", {
-							title: __("Invoice {0} stayed in draft", [responseInvoiceName || ""]),
-							color: "warning",
+							title: __("Error submitting invoice: {0}", [responseInvoiceName || ""]),
+							color: "error",
 							detail: backgroundReason,
 						});
 						this.finishSubmissionNavigation(true);


### PR DESCRIPTION
## Summary
- add a bell notification control between the offline invoices button and the menu on the navbar
- track invoice submission failures (when background submissions are allowed) and surface the invoice number and reason in the notification list and snackbar
- expose a dedicated notification bell component with unread badges and clear-all support

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69467ec1421c83268680af8b8cf0b805)