### PR TITLE
Move remove-first-item shortcut to Alt+E and restore Alt+R to rate focus

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -150,6 +150,15 @@ export default {
 			return;
 		}
 
+		if (keyLower === "e") {
+			consumeEvent(event);
+			const firstItem = this.items?.[0];
+			if (firstItem) {
+				this.remove_item?.(firstItem);
+			}
+			return;
+		}
+
 		if (keyLower === "f") {
 			consumeEvent(event);
 			const input = this.$refs.itemSearchField;


### PR DESCRIPTION
### Motivation
- Restore `Alt+R` to focus the rate field as originally expected.
- Move the remove-first-item shortcut to `Alt+E` to match the user's requested behavior.
- Keep keyboard shortcuts aligned with POS quick-edit workflows.

### Description
- Update `frontend/src/posapp/components/pos/invoiceShortcuts.js` to keep the `keyLower === "r"` branch calling `this.focusItemTableField("rate")`.
- Add a new `keyLower === "e"` branch that calls `consumeEvent(event)` and invokes `this.remove_item?.(this.items?.[0])` when a first item exists.
- Ensure the event is consumed with `consumeEvent(event)` so the keyboard event is not propagated.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957d918c1c88326be8441e10098e353)