### PR TITLE
Allow ESC to close closing shift dialog and correct Alt+7 README shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Notes:
 - `Alt + 4` select top item.
 - `Alt + 5` focus customer search.
 - `Alt + 6` select first customer.
-- `Alt + 7` load draft orders.
+- `Alt + 7` load sales orders.
 - `Alt + 8` open returns.
 - `Alt + 9` focus delivery charges.
 - `Alt + `` focus posting date.

--- a/frontend/src/posapp/components/pos/ClosingDialog.vue
+++ b/frontend/src/posapp/components/pos/ClosingDialog.vue
@@ -952,6 +952,11 @@ export default {
 	watch: {},
 
 	methods: {
+		handleKeydown(event) {
+			if (event.key === "Escape" && this.closingDialog) {
+				this.close_dialog();
+			}
+		},
 		close_dialog() {
 			this.closingDialog = false;
 			this.overview = null;
@@ -1554,9 +1559,13 @@ export default {
 			}
 		});
 	},
+	mounted() {
+		window.addEventListener("keydown", this.handleKeydown);
+	},
 	beforeUnmount() {
 		this.eventBus.off("open_ClosingDialog");
 		this.eventBus.off("register_pos_profile");
+		window.removeEventListener("keydown", this.handleKeydown);
 	},
 };
 </script>


### PR DESCRIPTION
### Motivation

- Users need the POS closing shift dialog to close when `Escape` is pressed while the dialog is open.
- The README documented `Alt + 7` as loading drafts but it actually loads sales orders and must be corrected.

### Description

- Added a `handleKeydown` method to `frontend/src/posapp/components/pos/ClosingDialog.vue` to detect `Escape` and call `close_dialog` when the closing dialog is open.
- Registered the key handler in `mounted()` and removed it in `beforeUnmount()` to avoid leaking event listeners.
- Updated `README.md` to change the `Alt + 7` shortcut description to `load sales orders`.

### Testing

- Ran `yarn format`, which completed successfully.
- Ran `npx eslint .`, which reported many existing `no-undef`/`no-unused-vars` issues across the repository and therefore failed linting (ESLint reported ~448 problems).
- Ran frontend unit tests with `cd frontend && yarn test`, which failed in this environment due to a missing IndexedDB API and two Vitest failures in `tests/invoiceItemMethods.spec.js` (test environment limitations produced the failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958ae7dcba48326ad5c6e8485816efe)