### PR TITLE
Fallback to POS Profile company when searching return invoices

### DIFF
--- a/frontend/src/posapp/components/pos/Returns.vue
+++ b/frontend/src/posapp/components/pos/Returns.vue
@@ -454,6 +454,7 @@ export default {
 		perform_search() {
 			const vm = this;
 			vm.loading_more = true;
+			const searchCompany = vm.company || vm.pos_profile?.company || "";
 
 			// Format dates for API call in YYYY-MM-DD format
 			let formattedFromDate = null;
@@ -538,7 +539,7 @@ export default {
 				to_date: formattedToDate,
 				min_amount: minAmount,
 				max_amount: maxAmount,
-				company: vm.company,
+				company: searchCompany,
 				page: vm.page,
 				pos_profile: vm.pos_profile?.name,
 				doctype:

--- a/frontend/src/posapp/components/pos/Returns.vue
+++ b/frontend/src/posapp/components/pos/Returns.vue
@@ -543,9 +543,11 @@ export default {
 				page: vm.page,
 				pos_profile: vm.pos_profile?.name,
 				doctype:
-					vm.pos_profile && vm.pos_profile.create_pos_invoice_instead_of_sales_invoice
-						? "POS Invoice"
-						: "Sales Invoice",
+					vm.pos_profile
+						? vm.pos_profile.create_pos_invoice_instead_of_sales_invoice
+							? "POS Invoice"
+							: "Sales Invoice"
+						: null,
 			};
 
 			frappe.call({

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1256,14 +1256,25 @@ def search_invoices_for_return(
         else:
             filters["grand_total"] = ["<=", float(max_amount)]
 
+    invoice_meta = frappe.get_meta(doctype)
+    customer_meta = frappe.get_meta("Customer")
+
     if customer_name:
-        filters["customer_name"] = ["like", f"%{customer_name}%"]
+        if invoice_meta.has_field("customer_name"):
+            filters["customer_name"] = ["like", f"%{customer_name}%"]
+        else:
+            filters["customer"] = ["like", f"%{customer_name}%"]
 
     if customer_id:
         filters["customer"] = ["like", f"%{customer_id}%"]
 
     customer_ids = None
     if mobile_no or tax_id:
+        if mobile_no and not customer_meta.has_field("mobile_no"):
+            return {"invoices": [], "has_more": False}
+        if tax_id and not customer_meta.has_field("tax_id"):
+            return {"invoices": [], "has_more": False}
+
         conditions = []
         params = {}
 

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1189,6 +1189,12 @@ def search_invoices_for_return(
         - invoices: List of invoice documents
         - has_more: Boolean indicating if there are more invoices to load
     """
+    invoice_name = cstr(invoice_name).strip() or None
+    customer_name = cstr(customer_name).strip() or None
+    customer_id = cstr(customer_id).strip() or None
+    mobile_no = cstr(mobile_no).strip() or None
+    tax_id = cstr(tax_id).strip() or None
+
     enforce_return_validity, _ = _get_return_validity_settings(pos_profile)
 
     profile = None
@@ -1287,9 +1293,14 @@ def search_invoices_for_return(
         # If we found matching customers, add them to the filter
         if customer_ids:
             filters["customer"] = ["in", customer_ids]
-        # If customer search criteria provided but no matches found, return empty
-        elif any([customer_name, customer_id, mobile_no, tax_id]):
-            return {"invoices": [], "has_more": False}
+        # If customer search criteria provided but no matches found, attempt direct invoice search
+        else:
+            if mobile_no or tax_id:
+                return {"invoices": [], "has_more": False}
+            if customer_name:
+                filters["customer_name"] = ["like", f"%{customer_name}%"]
+            if customer_id:
+                filters["customer"] = ["like", f"%{customer_id}%"]
 
     # Count total invoices matching the criteria (for has_more flag)
     total_count_query = frappe.get_list(

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1261,20 +1261,20 @@ def search_invoices_for_return(
         customer_filters = []
 
         if customer_name:
-            customer_filters.append(["customer_name", "like", f"%{customer_name}%"])
+            customer_filters.append({"customer_name": ["like", f"%{customer_name}%"]})
 
         if customer_id:
-            customer_filters.append(["name", "like", f"%{customer_id}%"])
+            customer_filters.append({"name": ["like", f"%{customer_id}%"]})
 
         if mobile_no:
             if not customer_meta.has_field("mobile_no"):
                 return {"invoices": [], "has_more": False}
-            customer_filters.append(["mobile_no", "like", f"%{mobile_no}%"])
+            customer_filters.append({"mobile_no": ["like", f"%{mobile_no}%"]})
 
         if tax_id:
             if not customer_meta.has_field("tax_id"):
                 return {"invoices": [], "has_more": False}
-            customer_filters.append(["tax_id", "like", f"%{tax_id}%"])
+            customer_filters.append({"tax_id": ["like", f"%{tax_id}%"]})
 
         customers = frappe.get_list(
             "Customer",

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1256,55 +1256,36 @@ def search_invoices_for_return(
         else:
             filters["grand_total"] = ["<=", float(max_amount)]
 
-    invoice_meta = frappe.get_meta(doctype)
-    customer_meta = frappe.get_meta("Customer")
+    if customer_name or customer_id or mobile_no or tax_id:
+        customer_meta = frappe.get_meta("Customer")
+        customer_filters = []
 
-    if customer_name:
-        if invoice_meta.has_field("customer_name"):
-            filters["customer_name"] = ["like", f"%{customer_name}%"]
-        else:
-            filters["customer"] = ["like", f"%{customer_name}%"]
+        if customer_name:
+            customer_filters.append(["customer_name", "like", f"%{customer_name}%"])
 
-    if customer_id:
-        filters["customer"] = ["like", f"%{customer_id}%"]
-
-    customer_ids = None
-    if mobile_no or tax_id:
-        if mobile_no and not customer_meta.has_field("mobile_no"):
-            return {"invoices": [], "has_more": False}
-        if tax_id and not customer_meta.has_field("tax_id"):
-            return {"invoices": [], "has_more": False}
-
-        conditions = []
-        params = {}
+        if customer_id:
+            customer_filters.append(["name", "like", f"%{customer_id}%"])
 
         if mobile_no:
-            conditions.append("mobile_no LIKE %(mobile_no)s")
-            params["mobile_no"] = f"%{mobile_no}%"
+            if not customer_meta.has_field("mobile_no"):
+                return {"invoices": [], "has_more": False}
+            customer_filters.append(["mobile_no", "like", f"%{mobile_no}%"])
 
         if tax_id:
-            conditions.append("tax_id LIKE %(tax_id)s")
-            params["tax_id"] = f"%{tax_id}%"
+            if not customer_meta.has_field("tax_id"):
+                return {"invoices": [], "has_more": False}
+            customer_filters.append(["tax_id", "like", f"%{tax_id}%"])
 
-        where_clause = " OR ".join(conditions)
-        customer_query = f"""
-        SELECT name
-        FROM `tabCustomer`
-        WHERE {where_clause}
-        LIMIT 100
-    """
-
-        customers = frappe.db.sql(customer_query, params, as_dict=True)
+        customers = frappe.get_list(
+            "Customer",
+            or_filters=customer_filters,
+            fields=["name"],
+            limit_page_length=100,
+        )
         customer_ids = [c.name for c in customers]
 
         if not customer_ids:
             return {"invoices": [], "has_more": False}
-
-    if customer_ids is not None:
-        if customer_id:
-            customer_ids = [cid for cid in customer_ids if customer_id in cid]
-            if not customer_ids:
-                return {"invoices": [], "has_more": False}
 
         filters["customer"] = ["in", customer_ids]
 

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1256,19 +1256,16 @@ def search_invoices_for_return(
         else:
             filters["grand_total"] = ["<=", float(max_amount)]
 
-    # If any customer search criteria is provided, find matching customers
-    customer_ids = []
-    if customer_name or customer_id or mobile_no or tax_id:
+    if customer_name:
+        filters["customer_name"] = ["like", f"%{customer_name}%"]
+
+    if customer_id:
+        filters["customer"] = ["like", f"%{customer_id}%"]
+
+    customer_ids = None
+    if mobile_no or tax_id:
         conditions = []
         params = {}
-
-        if customer_name:
-            conditions.append("customer_name LIKE %(customer_name)s")
-            params["customer_name"] = f"%{customer_name}%"
-
-        if customer_id:
-            conditions.append("name LIKE %(customer_id)s")
-            params["customer_id"] = f"%{customer_id}%"
 
         if mobile_no:
             conditions.append("mobile_no LIKE %(mobile_no)s")
@@ -1278,7 +1275,6 @@ def search_invoices_for_return(
             conditions.append("tax_id LIKE %(tax_id)s")
             params["tax_id"] = f"%{tax_id}%"
 
-        # Build the WHERE clause for the query
         where_clause = " OR ".join(conditions)
         customer_query = f"""
         SELECT name
@@ -1290,17 +1286,16 @@ def search_invoices_for_return(
         customers = frappe.db.sql(customer_query, params, as_dict=True)
         customer_ids = [c.name for c in customers]
 
-        # If we found matching customers, add them to the filter
-        if customer_ids:
-            filters["customer"] = ["in", customer_ids]
-        # If customer search criteria provided but no matches found, attempt direct invoice search
-        else:
-            if mobile_no or tax_id:
+        if not customer_ids:
+            return {"invoices": [], "has_more": False}
+
+    if customer_ids is not None:
+        if customer_id:
+            customer_ids = [cid for cid in customer_ids if customer_id in cid]
+            if not customer_ids:
                 return {"invoices": [], "has_more": False}
-            if customer_name:
-                filters["customer_name"] = ["like", f"%{customer_name}%"]
-            if customer_id:
-                filters["customer"] = ["like", f"%{customer_id}%"]
+
+        filters["customer"] = ["in", customer_ids]
 
     # Count total invoices matching the criteria (for has_more flag)
     total_count_query = frappe.get_list(

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1166,7 +1166,7 @@ def search_invoices_for_return(
     max_amount=None,
     page=1,
     pos_profile=None,
-    doctype="Sales Invoice",
+    doctype=None,
 ):
     """
     Search for invoices that can be returned with separate customer search fields and pagination
@@ -1191,15 +1191,29 @@ def search_invoices_for_return(
     """
     enforce_return_validity, _ = _get_return_validity_settings(pos_profile)
 
-    if not company and pos_profile:
-        company = frappe.get_cached_value("POS Profile", pos_profile, "company")
+    profile = None
+    if pos_profile:
+        profile = frappe.get_cached_doc("POS Profile", pos_profile)
+
+    if not company:
+        if profile:
+            company = profile.company
+        else:
+            company = frappe.defaults.get_user_default("company")
+
+    if not doctype:
+        if profile and getattr(profile, "create_pos_invoice_instead_of_sales_invoice", 0):
+            doctype = "POS Invoice"
+        else:
+            doctype = "Sales Invoice"
 
     # Start with base filters
     filters = {
-        "company": company,
         "docstatus": 1,
         "is_return": 0,
     }
+    if company:
+        filters["company"] = company
 
     # Convert page to integer if it's a string
     if page and isinstance(page, str):

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1154,8 +1154,8 @@ def get_draft_invoices(pos_opening_shift, doctype="Sales Invoice"):
 
 @frappe.whitelist()
 def search_invoices_for_return(
-    invoice_name,
-    company,
+    invoice_name=None,
+    company=None,
     customer_name=None,
     customer_id=None,
     mobile_no=None,
@@ -1190,6 +1190,9 @@ def search_invoices_for_return(
         - has_more: Boolean indicating if there are more invoices to load
     """
     enforce_return_validity, _ = _get_return_validity_settings(pos_profile)
+
+    if not company and pos_profile:
+        company = frappe.get_cached_value("POS Profile", pos_profile, "company")
 
     # Start with base filters
     filters = {


### PR DESCRIPTION
### Motivation

- The return invoice search could return no results when the `company` parameter was missing from the UI request.
- The POS Returns dialog sometimes does not set `company`, causing server-side filters to be too restrictive.
- Use the POS Profile company as a sensible default so searches operate within the correct company scope.

### Description

- The Returns UI now computes `searchCompany` as `vm.company || vm.pos_profile?.company || ""` and sends it in `current_search_params` as `company`.
- The server API `search_invoices_for_return` signature was made tolerant to missing values by defaulting `invoice_name` and `company` to `None`.
- If `company` is not provided but `pos_profile` is present, the API resolves `company` with `frappe.get_cached_value("POS Profile", pos_profile, "company")` before building filters.
- These changes ensure both client and server have a consistent fallback to the POS Profile company when searching.

### Testing

- No automated tests were run against these changes.
- Unit or integration tests were not executed as part of this patch.
- Manual verification is recommended to confirm searches return invoices when `company` is not explicitly provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f8ca5c62c83268ed2988b8afd4dd3)