### PR TITLE
Increase barcode search threshold to 8 digits

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2875,6 +2875,7 @@ export default {
 
 				onScan.attachTo(document, {
 					suffixKeyCodes: [],
+					minLength: 8,
 					keyCodeMapper: function (oEvent) {
 						oEvent.stopImmediatePropagation();
 						oEvent.preventDefault();

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2203,8 +2203,8 @@ export default {
 			// Keep first_search in sync with the value we are about to search for
 			vm.first_search = trimmedQuery;
 
-			// If the input is a numeric string longer than 6 characters, treat it as a barcode
-			if (/^\d{7,}$/.test(trimmedQuery)) {
+			// If the input is a numeric string with 8 or more characters, treat it as a barcode
+			if (/^\d{8,}$/.test(trimmedQuery)) {
 				vm.onBarcodeScanned(trimmedQuery);
 				return;
 			}


### PR DESCRIPTION
## Summary
- update the item search barcode detection to require at least eight numeric characters before auto-adding as a barcode scan

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a814c2b9083269010455d576718aa)