### PR TITLE
Add Alt+L shortcut for loading drafts

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -161,6 +161,12 @@ export default {
 			return;
 		}
 
+		if (keyLower === "l") {
+			consumeEvent(event);
+			this.get_draft_invoices?.();
+			return;
+		}
+
 		if (keyLower === "m") {
 			consumeEvent(event);
 			this.eventBus.emit("toggle_item_selector_settings");


### PR DESCRIPTION
### Motivation
- Provide a quick keyboard shortcut to open draft invoices from the POS screen using `Alt+L`.
- Improve keyboard accessibility so users can load drafts without touching the mouse.

### Description
- Added an `Alt+L` handler in `frontend/src/posapp/components/pos/invoiceShortcuts.js` that calls `this.get_draft_invoices?.()` when pressed.
- The new handler consumes the event with `consumeEvent(event)` and only triggers on Alt-only key presses.
- No other UI behavior or draft loading logic was modified.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957d71aeee8832682f17e7e89b9100c)