### PR TITLE
Increase barcode scan detection length to 12

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -729,7 +729,7 @@ export default {
 		keyboardScanLastTime: 0,
 		keyboardScanStartTime: 0,
 		keyboardScanPendingValue: "",
-		keyboardScanMinLength: 8,
+		keyboardScanMinLength: 12,
 		// Require scanner-like speed to avoid triggering on manual typing
 		keyboardScanMaxInterval: 45,
 		keyboardScanMaxDuration: 250,
@@ -2205,8 +2205,8 @@ export default {
 			// Keep first_search in sync with the value we are about to search for
 			vm.first_search = trimmedQuery;
 
-			// If the input is a numeric string longer than 8 characters, treat it as a barcode
-			if (/^\d{8,}$/.test(trimmedQuery)) {
+			// If the input is a numeric string 12 characters or longer, treat it as a barcode
+			if (/^\d{12,}$/.test(trimmedQuery)) {
 				vm.onBarcodeScanned(trimmedQuery);
 				return;
 			}


### PR DESCRIPTION
### Motivation
- Reduce false positives by requiring longer numeric sequences before treating them as barcodes.
- Make keyboard scanner minimum length and automatic barcode detection consistent at 12 characters.
- Prevent manual typing shorter than 12 digits from being interpreted as barcode scans.

### Description
- Change `keyboardScanMinLength` from `8` to `12` in `frontend/src/posapp/components/pos/ItemsSelector.vue`.
- Update barcode detection regex from `/^\d{8,}$/` to `/^\d{12,}$/` and adjust the comment to state "12 characters or longer".
- No other functional changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f505befa8832698c84459dde8188a)