### PR TITLE
Use query builder Sum for Bin aggregates (Frappe v16)

### DIFF
--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -7,6 +7,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 
 import frappe
 from erpnext.setup.utils import get_exchange_rate
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Sum
 from frappe.utils import flt, nowdate
 from frappe.utils.caching import redis_cache
 
@@ -118,14 +120,14 @@ def _fetch_bin_qty(warehouse: str, item_codes: Tuple[str, ...]):
         warehouses = frappe.db.get_descendants("Warehouse", warehouse) or []
         if not warehouses:
             return []
-        return frappe.get_all(
-            "Bin",
-            fields=["item_code", "sum(actual_qty) as actual_qty"],
-            filters={
-                "warehouse": ["in", warehouses],
-                "item_code": ["in", item_codes],
-            },
-            group_by="item_code",
+        bin_doctype = DocType("Bin")
+        return (
+            frappe.qb.from_(bin_doctype)
+            .select(bin_doctype.item_code, Sum(bin_doctype.actual_qty).as_("actual_qty"))
+            .where(bin_doctype.warehouse.isin(warehouses))
+            .where(bin_doctype.item_code.isin(item_codes))
+            .groupby(bin_doctype.item_code)
+            .run(as_dict=True)
         )
 
     return frappe.get_all(

--- a/posawesome/posawesome/api/items.py
+++ b/posawesome/posawesome/api/items.py
@@ -13,6 +13,8 @@ from erpnext.stock.doctype.batch.batch import (
 )
 from erpnext.stock.get_item_details import get_item_details
 from frappe import _, as_json
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, cstr, flt, get_datetime, nowdate
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.caching import redis_cache
@@ -139,10 +141,13 @@ def get_stock_availability(item_code, warehouse):
         # Include all child warehouses when a group warehouse is set
         warehouses = frappe.db.get_descendants("Warehouse", warehouse) or []
 
-    rows = frappe.get_all(
-        "Bin",
-        fields=["sum(actual_qty) as actual_qty"],
-        filters={"item_code": item_code, "warehouse": ["in", warehouses]},
+    bin_doctype = DocType("Bin")
+    rows = (
+        frappe.qb.from_(bin_doctype)
+        .select(Sum(bin_doctype.actual_qty).as_("actual_qty"))
+        .where(bin_doctype.item_code == item_code)
+        .where(bin_doctype.warehouse.isin(warehouses))
+        .run(as_dict=True)
     )
 
     return flt(rows[0].actual_qty) if rows else 0.0


### PR DESCRIPTION
### Motivation
- Frappe v16 rejects SQL functions passed as strings in `fields` (e.g. `"sum(actual_qty) as actual_qty"`), causing validation errors during stock availability lookups.
- The change updates aggregation queries to use the Frappe Query Builder so stock calculations work under v16.

### Description
- Replaced `frappe.get_all` string-aggregate queries with Query Builder expressions using `DocType` and `Sum` in `get_stock_availability`.
- Updated `_fetch_bin_qty` to use `frappe.qb` with `Sum(...)` and `groupby` when the warehouse is a group, preserving the same `as_dict=True` return shape.
- Added imports for `DocType` and `Sum` and retained downstream behavior using `flt` to coerce numeric results.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d6804423c8326b9878b6fce1b68a9)