### PR TITLE
Fix POS overlap with ERPNext v16 left sidebar

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -158,6 +158,8 @@ export default {
 	},
 	mounted() {
 		this.remove_frappe_nav();
+		this.adjust_frappe_sidebar_offset();
+		window.addEventListener("resize", this.adjust_frappe_sidebar_offset);
 		initLoadingSources(["init", "items", "customers"]);
 		this.initializeData();
 		this.setupNetworkListeners();
@@ -479,10 +481,28 @@ export default {
 		},
 
 		remove_frappe_nav() {
-			this.$nextTick(function () {
+			this.$nextTick(() => {
 				$(".page-head").remove();
 				$(".navbar.navbar-default.navbar-fixed-top").remove();
+				this.adjust_frappe_sidebar_offset();
 			});
+		},
+		adjust_frappe_sidebar_offset() {
+			const sidebar = document.querySelector(
+				".desk-sidebar, .app-sidebar, .sidebar, .side-section, .layout-side-section",
+			);
+			let sidebarWidth = 0;
+			if (sidebar) {
+				const sidebarStyles = window.getComputedStyle(sidebar);
+				const rect = sidebar.getBoundingClientRect();
+				if (sidebarStyles.display !== "none" && rect.width > 0) {
+					sidebarWidth = rect.width;
+				}
+			}
+			document.documentElement.style.setProperty(
+				"--posa-desk-sidebar-width",
+				`${sidebarWidth}px`,
+			);
 		},
 	},
 	beforeUnmount() {
@@ -490,6 +510,7 @@ export default {
 			this.eventBus.off("pending_invoices_changed");
 			this.eventBus.off("data-loaded");
 		}
+		window.removeEventListener("resize", this.adjust_frappe_sidebar_offset);
 	},
 	created: function () {
 		setTimeout(() => {
@@ -505,6 +526,8 @@ export default {
 	height: 100dvh;
 	max-height: 100dvh;
 	overflow: hidden;
+	padding-inline-start: var(--posa-desk-sidebar-width, 0px);
+	box-sizing: border-box;
 }
 
 .main-content {


### PR DESCRIPTION
### Motivation
- ERPNext v16 can render a persistent left desk/sidebar that overlaps the POS app, preventing access to POS and Payments UI elements.
- The POS app should start after the ERPNext sidebar so controls and pages are visible and usable.
- Sidebar width can vary and may change on resize, so the layout needs a dynamic solution.

### Description
- Added `adjust_frappe_sidebar_offset` to `frontend/src/posapp/Home.vue` to detect common sidebar selectors and set a CSS variable `--posa-desk-sidebar-width` based on the measured width.
- Applied `padding-inline-start: var(--posa-desk-sidebar-width, 0px)` and `box-sizing: border-box` to the POS app container `.container1` so content begins after the desk sidebar.
- Invoke the adjustment on `mounted`, after `remove_frappe_nav`, and on window `resize`, and remove the resize listener in `beforeUnmount`.
- Converted the `$nextTick` callback to an arrow function to retain `this` when calling the new adjustment method.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69575b7015048326addb2672f35da865)