### PR TITLE
Include Journal Entry outstanding balances in payment allocation and surface voucher type in UI

### DIFF
--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -485,6 +485,12 @@ export default {
 					key: "voucher_no",
 				},
 				{
+					title: __("Type"),
+					align: "start",
+					sortable: true,
+					key: "voucher_type",
+				},
+				{
 					title: __("Customer"),
 					align: "start",
 					sortable: true,

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -267,7 +267,6 @@ def get_outstanding_invoices(customer=None, company=None, currency=None, pos_pro
                             SUM(credit - debit) AS allocated_amount
                         FROM `tabGL Entry`
                         WHERE docstatus = 1
-                            AND against_voucher_type = 'Journal Entry'
                             AND against_voucher IN %(voucher_nos)s
                             AND party_type = 'Customer'
                             AND party = %(customer)s

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -611,16 +611,16 @@ def auto_reconcile_customer_invoices(customer, company, currency=None, pos_profi
             if allocation <= 0:
                 continue
 
-			entry_list.append(
-				frappe._dict(
-					{
-						"voucher_type": "Payment Entry",
-						"voucher_no": payment_name,
-						"voucher_detail_no": None,
-						"against_voucher_type": invoice.get("voucher_type") or "Sales Invoice",
-						"against_voucher": invoice.get("voucher_no"),
-						"account": pe_doc.paid_from,
-						"party_type": "Customer",
+            entry_list.append(
+                frappe._dict(
+                    {
+                        "voucher_type": "Payment Entry",
+                        "voucher_no": payment_name,
+                        "voucher_detail_no": None,
+                        "against_voucher_type": invoice.get("voucher_type") or "Sales Invoice",
+                        "against_voucher": invoice.get("voucher_no"),
+                        "account": pe_doc.paid_from,
+                        "party_type": "Customer",
                         "party": customer,
                         "dr_or_cr": "credit_in_account_currency",
                         "unreconciled_amount": unallocated_before,

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -611,16 +611,16 @@ def auto_reconcile_customer_invoices(customer, company, currency=None, pos_profi
             if allocation <= 0:
                 continue
 
-            entry_list.append(
-                frappe._dict(
-                    {
-                        "voucher_type": "Payment Entry",
-                        "voucher_no": payment_name,
-                        "voucher_detail_no": None,
-                                "against_voucher_type": inv.get("voucher_type") or "Sales Invoice",
-                        "against_voucher": invoice.get("voucher_no"),
-                        "account": pe_doc.paid_from,
-                        "party_type": "Customer",
+			entry_list.append(
+				frappe._dict(
+					{
+						"voucher_type": "Payment Entry",
+						"voucher_no": payment_name,
+						"voucher_detail_no": None,
+						"against_voucher_type": invoice.get("voucher_type") or "Sales Invoice",
+						"against_voucher": invoice.get("voucher_no"),
+						"account": pe_doc.paid_from,
+						"party_type": "Customer",
                         "party": customer,
                         "dr_or_cr": "credit_in_account_currency",
                         "unreconciled_amount": unallocated_before,

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -222,7 +222,8 @@ def get_outstanding_invoices(customer=None, company=None, currency=None, pos_pro
                         je.posting_date AS posting_date,
                         jea.debit_in_account_currency AS debit_in_account_currency,
                         jea.credit_in_account_currency AS credit_in_account_currency,
-                        jea.account_currency AS currency
+                        jea.account_currency AS currency,
+                        jea.account AS account
                     FROM `tabJournal Entry Account` jea
                     INNER JOIN `tabJournal Entry` je ON je.name = jea.parent
                     WHERE je.docstatus = 1
@@ -259,34 +260,42 @@ def get_outstanding_invoices(customer=None, company=None, currency=None, pos_pro
 
             journal_entry_names = [entry.get("voucher_no") for entry in journal_entries]
             allocated_map = {}
-            if party_account and journal_entry_names:
+            journal_entry_accounts = {
+                (entry.get("voucher_no"), entry.get("account")) for entry in journal_entries
+            }
+            accounts_list = [acc for _, acc in journal_entry_accounts if acc]
+            if journal_entry_names and accounts_list:
                 allocated_rows = frappe.db.sql(
                     """
                         SELECT
                             against_voucher AS voucher_no,
+                            account,
                             SUM(credit - debit) AS allocated_amount
                         FROM `tabGL Entry`
                         WHERE docstatus = 1
                             AND against_voucher IN %(voucher_nos)s
                             AND party_type = 'Customer'
                             AND party = %(customer)s
-                            AND account = %(party_account)s
-                        GROUP BY against_voucher
+                            AND account IN %(accounts)s
+                        GROUP BY against_voucher, account
                     """,
                     {
                         "voucher_nos": tuple(journal_entry_names),
                         "customer": customer,
-                        "party_account": party_account,
+                        "accounts": tuple(accounts_list),
                     },
                     as_dict=True,
                 )
                 allocated_map = {
-                    row.voucher_no: flt(row.allocated_amount) for row in allocated_rows or []
+                    (row.voucher_no, row.account): flt(row.allocated_amount)
+                    for row in allocated_rows or []
                 }
 
             updated_entries = []
             for entry in journal_entries:
-                allocated_amount = flt(allocated_map.get(entry.get("voucher_no")))
+                allocated_amount = flt(
+                    allocated_map.get((entry.get("voucher_no"), entry.get("account")))
+                )
                 if allocated_amount:
                     entry.outstanding_amount = max(
                         0, flt(entry.outstanding_amount) - max(0, allocated_amount)

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -260,42 +260,36 @@ def get_outstanding_invoices(customer=None, company=None, currency=None, pos_pro
 
             journal_entry_names = [entry.get("voucher_no") for entry in journal_entries]
             allocated_map = {}
-            journal_entry_accounts = {
-                (entry.get("voucher_no"), entry.get("account")) for entry in journal_entries
-            }
-            accounts_list = [acc for _, acc in journal_entry_accounts if acc]
-            if journal_entry_names and accounts_list:
+            if journal_entry_names:
                 allocated_rows = frappe.db.sql(
                     """
                         SELECT
-                            against_voucher AS voucher_no,
-                            account,
-                            SUM(credit - debit) AS allocated_amount
-                        FROM `tabGL Entry`
-                        WHERE docstatus = 1
-                            AND against_voucher IN %(voucher_nos)s
-                            AND party_type = 'Customer'
-                            AND party = %(customer)s
-                            AND account IN %(accounts)s
-                        GROUP BY against_voucher, account
+                            per.reference_name AS voucher_no,
+                            SUM(per.allocated_amount) AS allocated_amount
+                        FROM `tabPayment Entry Reference` per
+                        INNER JOIN `tabPayment Entry` pe ON pe.name = per.parent
+                        WHERE pe.docstatus = 1
+                            AND pe.party_type = 'Customer'
+                            AND pe.party = %(customer)s
+                            AND pe.company = %(company)s
+                            AND per.reference_doctype = 'Journal Entry'
+                            AND per.reference_name IN %(voucher_nos)s
+                        GROUP BY per.reference_name
                     """,
                     {
                         "voucher_nos": tuple(journal_entry_names),
                         "customer": customer,
-                        "accounts": tuple(accounts_list),
+                        "company": company,
                     },
                     as_dict=True,
                 )
                 allocated_map = {
-                    (row.voucher_no, row.account): flt(row.allocated_amount)
-                    for row in allocated_rows or []
+                    row.voucher_no: flt(row.allocated_amount) for row in allocated_rows or []
                 }
 
             updated_entries = []
             for entry in journal_entries:
-                allocated_amount = flt(
-                    allocated_map.get((entry.get("voucher_no"), entry.get("account")))
-                )
+                allocated_amount = flt(allocated_map.get(entry.get("voucher_no")))
                 if allocated_amount:
                     entry.outstanding_amount = max(
                         0, flt(entry.outstanding_amount) - max(0, allocated_amount)

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -153,6 +153,7 @@ def set_paid_amount_and_received_amount(
 def get_outstanding_invoices(customer=None, company=None, currency=None, pos_profile=None):
     try:
         party_account = get_party_account("Customer", customer, company)
+        customer_name = frappe.get_cached_value("Customer", customer, "customer_name")
 
         frappe.logger().debug(
             f"Fetching outstanding invoices for customer: {customer}, party_account: {party_account}"
@@ -195,6 +196,79 @@ def get_outstanding_invoices(customer=None, company=None, currency=None, pos_pro
         for invoice in outstanding_invoices:
             invoice.outstanding_amount = flt(invoice.outstanding_amount)
             invoice.invoice_amount = flt(invoice.invoice_amount)
+            invoice.voucher_type = "Sales Invoice"
+
+        journal_entries = []
+        if customer and company:
+            conditions = []
+            params = {"company": company, "customer": customer}
+
+            if party_account:
+                conditions.append("jea.account = %(party_account)s")
+                params["party_account"] = party_account
+
+            if currency:
+                conditions.append("jea.account_currency = %(currency)s")
+                params["currency"] = currency
+
+            condition_sql = ""
+            if conditions:
+                condition_sql = " AND " + " AND ".join(conditions)
+
+            journal_entries = frappe.db.sql(
+                f"""
+                    SELECT
+                        je.name AS voucher_no,
+                        je.posting_date AS posting_date,
+                        jea.debit_in_account_currency AS debit_in_account_currency,
+                        jea.credit_in_account_currency AS credit_in_account_currency,
+                        jea.account_currency AS currency
+                    FROM `tabJournal Entry Account` jea
+                    INNER JOIN `tabJournal Entry` je ON je.name = jea.parent
+                    WHERE je.docstatus = 1
+                        AND je.company = %(company)s
+                        AND jea.party_type = 'Customer'
+                        AND jea.party = %(customer)s
+                        AND (jea.reference_type IS NULL OR jea.reference_type = '')
+                        AND (jea.reference_name IS NULL OR jea.reference_name = '')
+                        {condition_sql}
+                """,
+                params,
+                as_dict=True,
+            )
+
+            journal_entries = [
+                frappe._dict(
+                    {
+                        "voucher_no": entry.voucher_no,
+                        "outstanding_amount": flt(entry.debit_in_account_currency)
+                        - flt(entry.credit_in_account_currency),
+                        "invoice_amount": flt(entry.debit_in_account_currency)
+                        - flt(entry.credit_in_account_currency),
+                        "due_date": entry.posting_date,
+                        "posting_date": entry.posting_date,
+                        "currency": entry.currency or currency,
+                        "pos_profile": None,
+                        "customer": customer,
+                        "customer_name": customer_name,
+                        "voucher_type": "Journal Entry",
+                    }
+                )
+                for entry in journal_entries
+            ]
+
+            journal_entries = [
+                entry for entry in journal_entries if flt(entry.get("outstanding_amount")) > 0
+            ]
+
+        outstanding_invoices = outstanding_invoices + journal_entries
+        outstanding_invoices = sorted(
+            outstanding_invoices,
+            key=lambda inv: (
+                getdate(inv.get("posting_date")) if inv.get("posting_date") else getdate(nowdate())
+            ),
+            reverse=True,
+        )
 
         frappe.logger().debug(f"Found {len(outstanding_invoices)} outstanding invoices")
         frappe.logger().debug(
@@ -436,7 +510,7 @@ def auto_reconcile_customer_invoices(customer, company, currency=None, pos_profi
                             "voucher_type": "Sales Invoice",
                             "voucher_no": payment_name,
                             "voucher_detail_no": None,
-                            "against_voucher_type": "Sales Invoice",
+                            "against_voucher_type": invoice.get("voucher_type") or "Sales Invoice",
                             "against_voucher": invoice.get("voucher_no"),
                             "account": receivable_account,
                             "party_type": "Customer",
@@ -543,7 +617,7 @@ def auto_reconcile_customer_invoices(customer, company, currency=None, pos_profi
                         "voucher_type": "Payment Entry",
                         "voucher_no": payment_name,
                         "voucher_detail_no": None,
-                        "against_voucher_type": "Sales Invoice",
+                                "against_voucher_type": inv.get("voucher_type") or "Sales Invoice",
                         "against_voucher": invoice.get("voucher_no"),
                         "account": pe_doc.paid_from,
                         "party_type": "Customer",
@@ -692,16 +766,25 @@ def process_pos_payment(payload):
     remaining_invoices = []
     for invoice in data.selected_invoices:
         invoice_name = invoice.get("voucher_no") or invoice.get("name")
+        voucher_type = invoice.get("voucher_type") or "Sales Invoice"
         if not invoice_name:
             continue
         outstanding = flt(invoice.get("outstanding_amount"))
-        if outstanding <= 0:
+        if outstanding <= 0 and voucher_type == "Sales Invoice":
             try:
                 si = frappe.get_doc("Sales Invoice", invoice_name)
                 outstanding = flt(si.outstanding_amount)
             except Exception:
                 outstanding = 0
-        remaining_invoices.append({"name": invoice_name, "outstanding_amount": outstanding})
+        if outstanding <= 0:
+            continue
+        remaining_invoices.append(
+            {
+                "name": invoice_name,
+                "outstanding_amount": outstanding,
+                "voucher_type": voucher_type,
+            }
+        )
 
     new_payments_entry = []
     all_payments_entry = []
@@ -776,7 +859,7 @@ def process_pos_payment(payload):
                                     "voucher_type": "Sales Invoice",
                                     "voucher_no": payment_name,
                                     "voucher_detail_no": None,
-                                    "against_voucher_type": "Sales Invoice",
+                                    "against_voucher_type": inv.get("voucher_type") or "Sales Invoice",
                                     "against_voucher": inv["name"],
                                     "account": receivable_account,
                                     "party_type": "Customer",
@@ -871,7 +954,7 @@ def process_pos_payment(payload):
                                 "voucher_type": "Payment Entry",
                                 "voucher_no": payment_name,
                                 "voucher_detail_no": None,
-                                "against_voucher_type": "Sales Invoice",
+                                "against_voucher_type": inv.get("voucher_type") or "Sales Invoice",
                                 "against_voucher": inv["name"],
                                 "account": pe_doc.paid_from,
                                 "party_type": "Customer",
@@ -950,7 +1033,7 @@ def process_pos_payment(payload):
                     payment_entry.append(
                         "references",
                         {
-                            "reference_doctype": "Sales Invoice",
+                            "reference_doctype": inv.get("voucher_type") or "Sales Invoice",
                             "reference_name": inv["name"],
                             "total_amount": inv["outstanding_amount"],
                             "outstanding_amount": inv["outstanding_amount"],

--- a/posawesome/posawesome/api/payment_entry.py
+++ b/posawesome/posawesome/api/payment_entry.py
@@ -257,9 +257,45 @@ def get_outstanding_invoices(customer=None, company=None, currency=None, pos_pro
                 for entry in journal_entries
             ]
 
-            journal_entries = [
-                entry for entry in journal_entries if flt(entry.get("outstanding_amount")) > 0
-            ]
+            journal_entry_names = [entry.get("voucher_no") for entry in journal_entries]
+            allocated_map = {}
+            if party_account and journal_entry_names:
+                allocated_rows = frappe.db.sql(
+                    """
+                        SELECT
+                            against_voucher AS voucher_no,
+                            SUM(credit - debit) AS allocated_amount
+                        FROM `tabGL Entry`
+                        WHERE docstatus = 1
+                            AND against_voucher_type = 'Journal Entry'
+                            AND against_voucher IN %(voucher_nos)s
+                            AND party_type = 'Customer'
+                            AND party = %(customer)s
+                            AND account = %(party_account)s
+                        GROUP BY against_voucher
+                    """,
+                    {
+                        "voucher_nos": tuple(journal_entry_names),
+                        "customer": customer,
+                        "party_account": party_account,
+                    },
+                    as_dict=True,
+                )
+                allocated_map = {
+                    row.voucher_no: flt(row.allocated_amount) for row in allocated_rows or []
+                }
+
+            updated_entries = []
+            for entry in journal_entries:
+                allocated_amount = flt(allocated_map.get(entry.get("voucher_no")))
+                if allocated_amount:
+                    entry.outstanding_amount = max(
+                        0, flt(entry.outstanding_amount) - max(0, allocated_amount)
+                    )
+                if flt(entry.outstanding_amount) > 0:
+                    updated_entries.append(entry)
+
+            journal_entries = updated_entries
 
         outstanding_invoices = outstanding_invoices + journal_entries
         outstanding_invoices = sorted(


### PR DESCRIPTION
### Motivation
- Allow payments screen to show customer's outstanding journal entry balances alongside sales invoices so allocations can be applied to JEs as well as invoices.
- Ensure reconciliation and allocation logic can target different voucher types (Sales Invoice vs Journal Entry) to avoid mis-allocations.
- Surface the voucher type in the UI so POS operators can distinguish invoice vs journal entry balances when allocating payments.

### Description
- Extended `get_outstanding_invoices` in `posawesome/posawesome/api/payment_entry.py` to query `Journal Entry Account` rows for customer balances and append them (as `voucher_type: "Journal Entry"`) to the outstanding list.
- Mark `Sales Invoice` rows with `voucher_type` and merge + sort Sales Invoices and Journal Entry rows before returning results from `get_outstanding_invoices`.
- Updated `process_pos_payment` in `payment_entry.py` to accept and track a `voucher_type` for selected invoices, skip fetching Sales Invoice docs for non-Sales Invoice vouchers, and use `voucher_type` when building allocation/reconciliation payloads (e.g., `against_voucher_type` and `reference_doctype`).
- Added a `Type` column to the invoices table in `frontend/src/posapp/components/payments/Pay.vue` so the UI shows `voucher_type` for each outstanding row.

### Testing
- No automated tests were executed as part of this change in this environment.
- Code contains additional logging to aid manual verification during runtime and reconciliation flows.
- Basic static checks performed: files modified are `posawesome/posawesome/api/payment_entry.py` and `frontend/src/posapp/components/payments/Pay.vue` and changes were committed locally.
