### PR TITLE
Fix Close Shift dialog when Payments page is open

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -3,6 +3,7 @@
 		<AppLoadingOverlay :visible="globalLoading" />
 		<UpdatePrompt />
 		<v-main class="main-content">
+			<ClosingDialog />
 			<Navbar
 				:pos-profile="posProfile"
 				:pending-invoices="pendingInvoices"
@@ -42,9 +43,11 @@
 import Navbar from "./components/Navbar.vue";
 import POS from "./components/pos/Pos.vue";
 import Payments from "./components/payments/Pay.vue";
+import ClosingDialog from "./components/pos/ClosingDialog.vue";
 import AppLoadingOverlay from "./components/ui/LoadingOverlay.vue";
 import UpdatePrompt from "./components/ui/UpdatePrompt.vue";
 import { useLoading } from "./composables/useLoading.js";
+import { usePosShift } from "./composables/usePosShift.js";
 import { loadingState, initLoadingSources, setSourceProgress, markSourceLoaded } from "./utils/loading.js";
 import { useCustomersStore } from "./stores/customersStore.js";
 import { storeToRefs } from "pinia";
@@ -80,11 +83,13 @@ export default {
 	setup() {
 		const { isRtl, rtlStyles, rtlClasses } = useRtl();
 		const { overlayVisible } = useLoading();
+		const { get_closing_data } = usePosShift();
 		return {
 			isRtl,
 			rtlStyles,
 			rtlClasses,
 			globalLoading: overlayVisible,
+			get_closing_data,
 		};
 	},
 	data: function () {
@@ -147,6 +152,7 @@ export default {
 		Navbar,
 		POS,
 		Payments,
+		ClosingDialog,
 		AppLoadingOverlay,
 		UpdatePrompt,
 	},
@@ -331,8 +337,7 @@ export default {
 		},
 
 		handleCloseShift() {
-			// Trigger POS closing dialog via event bus
-			this.eventBus.emit("open_closing_dialog");
+			this.get_closing_data();
 		},
 
 		handlePrintLastInvoice() {

--- a/frontend/src/posapp/components/pos/ClosingDialog.vue
+++ b/frontend/src/posapp/components/pos/ClosingDialog.vue
@@ -1,7 +1,6 @@
 <template>
-	<v-row justify="center">
-		<v-dialog v-model="closingDialog" max-width="900px" persistent>
-			<v-card elevation="8" class="closing-dialog-card">
+	<v-dialog v-model="closingDialog" max-width="900px" persistent>
+		<v-card elevation="8" class="closing-dialog-card">
 				<!-- Enhanced White Header -->
 				<v-card-title class="closing-header pa-6 d-flex align-center">
 					<div class="header-content">
@@ -868,9 +867,8 @@
 						<span>{{ __("Submit") }}</span>
 					</v-btn>
 				</v-card-actions>
-			</v-card>
-		</v-dialog>
-	</v-row>
+		</v-card>
+	</v-dialog>
 </template>
 
 <script>

--- a/frontend/src/posapp/components/pos/Pos.vue
+++ b/frontend/src/posapp/components/pos/Pos.vue
@@ -4,7 +4,6 @@
 		:class="rtlClasses"
 		:style="[responsiveStyles, rtlStyles]"
 	>
-		<ClosingDialog></ClosingDialog>
 		<Drafts></Drafts>
 		<SalesOrders></SalesOrders>
 		<Returns></Returns>
@@ -50,7 +49,6 @@ import PosOffers from "./PosOffers.vue";
 import PosCoupons from "./PosCoupons.vue";
 import Drafts from "./Drafts.vue";
 import SalesOrders from "./SalesOrders.vue";
-import ClosingDialog from "./ClosingDialog.vue";
 import NewAddress from "./NewAddress.vue";
 import Variants from "./Variants.vue";
 import Returns from "./Returns.vue";
@@ -104,7 +102,6 @@ export default {
 		OpeningDialog,
 		Payments,
 		Drafts,
-		ClosingDialog,
 
 		Returns,
 		PosOffers,
@@ -167,9 +164,6 @@ export default {
 				this.showOffers = false;
 				this.payment = false;
 			});
-			this.eventBus.on("open_closing_dialog", () => {
-				this.get_closing_data();
-			});
 			this.eventBus.on("submit_closing_pos", (data) => {
 				this.submit_closing_pos(data);
 			});
@@ -187,7 +181,6 @@ export default {
 		this.eventBus.off("LoadPosProfile");
 		this.eventBus.off("show_offers");
 		this.eventBus.off("show_coupons");
-		this.eventBus.off("open_closing_dialog");
 		this.eventBus.off("submit_closing_pos");
 		this.eventBus.off("items_loaded");
 	},

--- a/frontend/src/posapp/composables/usePosShift.js
+++ b/frontend/src/posapp/composables/usePosShift.js
@@ -91,6 +91,13 @@ export function usePosShift(openDialog) {
 	}
 
 	function get_closing_data() {
+		const cachedOpeningShift = getOpeningStorage()?.pos_opening_shift;
+		if (!pos_opening_shift.value && cachedOpeningShift) {
+			pos_opening_shift.value = cachedOpeningShift;
+		}
+		if (!pos_opening_shift.value) {
+			return Promise.resolve();
+		}
 		return frappe
 			.call(
 				"posawesome.posawesome.doctype.pos_closing_shift.pos_closing_shift.make_closing_shift_from_opening",


### PR DESCRIPTION
### Motivation
- Fix the bug where clicking "Close Shift" from the navbar did not open the closing dialog when the Payments view was active.
- Make the closing dialog available app-wide so the action works regardless of which POS subview is shown.
- Ensure closing data can be prepared even if the live opening shift is not present in memory by using cached opening data as a fallback.

### Description
- Rendered `ClosingDialog` at the app level in `Home.vue` so it is available outside `Pos.vue` by importing and adding `ClosingDialog` to `Home.vue` and the template.
- Updated the navbar action to call `handleCloseShift` → `get_closing_data` from `usePosShift` instead of emitting the `open_closing_dialog` event.
- Removed the `open_closing_dialog` listener and the `ClosingDialog` import/registration from `Pos.vue` to avoid relying on the POS page being mounted.
- Added a fallback in `usePosShift.get_closing_data` to populate `pos_opening_shift` from `getOpeningStorage()` and return early if no opening shift is available.

### Testing
- No automated tests were run for this change.
- Changes were committed and the code updated across `Home.vue`, `Pos.vue`, and `usePosShift.js` without running a test suite.