### PR TITLE
Keep additional discount fields from clearing on focus/blur

### DIFF
--- a/frontend/src/posapp/components/pos/InvoiceSummary.vue
+++ b/frontend/src/posapp/components/pos/InvoiceSummary.vue
@@ -273,20 +273,28 @@ export default {
 	watch: {
 		additional_discount(value) {
 			if (!this.isEditingAdditionalDiscount) {
-				this.additionalDiscountDisplay = value;
+				this.additionalDiscountDisplay = this.normalizeDiscountDisplay(value);
 			}
 		},
 		additional_discount_percentage(value) {
 			if (!this.isEditingAdditionalDiscountPercentage) {
-				this.additionalDiscountPercentageDisplay = value;
+				this.additionalDiscountPercentageDisplay = this.normalizeDiscountDisplay(value);
 			}
 		},
 	},
 	created() {
-		this.additionalDiscountDisplay = this.additional_discount;
-		this.additionalDiscountPercentageDisplay = this.additional_discount_percentage;
+		this.additionalDiscountDisplay = this.normalizeDiscountDisplay(this.additional_discount);
+		this.additionalDiscountPercentageDisplay = this.normalizeDiscountDisplay(
+			this.additional_discount_percentage,
+		);
 	},
 	methods: {
+		normalizeDiscountDisplay(value) {
+			if (value === 0 || value === "0") {
+				return "";
+			}
+			return value;
+		},
 		// Debounced handlers for better performance
 		handleAdditionalDiscountUpdate(value) {
 			this.$emit("update:additional_discount", value);

--- a/frontend/src/posapp/components/pos/InvoiceSummary.vue
+++ b/frontend/src/posapp/components/pos/InvoiceSummary.vue
@@ -239,12 +239,8 @@ export default {
 			paymentLoading: false,
 			additionalDiscountDisplay: null,
 			additionalDiscountPercentageDisplay: null,
-			previousAdditionalDiscount: null,
-			previousAdditionalDiscountPercentage: null,
 			isEditingAdditionalDiscount: false,
 			isEditingAdditionalDiscountPercentage: false,
-			isAdditionalDiscountDirty: false,
-			isAdditionalDiscountPercentageDirty: false,
 		};
 	},
 	emits: [
@@ -293,21 +289,14 @@ export default {
 	methods: {
 		// Debounced handlers for better performance
 		handleAdditionalDiscountUpdate(value) {
-			this.isAdditionalDiscountDirty = true;
 			this.$emit("update:additional_discount", value);
 		},
 
 		handleAdditionalDiscountFocus() {
 			this.isEditingAdditionalDiscount = true;
-			this.isAdditionalDiscountDirty = false;
-			this.previousAdditionalDiscount = this.additional_discount;
-			this.additionalDiscountDisplay = "";
 		},
 
 		handleAdditionalDiscountBlur() {
-			if (!this.isAdditionalDiscountDirty) {
-				this.$emit("update:additional_discount", this.previousAdditionalDiscount);
-			}
 			this.isEditingAdditionalDiscount = false;
 		},
 
@@ -321,24 +310,14 @@ export default {
 		},
 
 		handleAdditionalDiscountPercentageUpdate(value) {
-			this.isAdditionalDiscountPercentageDirty = true;
 			this.$emit("update:additional_discount_percentage", value);
 		},
 
 		handleAdditionalDiscountPercentageFocus() {
 			this.isEditingAdditionalDiscountPercentage = true;
-			this.isAdditionalDiscountPercentageDirty = false;
-			this.previousAdditionalDiscountPercentage = this.additional_discount_percentage;
-			this.additionalDiscountPercentageDisplay = "";
 		},
 
 		handleAdditionalDiscountPercentageBlur() {
-			if (!this.isAdditionalDiscountPercentageDirty) {
-				this.$emit(
-					"update:additional_discount_percentage",
-					this.previousAdditionalDiscountPercentage,
-				);
-			}
 			this.isEditingAdditionalDiscountPercentage = false;
 		},
 


### PR DESCRIPTION
### Motivation
- Prevent additional discount inputs from being cleared or auto-restored when users focus/blur the field so edits are preserved.
- Simplify edit-state management for the amount and percentage inputs to reduce unexpected UI behavior.
- Make the display values follow the underlying props while the user is editing without forcing empty/previous values on focus/blur.

### Description
- Updated `frontend/src/posapp/components/pos/InvoiceSummary.vue` to stop clearing the discount inputs on focus and to stop restoring previous values on blur.
- Removed the `previousAdditionalDiscount`, `previousAdditionalDiscountPercentage`, `isAdditionalDiscountDirty`, and `isAdditionalDiscountPercentageDirty` state variables and related logic.
- Kept the existing watchers and `created` initialization to sync `additionalDiscountDisplay` and `additionalDiscountPercentageDisplay` with the incoming props.
- Update handlers still emit `update:additional_discount` and `update:additional_discount_percentage` as before.

### Testing
- Ran `cd frontend && yarn format` and formatting completed successfully.
- Ran `cd frontend && npx eslint .` which failed due to existing repo-wide lint errors unrelated to this change.
- Ran `cd frontend && yarn test` (Vitest) and the suite reported 2 failing tests and environment errors (IndexedDB missing / Dexie errors and a mock missing an export), so the test suite did not fully pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695954f923a0832682a19f8dfa56c76d)