### PR TITLE
Focus customer name field and add Esc handling to New Customer dialog

### DIFF
--- a/frontend/src/posapp/components/pos/UpdateCustomer.vue
+++ b/frontend/src/posapp/components/pos/UpdateCustomer.vue
@@ -1,6 +1,11 @@
 <template>
 	<v-row justify="center">
-		<v-dialog v-model="customerDialog" max-width="600px" persistent>
+		<v-dialog
+			v-model="customerDialog"
+			max-width="600px"
+			persistent
+			@keydown.esc.capture.stop.prevent="handleDialogEscape"
+		>
 			<v-card>
 				<v-card-title class="d-flex align-center">
 					<span v-if="customer_id" class="text-h5 text-primary">{{ __("Update Customer") }}</span>
@@ -20,6 +25,7 @@
 						<v-row>
 							<v-col cols="12">
 								<v-text-field
+									ref="customerNameField"
 									density="compact"
 									color="primary"
 									:label="frappe._('Customer Name') + ' *'"
@@ -186,7 +192,11 @@
 		</v-dialog>
 
 		<!-- Confirmation Dialog -->
-		<v-dialog v-model="confirmDialog" max-width="400px">
+		<v-dialog
+			v-model="confirmDialog"
+			max-width="400px"
+			@keydown.esc.capture.stop.prevent="handleConfirmEscape"
+		>
 			<v-card>
 				<v-card-title class="text-h5 text-primary">
 					{{ __("Confirm Close") }}
@@ -338,6 +348,24 @@ export default {
 	},
 	computed: {},
 	methods: {
+		focusCustomerNameField() {
+			this.$nextTick(() => {
+				const field = this.$refs.customerNameField;
+				if (field && typeof field.focus === "function") {
+					field.focus();
+				}
+			});
+		},
+		handleDialogEscape() {
+			if (this.confirmDialog) {
+				this.confirmClose();
+				return;
+			}
+			this.confirm_close();
+		},
+		handleConfirmEscape() {
+			this.confirmClose();
+		},
 		// Add a new method to update calendar date
 		updateCalendarDate(day, month, year) {
 			// First close the date picker if it's open
@@ -655,6 +683,7 @@ export default {
 		}
 		this.eventBus.on("open_update_customer", (data) => {
 			this.customerDialog = true;
+			this.focusCustomerNameField();
 
 			if (data) {
 				this.customer_name = data.customer_name;


### PR DESCRIPTION
### Motivation
- Ensure the Customer Name field is focused automatically when opening the Create/Update Customer dialog to speed up data entry.
- Make the dialog easier to dismiss via the Escape key and ensure the Confirm Close dialog also responds to Escape.

### Description
- Added a `ref="customerNameField"` to the Customer Name `v-text-field` and implemented `focusCustomerNameField()` to focus it via `$nextTick`.
- Wire `focusCustomerNameField()` to the `open_update_customer` event so the name field is focused when the dialog opens.
- Added `@keydown.esc.capture.stop.prevent` handlers on the main customer dialog and the confirm dialog and implemented `handleDialogEscape()` and `handleConfirmEscape()` to close the dialogs in the requested sequence.
- Minor UI wiring to call confirmation logic when appropriate (preserve existing confirm/close behavior).

### Testing
- Ran formatting with `yarn --cwd frontend format` which completed successfully.
- Ran ESLint (`npx eslint frontend/src/posapp/components/pos/UpdateCustomer.vue`) which failed due to a missing `globals` package required by the repo ESLint configuration.
- Ran unit tests with `yarn --cwd frontend test` which failed in this environment due to missing IndexedDB API in the test runtime and two unrelated Vitest failures (mock/export and `__` not defined); these failures appear pre-existing and are not caused by the UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958ab4707f88326a55273ba7ba87523)