### PR TITLE
ItemsSelector: observe container resize to fix zoom/layout breakage (#2693)

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -731,6 +731,7 @@ export default {
 		selectorContainerWidth: 0,
 		selectorContainerHeight: 0,
 		resizeObserver: null,
+		observedItemsContainer: null,
 		virtualScrollPending: false,
 		metricsRaf: null,
 		// Fixed page size for incremental item loading to avoid
@@ -988,6 +989,18 @@ export default {
 		},
 		items_view() {
 			this.$nextTick(() => {
+				if (this.resizeObserver) {
+					const itemsEl = this.getItemsContainerElement();
+					if (this.observedItemsContainer && this.observedItemsContainer !== itemsEl) {
+						this.resizeObserver.unobserve(this.observedItemsContainer);
+						this.observedItemsContainer = null;
+					}
+					if (itemsEl && this.observedItemsContainer !== itemsEl) {
+						this.resizeObserver.observe(itemsEl);
+						this.observedItemsContainer = itemsEl;
+						this.handleItemsContainerResize();
+					}
+				}
 				if (this.items_view === "card") {
 					this.checkItemContainerOverflow();
 					this.scheduleCardMetricsUpdate();
@@ -1226,6 +1239,28 @@ export default {
 			const ref = this.$refs.selectorContainer;
 			return ref && ref.$el ? ref.$el : ref;
 		},
+		getItemsContainerElement() {
+			const ref = this.$refs.itemsContainer;
+			return ref && ref.$el ? ref.$el : ref;
+		},
+		updateItemsContainerWidth(rect) {
+			let width = rect?.width;
+			if (!width) {
+				const el = this.getItemsContainerElement();
+				if (!el || typeof el.getBoundingClientRect !== "function") {
+					return false;
+				}
+				width = el.getBoundingClientRect().width;
+			}
+
+			const roundedWidth = Math.round(width);
+			if (roundedWidth !== Math.round(this.cardContainerWidth)) {
+				this.cardContainerWidth = width;
+				return true;
+			}
+
+			return false;
+		},
 		updateSelectorContainerDimensions(rect) {
 			let width = rect?.width;
 			let height = rect?.height;
@@ -1260,21 +1295,42 @@ export default {
 				this.scheduleCardMetricsUpdate();
 			}
 		},
+		handleItemsContainerResize(rect) {
+			const updated = this.updateItemsContainerWidth(rect);
+			if (updated) {
+				this.scheduleCardMetricsUpdate();
+			}
+		},
 		setupResizeObserver() {
 			if (typeof ResizeObserver !== "undefined") {
 				const debouncedResizeHandler = _.debounce((entries) => {
+					const selectorEl = this.getSelectorContainerElement();
+					const itemsEl = this.getItemsContainerElement();
 					for (const entry of entries) {
 						// Benchmark: ~60fps throttle to avoid resize/layout thrash.
-						this.handleContainerResize(entry.contentRect);
+						if (itemsEl && entry.target === itemsEl) {
+							this.handleItemsContainerResize(entry.contentRect);
+						} else if (selectorEl && entry.target === selectorEl) {
+							this.handleContainerResize(entry.contentRect);
+						} else {
+							this.handleContainerResize(entry.contentRect);
+							this.handleItemsContainerResize(entry.contentRect);
+						}
 					}
 				}, 16);
 
 				this.resizeObserver = new ResizeObserver(debouncedResizeHandler);
 				this.$nextTick(() => {
-					const el = this.getSelectorContainerElement();
-					if (el) {
-						this.resizeObserver.observe(el);
+					const selectorEl = this.getSelectorContainerElement();
+					if (selectorEl) {
+						this.resizeObserver.observe(selectorEl);
 						this.handleContainerResize();
+					}
+					const itemsEl = this.getItemsContainerElement();
+					if (itemsEl) {
+						this.resizeObserver.observe(itemsEl);
+						this.observedItemsContainer = itemsEl;
+						this.handleItemsContainerResize();
 					}
 				});
 			} else {
@@ -1283,6 +1339,10 @@ export default {
 		},
 		cleanupResizeObserver() {
 			if (this.resizeObserver) {
+				if (this.observedItemsContainer) {
+					this.resizeObserver.unobserve(this.observedItemsContainer);
+					this.observedItemsContainer = null;
+				}
 				this.resizeObserver.disconnect();
 				this.resizeObserver = null;
 			} else {
@@ -1442,7 +1502,9 @@ export default {
 				return;
 			}
 
-			const containerHeight = parseFloat(getComputedStyle(el).getPropertyValue("--container-height"));
+			const containerHeight =
+				this.selectorContainerHeight ||
+				parseFloat(getComputedStyle(el).getPropertyValue("--container-height"));
 			if (isNaN(containerHeight)) {
 				this.isOverflowing = false;
 				return;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -29,6 +29,7 @@
 				'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable pos-themed-card',
 				rtlClasses,
 			]"
+			ref="selectorContainer"
 			:style="{
 				height: responsiveStyles['--container-height'],
 				maxHeight: responsiveStyles['--container-height'],
@@ -727,6 +728,9 @@ export default {
 		// Prevent repeated server fetches when local storage is empty
 		fallbackAttempted: false,
 		cardContainerWidth: 0,
+		selectorContainerWidth: 0,
+		selectorContainerHeight: 0,
+		resizeObserver: null,
 		virtualScrollPending: false,
 		metricsRaf: null,
 		// Fixed page size for incremental item loading to avoid
@@ -1217,6 +1221,73 @@ export default {
 					this.cardContainerWidth = width;
 				}
 			});
+		},
+		getSelectorContainerElement() {
+			const ref = this.$refs.selectorContainer;
+			return ref && ref.$el ? ref.$el : ref;
+		},
+		updateSelectorContainerDimensions(rect) {
+			let width = rect?.width;
+			let height = rect?.height;
+			if (!width || !height) {
+				const el = this.getSelectorContainerElement();
+				if (!el || typeof el.getBoundingClientRect !== "function") {
+					return false;
+				}
+				const bounds = el.getBoundingClientRect();
+				width = bounds.width;
+				height = bounds.height;
+			}
+
+			const roundedWidth = Math.round(width);
+			const roundedHeight = Math.round(height);
+			if (
+				roundedWidth !== Math.round(this.selectorContainerWidth) ||
+				roundedHeight !== Math.round(this.selectorContainerHeight)
+			) {
+				this.selectorContainerWidth = width;
+				this.selectorContainerHeight = height;
+				return true;
+			}
+
+			return false;
+		},
+		handleContainerResize(rect) {
+			const updated = this.updateSelectorContainerDimensions(rect);
+			if (updated) {
+				this.itemsPerPage = this.items_per_page;
+				this.checkItemContainerOverflow();
+				this.scheduleCardMetricsUpdate();
+			}
+		},
+		setupResizeObserver() {
+			if (typeof ResizeObserver !== "undefined") {
+				const debouncedResizeHandler = _.debounce((entries) => {
+					for (const entry of entries) {
+						// Benchmark: ~60fps throttle to avoid resize/layout thrash.
+						this.handleContainerResize(entry.contentRect);
+					}
+				}, 16);
+
+				this.resizeObserver = new ResizeObserver(debouncedResizeHandler);
+				this.$nextTick(() => {
+					const el = this.getSelectorContainerElement();
+					if (el) {
+						this.resizeObserver.observe(el);
+						this.handleContainerResize();
+					}
+				});
+			} else {
+				window.addEventListener("resize", this.handleContainerResize);
+			}
+		},
+		cleanupResizeObserver() {
+			if (this.resizeObserver) {
+				this.resizeObserver.disconnect();
+				this.resizeObserver = null;
+			} else {
+				window.removeEventListener("resize", this.handleContainerResize);
+			}
 		},
 		async onVirtualRangeUpdate(_startIndex, _endIndex, _visibleStartIndex, visibleEndIndex) {
 			const total = this.displayedItems ? this.displayedItems.length : 0;
@@ -4363,38 +4434,41 @@ export default {
 		headers() {
 			return this.getItemsHeaders();
 		},
+		responsiveWidth() {
+			return this.selectorContainerWidth || this.cardContainerWidth || this.windowWidth;
+		},
 		cardColumns() {
-			if (this.windowWidth <= 768) {
+			if (this.responsiveWidth <= 768) {
 				return 1;
 			}
-			if (this.windowWidth <= 1200) {
+			if (this.responsiveWidth <= 1200) {
 				return 2;
 			}
 			return 3;
 		},
 		cardGap() {
-			if (this.windowWidth <= 768) {
+			if (this.responsiveWidth <= 768) {
 				return 10;
 			}
-			if (this.windowWidth <= 1200) {
+			if (this.responsiveWidth <= 1200) {
 				return 12;
 			}
 			return 16;
 		},
 		cardPadding() {
-			if (this.windowWidth <= 768) {
+			if (this.responsiveWidth <= 768) {
 				return 10;
 			}
-			if (this.windowWidth <= 1200) {
+			if (this.responsiveWidth <= 1200) {
 				return 12;
 			}
 			return 16;
 		},
 		cardRowHeight() {
-			if (this.windowWidth <= 768) {
+			if (this.responsiveWidth <= 768) {
 				return 260;
 			}
-			if (this.windowWidth <= 1200) {
+			if (this.responsiveWidth <= 1200) {
 				return 280;
 			}
 			return 300;
@@ -4728,7 +4802,7 @@ export default {
 
 		// Apply the configured items per page on mount
 		this.itemsPerPage = this.items_per_page;
-		window.addEventListener("resize", this.checkItemContainerOverflow);
+		this.setupResizeObserver();
 		this.$nextTick(() => {
 			this.checkItemContainerOverflow();
 			this.scheduleCardMetricsUpdate();
@@ -4801,7 +4875,7 @@ export default {
 		this.eventBus.off("focus_item_search");
 		this.eventBus.off("select_top_item");
 		this.eventBus.off("toggle_item_selector_settings");
-		window.removeEventListener("resize", this.checkItemContainerOverflow);
+		this.cleanupResizeObserver();
 		if (this.metricsRaf) {
 			cancelAnimationFrame(this.metricsRaf);
 			this.metricsRaf = null;


### PR DESCRIPTION
### Motivation
- The ItemsSelector layout did not react to container size changes (zoom, side panels, dialog resize) and produced misaligned card/grid layouts.
- The ItemsTable component already uses a container-aware resize approach; ItemsSelector should mirror that behavior to remain layout-stable.
- Recompute layout metrics (columns, card width, visible rows / virtualization) from the actual container to avoid stale measurements.
- Keep the change minimal and compatible with the existing Vue + Vuetify codebase and performance profile.

### Description
- Added a `ref="selectorContainer"` and reactive fields `selectorContainerWidth`, `selectorContainerHeight`, and `resizeObserver` to the component state.
- Implemented `setupResizeObserver`, `cleanupResizeObserver`, `handleContainerResize`, and `updateSelectorContainerDimensions` to observe the selector container via `ResizeObserver` (debounced with `_.debounce`) and fall back to `resize` events.
- Introduced `responsiveWidth` (prefers `selectorContainerWidth`) and switched card layout breakpoints (`cardColumns`, `cardGap`, `cardPadding`, `cardRowHeight`) to use it so columns/cards are recomputed from the container size.
- Wire-up observer lifecycle: start in `mounted()` (`setupResizeObserver`) and clean in `beforeUnmount()` (`cleanupResizeObserver`), and trigger `checkItemContainerOverflow`, `scheduleCardMetricsUpdate`, and `itemsPerPage` refresh on container changes.

### Testing
- Ran `yarn --cwd frontend format`, which completed successfully.
- Ran `yarn --cwd frontend eslint .`, which failed due to existing repository lint issues unrelated to this change (pre-existing errors across multiple files).
- Ran `yarn --cwd frontend test`, which failed in this environment due to missing IndexedDB API and a couple of existing unit test failures unrelated to the resize logic.
- Note: manual verification recommended (open POS, change browser zoom to 90/80/110% and toggle side panels) to confirm the ItemsSelector grid/list remains aligned and virtualization/scrolling behave correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a226973788326a13207e8117b6b5b)