### PR TITLE
perf: avoid forced re-renders in payments screen

### DIFF
--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -770,10 +770,8 @@ export default {
 		onInvoiceSelected(event) {
 			if (event && event.item && event.item.customer) {
 				useCustomersStore().setSelectedCustomer(event.item.customer);
-				// Force UI to update total calculations
-				this.$nextTick(() => {
-					this.$forceUpdate();
-				});
+				// Optimization: rely on Vue reactivity to update totals and selection UI.
+				// Avoiding $forceUpdate prevents full component re-renders on every row click.
 			}
 		},
 		get_outstanding_invoices() {
@@ -798,10 +796,7 @@ export default {
 					if (r.message) {
 						this.outstanding_invoices = r.message;
 						this.invoices_loading = false;
-						// Force refresh UI after data is loaded
-						this.$nextTick(() => {
-							this.$forceUpdate();
-						});
+						// Optimization: data table and totals reactively update without forcing a full re-render.
 					}
 				});
 		},
@@ -892,10 +887,7 @@ export default {
 
 				await this.get_outstanding_invoices();
 				await this.get_unallocated_payments();
-
-				this.$nextTick(() => {
-					this.$forceUpdate();
-				});
+				// Optimization: avoid $forceUpdate after data refresh to keep reconciliation fast on large lists.
 
 				if (this.auto_reconcile_summary) {
 					this.eventBus.emit("show_message", {
@@ -1159,7 +1151,6 @@ export default {
 			this.$nextTick(() => {
 				console.log("Selected invoices:", this.selected_invoices);
 				console.log("Total selected amount:", this.total_selected_invoices);
-				this.$forceUpdate();
 			});
 		},
 		isSelected(item) {


### PR DESCRIPTION
### Motivation
- The payments/checkout UI was forcing full component re-renders (`$forceUpdate`) on invoice selection and data refresh, causing sluggishness on large invoice/payment lists. 
- Removing manual re-renders lets Vue's reactivity update the DOM more selectively and reduces main-thread work during user interactions. 
- The change targets the hot path users hit during checkout/reconciliation where responsiveness matters most. 
- Expected outcome is noticeably improved UI responsiveness when selecting invoices or reconciling many payments.

### Description
- Removed explicit `this.$forceUpdate()` calls from `onInvoiceSelected`, `get_outstanding_invoices` and the auto-reconcile refresh path in `frontend/src/posapp/components/payments/Pay.vue`. 
- Kept informative inline comments explaining the optimization rationale so future maintainers understand why forced re-renders were removed. 
- Preserved existing behavior and data flow while relying on reactive updates from `selected_invoices`, `outstanding_invoices`, and related computed totals. 
- Expected impact: reduces full-component re-renders per user action (e.g., selecting/unselecting invoices), improving perceived latency on large lists.

### Testing
- Ran formatting with `pnpm --dir frontend format`, which completed successfully against the frontend codebase. 
- Ran lint with `pnpm --dir frontend exec eslint .`, which reported many existing linting issues unrelated to this change and therefore failed. 
- Ran unit tests with `pnpm --dir frontend test` (Vitest), which ran but failed due to the test environment missing IndexedDB and two existing unit test failures, so test suite did not fully pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959350d48488326880b83e021930525)