### PR TITLE
Make payment submission navigation instant for background submissions

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -819,7 +819,6 @@
 /* global frappe, __, get_currency_symbol */
 // Importing format mixin for currency and utility functions
 import format, { formatUtils } from "../../format";
-import { parseBooleanSetting } from "../../utils/stock.js";
 import { getSmartTenderSuggestions } from "../../../utils/smartTender.js";
 import {
 	saveOfflineInvoice,
@@ -1373,6 +1372,13 @@ export default {
 				this.eventBus.emit("reset_posting_date");
 			}
 		},
+		resetPaymentState() {
+			this.customer_credit_dict = [];
+			this.redeem_customer_credit = false;
+			this.is_cashback = true;
+			this.is_credit_return = false;
+			this.sales_person = "";
+		},
 		// Highlight and focus the submit button when payment screen opens
 		handleShowPayment(data) {
 			if (data === "true") {
@@ -1614,6 +1620,13 @@ export default {
 			if (this.invoice_doc.is_return) {
 				this.ensureReturnPaymentsAreNegative();
 			}
+			const invoiceSnapshot = this.invoice_doc;
+			const submittedItemsSnapshot = Array.isArray(invoiceSnapshot?.items) ? invoiceSnapshot.items : [];
+			const submittedCodesSnapshot = submittedItemsSnapshot
+				.map((item) => (item ? item.item_code : null))
+				.filter((code) => code !== undefined && code !== null);
+			const shouldNavigateEarly = Boolean(this.pos_profile?.posa_allow_submissions_in_background_job);
+			let navigatedEarly = false;
 			let totalPayedAmount = 0;
 			this.invoice_doc.payments.forEach((payment) => {
 				payment.amount = this.flt(payment.amount);
@@ -1680,6 +1693,15 @@ export default {
 			}
 
 			try {
+				if (shouldNavigateEarly) {
+					if (print) {
+						this.load_print_page();
+					}
+					this.resetPaymentState();
+					this.finishSubmissionNavigation(true);
+					navigatedEarly = true;
+				}
+
 				const r = await frappe.call({
 					method:
 						this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
@@ -1742,15 +1764,11 @@ export default {
 					return;
 				}
 
-				if (print) {
+				if (print && !navigatedEarly) {
 					this.load_print_page();
 				}
-				this.customer_credit_dict = [];
-				this.redeem_customer_credit = false;
-				this.is_cashback = true;
-				this.is_credit_return = false;
-				this.sales_person = "";
-				this.eventBus.emit("set_last_invoice", this.invoice_doc.name);
+				this.resetPaymentState();
+				this.eventBus.emit("set_last_invoice", invoiceSnapshot?.name);
 				this.eventBus.emit("show_message", {
 					title:
 						this.invoiceType === "Order" && this.pos_profile.posa_create_only_sales_order
@@ -1761,20 +1779,18 @@ export default {
 					color: "success",
 				});
 				frappe.utils.play_sound("submit");
-				const submittedItems = Array.isArray(this.invoice_doc.items) ? this.invoice_doc.items : [];
-				updateLocalStock(submittedItems);
-				stockCoordinator.applyInvoiceConsumption(submittedItems, {
+				updateLocalStock(submittedItemsSnapshot);
+				stockCoordinator.applyInvoiceConsumption(submittedItemsSnapshot, {
 					source: "invoice",
 				});
-				const submittedCodes = submittedItems
-					.map((item) => (item ? item.item_code : null))
-					.filter((code) => code !== undefined && code !== null);
 				this.eventBus.emit("invoice_stock_adjusted", {
-					items: submittedItems,
-					item_codes: submittedCodes,
+					items: submittedItemsSnapshot,
+					item_codes: submittedCodesSnapshot,
 					timestamp: Date.now(),
 				});
-				this.finishSubmissionNavigation(true);
+				if (!navigatedEarly) {
+					this.finishSubmissionNavigation(true);
+				}
 				this.scheduleBackgroundStatusCheck(responseInvoiceName, r.message?.doctype);
 			} catch (exc) {
 				console.error("Error submitting invoice:", exc);


### PR DESCRIPTION
### Motivation
- The payments flow currently waits for server submission which delays showing a new invoice after submit/print; background submission should allow instant navigation. 
- Preserve stock update and notification behavior while allowing the UI to return immediately when background submits are enabled. 
- Remove an unused import flagged by lint to keep the file clean. 

### Description
- When `pos_profile.posa_allow_submissions_in_background_job` is enabled, navigate away from the payments view immediately by loading print (if requested), resetting payment UI state via `resetPaymentState()`, and calling `finishSubmissionNavigation(true)` so new invoices appear instantly. 
- Take a snapshot of `this.invoice_doc` and its `items` (`invoiceSnapshot`, `submittedItemsSnapshot`, `submittedCodesSnapshot`) before navigating and use those snapshots for `updateLocalStock`, `stockCoordinator.applyInvoiceConsumption`, and the `invoice_stock_adjusted` event so async submission can still update stock and notifications correctly. 
- Guard printing and final navigation to avoid duplicating behavior when early navigation has already occurred using a `navigatedEarly` flag. 
- Remove the unused `parseBooleanSetting` import to satisfy lint rules. 

### Testing
- Ran code formatting check with `npx prettier --check frontend/src/posapp/components/pos/Payments.vue` which passed. 
- Ran lint with `npx eslint frontend/src/posapp/components/pos/Payments.vue` which passed after removing the unused import. 
- Ran the frontend unit tests with `yarn --cwd frontend test --run`; the test run reported environment issues and failures: IndexedDB API missing in the test environment and 2 failing tests in `tests/invoiceItemMethods.spec.js` (a missing mocked export `evaluatePricingRules` and `__` global not defined). 
- No benchmark harness was available to run benchmarks as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958047fa684832695143fa1dfb45355)