### PR TITLE
Preserve payment splits on return invoices

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -2697,23 +2697,30 @@ export default {
 			this.eventBus.on("send_invoice_doc_payment", (invoice_doc) => {
 				this.invoice_doc = invoice_doc;
 				const default_payment = this.invoice_doc.payments.find((payment) => payment.default === 1);
+				const hasReturnPayments = this.invoice_doc.payments.some(
+					(payment) => Math.abs(this.flt(payment.amount || 0, this.currency_precision)) > 0,
+				);
 				this.is_credit_sale = false;
 				this.is_write_off_change = false;
 				if (invoice_doc.is_return) {
 					this.is_return = true;
 					this.is_credit_return = false;
-					// Reset all payment amounts to zero for returns
-					invoice_doc.payments.forEach((payment) => {
-						payment.amount = 0;
-						payment.base_amount = 0;
-					});
-					// Set default payment to negative amount for returns
-					if (default_payment) {
-						const amount = invoice_doc.rounded_total || invoice_doc.grand_total;
-						default_payment.amount = -Math.abs(amount);
-						if (default_payment.base_amount !== undefined) {
-							default_payment.base_amount = -Math.abs(amount);
+					if (!hasReturnPayments) {
+						// Reset all payment amounts to zero for returns
+						invoice_doc.payments.forEach((payment) => {
+							payment.amount = 0;
+							payment.base_amount = 0;
+						});
+						// Set default payment to negative amount for returns
+						if (default_payment) {
+							const amount = invoice_doc.rounded_total || invoice_doc.grand_total;
+							default_payment.amount = -Math.abs(amount);
+							if (default_payment.base_amount !== undefined) {
+								default_payment.base_amount = -Math.abs(amount);
+							}
 						}
+					} else {
+						this.ensureReturnPaymentsAreNegative();
 					}
 				} else if (default_payment) {
 					// For regular invoices, set positive amount

--- a/frontend/src/posapp/components/pos/Returns.vue
+++ b/frontend/src/posapp/components/pos/Returns.vue
@@ -639,6 +639,18 @@ export default {
 				invoice_doc.customer = return_doc.customer;
 				invoice_doc.discount_amount = return_doc.discount_amount;
 				invoice_doc.additional_discount_percentage = return_doc.additional_discount_percentage;
+				invoice_doc.payments = Array.isArray(return_doc.payments)
+					? return_doc.payments.map((payment) => ({
+							mode_of_payment: payment.mode_of_payment,
+							amount: payment.amount,
+							base_amount: payment.base_amount,
+							default: payment.default,
+							account: payment.account,
+							type: payment.type,
+							currency: payment.currency,
+							conversion_rate: payment.conversion_rate,
+						}))
+					: [];
 
 				// Make sure grand_total is negative for returns
 				if (return_doc.grand_total > 0) {

--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -2273,6 +2273,49 @@ export default {
 
 	// Prepare payments array for invoice doc
 	get_payments() {
+		if (this.isReturnInvoice && Array.isArray(this.invoice_doc?.payments) && this.invoice_doc.payments.length) {
+			const total_amount = Math.abs(this.subtotal);
+			const sourcePayments = this.invoice_doc.payments.filter((payment) => payment?.mode_of_payment);
+			const sourceTotal = sourcePayments.reduce(
+				(sum, payment) => sum + Math.abs(this.flt(payment.amount || 0, this.currency_precision)),
+				0,
+			);
+
+			if (sourcePayments.length && sourceTotal > 0 && total_amount > 0) {
+				const baseCurrency = this.price_list_currency || this.pos_profile.currency;
+				let remaining_amount = total_amount;
+
+				return sourcePayments.map((payment, index) => {
+					const share = Math.abs(this.flt(payment.amount || 0, this.currency_precision)) / sourceTotal;
+					let payment_amount =
+						index === sourcePayments.length - 1
+							? remaining_amount
+							: this.flt(total_amount * share, this.currency_precision);
+					payment_amount = -Math.abs(payment_amount);
+					remaining_amount = this.flt(
+						remaining_amount - Math.abs(payment_amount),
+						this.currency_precision,
+					);
+
+					const base_amount =
+						this.selected_currency !== baseCurrency
+							? this.flt(payment_amount / (this.exchange_rate || 1), this.currency_precision)
+							: payment_amount;
+
+					return {
+						amount: payment_amount,
+						base_amount: base_amount,
+						mode_of_payment: payment.mode_of_payment,
+						default: payment.default,
+						account: payment.account || "",
+						type: payment.type || "Cash",
+						currency: this.selected_currency || this.pos_profile.currency,
+						conversion_rate: this.conversion_rate || 1,
+					};
+				});
+			}
+		}
+
 		const payments = [];
 		// Use this.subtotal which is already in selected currency and includes all calculations
 		const total_amount = this.subtotal;


### PR DESCRIPTION
### Motivation

- Ensure returns mirror the original invoice payment composition when an invoice was paid using multiple payment modes.
- Prevent the POS from overwriting or collapsing multi-method payments into a single default payment when creating a return.
- Keep negative/return-signed payment values consistent across client-side invoice construction and payment UI.

### Description

- Copy original invoice `payments` into the return payload in `frontend/src/posapp/components/pos/Returns.vue` so return documents include the original payment modes and metadata.
- In `get_payments()` (`frontend/src/posapp/components/pos/invoiceItemMethods.js`) detect return invoices with existing source payments and build the return `payments` array by splitting the return total proportionally across the original payment modes while preserving negative amounts and computing `base_amount` using the exchange rate.
- Update `frontend/src/posapp/components/pos/Payments.vue` to avoid resetting return payment amounts when the return already contains payment splits, and call `ensureReturnPaymentsAreNegative()` to normalize existing payments.
- Added safeguards for currency conversion, base amount calculation, and fallbacks for missing payment fields (`account`, `type`, `conversion_rate`).

### Testing

- No automated tests were executed for this change.
- Basic runtime checks performed during development: loading a return with existing `payments` preserves modes and amounts and the payment UI shows negative amounts as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955fb712c748326b2b5807f7b9055ca)