### PR TITLE
Add Pinia returns store and wire Returns.vue to centralized state

### DIFF
--- a/frontend/src/posapp/components/pos/Returns.vue
+++ b/frontend/src/posapp/components/pos/Returns.vue
@@ -254,32 +254,18 @@
 <script>
 /* global __, frappe */
 import format, { formatUtils } from "../../format";
+import { useReturnsStore } from "../../stores/returnsStore.js";
+import { storeToRefs } from "pinia";
 
 export default {
 	mixins: [format],
+	setup() {
+		const returnsStore = useReturnsStore();
+		const storeRefs = storeToRefs(returnsStore);
+		return { returnsStore, ...storeRefs };
+	},
 	data: () => ({
-		invoicesDialog: false,
 		singleSelect: true,
-		selected: [],
-		dialog_data: [],
-		company: "",
-		invoice_name: "",
-		customer_name: "",
-		customer_id: "",
-		mobile_no: "",
-		tax_id: "",
-		from_date: null,
-		to_date: null,
-		from_date_formatted: null,
-		to_date_formatted: null,
-		min_amount: "",
-		max_amount: "",
-		pos_profile: "",
-		page: 1,
-		has_more_invoices: false,
-		loading_more: false,
-		searched_once: false,
-		current_search_params: null,
 		headers: [
 			{
 				title: __("Customer"),
@@ -422,24 +408,10 @@ export default {
 			this.to_date_formatted = null;
 		},
 		close_dialog() {
-			this.invoicesDialog = false;
+			this.returnsStore.closeDialog();
 		},
 		clear_search() {
-			this.invoice_name = "";
-			this.customer_name = "";
-			this.customer_id = "";
-			this.mobile_no = "";
-			this.tax_id = "";
-			this.from_date = null;
-			this.to_date = null;
-			this.from_date_formatted = null;
-			this.to_date_formatted = null;
-			this.min_amount = "";
-			this.max_amount = "";
-			this.dialog_data = [];
-			this.page = 1;
-			this.has_more_invoices = false;
-			this.searched_once = false;
+			this.returnsStore.resetSearch();
 		},
 		search_invoices_by_enter(e) {
 			if (e.keyCode === 13) {
@@ -662,28 +634,11 @@ export default {
 	},
 	created: function () {
 		this.eventBus.on("open_returns", (data) => {
-			this.invoicesDialog = true;
-			this.company = data;
-			this.invoice_name = "";
-			this.customer_name = "";
-			this.customer_id = "";
-			this.mobile_no = "";
-			this.tax_id = "";
-			this.from_date = null;
-			this.to_date = null;
-			this.from_date_formatted = null;
-			this.to_date_formatted = null;
-			this.min_amount = "";
-			this.max_amount = "";
-			this.dialog_data = [];
-			this.selected = [];
-			this.page = 1;
-			this.has_more_invoices = false;
-			this.searched_once = false;
+			this.returnsStore.openDialog(data);
 		});
 
 		this.eventBus.on("register_pos_profile", (data) => {
-			this.pos_profile = data.pos_profile;
+			this.returnsStore.setPosProfile(data.pos_profile);
 		});
 	},
 	beforeUnmount() {

--- a/frontend/src/posapp/stores/index.js
+++ b/frontend/src/posapp/stores/index.js
@@ -11,6 +11,7 @@ export const pinia = createPinia();
 export { useCustomersStore } from "./customersStore.js";
 export { useItemsStore } from "./itemsStore.js";
 export { useInvoiceStore } from "./invoiceStore.js";
+export { useReturnsStore } from "./returnsStore.js";
 export { useUpdateStore, formatBuildVersion } from "./updateStore.js";
 export { usePricingRulesStore } from "./pricingRulesStore.js";
 

--- a/frontend/src/posapp/stores/returnsStore.js
+++ b/frontend/src/posapp/stores/returnsStore.js
@@ -1,0 +1,98 @@
+/**
+ * Centralized returns dialog state management using Pinia.
+ */
+
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export const useReturnsStore = defineStore("returns", () => {
+	const invoicesDialog = ref(false);
+	const selected = ref([]);
+	const dialog_data = ref([]);
+	const company = ref("");
+	const invoice_name = ref("");
+	const customer_name = ref("");
+	const customer_id = ref("");
+	const mobile_no = ref("");
+	const tax_id = ref("");
+	const from_date = ref(null);
+	const to_date = ref(null);
+	const from_date_formatted = ref(null);
+	const to_date_formatted = ref(null);
+	const min_amount = ref("");
+	const max_amount = ref("");
+	const pos_profile = ref(null);
+	const page = ref(1);
+	const has_more_invoices = ref(false);
+	const loading_more = ref(false);
+	const searched_once = ref(false);
+	const current_search_params = ref(null);
+
+	const resetSearch = () => {
+		invoice_name.value = "";
+		customer_name.value = "";
+		customer_id.value = "";
+		mobile_no.value = "";
+		tax_id.value = "";
+		from_date.value = null;
+		to_date.value = null;
+		from_date_formatted.value = null;
+		to_date_formatted.value = null;
+		min_amount.value = "";
+		max_amount.value = "";
+		dialog_data.value = [];
+		page.value = 1;
+		has_more_invoices.value = false;
+		loading_more.value = false;
+		searched_once.value = false;
+		current_search_params.value = null;
+	};
+
+	const resetDialog = () => {
+		resetSearch();
+		selected.value = [];
+	};
+
+	const openDialog = (companyName = "") => {
+		invoicesDialog.value = true;
+		company.value = companyName || "";
+		resetDialog();
+	};
+
+	const closeDialog = () => {
+		invoicesDialog.value = false;
+	};
+
+	const setPosProfile = (profile) => {
+		pos_profile.value = profile || null;
+	};
+
+	return {
+		invoicesDialog,
+		selected,
+		dialog_data,
+		company,
+		invoice_name,
+		customer_name,
+		customer_id,
+		mobile_no,
+		tax_id,
+		from_date,
+		to_date,
+		from_date_formatted,
+		to_date_formatted,
+		min_amount,
+		max_amount,
+		pos_profile,
+		page,
+		has_more_invoices,
+		loading_more,
+		searched_once,
+		current_search_params,
+		resetSearch,
+		resetDialog,
+		openDialog,
+		closeDialog,
+		setPosProfile,
+	};
+});


### PR DESCRIPTION
### Motivation
- Centralize the returns dialog and search state in Pinia to avoid duplicated local component state and match existing store patterns (e.g. `invoiceStore`).
- Make the returns dialog state reusable across components and easier to maintain and extend.
- Move imperative open/reset logic out of the component to simplify `Returns.vue` and prepare for future features.

### Description
- Add a new Pinia store `useReturnsStore` in `frontend/src/posapp/stores/returnsStore.js` exposing state and helpers like `resetSearch`, `resetDialog`, `openDialog`, `closeDialog`, and `setPosProfile`.
- Export `useReturnsStore` from `frontend/src/posapp/stores/index.js` so other parts of the app can import it.
- Update `frontend/src/posapp/components/pos/Returns.vue` to use the new store via `useReturnsStore` and `storeToRefs`, and replace local dialog/search state usages with store calls (e.g. `returnsStore.openDialog()`, `returnsStore.resetSearch()`, `returnsStore.closeDialog()`).
- Minimal component refactor preserves existing behavior while delegating state ownership to Pinia.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f850a2f3c83268e31a52885391ee1)