### PR TITLE
Center navbar actions and route offline sync alerts

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -378,6 +378,8 @@ export default {
 				this.eventBus.emit("show_message", {
 					title: `${pending} invoice${pending > 1 ? "s" : ""} pending for sync`,
 					color: "warning",
+					groupId: "offline-sync-pending",
+					detail: this.__("Pending offline invoices waiting for connectivity"),
 				});
 			}
 			if (isOffline()) {
@@ -389,12 +391,16 @@ export default {
 					this.eventBus.emit("show_message", {
 						title: `${result.synced} offline invoice${result.synced > 1 ? "s" : ""} synced`,
 						color: "success",
+						groupId: "offline-sync-result",
+						detail: this.__("{0} invoice(s) synced successfully", [result.synced]),
 					});
 				}
 				if (result.drafted) {
 					this.eventBus.emit("show_message", {
 						title: `${result.drafted} offline invoice${result.drafted > 1 ? "s" : ""} saved as draft`,
 						color: "warning",
+						groupId: "offline-sync-result",
+						detail: this.__("{0} invoice(s) left as draft", [result.drafted]),
 					});
 				}
 			}

--- a/frontend/src/posapp/components/Navbar.vue
+++ b/frontend/src/posapp/components/Navbar.vue
@@ -505,6 +505,16 @@ export default {
 				return;
 			}
 
+			const isOfflineSync = this.isOfflineSyncNotification(notification);
+			if (isOfflineSync) {
+				this.addBellNotification({
+					title: notification.summary || notification.title,
+					detail: notification.latestDetail || "",
+					color: notification.color,
+					timestamp: Date.now(),
+				});
+			}
+
 			if (this.shouldThrottleNotification(notification)) {
 				return;
 			}
@@ -558,6 +568,7 @@ export default {
 				timeout,
 				count,
 				key: baseKey,
+				groupId: providedKey || null,
 				summary,
 				latestDetail: detail,
 				cooldownMs,
@@ -579,6 +590,23 @@ export default {
 
 			this.lastNotificationShownAt[notification.key] = now;
 			return false;
+		},
+		isOfflineSyncNotification(notification) {
+			if (!notification) {
+				return false;
+			}
+
+			if (notification.groupId && notification.groupId.startsWith("offline-sync")) {
+				return true;
+			}
+
+			const title = `${notification.title} ${notification.summary || ""}`.toLowerCase();
+			return (
+				title.includes("offline invoice") ||
+				title.includes("pending for sync") ||
+				title.includes("synced") ||
+				title.includes("saved as draft")
+			);
 		},
 		getNotificationCooldown(notification) {
 			if (typeof notification.cooldownMs === "number") {

--- a/frontend/src/posapp/components/navbar/NavbarAppBar.vue
+++ b/frontend/src/posapp/components/navbar/NavbarAppBar.vue
@@ -57,62 +57,102 @@
 		<div :class="['pos-navbar-actions-section', isRtl ? 'rtl-actions-section' : 'ltr-actions-section']">
 			<!-- Mobile: Show only essential items, others in menu -->
 			<template v-if="isMobile">
-				<!-- Always visible status indicator -->
-				<slot name="status-indicator"></slot>
+				<div class="mobile-center-cluster">
+					<!-- Always visible status indicator -->
+					<slot name="status-indicator"></slot>
 
-				<!-- Offline Invoices with higher priority on mobile -->
-				<v-btn
-					icon
-					size="small"
-					:class="[
-						'offline-invoices-btn mobile-btn pos-themed-button',
-						isRtl ? 'rtl-offline-btn' : 'ltr-offline-btn',
-						{ 'has-pending': pendingInvoices > 0 },
-					]"
-					:aria-label="__('View offline invoices') + ` (${pendingInvoices})`"
-					@click="$emit('show-offline-invoices')"
-				>
-					<v-badge v-if="pendingInvoices > 0" :content="pendingInvoices" color="error" overlap>
-						<v-icon class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
-					</v-badge>
-					<v-icon v-else class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
-					<v-tooltip activator="parent" location="bottom">
-						{{ __("Offline Invoices") }} ({{ pendingInvoices }})
-					</v-tooltip>
-				</v-btn>
+					<!-- Offline Invoices with higher priority on mobile -->
+					<v-btn
+						icon
+						size="small"
+						:class="[
+							'offline-invoices-btn mobile-btn pos-themed-button',
+							isRtl ? 'rtl-offline-btn' : 'ltr-offline-btn',
+							{ 'has-pending': pendingInvoices > 0 },
+						]"
+						:aria-label="__('View offline invoices') + ` (${pendingInvoices})`"
+						@click="$emit('show-offline-invoices')"
+					>
+						<v-badge v-if="pendingInvoices > 0" :content="pendingInvoices" color="error" overlap>
+							<v-icon class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
+						</v-badge>
+						<v-icon v-else class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
+						<v-tooltip activator="parent" location="bottom">
+							{{ __("Offline Invoices") }} ({{ pendingInvoices }})
+						</v-tooltip>
+					</v-btn>
 
-				<!-- Notification bell between offline invoices and menu -->
-				<slot name="notification-bell"></slot>
+					<!-- Notification bell between offline invoices and menu -->
+					<slot name="notification-bell"></slot>
 
-				<!-- Mobile Menu - contains all other items -->
-				<slot name="menu"></slot>
+					<!-- Mobile Menu - contains all other items -->
+					<slot name="menu"></slot>
+				</div>
 			</template>
 
 			<!-- Desktop: Show all items normally -->
 			<template v-else>
-				<!-- Enhanced connectivity status indicator (kept outside info menu) -->
-				<div class="gadget-wrapper status-gadget">
-					<slot name="status-indicator"></slot>
+				<div class="actions-left">
+					<!-- Enhanced connectivity status indicator (kept outside info menu) -->
+					<div class="gadget-wrapper status-gadget">
+						<slot name="status-indicator"></slot>
+					</div>
+
+					<NavbarInfoGadgets
+						:class="['info-gadgets-wrapper', isRtl ? 'rtl-info-gadgets' : 'ltr-info-gadgets']"
+					>
+						<!-- Cache Usage Meter -->
+						<template #cache-usage-meter>
+							<slot name="cache-usage-meter"></slot>
+						</template>
+
+						<!-- Database Usage Gadget -->
+						<template #db-usage-gadget>
+							<slot name="db-usage-gadget"></slot>
+						</template>
+
+						<!-- CPU Load Gadget -->
+						<template #cpu-gadget>
+							<slot name="cpu-gadget"></slot>
+						</template>
+					</NavbarInfoGadgets>
 				</div>
 
-				<NavbarInfoGadgets
-					:class="['info-gadgets-wrapper', isRtl ? 'rtl-info-gadgets' : 'ltr-info-gadgets']"
-				>
-					<!-- Cache Usage Meter -->
-					<template #cache-usage-meter>
-						<slot name="cache-usage-meter"></slot>
-					</template>
+				<div class="nav-center-cluster">
+					<v-btn
+						icon
+						:class="[
+							'offline-invoices-btn pos-themed-button',
+							isRtl ? 'rtl-offline-btn' : 'ltr-offline-btn',
+							{ 'has-pending': pendingInvoices > 0 },
+						]"
+						:aria-label="__('View offline invoices') + ` (${pendingInvoices})`"
+						:aria-describedby="'offline-invoices-tooltip'"
+						@click="$emit('show-offline-invoices')"
+						@keydown.enter="$emit('show-offline-invoices')"
+						tabindex="0"
+					>
+						<v-badge v-if="pendingInvoices > 0" :content="pendingInvoices" color="error" overlap>
+							<v-icon class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
+						</v-badge>
+						<v-icon v-else class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
+						<v-tooltip
+							id="offline-invoices-tooltip"
+							activator="parent"
+							:location="isRtl ? 'bottom start' : 'bottom end'"
+							:open-delay="500"
+							:close-delay="200"
+						>
+							{{ __("Offline Invoices") }} ({{ pendingInvoices }})
+						</v-tooltip>
+					</v-btn>
 
-					<!-- Database Usage Gadget -->
-					<template #db-usage-gadget>
-						<slot name="db-usage-gadget"></slot>
-					</template>
+					<!-- Notification bell between offline invoices and menu -->
+					<slot name="notification-bell"></slot>
 
-					<!-- CPU Load Gadget -->
-					<template #cpu-gadget>
-						<slot name="cpu-gadget"></slot>
-					</template>
-				</NavbarInfoGadgets>
+					<!-- Menu component slot -->
+					<slot name="menu"></slot>
+				</div>
 
 				<div :class="['profile-section', isRtl ? 'rtl-profile-section' : 'ltr-profile-section']">
 					<v-chip
@@ -134,40 +174,6 @@
 						</span>
 					</v-chip>
 				</div>
-
-				<v-btn
-					icon
-					:class="[
-						'offline-invoices-btn pos-themed-button',
-						isRtl ? 'rtl-offline-btn' : 'ltr-offline-btn',
-						{ 'has-pending': pendingInvoices > 0 },
-					]"
-					:aria-label="__('View offline invoices') + ` (${pendingInvoices})`"
-					:aria-describedby="'offline-invoices-tooltip'"
-					@click="$emit('show-offline-invoices')"
-					@keydown.enter="$emit('show-offline-invoices')"
-					tabindex="0"
-				>
-					<v-badge v-if="pendingInvoices > 0" :content="pendingInvoices" color="error" overlap>
-						<v-icon class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
-					</v-badge>
-					<v-icon v-else class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
-					<v-tooltip
-						id="offline-invoices-tooltip"
-						activator="parent"
-						:location="isRtl ? 'bottom start' : 'bottom end'"
-						:open-delay="500"
-						:close-delay="200"
-					>
-						{{ __("Offline Invoices") }} ({{ pendingInvoices }})
-					</v-tooltip>
-				</v-btn>
-
-				<!-- Notification bell between offline invoices and menu -->
-				<slot name="notification-bell"></slot>
-
-				<!-- Menu component slot -->
-				<slot name="menu"></slot>
 			</template>
 		</div>
 
@@ -385,6 +391,7 @@ export default {
 	gap: 8px;
 	flex-direction: row;
 	/* Default to normal row */
+	flex: 1;
 }
 
 .rtl-actions-section {
@@ -401,28 +408,11 @@ export default {
 	order: 1;
 }
 
-.ltr-info-gadgets {
-	order: 2;
-}
-
-.ltr-actions-section .profile-section {
-	order: 3;
-}
-
-.ltr-actions-section .offline-invoices-btn {
-	order: 4;
-}
-
-.ltr-actions-section .notification-bell-btn {
-	order: 5;
-}
-
-/* Menu should be the last element */
-.ltr-actions-section> :last-child,
-/* menu slot */
-.ltr-actions-section .v-menu,
-.ltr-actions-section [role="menu"] {
-	order: 6 !important;
+.actions-left {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-shrink: 0;
 }
 
 /* RTL adjustments for gadgets - reverse the order */
@@ -442,12 +432,22 @@ export default {
 	order: 1;
 }
 
-/* RTL Menu should be first */
-.rtl-actions-section> :last-child,
-/* menu slot */
-.rtl-actions-section .v-menu,
-.rtl-actions-section [role="menu"] {
-	order: 0 !important;
+/* Center cluster for offline invoices, notification bell, and menu */
+.nav-center-cluster {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	margin-inline: auto;
+	flex: 1;
+}
+
+.mobile-center-cluster {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	flex: 1;
 }
 
 .pos-navbar-enhanced:hover {

--- a/frontend/src/posapp/components/navbar/StatusIndicator.vue
+++ b/frontend/src/posapp/components/navbar/StatusIndicator.vue
@@ -11,16 +11,13 @@
 					'status-offline': statusColor === 'red',
 				}"
 			>
-				{{ statusText }}
+				{{ connectionStateLabel }}
 			</div>
-			<div class="status-detail-inline">{{ syncInfoText }}</div>
 		</div>
 	</div>
 </template>
 
 <script>
-import { useDataSync } from "../../composables/useDataSync";
-
 // Avoid relying on `import.meta` so the file can be bundled with older
 // JavaScript targets without warnings from esbuild. Debug logging can be
 // toggled by changing this flag during development.
@@ -35,15 +32,6 @@ export default {
 		isIpHost: Boolean,
 		syncTotals: Object,
 		cacheReady: Boolean,
-	},
-	setup() {
-		const { lastSyncSize, estimatedHourlyUsage, isSyncing, formattedLastSyncTime } = useDataSync(30);
-		return {
-			lastSyncSize,
-			estimatedHourlyUsage,
-			isSyncing,
-			formattedLastSyncTime,
-		};
 	},
 	computed: {
 		/**
@@ -156,38 +144,20 @@ export default {
 
 			return this.__(`Server Offline (${hostname})`);
 		},
-		/**
-		 * Returns a short string summarizing the last offline invoice sync results.
-		 */
-		syncInfoText() {
-			const { pending, synced, drafted } = this.syncTotals;
-
-			if (!this.cacheReady) {
-				return this.__("Loading cache...");
+		connectionStateLabel() {
+			if (this.serverConnecting) {
+				return this.__("Connecting...");
 			}
 
-			// Ensure we have valid numbers
-			const pendingCount = pending || 0;
-			const syncedCount = synced || 0;
-			const draftedCount = drafted || 0;
-
-			let status = "";
 			if (!this.networkOnline) {
-				// In offline mode, show all available information
-				if (pendingCount > 0 || syncedCount > 0 || draftedCount > 0) {
-					status = `Pending: ${pendingCount} | Synced: ${syncedCount} | Draft: ${draftedCount}`;
-				} else {
-					status = "Offline Mode";
-				}
-			} else {
-				// Online mode - show full status
-				status = `To Sync: ${pendingCount} | Synced: ${syncedCount} | Draft: ${draftedCount}`;
+				return this.__("Offline");
 			}
 
-			if (this.networkOnline) {
-				status += ` | Usage: ${this.lastSyncSize} (Est: ${this.estimatedHourlyUsage}/hr) | Sync: ${this.formattedLastSyncTime}`;
+			if (!this.isIpHost && !this.serverOnline) {
+				return this.__("Server Offline");
 			}
-			return status;
+
+			return this.__("Online");
 		},
 	},
 };
@@ -220,8 +190,8 @@ export default {
 .status-info-always-visible {
 	display: flex;
 	flex-direction: column;
-	align-items: flex-start;
-	min-width: 120px;
+	align-items: center;
+	min-width: 96px;
 }
 
 .status-title-inline {
@@ -240,10 +210,7 @@ export default {
 }
 
 .status-detail-inline {
-	font-size: 11px;
-	color: #666;
-	line-height: 1.2;
-	margin-top: 2px;
+	display: none;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
## Summary
- center the offline invoice button, notification bell, and menu for both desktop and mobile navbars
- simplify the status indicator to show connectivity state while moving offline sync details into notifications
- route offline sync and draft updates into the notification center with grouped messaging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69468e0479ec8326953a0163e01d1e16)