### PR TITLE
Trigger payment submit shortcuts from invoice view (Alt+X / Alt+P)

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -2031,6 +2031,15 @@ export default {
 				this.submit(null, false, false);
 			}
 		},
+		handleSubmitPaymentShortcut({ print = false } = {}) {
+			if (!this.paymentVisible) {
+				return;
+			}
+
+			this.$nextTick(() => {
+				this.submit(null, false, print);
+			});
+		},
 		// Get available customer credit and auto-allocate
 		get_available_credit(use_credit) {
 			this.clear_all_amounts();
@@ -2803,6 +2812,7 @@ export default {
 			this.eventBus.on("set_mpesa_payment", (data) => {
 				this.set_mpesa_payment(data);
 			});
+			this.eventBus.on("submit_payment_shortcut", this.handleSubmitPaymentShortcut);
 			// Clear any stored invoice when parent emits clear_invoice
 			this.eventBus.on("clear_invoice", () => {
 				this.invoice_doc = "";
@@ -2823,6 +2833,7 @@ export default {
 		this.eventBus.off("update_invoice_type");
 		this.eventBus.off("set_pos_settings");
 		this.eventBus.off("set_mpesa_payment");
+		this.eventBus.off("submit_payment_shortcut", this.handleSubmitPaymentShortcut);
 		this.eventBus.off("clear_invoice");
 		this.eventBus.off("network-online", this.syncPendingInvoices);
 		this.eventBus.off("server-online", this.syncPendingInvoices);

--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -201,12 +201,18 @@ export default {
 		}
 
 		if (keyLower === "x" || keyLower === "p") {
-			consumeEvent(event);
 			if (this.paymentVisible) {
 				return;
 			}
+			consumeEvent(event);
 
 			const shouldPrint = keyLower === "p";
+			const shouldSubmit = window.confirm(
+				__("Payments are not open. Do you want to open payments and submit?"),
+			);
+			if (!shouldSubmit) {
+				return;
+			}
 			await this.show_payment?.();
 			if (this.paymentVisible) {
 				this.eventBus.emit("submit_payment_shortcut", { print: shouldPrint });

--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -9,7 +9,7 @@ const isDigit = (event, digit) =>
 const isBackquote = (event) => event.key === "`" || event.code === "Backquote";
 
 export default {
-	handleInvoiceShortcut(event) {
+	async handleInvoiceShortcut(event) {
 		if (event.defaultPrevented) {
 			return;
 		}
@@ -197,6 +197,20 @@ export default {
 		if (keyLower === "d") {
 			consumeEvent(event);
 			this.show_payment?.();
+			return;
+		}
+
+		if (keyLower === "x" || keyLower === "p") {
+			consumeEvent(event);
+			if (this.paymentVisible) {
+				return;
+			}
+
+			const shouldPrint = keyLower === "p";
+			await this.show_payment?.();
+			if (this.paymentVisible) {
+				this.eventBus.emit("submit_payment_shortcut", { print: shouldPrint });
+			}
 		}
 	},
 


### PR DESCRIPTION
### Motivation
- Allow users to press Alt+X or Alt+P while on the invoice screen to open the payment dialog and immediately submit (or submit+print) without first manually opening payments.
- Ensure the invoice-level shortcut cooperates with the existing payments view submit logic and preserves the print flag.

### Description
- Made `handleInvoiceShortcut` in `frontend/src/posapp/components/pos/invoiceShortcuts.js` async and added handling for `x` and `p` to open payments and then emit a `submit_payment_shortcut` event with `{ print }` when the payments view is visible.
- Added `handleSubmitPaymentShortcut` in `frontend/src/posapp/components/pos/Payments.vue` that listens for `submit_payment_shortcut` and invokes `submit(null, false, print)` via `$nextTick` when the payments dialog is open.
- Registered and cleaned up the new event listener (`submit_payment_shortcut`) in the Payments component lifecycle hooks and kept existing Alt+D behavior for opening/closing payments.

### Testing
- No automated tests were run for this change.
- Manual verification should include pressing Alt+X and Alt+P from the invoice screen to confirm payments open and submit or submit+print is triggered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957db3cc7e88326a26fe5ca52dfccfd)