### PR TITLE
Refactor POS keyboard shortcuts and add new quick-key handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ After switching branches or pulling latest changes:
 5. bench build --app posawesome
 6. bench --site your.site migrate
 
-Go to developer tools in browser, then go to application tab, then go to storage and clear site data. 
-After clearing site data go to browser settings and delete cache and images data in history also. 
+Go to developer tools in browser, then go to application tab, then go to storage and clear site data.
+After clearing site data go to browser settings and delete cache and images data in history also.
 
 ### Electron Desktop App
 
@@ -74,6 +74,7 @@ Notes:
 ### Main Features
 
 #### 🎨 UI/UX & Interface
+
 - **Modern Interface**: User-friendly design using Vue.js and Vuetify, optimized for speed and experience.
 - **View Modes**: Toggle between List View (efficient for data entry) and Card View (visual with item images).
 - **Dark Mode & Theming**: Built-in dark mode support with automatic or manual toggle, plus customizable theme options.
@@ -85,6 +86,7 @@ Notes:
 - **Multi-Language**: Supports English, Arabic, Portuguese, Spanish, and more.
 
 #### 💸 Transactions & Sales
+
 - **Multi-Currency**: Full support for invoicing in different currencies with automatic exchange rate fetching.
 - **Quotations**: Create, update, and submit Quotations directly from the POS interface.
 - **Sales Orders**: Create Sales Orders directly. Configurable "Sales Order Only" mode available.
@@ -95,6 +97,7 @@ Notes:
 - **Customer PO**: Capture Customer Purchase Order (PO) number and date.
 
 #### 📦 Inventory & Products
+
 - **Batch & Serial**: Comprehensive support for Batch and Serial number selection and search.
 - **Product Bundles**: Auto-apply batches for bundle items.
 - **Variants**: Support for template items with product variants.
@@ -103,6 +106,7 @@ Notes:
 - **Stock Validation**: Configurable stock validation (warn or block) including negative stock handling.
 
 #### 💳 Payments & Pricing
+
 - **Smart Tender**: "Quick Cash" suggestions based on currency denominations for faster checkout.
 - **Split Payments**: Accept multiple payment modes for a single transaction.
 - **M-Pesa**: Integrated M-Pesa mobile payment support.
@@ -115,6 +119,7 @@ Notes:
 - **Payment Reconciliation**: Reconcile payments against existing invoices.
 
 #### 🔄 Offline & Technical
+
 - **Robust Offline Mode**: Create invoices and customers offline. Data syncs automatically when reconnected.
 - **Background Sync**: Advanced background synchronization for offline transactions and master data updates.
 - **Local Storage**: Option to use browser Local Storage for caching to improve reliability.
@@ -122,6 +127,7 @@ Notes:
 - **Drafts**: Failed offline submissions are safely saved as Draft documents.
 
 #### ⚙️ Configuration & Shift Management
+
 - **Shift Management**: Opening and Closing shifts with cash reconciliation and detailed payment breakdown reports.
 - **Customer Balance**: Option to display current customer balance on the main screen.
 - **Address Management**: Manage multiple shipping addresses for customers.
@@ -129,13 +135,48 @@ Notes:
 
 ### Shortcuts:
 
-- `CTRL or CMD + S` open payments
-- `CTRL or CMD + X` submit payments
-- `CTRL or CMD + D` remove the first item from the top
-- `CTRL or CMD + A` expand the first item from the top
-- `CTRL or CMD + E` focus on discount field
-- `CTRL or CMD + B` focus on customer search
-- `CTRL or CMD + I` focus on item search field
+#### Global (Invoice Screen)
+
+- `F4` profile switch (currently shows “not available” message).
+- `F5` open new customer form.
+- `F11` open shift details.
+- `F12` POS lock (currently shows “not available” message).
+
+#### Alt + Number
+
+- `Alt + 1` close payments panel.
+- `Alt + 2` clear invoice, reset posting date, focus item search.
+- `Alt + 3` focus item search.
+- `Alt + 4` select top item.
+- `Alt + 5` focus customer search.
+- `Alt + 6` select first customer.
+- `Alt + 7` load draft orders.
+- `Alt + 8` open returns.
+- `Alt + 9` focus delivery charges.
+- `Alt + \`` focus posting date.
+
+#### Alt + Keys
+
+- `Alt + PageUp` open payments panel.
+- `Alt + Home` go to home and reload.
+- `Alt + Q` focus quantity field for the next item (cycles).
+- `Alt + U` focus UOM field for the next item (cycles).
+- `Alt + R` focus rate field for the next item (cycles).
+- `Alt + E` remove the first item from the top.
+- `Alt + F` focus item search field.
+- `Alt + L` load draft invoices.
+- `Alt + M` toggle item selector settings.
+- `Alt + S` save and clear invoice.
+- `Alt + C` open cancel dialog.
+- `Alt + D` open payments panel.
+- `Alt + X` open payments, then submit (prompts if payments are closed).
+- `Alt + P` open payments, then submit & print (prompts if payments are closed).
+
+#### Payments Panel
+
+- `Alt + X` submit payment.
+- `Ctrl/Cmd + X` submit payment.
+- `Alt + P` submit payment and print.
 
 ---
 

--- a/frontend/src/posapp/components/pos/Customer.vue
+++ b/frontend/src/posapp/components/pos/Customer.vue
@@ -323,6 +323,27 @@ export default {
 			eventBus?.emit("open_update_customer", customerInfo.value || {});
 		};
 
+		const selectFirstCustomer = () => {
+			const list =
+				filteredCustomers.value && filteredCustomers.value.length
+					? filteredCustomers.value
+					: customers.value;
+
+			if (!list || !list.length) {
+				return;
+			}
+
+			const first = list[0];
+			tempSelectedCustomer.value = first.name;
+			internalCustomer.value = first.name;
+			customersStore.setSelectedCustomer(first.name);
+			closeCustomerMenu();
+		};
+
+		const openNewCustomer = () => {
+			new_customer();
+		};
+
 		const focusCustomerSearch = async () => {
 			const dropdown = customerDropdown.value;
 			if (!dropdown) {
@@ -350,7 +371,7 @@ export default {
 			}
 		};
 
-		expose({ focusCustomerSearch });
+		expose({ focusCustomerSearch, selectFirstCustomer, openNewCustomer });
 
 		const busHandlers = [];
 
@@ -414,6 +435,8 @@ export default {
 			handleEnter,
 			new_customer,
 			edit_customer,
+			selectFirstCustomer,
+			openNewCustomer,
 			focusCustomerSearch,
 		};
 	},

--- a/frontend/src/posapp/components/pos/DeliveryCharges.vue
+++ b/frontend/src/posapp/components/pos/DeliveryCharges.vue
@@ -2,6 +2,7 @@
 	<v-row align="center" class="items px-3 py-2 mt-0" v-if="pos_profile.posa_use_delivery_charges">
 		<v-col cols="12" sm="8" class="pb-0 mb-0 pr-0 pt-0">
 			<v-autocomplete
+				ref="deliveryChargesInput"
 				density="compact"
 				clearable
 				auto-select-first
@@ -73,6 +74,13 @@ export default {
 	methods: {
 		onUpdate(val) {
 			this.$emit("update:selected_delivery_charge", val);
+		},
+		focusDeliveryCharges() {
+			const input = this.$refs.deliveryChargesInput?.$el?.querySelector("input");
+			if (input) {
+				input.focus();
+				input.select?.();
+			}
 		},
 	},
 };

--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -51,6 +51,7 @@
 
 				<!-- Delivery Charges Section (Only if enabled in POS profile) -->
 				<DeliveryCharges
+					ref="deliveryChargesComponent"
 					:pos_profile="pos_profile"
 					:delivery_charges="delivery_charges"
 					:selected_delivery_charge="selected_delivery_charge"
@@ -69,6 +70,7 @@
 
 				<!-- Posting Date and Customer Balance Section -->
 				<PostingDateRow
+					ref="postingDateComponent"
 					:pos_profile="pos_profile"
 					:posting_date_display="posting_date_display"
 					:customer_balance="customer_balance"
@@ -423,6 +425,11 @@ export default {
 			selected_price_list: "", // Currently selected price list
 			price_list_currency: "", // Currency of the selected price list
 			_shortcutHandlers: {},
+			shortcutCycle: {
+				qty: 0,
+				uom: 0,
+				rate: 0,
+			},
 			selected_columns: [], // Selected columns for items table
 			temp_selected_columns: [], // Temporary array for column selection
 			available_columns: [], // All available columns
@@ -1606,19 +1613,8 @@ export default {
 		);
 		this._shortcutHandlers = this._shortcutHandlers || {};
 
-		this._shortcutHandlers.shortOpenPayment = this.shortOpenPayment.bind(this);
-		this._shortcutHandlers.shortDeleteFirstItem = this.shortDeleteFirstItem.bind(this);
-		this._shortcutHandlers.shortOpenFirstItem = this.shortOpenFirstItem.bind(this);
-		this._shortcutHandlers.shortSelectDiscount = this.shortSelectDiscount.bind(this);
-		this._shortcutHandlers.shortFocusCustomer = this.shortFocusCustomer.bind(this);
-		this._shortcutHandlers.shortFocusItem = this.shortFocusItem.bind(this);
-
-		document.addEventListener("keydown", this._shortcutHandlers.shortOpenPayment);
-		document.addEventListener("keydown", this._shortcutHandlers.shortDeleteFirstItem);
-		document.addEventListener("keydown", this._shortcutHandlers.shortOpenFirstItem);
-		document.addEventListener("keydown", this._shortcutHandlers.shortSelectDiscount);
-		document.addEventListener("keydown", this._shortcutHandlers.shortFocusCustomer);
-		document.addEventListener("keydown", this._shortcutHandlers.shortFocusItem);
+		this._shortcutHandlers.handleInvoiceShortcut = this.handleInvoiceShortcut.bind(this);
+		document.addEventListener("keydown", this._shortcutHandlers.handleInvoiceShortcut);
 	},
 	// Remove global keyboard shortcuts when component is unmounted
 	unmounted() {
@@ -1626,12 +1622,7 @@ export default {
 			return;
 		}
 
-		document.removeEventListener("keydown", this._shortcutHandlers.shortOpenPayment);
-		document.removeEventListener("keydown", this._shortcutHandlers.shortDeleteFirstItem);
-		document.removeEventListener("keydown", this._shortcutHandlers.shortOpenFirstItem);
-		document.removeEventListener("keydown", this._shortcutHandlers.shortSelectDiscount);
-		document.removeEventListener("keydown", this._shortcutHandlers.shortFocusCustomer);
-		document.removeEventListener("keydown", this._shortcutHandlers.shortFocusItem);
+		document.removeEventListener("keydown", this._shortcutHandlers.handleInvoiceShortcut);
 
 		this._shortcutHandlers = {};
 	},

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -5071,15 +5071,13 @@ export default {
 }
 
 :deep(.item-row-highlighted) {
-	background-color: rgba(25, 118, 210, 0.28);
-	box-shadow:
-		inset 0 0 0 2px rgba(25, 118, 210, 0.6),
-		inset 0 0 0 6px rgba(25, 118, 210, 0.12);
+	background-color: rgba(25, 118, 210, 0.32);
 }
 
 :deep(.item-row-highlighted td) {
 	font-weight: 600;
 	color: var(--primary-color, #1976d2);
+	background-color: rgba(25, 118, 210, 0.32);
 }
 
 .card-item-image-container {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -428,6 +428,7 @@
 								:no-data-text="__('No items found')"
 								@click:row="click_item_row"
 								:item-class="getItemRowClass"
+								:row-props="getItemRowProps"
 								@scroll.passive="onListScroll"
 							>
 								<template v-slot:item.rate="{ item }">
@@ -3566,13 +3567,32 @@ export default {
 			});
 		},
 		isItemHighlighted(item) {
-			if (!item || !this.highlightedItemCode) {
+			const resolvedItem = this.resolveHighlightedItem(item);
+			if (!resolvedItem || !this.highlightedItemCode) {
 				return false;
 			}
-			return item.item_code === this.highlightedItemCode;
+			return resolvedItem.item_code === this.highlightedItemCode;
 		},
 		getItemRowClass(item) {
 			return this.isItemHighlighted(item) ? "item-row-highlighted" : "";
+		},
+		getItemRowProps(item) {
+			return this.isItemHighlighted(item) ? { class: "item-row-highlighted" } : {};
+		},
+		resolveHighlightedItem(item) {
+			if (!item || typeof item !== "object") {
+				return item;
+			}
+
+			if (item.raw) {
+				return item.raw;
+			}
+
+			if (item.item) {
+				return item.item.raw || item.item;
+			}
+
+			return item;
 		},
 		async selectHighlightedItem() {
 			if (!Array.isArray(this.displayedItems) || this.displayedItems.length === 0) {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3560,7 +3560,16 @@ export default {
 				}
 
 				const tableEl = tableRef?.$el || tableRef;
+				const wrapper = tableEl?.querySelector?.(".v-table__wrapper");
 				const rows = tableEl?.querySelectorAll?.("tbody tr");
+				if (wrapper && rows && rows.length > 0) {
+					const rowHeight = rows[0].getBoundingClientRect().height || 0;
+					if (rowHeight > 0) {
+						wrapper.scrollTop = rowHeight * index;
+						return;
+					}
+				}
+
 				if (rows && rows[index]) {
 					rows[index].scrollIntoView({ block: "nearest" });
 				}

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -5065,12 +5065,14 @@ export default {
 
 .card-item-card.item-highlighted {
 	border-color: var(--primary-color, #1976d2);
-	box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.2);
-	transform: translate3d(0, -1px, 0);
+	box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.35), 0 8px 20px rgba(25, 118, 210, 0.2);
+	transform: translate3d(0, -2px, 0);
+	background: rgba(25, 118, 210, 0.08);
 }
 
 :deep(.item-row-highlighted) {
-	background-color: rgba(25, 118, 210, 0.12);
+	background-color: rgba(25, 118, 210, 0.18);
+	box-shadow: inset 0 0 0 2px rgba(25, 118, 210, 0.35);
 }
 
 .card-item-image-container {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -276,7 +276,7 @@
 									<div
 										v-if="item"
 										:key="item.item_code"
-										class="card-item-card"
+										:class="['card-item-card', { 'item-highlighted': isItemHighlighted(item) }]"
 										:style="{
 											width: cardColumnWidth + 'px',
 											height: cardRowHeight + 'px',
@@ -416,6 +416,7 @@
 						</div>
 						<div v-else class="items-table-container">
 							<v-data-table-virtual
+								ref="itemsTable"
 								:headers="headers"
 								:items="displayedItems"
 								class="sleek-data-table overflow-y-auto"
@@ -426,6 +427,7 @@
 								:header-props="headerProps"
 								:no-data-text="__('No items found')"
 								@click:row="click_item_row"
+								:item-class="getItemRowClass"
 								@scroll.passive="onListScroll"
 							>
 								<template v-slot:item.rate="{ item }">
@@ -764,6 +766,8 @@ export default {
 		keyboardScanMaxInterval: 45,
 		keyboardScanMaxDuration: 250,
 		keyboardScanProcessingDelay: 100,
+		highlightedIndex: -1,
+		highlightedItemCode: null,
 		lastInvoiceRates: {},
 		lastInvoiceRateScheduler: null,
 		lastInvoiceRateLoading: false,
@@ -772,6 +776,7 @@ export default {
 	watch: {
 		search_input(newValue) {
 			this.first_search = newValue;
+			this.clearHighlightedItem();
 			this.search_onchange();
 		},
 		customer: _.debounce(function () {
@@ -919,6 +924,7 @@ export default {
 				this.scheduleCardMetricsUpdate();
 			});
 			this.scheduleLastInvoiceRateRefresh();
+			this.syncHighlightedItem();
 		},
 		// Automatically search when the query has at least 3 characters
 		first_search: _.debounce(function (val, oldVal) {
@@ -2221,7 +2227,14 @@ export default {
 				}
 			}
 		},
-		onEnter() {
+		onEnter(event) {
+			if (this.highlightedIndex >= 0) {
+				if (event && typeof event.preventDefault === "function") {
+					event.preventDefault();
+				}
+				this.selectHighlightedItem();
+				return;
+			}
 			if (this.search_onchange.cancel) {
 				this.search_onchange.cancel();
 			}
@@ -3369,6 +3382,12 @@ export default {
 
 			const key = event.key || "";
 
+			if (key === "ArrowDown" || key === "ArrowUp") {
+				event.preventDefault();
+				this.navigateHighlightedItem(key === "ArrowDown" ? 1 : -1);
+				return;
+			}
+
 			if (key === "Enter" || key === "Escape") {
 				return;
 			}
@@ -3472,6 +3491,108 @@ export default {
 			this.keyboardScanLastTime = 0;
 			this.keyboardScanStartTime = 0;
 			this.keyboardScanPendingValue = "";
+		},
+		clearHighlightedItem() {
+			this.highlightedIndex = -1;
+			this.highlightedItemCode = null;
+		},
+		syncHighlightedItem() {
+			if (!Array.isArray(this.displayedItems) || this.displayedItems.length === 0) {
+				this.clearHighlightedItem();
+				return;
+			}
+
+			if (this.highlightedItemCode) {
+				const index = this.displayedItems.findIndex(
+					(item) => item && item.item_code === this.highlightedItemCode,
+				);
+				if (index >= 0) {
+					this.highlightedIndex = index;
+					return;
+				}
+			}
+
+			this.clearHighlightedItem();
+		},
+		navigateHighlightedItem(direction) {
+			if (!Array.isArray(this.displayedItems) || this.displayedItems.length === 0) {
+				this.clearHighlightedItem();
+				return;
+			}
+
+			let nextIndex = this.highlightedIndex;
+			if (nextIndex < 0) {
+				nextIndex = direction > 0 ? 0 : this.displayedItems.length - 1;
+			} else {
+				nextIndex += direction;
+			}
+
+			if (nextIndex < 0) {
+				nextIndex = 0;
+			}
+
+			if (nextIndex >= this.displayedItems.length) {
+				nextIndex = this.displayedItems.length - 1;
+			}
+
+			const nextItem = this.displayedItems[nextIndex];
+			if (!nextItem) {
+				this.clearHighlightedItem();
+				return;
+			}
+
+			this.highlightedIndex = nextIndex;
+			this.highlightedItemCode = nextItem.item_code || null;
+			this.scrollHighlightedItemIntoView(nextIndex);
+		},
+		scrollHighlightedItemIntoView(index) {
+			this.$nextTick(() => {
+				if (this.items_view === "card") {
+					this.$refs.itemsContainer?.scrollToItem?.(index);
+					return;
+				}
+
+				const tableRef = this.$refs.itemsTable;
+				if (tableRef?.scrollToIndex) {
+					tableRef.scrollToIndex(index);
+					return;
+				}
+
+				const tableEl = tableRef?.$el || tableRef;
+				const rows = tableEl?.querySelectorAll?.("tbody tr");
+				if (rows && rows[index]) {
+					rows[index].scrollIntoView({ block: "nearest" });
+				}
+			});
+		},
+		isItemHighlighted(item) {
+			if (!item || !this.highlightedItemCode) {
+				return false;
+			}
+			return item.item_code === this.highlightedItemCode;
+		},
+		getItemRowClass(item) {
+			return this.isItemHighlighted(item) ? "item-row-highlighted" : "";
+		},
+		async selectHighlightedItem() {
+			if (!Array.isArray(this.displayedItems) || this.displayedItems.length === 0) {
+				return;
+			}
+
+			const index = this.highlightedIndex;
+			if (index < 0 || index >= this.displayedItems.length) {
+				return;
+			}
+
+			const item = this.displayedItems[index];
+			if (!item) {
+				return;
+			}
+
+			await this.add_item(item);
+			this.clearHighlightedItem();
+			this.clearSearch();
+			this.focusItemSearch();
 		},
 		async processScannedItem(scannedCode) {
 			const mark = perfMarkStart("pos:scan-process");
@@ -4940,6 +5061,16 @@ export default {
 	transform: translate3d(0, -2px, 0);
 	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 	border-color: var(--primary-color, #1976d2);
+}
+
+.card-item-card.item-highlighted {
+	border-color: var(--primary-color, #1976d2);
+	box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.2);
+	transform: translate3d(0, -1px, 0);
+}
+
+:deep(.item-row-highlighted) {
+	background-color: rgba(25, 118, 210, 0.12);
 }
 
 .card-item-image-container {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3571,6 +3571,12 @@ export default {
 				const wrapper = tableEl?.querySelector?.(".v-table__wrapper");
 				const rows = tableEl?.querySelectorAll?.("tbody tr");
 				if (wrapper && rows && rows.length > 0) {
+					const targetRow = rows[index];
+					if (targetRow && typeof targetRow.offsetTop === "number") {
+						wrapper.scrollTop = Math.max(0, targetRow.offsetTop - wrapper.clientHeight / 2);
+						return;
+					}
+
 					const rowHeight = rows[0].getBoundingClientRect().height || 0;
 					if (rowHeight > 0) {
 						wrapper.scrollTop = rowHeight * index;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -5071,8 +5071,15 @@ export default {
 }
 
 :deep(.item-row-highlighted) {
-	background-color: rgba(25, 118, 210, 0.18);
-	box-shadow: inset 0 0 0 2px rgba(25, 118, 210, 0.35);
+	background-color: rgba(25, 118, 210, 0.28);
+	box-shadow:
+		inset 0 0 0 2px rgba(25, 118, 210, 0.6),
+		inset 0 0 0 6px rgba(25, 118, 210, 0.12);
+}
+
+:deep(.item-row-highlighted td) {
+	font-weight: 600;
+	color: var(--primary-color, #1976d2);
 }
 
 .card-item-image-container {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -3554,8 +3554,16 @@ export default {
 				}
 
 				const tableRef = this.$refs.itemsTable;
-				if (tableRef?.scrollToIndex) {
-					tableRef.scrollToIndex(index);
+				const scrollToIndex =
+					tableRef?.scrollToIndex || tableRef?.$?.exposed?.scrollToIndex || null;
+				if (scrollToIndex) {
+					const scheduleScroll =
+						typeof requestAnimationFrame === "function"
+							? requestAnimationFrame
+							: (callback) => setTimeout(callback, 0);
+					scheduleScroll(() => {
+						scrollToIndex(index);
+					});
 					return;
 				}
 

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -2004,6 +2004,12 @@ export default {
 			}
 			this.add_item(item);
 		},
+		selectTopItem() {
+			if (!this.displayedItems || !this.displayedItems.length) {
+				return;
+			}
+			this.add_item(this.displayedItems[0]);
+		},
 		async click_item_row(event, { item }) {
 			const targets = document.querySelectorAll(".items-table-container");
 			const target = targets[targets.length - 1];
@@ -4464,6 +4470,12 @@ export default {
 		this.eventBus.on("focus_item_search", () => {
 			this.focusItemSearch();
 		});
+		this.eventBus.on("select_top_item", () => {
+			this.selectTopItem();
+		});
+		this.eventBus.on("toggle_item_selector_settings", () => {
+			this.toggleItemSettings();
+		});
 
 		// Manually trigger a full item reload when requested
 		this.eventBus.on("force_reload_items", async () => {
@@ -4621,6 +4633,8 @@ export default {
 		this.eventBus.off("update_customer_price_list");
 		this.eventBus.off("force_reload_items");
 		this.eventBus.off("focus_item_search");
+		this.eventBus.off("select_top_item");
+		this.eventBus.off("toggle_item_selector_settings");
 		window.removeEventListener("resize", this.checkItemContainerOverflow);
 		if (this.metricsRaf) {
 			cancelAnimationFrame(this.metricsRaf);

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -904,6 +904,49 @@ export default {
 			}
 			return Array.isArray(item?.serial_no_data) ? item.serial_no_data : [];
 		},
+		focusItemField(index, field) {
+			const rows = this.$el?.querySelectorAll?.("tr.cart-item-row");
+			const row = rows?.[index];
+			if (!row) {
+				return false;
+			}
+
+			row.scrollIntoView({ block: "center" });
+
+			const findCell = (key) => row.querySelector(`td[data-column-key='${key}']`);
+			const cell = findCell(field);
+			if (!cell) {
+				return false;
+			}
+
+			if (field === "qty") {
+				cell.querySelector(".pos-table__qty-display")?.click();
+				this.$nextTick(() => {
+					cell.querySelector(".pos-table__qty-input input")?.focus?.();
+				});
+				return true;
+			}
+
+			if (field === "uom") {
+				const input = cell.querySelector(".uom-select input") || cell.querySelector("input");
+				if (input) {
+					input.focus();
+					return true;
+				}
+				cell.querySelector(".uom-select")?.click?.();
+				return true;
+			}
+
+			if (field === "rate") {
+				cell.querySelector(".pos-table__editor-display")?.click();
+				this.$nextTick(() => {
+					cell.querySelector(".pos-table__editor-input input")?.focus?.();
+				});
+				return true;
+			}
+
+			return false;
+		},
 
 		customItemFilter(value, search, item) {
 			if (search == null) {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -2031,6 +2031,15 @@ export default {
 				this.submit(null, false, false);
 			}
 		},
+		handleSubmitPaymentShortcut({ print = false } = {}) {
+			if (!this.paymentVisible) {
+				return;
+			}
+
+			this.$nextTick(() => {
+				this.submit(null, false, print);
+			});
+		},
 		// Get available customer credit and auto-allocate
 		get_available_credit(use_credit) {
 			this.clear_all_amounts();
@@ -2803,6 +2812,7 @@ export default {
 			this.eventBus.on("set_mpesa_payment", (data) => {
 				this.set_mpesa_payment(data);
 			});
+			this.eventBus.on("submit_payment_shortcut", this.handleSubmitPaymentShortcut);
 			// Clear any stored invoice when parent emits clear_invoice
 			this.eventBus.on("clear_invoice", () => {
 				this.invoice_doc = "";
@@ -2823,6 +2833,7 @@ export default {
 		this.eventBus.off("update_invoice_type");
 		this.eventBus.off("set_pos_settings");
 		this.eventBus.off("set_mpesa_payment");
+		this.eventBus.off("submit_payment_shortcut", this.handleSubmitPaymentShortcut);
 		this.eventBus.off("clear_invoice");
 		this.eventBus.off("network-online", this.syncPendingInvoices);
 		this.eventBus.off("server-online", this.syncPendingInvoices);

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -886,6 +886,8 @@ export default {
 			highlightSubmit: false, // Highlight state for submit button
 			last_payment_change_was_cash: null, // Track last edited payment type
 			backgroundStatusCheck: null,
+			paymentVisible: false,
+			_shortcutHandlers: {},
 		};
 	},
 	computed: {
@@ -1374,6 +1376,7 @@ export default {
 		// Highlight and focus the submit button when payment screen opens
 		handleShowPayment(data) {
 			if (data === "true") {
+				this.paymentVisible = true;
 				this.$nextTick(() => {
 					setTimeout(() => {
 						const btn = this.$refs.submitButton;
@@ -1386,6 +1389,7 @@ export default {
 					}, 100);
 				});
 			} else {
+				this.paymentVisible = false;
 				this.highlightSubmit = false;
 			}
 		},
@@ -2005,14 +2009,26 @@ export default {
 				this.invoice_doc.due_date = today;
 			}
 		},
-		// Keyboard shortcut for payment submit (Ctrl+X)
-		shortPay(e) {
-			if (e.key.toLowerCase() === "x" && (e.ctrlKey || e.metaKey)) {
-				e.preventDefault();
-				e.stopPropagation();
-				if (this.invoice_doc && this.invoice_doc.payments) {
-					this.submit_invoice();
-				}
+		// Keyboard shortcuts for payment submit (Alt+X) and submit+print (Alt+P)
+		handlePaymentShortcut(event) {
+			if (!this.paymentVisible) {
+				return;
+			}
+
+			const isAltOnly = event.altKey && !event.ctrlKey && !event.metaKey;
+			const key = event.key.toLowerCase();
+
+			if (isAltOnly && key === "p") {
+				event.preventDefault();
+				event.stopPropagation();
+				this.submit(null, false, true);
+				return;
+			}
+
+			if ((isAltOnly || event.ctrlKey || event.metaKey) && key === "x") {
+				event.preventDefault();
+				event.stopPropagation();
+				this.submit(null, false, false);
 			}
 		},
 		// Get available customer credit and auto-allocate
@@ -2684,7 +2700,9 @@ export default {
 	// Lifecycle hook: created
 	created() {
 		// Register keyboard shortcut for payment
-		document.addEventListener("keydown", this.shortPay.bind(this));
+		this._shortcutHandlers = this._shortcutHandlers || {};
+		this._shortcutHandlers.handlePaymentShortcut = this.handlePaymentShortcut.bind(this);
+		document.addEventListener("keydown", this._shortcutHandlers.handlePaymentShortcut);
 		this.syncPendingInvoices();
 		this.eventBus.on("network-online", this.syncPendingInvoices);
 		// Also sync when the server connection is re-established
@@ -2814,7 +2832,11 @@ export default {
 	// Lifecycle hook: unmounted
 	unmounted() {
 		// Remove keyboard shortcut listener
-		document.removeEventListener("keydown", this.shortPay);
+		if (!this._shortcutHandlers) {
+			return;
+		}
+		document.removeEventListener("keydown", this._shortcutHandlers.handlePaymentShortcut);
+		this._shortcutHandlers = {};
 	},
 };
 </script>

--- a/frontend/src/posapp/components/pos/Pos.vue
+++ b/frontend/src/posapp/components/pos/Pos.vue
@@ -154,6 +154,9 @@ export default {
 				this.showOffers = false;
 				this.coupons = false;
 			});
+			this.eventBus.on("open_shift_details", () => {
+				this.get_closing_data();
+			});
 			this.eventBus.on("show_offers", (data) => {
 				this.showOffers = data === "true";
 				this.payment = false;
@@ -179,6 +182,7 @@ export default {
 		this.eventBus.off("register_pos_data");
 		this.eventBus.off("register_pos_profile");
 		this.eventBus.off("LoadPosProfile");
+		this.eventBus.off("open_shift_details");
 		this.eventBus.off("show_offers");
 		this.eventBus.off("show_coupons");
 		this.eventBus.off("submit_closing_pos");

--- a/frontend/src/posapp/components/pos/PostingDateRow.vue
+++ b/frontend/src/posapp/components/pos/PostingDateRow.vue
@@ -2,6 +2,7 @@
 	<v-row align="center" class="items px-3 py-2 mt-0" v-if="pos_profile.posa_allow_change_posting_date">
 		<v-col cols="12" sm="4" class="pb-2">
 			<VueDatePicker
+				ref="postingDatePicker"
 				v-model="internal_posting_date_display"
 				model-type="format"
 				format="dd-MM-yyyy"
@@ -78,6 +79,13 @@ export default {
 		},
 		onPriceListUpdate(val) {
 			this.$emit("update:priceList", val);
+		},
+		focusPostingDate() {
+			const input = this.$refs.postingDatePicker?.$el?.querySelector("input");
+			if (input) {
+				input.focus();
+				input.select?.();
+			}
 		},
 	},
 };

--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -201,12 +201,18 @@ export default {
 		}
 
 		if (keyLower === "x" || keyLower === "p") {
-			consumeEvent(event);
 			if (this.paymentVisible) {
 				return;
 			}
+			consumeEvent(event);
 
 			const shouldPrint = keyLower === "p";
+			const shouldSubmit = window.confirm(
+				__("Payments are not open. Do you want to open payments and submit?"),
+			);
+			if (!shouldSubmit) {
+				return;
+			}
 			await this.show_payment?.();
 			if (this.paymentVisible) {
 				this.eventBus.emit("submit_payment_shortcut", { print: shouldPrint });

--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -150,6 +150,15 @@ export default {
 			return;
 		}
 
+		if (keyLower === "e") {
+			consumeEvent(event);
+			const firstItem = this.items?.[0];
+			if (firstItem) {
+				this.remove_item?.(firstItem);
+			}
+			return;
+		}
+
 		if (keyLower === "f") {
 			consumeEvent(event);
 			const input = this.$refs.itemSearchField;

--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -1,107 +1,205 @@
+/* global frappe, __ */
+const isAltOnly = (event) => event.altKey && !event.ctrlKey && !event.metaKey;
+const consumeEvent = (event) => {
+	event.preventDefault();
+	event.stopPropagation();
+};
+const isDigit = (event, digit) =>
+	event.key === String(digit) || event.code === `Digit${digit}` || event.code === `Numpad${digit}`;
+const isBackquote = (event) => event.key === "`" || event.code === "Backquote";
+
 export default {
-	shortOpenFirstItem(e) {
-		if (e.key.toLowerCase() === "a" && (e.ctrlKey || e.metaKey)) {
-			try {
-				e.preventDefault();
-				e.stopPropagation();
-
-				if (!this.items || this.items.length === 0) {
-					console.log("No items to expand/collapse");
-					return;
-				}
-
-				const firstItem = this.items[0];
-				console.log("Processing first item:", firstItem.item_code);
-
-				// Check if first item is currently expanded using its ID
-				const isExpanded = this.expanded.includes(firstItem.posa_row_id);
-
-				// Toggle expanded state using item ID
-				if (isExpanded) {
-					console.log("Collapsing item:", firstItem.item_code);
-					this.expanded = [];
-				} else {
-					console.log("Expanding item:", firstItem.item_code);
-					this.expanded = [firstItem.posa_row_id];
-					// Update item details when expanding
-					this.$nextTick(() => {
-						this.update_item_detail(firstItem);
-					});
-				}
-			} catch (error) {
-				console.error("Error in shortOpenFirstItem:", error);
-				this.eventBus.emit("show_message", {
-					title: __("Error toggling item details"),
-					color: "error",
-				});
-			}
+	handleInvoiceShortcut(event) {
+		if (event.defaultPrevented) {
+			return;
 		}
-	},
 
-	handleExpandedUpdate(newExpanded) {
-		console.log("Expanded state updated:", newExpanded);
-		this.expanded = newExpanded;
+		const key = event.key;
+		const keyLower = key.toLowerCase();
 
-		// Update item details for newly expanded items
-		if (newExpanded && newExpanded.length > 0) {
-			const expandedItemId = newExpanded[0];
-			const expandedItem = this.items.find((item) => item.posa_row_id === expandedItemId);
-			if (expandedItem) {
-				this.$nextTick(() => {
-					this.update_item_detail(expandedItem);
-				});
-			}
+		if (key === "F4") {
+			consumeEvent(event);
+			this.eventBus.emit("show_message", {
+				title: __("Profile switching is not available yet"),
+				color: "warning",
+			});
+			return;
 		}
-	},
 
-	// Keyboard shortcut: open payment dialog
-	shortOpenPayment(e) {
-		if (e.key === "s" && (e.ctrlKey || e.metaKey)) {
-			e.preventDefault();
-			this.show_payment();
+		if (key === "F5") {
+			consumeEvent(event);
+			this.$refs.customerComponent?.openNewCustomer?.();
+			return;
 		}
-	},
 
-	// Keyboard shortcut: delete first item from the invoice
-	shortDeleteFirstItem(e) {
-		if (e.key === "d" && (e.ctrlKey || e.metaKey)) {
-			e.preventDefault();
-			this.remove_item(this.items[0]);
+		if (key === "F11") {
+			consumeEvent(event);
+			this.eventBus.emit("open_shift_details");
+			return;
 		}
-	},
 
-	shortSelectDiscount(e) {
-		console.log("Shortcut pressed:", e.key, e.ctrlKey);
-		if (e.key.toLowerCase() === "e" && (e.ctrlKey || e.metaKey)) {
-			console.log("Focusing discount field");
-			e.preventDefault();
-			e.stopPropagation();
-			if (this.$refs.discount) {
-				this.$refs.discount.focus();
-				console.log("Discount field focused");
+		if (key === "F12") {
+			consumeEvent(event);
+			this.eventBus.emit("show_message", {
+				title: __("POS lock is not available yet"),
+				color: "warning",
+			});
+			return;
+		}
+
+		if (!isAltOnly(event)) {
+			return;
+		}
+
+		if (isDigit(event, 1)) {
+			consumeEvent(event);
+			if (typeof this.close_payments === "function") {
+				this.close_payments();
 			} else {
-				console.log("Discount field ref not found");
+				this.eventBus.emit("show_payment", "false");
 			}
+			return;
+		}
+
+		if (isDigit(event, 2)) {
+			consumeEvent(event);
+			if (typeof this.clear_invoice === "function") {
+				this.clear_invoice();
+				this.eventBus.emit("reset_posting_date");
+				this.eventBus.emit("focus_item_search");
+			}
+			return;
+		}
+
+		if (isDigit(event, 3)) {
+			consumeEvent(event);
+			this.eventBus.emit("focus_item_search");
+			return;
+		}
+
+		if (isDigit(event, 4)) {
+			consumeEvent(event);
+			this.eventBus.emit("select_top_item");
+			return;
+		}
+
+		if (isDigit(event, 5)) {
+			consumeEvent(event);
+			this.focusCustomerSearchField?.();
+			return;
+		}
+
+		if (isDigit(event, 6)) {
+			consumeEvent(event);
+			this.$refs.customerComponent?.selectFirstCustomer?.();
+			return;
+		}
+
+		if (isDigit(event, 7)) {
+			consumeEvent(event);
+			this.get_draft_orders?.();
+			return;
+		}
+
+		if (isDigit(event, 8)) {
+			consumeEvent(event);
+			this.open_returns?.();
+			return;
+		}
+
+		if (isDigit(event, 9)) {
+			consumeEvent(event);
+			this.$refs.deliveryChargesComponent?.focusDeliveryCharges?.();
+			return;
+		}
+
+		if (isBackquote(event)) {
+			consumeEvent(event);
+			this.$refs.postingDateComponent?.focusPostingDate?.();
+			return;
+		}
+
+		if (key === "PageUp") {
+			consumeEvent(event);
+			this.show_payment?.();
+			return;
+		}
+
+		if (key === "Home") {
+			consumeEvent(event);
+			frappe.set_route("/");
+			location.reload();
+			return;
+		}
+
+		if (keyLower === "q") {
+			consumeEvent(event);
+			this.focusItemTableField("qty");
+			return;
+		}
+
+		if (keyLower === "u") {
+			consumeEvent(event);
+			this.focusItemTableField("uom");
+			return;
+		}
+
+		if (keyLower === "r") {
+			consumeEvent(event);
+			this.focusItemTableField("rate");
+			return;
+		}
+
+		if (keyLower === "f") {
+			consumeEvent(event);
+			const input = this.$refs.itemSearchField;
+			if (input?.focus) {
+				input.focus();
+			} else {
+				input?.$el?.querySelector?.("input")?.focus?.();
+			}
+			return;
+		}
+
+		if (keyLower === "m") {
+			consumeEvent(event);
+			this.eventBus.emit("toggle_item_selector_settings");
+			return;
+		}
+
+		if (keyLower === "s") {
+			consumeEvent(event);
+			this.save_and_clear_invoice?.();
+			return;
+		}
+
+		if (keyLower === "c") {
+			consumeEvent(event);
+			this.cancel_dialog = true;
+			return;
+		}
+
+		if (keyLower === "d") {
+			consumeEvent(event);
+			this.show_payment?.();
 		}
 	},
 
-	shortFocusCustomer(e) {
-		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "b") {
-			e.preventDefault();
-			e.stopPropagation();
-			if (typeof this.focusCustomerSearchField === "function") {
-				this.focusCustomerSearchField();
-			}
+	focusItemTableField(field) {
+		const count = this.items?.length || 0;
+		if (!count) {
+			return;
 		}
-	},
 
-	shortFocusItem(e) {
-		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "i") {
-			e.preventDefault();
-			e.stopPropagation();
-			if (typeof this.focusItemSearchField === "function") {
-				this.focusItemSearchField();
-			}
+		if (!this.shortcutCycle) {
+			this.shortcutCycle = { qty: 0, uom: 0, rate: 0 };
 		}
+
+		let index = Number.isInteger(this.shortcutCycle[field]) ? this.shortcutCycle[field] : 0;
+		if (index >= count) {
+			index = 0;
+		}
+		this.shortcutCycle[field] = (index + 1) % count;
+		this.$refs.itemsTable?.focusItemField?.(index, field);
 	},
 };

--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -9,7 +9,7 @@ const isDigit = (event, digit) =>
 const isBackquote = (event) => event.key === "`" || event.code === "Backquote";
 
 export default {
-	handleInvoiceShortcut(event) {
+	async handleInvoiceShortcut(event) {
 		if (event.defaultPrevented) {
 			return;
 		}
@@ -197,6 +197,20 @@ export default {
 		if (keyLower === "d") {
 			consumeEvent(event);
 			this.show_payment?.();
+			return;
+		}
+
+		if (keyLower === "x" || keyLower === "p") {
+			consumeEvent(event);
+			if (this.paymentVisible) {
+				return;
+			}
+
+			const shouldPrint = keyLower === "p";
+			await this.show_payment?.();
+			if (this.paymentVisible) {
+				this.eventBus.emit("submit_payment_shortcut", { print: shouldPrint });
+			}
 		}
 	},
 

--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -161,6 +161,12 @@ export default {
 			return;
 		}
 
+		if (keyLower === "l") {
+			consumeEvent(event);
+			this.get_draft_invoices?.();
+			return;
+		}
+
 		if (keyLower === "m") {
 			consumeEvent(event);
 			this.eventBus.emit("toggle_item_selector_settings");


### PR DESCRIPTION
### Motivation
- Replace ad-hoc shortcut handlers with a single, extensible shortcut router to support a broader set of quick keys (Alt + digit, Alt + letter, and F-keys) and future additions.
- Enable keyboard-driven navigation and focus for common POS actions such as item search, customer search, delivery charges, posting date and table cell editing.
- Improve UX by cycling focus through item table fields (`qty`, `uom`, `rate`) and gating payment shortcuts to the payments view.
- Provide safe stubs / user feedback for conceptual features (profile switch / POS lock) while keeping the UI stable.

### Description
- Centralized invoice shortcuts into `frontend/src/posapp/components/pos/invoiceShortcuts.js` and implemented `handleInvoiceShortcut` to handle `Alt+1..9`, `` ` ``, letter shortcuts and `F4/F5/F11/F12`; wired into `Invoice.vue` via a single `keydown` listener (`_shortcutHandlers.handleInvoiceShortcut`).
- Added helpers and component refs so shortcuts can focus or act on UI parts: `Customer.vue` exposes `selectFirstCustomer` and `openNewCustomer`, `DeliveryCharges.vue` exposes `focusDeliveryCharges`, `PostingDateRow.vue` exposes `focusPostingDate`, `ItemsSelector.vue` adds `selectTopItem` and listens to `select_top_item`/`toggle_item_selector_settings`, and `Invoice.vue` includes refs for these components.
- Implemented table-focused editing helpers in `ItemsTable.vue` (`focusItemField`) and a cycling mechanism (`shortcutCycle`) in `Invoice.vue` to iterate through rows when `Alt+Q`, `Alt+U` and `Alt+R` are pressed.
- Reworked payment shortcuts in `Payments.vue` to use `Alt+X` (submit) and `Alt+P` (submit + print) while preserving `Ctrl/Meta+X` behavior, and added `paymentVisible` state and proper registration/unregistration of keyboard listeners.
- Minor wiring: `Pos.vue` listens for `open_shift_details` to show shift info, and eventbus wiring was added/cleaned up across components to support the new shortcuts.

### Testing
- No automated tests were executed as part of this change.
- All modifications were committed locally (`git commit`) but no CI/test run was triggered.
- Manual runtime validation is recommended in a development environment to verify keyboard interactions across views.
- If desired, add unit or integration tests for `handleInvoiceShortcut` and `handlePaymentShortcut` to validate key mappings and focus behavior automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957a67e6b64832687bc9ad273cd5e7f)