### PR TITLE
Improve keyboard barcode scan detection

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -730,7 +730,9 @@ export default {
 		keyboardScanStartTime: 0,
 		keyboardScanPendingValue: "",
 		keyboardScanMinLength: 6,
-		keyboardScanMaxInterval: 65,
+		// Require scanner-like speed to avoid triggering on manual typing
+		keyboardScanMaxInterval: 45,
+		keyboardScanMaxDuration: 250,
 		keyboardScanProcessingDelay: 100,
 		lastInvoiceRates: {},
 		lastInvoiceRateScheduler: null,
@@ -3411,6 +3413,14 @@ export default {
 
 			if (!duration || duration <= 0) {
 				return true;
+			}
+
+			if (
+				this.keyboardScanMaxDuration &&
+				typeof this.keyboardScanMaxDuration === "number" &&
+				duration > this.keyboardScanMaxDuration
+			) {
+				return false;
 			}
 
 			const averageInterval = duration / code.length;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -729,7 +729,7 @@ export default {
 		keyboardScanLastTime: 0,
 		keyboardScanStartTime: 0,
 		keyboardScanPendingValue: "",
-		keyboardScanMinLength: 6,
+		keyboardScanMinLength: 8,
 		// Require scanner-like speed to avoid triggering on manual typing
 		keyboardScanMaxInterval: 45,
 		keyboardScanMaxDuration: 250,

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2205,8 +2205,8 @@ export default {
 			// Keep first_search in sync with the value we are about to search for
 			vm.first_search = trimmedQuery;
 
-			// If the input is a numeric string longer than 6 characters, treat it as a barcode
-			if (/^\d{7,}$/.test(trimmedQuery)) {
+			// If the input is a numeric string longer than 8 characters, treat it as a barcode
+			if (/^\d{8,}$/.test(trimmedQuery)) {
 				vm.onBarcodeScanned(trimmedQuery);
 				return;
 			}


### PR DESCRIPTION
## Summary
- tighten keyboard scan interval threshold to better distinguish scanners from manual typing
- add a maximum scan duration check to avoid triggering scans mid-entry on longer item codes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a856c8b5883269b21534c5817a38a)