### PR TITLE
Disable auto-print when opening print preview in new tab

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1973,7 +1973,7 @@ export default {
 					encodeURIComponent(doctype) +
 					"&name=" +
 					this.invoice_doc.name +
-					"&trigger_print=1" +
+					"&trigger_print=0" +
 					"&format=" +
 					print_format;
 


### PR DESCRIPTION
### Motivation

- Prevent the print dialog from auto-triggering when users open the print preview in a new browser tab via the POS settings. 
- Keep the existing silent and inline print flows unchanged while making `pos_profile.posa_open_print_in_new_tab` open a preview only. 
- Reduce surprising behavior for users who expect to review the preview before printing. 

### Description

- Update `frontend/src/posapp/components/pos/Payments.vue` to set `trigger_print=0` for the `newTabUrl` used when `pos_profile.posa_open_print_in_new_tab` is true. 
- Preserve existing behavior for the normal print URL (keeps `trigger_print=1`) and for `silentPrint`/`watchPrintWindow` flows. 

### Testing

- Ran `yarn format`, which completed successfully. 
- Ran `yarn eslint frontend/src`, which failed due to existing lint errors in the repository (pre-existing issues unrelated to this change). 
- Ran `yarn --cwd frontend test` (`vitest`), which executed the test suite but had failures: 2 tests failed in `tests/invoiceItemMethods.spec.js` and the test logs show IndexedDB/Dexie errors in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594c8b5fc883269009f7176c62c7f1)