### PR TITLE
Refine navbar offline sync notifications and layout

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -16,7 +16,6 @@
 				:cache-usage="cacheUsage"
 				:cache-usage-loading="cacheUsageLoading"
 				:cache-usage-details="cacheUsageDetails"
-				:cache-ready="cacheReady"
 				:loading-progress="loadingProgress"
 				:loading-active="loadingActive"
 				:loading-message="loadingMessage"
@@ -57,7 +56,6 @@ import {
 	purgeOldQueueEntries,
 	initPromise,
 	memoryInitPromise,
-	isCacheReady,
 	toggleManualOffline,
 	isManualOffline,
 	syncOfflineInvoices,
@@ -112,7 +110,6 @@ export default {
 			cacheUsage: 0,
 			cacheUsageLoading: false,
 			cacheUsageDetails: { total: 0, indexedDB: 0, localStorage: 0 },
-			cacheReady: false,
 
 			// Loading progress handled via utility
 		};
@@ -155,8 +152,6 @@ export default {
 	},
 	mounted() {
 		this.remove_frappe_nav();
-		// Initialize cache ready state early from stored value
-		this.cacheReady = isCacheReady();
 		initLoadingSources(["init", "items", "customers"]);
 		this.initializeData();
 		this.setupNetworkListeners();
@@ -197,7 +192,6 @@ export default {
 		async initializeData() {
 			await initPromise;
 			await memoryInitPromise;
-			this.cacheReady = true;
 			checkDbHealth().catch(() => {});
 			// Load POS profile from cache or storage
 			const openingData = getOpeningStorage();

--- a/frontend/src/posapp/components/Navbar.vue
+++ b/frontend/src/posapp/components/Navbar.vue
@@ -18,8 +18,6 @@
 					:server-online="serverOnline"
 					:server-connecting="serverConnecting"
 					:is-ip-host="isIpHost"
-					:sync-totals="syncTotals"
-					:cache-ready="cacheReady"
 				/>
 			</template>
 
@@ -194,7 +192,6 @@ export default {
 			type: Object,
 			default: () => ({ total: 0, indexedDB: 0, localStorage: 0 }),
 		},
-		cacheReady: Boolean,
 		loadingProgress: {
 			type: Number,
 			default: 0,
@@ -233,29 +230,28 @@ export default {
 			clearQueuedOnClose: false,
 			lastNotificationShownAt: {},
 			clearingCache: false,
-			initialCacheRefreshRequested: false,
 			notificationUpdateHandle: null,
 			notificationUpdateUsesTimeout: false,
 			notificationCenter: {
 				items: [],
 				unread: 0,
 			},
+			lastSyncTotalsSnapshot: { pending: 0, synced: 0, drafted: 0 },
+			syncNotificationPrimed: false,
 		};
 	},
 	watch: {
-		cacheReady: {
-			handler(newVal) {
-				if (newVal && !this.initialCacheRefreshRequested) {
-					this.initialCacheRefreshRequested = true;
-					this.refreshCacheUsage();
-				}
-			},
-			immediate: true,
-		},
 		snack(newVal, oldVal) {
 			if (!newVal && oldVal) {
 				this.handleSnackbarClosed();
 			}
+		},
+		syncTotals: {
+			handler(newTotals, oldTotals) {
+				this.handleSyncTotalsNotification(newTotals, oldTotals);
+			},
+			deep: true,
+			immediate: true,
 		},
 	},
 	computed: {
@@ -448,6 +444,101 @@ export default {
 		},
 		updateAfterDelete() {
 			this.$emit("update-after-delete");
+		},
+		handleSyncTotalsNotification(newTotals = {}, oldTotals = {}) {
+			const normalized = this.normalizeSyncTotals(newTotals);
+			const previous = this.syncNotificationPrimed
+				? this.normalizeSyncTotals(this.lastSyncTotalsSnapshot)
+				: this.normalizeSyncTotals(oldTotals);
+
+			// Prime state without spamming when component mounts
+			if (!this.syncNotificationPrimed) {
+				this.syncNotificationPrimed = true;
+				this.lastSyncTotalsSnapshot = normalized;
+
+				if (this.hasOfflineSyncCounts(normalized)) {
+					this.addBellNotification({
+						title: this.__("Offline invoices status"),
+						detail: this.__("Pending: {0} | Synced: {1} | Draft: {2}", [
+							normalized.pending,
+							normalized.synced,
+							normalized.drafted,
+						]),
+						color: normalized.pending ? "warning" : "success",
+					});
+				}
+				return;
+			}
+
+			const diffSynced = Math.max(0, normalized.synced - previous.synced);
+			const diffDrafted = Math.max(0, normalized.drafted - previous.drafted);
+
+			if (normalized.pending !== previous.pending) {
+				const pendingTitle =
+					normalized.pending > 0
+						? this.__("{0} offline invoice{1} pending", [
+								normalized.pending,
+								normalized.pending > 1 ? "s" : "",
+							])
+						: this.__("No pending offline invoices");
+
+				this.addBellNotification({
+					title: pendingTitle,
+					detail: this.__("Pending count updated from {0} to {1}", [
+						previous.pending,
+						normalized.pending,
+					]),
+					color: normalized.pending ? "warning" : "success",
+				});
+			}
+
+			if (diffSynced > 0) {
+				this.addBellNotification({
+					title: this.__("{0} offline invoice{1} synced", [
+						diffSynced,
+						diffSynced > 1 ? "s" : "",
+					]),
+					detail: this.__("Pending: {0}", [normalized.pending]),
+					color: "success",
+				});
+			}
+
+			if (diffDrafted > 0) {
+				this.addBellNotification({
+					title: this.__("{0} offline invoice{1} saved as draft", [
+						diffDrafted,
+						diffDrafted > 1 ? "s" : "",
+					]),
+					detail: this.__("Pending: {0}", [normalized.pending]),
+					color: "warning",
+				});
+			}
+
+			if (normalized.pending === 0 && previous.pending > 0 && diffSynced === 0 && diffDrafted === 0) {
+				this.addBellNotification({
+					title: this.__("Offline invoices synced"),
+					detail: this.__("All pending invoices are up to date"),
+					color: "success",
+				});
+			}
+
+			this.lastSyncTotalsSnapshot = normalized;
+		},
+		normalizeSyncTotals(totals = {}) {
+			const toNumber = (value) => {
+				const parsed = Number(value);
+				return Number.isFinite(parsed) ? parsed : 0;
+			};
+
+			return {
+				pending: toNumber(totals.pending),
+				synced: toNumber(totals.synced),
+				drafted: toNumber(totals.drafted),
+			};
+		},
+		hasOfflineSyncCounts(totals = {}) {
+			const normalized = this.normalizeSyncTotals(totals);
+			return normalized.pending > 0 || normalized.synced > 0 || normalized.drafted > 0;
 		},
 		handleInvoiceSubmissionFailed(payload = {}) {
 			const invoiceNumber =

--- a/frontend/src/posapp/components/navbar/NavbarAppBar.vue
+++ b/frontend/src/posapp/components/navbar/NavbarAppBar.vue
@@ -61,31 +61,42 @@
 				<slot name="status-indicator"></slot>
 
 				<!-- Offline Invoices with higher priority on mobile -->
-				<v-btn
-					icon
-					size="small"
+				<div
 					:class="[
-						'offline-invoices-btn mobile-btn pos-themed-button',
-						isRtl ? 'rtl-offline-btn' : 'ltr-offline-btn',
-						{ 'has-pending': pendingInvoices > 0 },
+						'primary-actions-cluster mobile-primary-actions',
+						isRtl ? 'rtl-primary-actions' : 'ltr-primary-actions',
 					]"
-					:aria-label="__('View offline invoices') + ` (${pendingInvoices})`"
-					@click="$emit('show-offline-invoices')"
 				>
-					<v-badge v-if="pendingInvoices > 0" :content="pendingInvoices" color="error" overlap>
-						<v-icon class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
-					</v-badge>
-					<v-icon v-else class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
-					<v-tooltip activator="parent" location="bottom">
-						{{ __("Offline Invoices") }} ({{ pendingInvoices }})
-					</v-tooltip>
-				</v-btn>
+					<v-btn
+						icon
+						size="small"
+						:class="[
+							'offline-invoices-btn mobile-btn pos-themed-button',
+							isRtl ? 'rtl-offline-btn' : 'ltr-offline-btn',
+							{ 'has-pending': pendingInvoices > 0 },
+						]"
+						:aria-label="__('View offline invoices') + ` (${pendingInvoices})`"
+						@click="$emit('show-offline-invoices')"
+					>
+						<v-badge v-if="pendingInvoices > 0" :content="pendingInvoices" color="error" overlap>
+							<v-icon class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
+						</v-badge>
+						<v-icon v-else class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
+						<v-tooltip activator="parent" location="bottom">
+							{{ __("Offline Invoices") }} ({{ pendingInvoices }})
+						</v-tooltip>
+					</v-btn>
 
-				<!-- Notification bell between offline invoices and menu -->
-				<slot name="notification-bell"></slot>
+					<!-- Notification bell centered between offline invoices and menu -->
+					<div class="notification-wrapper">
+						<slot name="notification-bell"></slot>
+					</div>
 
-				<!-- Mobile Menu - contains all other items -->
-				<slot name="menu"></slot>
+					<!-- Mobile Menu - contains all other items -->
+					<div class="menu-wrapper">
+						<slot name="menu"></slot>
+					</div>
+				</div>
 			</template>
 
 			<!-- Desktop: Show all items normally -->
@@ -135,39 +146,50 @@
 					</v-chip>
 				</div>
 
-				<v-btn
-					icon
+				<div
 					:class="[
-						'offline-invoices-btn pos-themed-button',
-						isRtl ? 'rtl-offline-btn' : 'ltr-offline-btn',
-						{ 'has-pending': pendingInvoices > 0 },
+						'primary-actions-cluster desktop-primary-actions',
+						isRtl ? 'rtl-primary-actions' : 'ltr-primary-actions',
 					]"
-					:aria-label="__('View offline invoices') + ` (${pendingInvoices})`"
-					:aria-describedby="'offline-invoices-tooltip'"
-					@click="$emit('show-offline-invoices')"
-					@keydown.enter="$emit('show-offline-invoices')"
-					tabindex="0"
 				>
-					<v-badge v-if="pendingInvoices > 0" :content="pendingInvoices" color="error" overlap>
-						<v-icon class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
-					</v-badge>
-					<v-icon v-else class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
-					<v-tooltip
-						id="offline-invoices-tooltip"
-						activator="parent"
-						:location="isRtl ? 'bottom start' : 'bottom end'"
-						:open-delay="500"
-						:close-delay="200"
+					<v-btn
+						icon
+						:class="[
+							'offline-invoices-btn pos-themed-button',
+							isRtl ? 'rtl-offline-btn' : 'ltr-offline-btn',
+							{ 'has-pending': pendingInvoices > 0 },
+						]"
+						:aria-label="__('View offline invoices') + ` (${pendingInvoices})`"
+						:aria-describedby="'offline-invoices-tooltip'"
+						@click="$emit('show-offline-invoices')"
+						@keydown.enter="$emit('show-offline-invoices')"
+						tabindex="0"
 					>
-						{{ __("Offline Invoices") }} ({{ pendingInvoices }})
-					</v-tooltip>
-				</v-btn>
+						<v-badge v-if="pendingInvoices > 0" :content="pendingInvoices" color="error" overlap>
+							<v-icon class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
+						</v-badge>
+						<v-icon v-else class="pos-text-primary">mdi-file-document-multiple-outline</v-icon>
+						<v-tooltip
+							id="offline-invoices-tooltip"
+							activator="parent"
+							:location="isRtl ? 'bottom start' : 'bottom end'"
+							:open-delay="500"
+							:close-delay="200"
+						>
+							{{ __("Offline Invoices") }} ({{ pendingInvoices }})
+						</v-tooltip>
+					</v-btn>
 
-				<!-- Notification bell between offline invoices and menu -->
-				<slot name="notification-bell"></slot>
+					<!-- Notification bell between offline invoices and menu -->
+					<div class="notification-wrapper">
+						<slot name="notification-bell"></slot>
+					</div>
 
-				<!-- Menu component slot -->
-				<slot name="menu"></slot>
+					<!-- Menu component slot -->
+					<div class="menu-wrapper">
+						<slot name="menu"></slot>
+					</div>
+				</div>
 			</template>
 		</div>
 
@@ -396,6 +418,39 @@ export default {
 	/* Explicit normal row for LTR */
 }
 
+.primary-actions-cluster {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	flex-shrink: 0;
+}
+
+.mobile-primary-actions {
+	gap: 6px;
+}
+
+.rtl-primary-actions {
+	flex-direction: row-reverse;
+}
+
+.ltr-primary-actions {
+	flex-direction: row;
+}
+
+.primary-actions-cluster .offline-invoices-btn,
+.primary-actions-cluster .notification-wrapper,
+.primary-actions-cluster .menu-wrapper {
+	order: 0;
+}
+
+.notification-wrapper,
+.menu-wrapper {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
 /* LTR Actions ordering for proper sequence */
 .status-gadget {
 	order: 1;
@@ -409,20 +464,8 @@ export default {
 	order: 3;
 }
 
-.ltr-actions-section .offline-invoices-btn {
+.ltr-actions-section .primary-actions-cluster {
 	order: 4;
-}
-
-.ltr-actions-section .notification-bell-btn {
-	order: 5;
-}
-
-/* Menu should be the last element */
-.ltr-actions-section> :last-child,
-/* menu slot */
-.ltr-actions-section .v-menu,
-.ltr-actions-section [role="menu"] {
-	order: 6 !important;
 }
 
 /* RTL adjustments for gadgets - reverse the order */
@@ -434,20 +477,8 @@ export default {
 	order: 3;
 }
 
-.rtl-actions-section .offline-invoices-btn {
-	order: 2;
-}
-
-.rtl-actions-section .notification-bell-btn {
+.rtl-actions-section .primary-actions-cluster {
 	order: 1;
-}
-
-/* RTL Menu should be first */
-.rtl-actions-section> :last-child,
-/* menu slot */
-.rtl-actions-section .v-menu,
-.rtl-actions-section [role="menu"] {
-	order: 0 !important;
 }
 
 .pos-navbar-enhanced:hover {

--- a/frontend/src/posapp/components/navbar/StatusIndicator.vue
+++ b/frontend/src/posapp/components/navbar/StatusIndicator.vue
@@ -11,19 +11,13 @@
 					'status-offline': statusColor === 'red',
 				}"
 			>
-				{{ statusText }}
+				{{ connectivityLabel }}
 			</div>
-			<div class="status-detail-inline">{{ syncInfoText }}</div>
 		</div>
 	</div>
 </template>
 
 <script>
-import { useDataSync } from "../../composables/useDataSync";
-
-// Avoid relying on `import.meta` so the file can be bundled with older
-// JavaScript targets without warnings from esbuild. Debug logging can be
-// toggled by changing this flag during development.
 const DEBUG = false;
 
 export default {
@@ -33,17 +27,6 @@ export default {
 		serverOnline: Boolean,
 		serverConnecting: Boolean,
 		isIpHost: Boolean,
-		syncTotals: Object,
-		cacheReady: Boolean,
-	},
-	setup() {
-		const { lastSyncSize, estimatedHourlyUsage, isSyncing, formattedLastSyncTime } = useDataSync(30);
-		return {
-			lastSyncSize,
-			estimatedHourlyUsage,
-			isSyncing,
-			formattedLastSyncTime,
-		};
 	},
 	computed: {
 		/**
@@ -157,37 +140,24 @@ export default {
 			return this.__(`Server Offline (${hostname})`);
 		},
 		/**
-		 * Returns a short string summarizing the last offline invoice sync results.
+		 * Short, user-friendly connectivity label for the navbar.
+		 * @returns {string}
 		 */
-		syncInfoText() {
-			const { pending, synced, drafted } = this.syncTotals;
-
-			if (!this.cacheReady) {
-				return this.__("Loading cache...");
+		connectivityLabel() {
+			if (this.serverConnecting) {
+				return this.__("Connecting");
 			}
 
-			// Ensure we have valid numbers
-			const pendingCount = pending || 0;
-			const syncedCount = synced || 0;
-			const draftedCount = drafted || 0;
-
-			let status = "";
 			if (!this.networkOnline) {
-				// In offline mode, show all available information
-				if (pendingCount > 0 || syncedCount > 0 || draftedCount > 0) {
-					status = `Pending: ${pendingCount} | Synced: ${syncedCount} | Draft: ${draftedCount}`;
-				} else {
-					status = "Offline Mode";
-				}
-			} else {
-				// Online mode - show full status
-				status = `To Sync: ${pendingCount} | Synced: ${syncedCount} | Draft: ${draftedCount}`;
+				return this.__("Offline");
 			}
 
-			if (this.networkOnline) {
-				status += ` | Usage: ${this.lastSyncSize} (Est: ${this.estimatedHourlyUsage}/hr) | Sync: ${this.formattedLastSyncTime}`;
+			if (this.networkOnline && this.serverOnline) {
+				return this.__("Online");
 			}
-			return status;
+
+			// Network is available but server is not responding
+			return this.__("Limited");
 		},
 	},
 };
@@ -239,22 +209,7 @@ export default {
 	color: #f44336;
 }
 
-.status-detail-inline {
-	font-size: 11px;
-	color: #666;
-	line-height: 1.2;
-	margin-top: 2px;
-}
-
-/* Responsive Design */
-@media (max-width: 768px) {
-	.status-info-always-visible {
-		display: none;
-	}
-
-	.status-section-enhanced {
-		margin-right: 4px;
-		/* Further reduced for mobile */
-	}
+.status-section-enhanced .status-info-always-visible {
+	min-width: unset;
 }
 </style>


### PR DESCRIPTION
## Summary
- group the offline invoice button, notification bell, and menu into a centered action cluster for mobile and desktop navbars
- simplify the status indicator to focus on connectivity while moving offline sync details into the notification center
- add automatic bell notifications for offline invoice pending/synced/draft counts and remove unused cache-ready wiring

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694691eb0d1883269a2cc717c2dc9e7a)