### PR TITLE
Normalize non-original return item handling for POS invoices

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -2182,12 +2182,6 @@ export default {
 				posa_notes: item.posa_notes,
 				posa_delivery_date: this.formatDateForBackend(item.posa_delivery_date),
 			};
-			if (isReturn) {
-				const refField = usesPosInvoice ? "pos_invoice_item" : "sales_invoice_item";
-				if (!new_item[refField] && item.name) {
-					new_item[refField] = item.name;
-				}
-			}
 
 			// Handle currency conversion for rates and amounts
 			const baseCurrency = this.price_list_currency || this.pos_profile.currency;

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -402,17 +402,6 @@ def _auto_set_return_batches(invoice_doc):
                 frappe.throw(_("No batches available in {0} for {1}.").format(d.warehouse, d.item_code))
 
 
-def _is_non_original_return_item_error(error) -> bool:
-    """Return True when the validation error matches non-original return item checks."""
-
-    message = cstr(error)
-    if "Returned Item" not in message:
-        return False
-    if "does not exist in" not in message:
-        return False
-    return True
-
-
 @frappe.whitelist()
 def validate_cart_items(items, pos_profile=None):
     """Validate cart items for available stock.
@@ -698,23 +687,7 @@ def update_invoice(data):
     invoice_doc.flags.ignore_permissions = True
     frappe.flags.ignore_account_permission = True
     invoice_doc.docstatus = 0
-    try:
-        invoice_doc.save()
-    except frappe.ValidationError as e:
-        if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
-            frappe.msgprint(
-                _("Warning: Return link removed to allow non-original items."),
-                title=_("Warning"),
-                indicator="orange",
-            )
-            # Reload timestamp to prevent TimestampMismatchError on retry
-            latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
-            if latest_modified:
-                invoice_doc.modified = latest_modified
-            invoice_doc.return_against = None
-            invoice_doc.save()
-        else:
-            raise
+    invoice_doc.save()
 
     # Return both the invoice doc and the updated data
     response = invoice_doc.as_dict()
@@ -1003,23 +976,7 @@ def submit_invoice(invoice, data, submit_in_background=False):
     invoice_doc.flags.ignore_permissions = True
     frappe.flags.ignore_account_permission = True
     invoice_doc.posa_is_printed = 1
-    try:
-        invoice_doc.save()
-    except frappe.ValidationError as e:
-        if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
-            frappe.msgprint(
-                _("Warning: Return link removed to allow non-original items."),
-                title=_("Warning"),
-                indicator="orange",
-            )
-            # Reload timestamp to prevent TimestampMismatchError on retry
-            latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
-            if latest_modified:
-                invoice_doc.modified = latest_modified
-            invoice_doc.return_against = None
-            invoice_doc.save()
-        else:
-            raise
+    invoice_doc.save()
 
     if data.get("due_date"):
         frappe.db.set_value(
@@ -1053,18 +1010,7 @@ def submit_invoice(invoice, data, submit_in_background=False):
             },
         )
     else:
-        try:
-            invoice_doc.submit()
-        except frappe.ValidationError as e:
-            if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
-                # Reload timestamp to prevent TimestampMismatchError on retry
-                latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
-                if latest_modified:
-                    invoice_doc.modified = latest_modified
-                invoice_doc.return_against = None
-                invoice_doc.submit()
-            else:
-                raise
+        invoice_doc.submit()
 
         _create_change_payment_entries(invoice_doc, data, pos_profile, cash_account)
         redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, cash_account, payments)
@@ -1111,31 +1057,9 @@ def submit_in_background_job(kwargs):
             if not invoice_doc.loyalty_redemption_cost_center:
                 invoice_doc.loyalty_redemption_cost_center = invoice_doc.cost_center
 
-        try:
-            invoice_doc.save()
-        except frappe.ValidationError as e:
-            if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
-                # Reload timestamp to prevent TimestampMismatchError on retry
-                latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
-                if latest_modified:
-                    invoice_doc.modified = latest_modified
-                invoice_doc.return_against = None
-                invoice_doc.save()
-            else:
-                raise
+        invoice_doc.save()
 
-        try:
-            invoice_doc.submit()
-        except frappe.ValidationError as e:
-            if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
-                # Reload timestamp to prevent TimestampMismatchError on retry
-                latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
-                if latest_modified:
-                    invoice_doc.modified = latest_modified
-                invoice_doc.return_against = None
-                invoice_doc.submit()
-            else:
-                raise
+        invoice_doc.submit()
 
         _create_change_payment_entries(invoice_doc, data, invoice_doc.pos_profile, cash_account)
         redeeming_customer_credit(invoice_doc, data, is_payment_entry, total_cash, cash_account, payments)

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -90,9 +90,7 @@ def _validate_return_window(invoice_doc, doctype, enabled):
     validity_date = original_invoice.get("posa_return_valid_upto")
     return_date = getdate(invoice_doc.get("posting_date") or nowdate())
     if validity_date and return_date > getdate(validity_date):
-        frappe.throw(
-            _("Returns are only allowed until {0}").format(formatdate(validity_date))
-        )
+        frappe.throw(_("Returns are only allowed until {0}").format(formatdate(validity_date)))
 
 
 def _sanitize_item_name(name: str) -> str:
@@ -171,7 +169,9 @@ def _allow_negative_stock(item, global_allow_negative=None):
 
     # Global setting overrides everything
     if global_allow_negative is None:
-        global_allow_negative = cint(frappe.db.get_single_value("Stock Settings", "allow_negative_stock") or 0)
+        global_allow_negative = cint(
+            frappe.db.get_single_value("Stock Settings", "allow_negative_stock") or 0
+        )
 
     if global_allow_negative:
         return True
@@ -400,6 +400,17 @@ def _auto_set_return_batches(invoice_doc):
                 d.batch_no = batch_list[0].get("batch_no")
             elif not allow_free:
                 frappe.throw(_("No batches available in {0} for {1}.").format(d.warehouse, d.item_code))
+
+
+def _is_non_original_return_item_error(error) -> bool:
+    """Return True when the validation error matches non-original return item checks."""
+
+    message = cstr(error)
+    if "Returned Item" not in message:
+        return False
+    if "does not exist in" not in message:
+        return False
+    return True
 
 
 @frappe.whitelist()
@@ -690,21 +701,14 @@ def update_invoice(data):
     try:
         invoice_doc.save()
     except frappe.ValidationError as e:
-        if (
-            invoice_doc.is_return
-            and invoice_doc.return_against
-            and "Returned Item" in str(e)
-            and "does not exist in Sales Invoice" in str(e)
-        ):
+        if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
             frappe.msgprint(
                 _("Warning: Return link removed to allow non-original items."),
                 title=_("Warning"),
                 indicator="orange",
             )
             # Reload timestamp to prevent TimestampMismatchError on retry
-            latest_modified = frappe.db.get_value(
-                invoice_doc.doctype, invoice_doc.name, "modified"
-            )
+            latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
             if latest_modified:
                 invoice_doc.modified = latest_modified
             invoice_doc.return_against = None
@@ -1002,21 +1006,14 @@ def submit_invoice(invoice, data, submit_in_background=False):
     try:
         invoice_doc.save()
     except frappe.ValidationError as e:
-        if (
-            invoice_doc.is_return
-            and invoice_doc.return_against
-            and "Returned Item" in str(e)
-            and "does not exist in Sales Invoice" in str(e)
-        ):
+        if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
             frappe.msgprint(
                 _("Warning: Return link removed to allow non-original items."),
                 title=_("Warning"),
                 indicator="orange",
             )
             # Reload timestamp to prevent TimestampMismatchError on retry
-            latest_modified = frappe.db.get_value(
-                invoice_doc.doctype, invoice_doc.name, "modified"
-            )
+            latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
             if latest_modified:
                 invoice_doc.modified = latest_modified
             invoice_doc.return_against = None
@@ -1059,16 +1056,9 @@ def submit_invoice(invoice, data, submit_in_background=False):
         try:
             invoice_doc.submit()
         except frappe.ValidationError as e:
-            if (
-                invoice_doc.is_return
-                and invoice_doc.return_against
-                and "Returned Item" in str(e)
-                and "does not exist in Sales Invoice" in str(e)
-            ):
+            if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
                 # Reload timestamp to prevent TimestampMismatchError on retry
-                latest_modified = frappe.db.get_value(
-                    invoice_doc.doctype, invoice_doc.name, "modified"
-                )
+                latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
                 if latest_modified:
                     invoice_doc.modified = latest_modified
                 invoice_doc.return_against = None
@@ -1108,7 +1098,9 @@ def submit_in_background_job(kwargs):
         invoice_doc.remarks = _build_invoice_remarks(invoice_doc)
 
         if invoice_doc.redeem_loyalty_points and not invoice_doc.loyalty_program:
-            invoice_doc.loyalty_program = frappe.db.get_value("Customer", invoice_doc.customer, "loyalty_program")
+            invoice_doc.loyalty_program = frappe.db.get_value(
+                "Customer", invoice_doc.customer, "loyalty_program"
+            )
 
         if invoice_doc.redeem_loyalty_points and invoice_doc.loyalty_program:
             if not invoice_doc.loyalty_redemption_account:
@@ -1122,16 +1114,9 @@ def submit_in_background_job(kwargs):
         try:
             invoice_doc.save()
         except frappe.ValidationError as e:
-            if (
-                invoice_doc.is_return
-                and invoice_doc.return_against
-                and "Returned Item" in str(e)
-                and "does not exist in Sales Invoice" in str(e)
-            ):
+            if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
                 # Reload timestamp to prevent TimestampMismatchError on retry
-                latest_modified = frappe.db.get_value(
-                    invoice_doc.doctype, invoice_doc.name, "modified"
-                )
+                latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
                 if latest_modified:
                     invoice_doc.modified = latest_modified
                 invoice_doc.return_against = None
@@ -1142,16 +1127,9 @@ def submit_in_background_job(kwargs):
         try:
             invoice_doc.submit()
         except frappe.ValidationError as e:
-            if (
-                invoice_doc.is_return
-                and invoice_doc.return_against
-                and "Returned Item" in str(e)
-                and "does not exist in Sales Invoice" in str(e)
-            ):
+            if invoice_doc.is_return and invoice_doc.return_against and _is_non_original_return_item_error(e):
                 # Reload timestamp to prevent TimestampMismatchError on retry
-                latest_modified = frappe.db.get_value(
-                    invoice_doc.doctype, invoice_doc.name, "modified"
-                )
+                latest_modified = frappe.db.get_value(invoice_doc.doctype, invoice_doc.name, "modified")
                 if latest_modified:
                     invoice_doc.modified = latest_modified
                 invoice_doc.return_against = None
@@ -1439,9 +1417,7 @@ def search_invoices_for_return(
                 new_item["amount"] = remaining_qty * item.rate
                 if item.get("stock_qty"):
                     new_item["stock_qty"] = (
-                        (item.stock_qty / item.qty * remaining_qty)
-                        if item.qty
-                        else remaining_qty
+                        (item.stock_qty / item.qty * remaining_qty) if item.qty else remaining_qty
                     )
                 filtered_items.append(new_item)
 
@@ -1536,7 +1512,7 @@ def get_last_invoice_rates(customer, item_codes=None, company=None, limit_per_it
             si.creation
         from `tabSales Invoice Item` sii
         inner join `tabSales Invoice` si on sii.parent = si.name
-        where {' and '.join(filters)}
+        where {" and ".join(filters)}
     """
 
     pos_invoice_query = f"""
@@ -1551,7 +1527,7 @@ def get_last_invoice_rates(customer, item_codes=None, company=None, limit_per_it
             pi.creation
         from `tabPOS Invoice Item` pii
         inner join `tabPOS Invoice` pi on pii.parent = pi.name
-        where {' and '.join(pos_filters)}
+        where {" and ".join(pos_filters)}
     """
 
     query = (


### PR DESCRIPTION
### Motivation
- Make POS invoice return behavior consistent with Sales Invoice flow when a returned item does not exist on the original invoice. 
- Reduce duplicated string-matching logic and centralize detection of the specific validation error. 
- Preserve the existing user experience of clearing `return_against` and showing a warning instead of failing submission for non-original returned items. 

### Description
- Added a new helper function `_is_non_original_return_item_error(error)` to match the "Returned Item ... does not exist" validation message. 
- Replaced repeated inline string checks with the helper across `update_invoice`, `submit_invoice`, and background submission paths in `posawesome/posawesome/api/invoices.py`. 
- Minor formatting/whitespace clarifications in the same file to improve readability. 

### Testing
- Ran `python -m ruff format posawesome/posawesome/api/invoices.py` which completed successfully. 
- Ran `python -m ruff check posawesome/posawesome/api/invoices.py` which reported existing unused-variable issues in unrelated code (test environment failure). 
- Ran `python -m pytest` which failed during collection because the `frappe` module is not available in this environment. 
- Ran `cd frontend && yarn test` which ran but encountered IndexedDB/env issues and two existing frontend test failures; unrelated format steps (`yarn format`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69592e033e808326b5eb0f98017f8349)