### PR TITLE
Refresh item caches on online reload

### DIFF
--- a/frontend/src/offline/index.js
+++ b/frontend/src/offline/index.js
@@ -109,6 +109,7 @@ export {
 	getCachedPriceListItems,
 	clearPriceListCache,
 	saveItemDetailsCache,
+	clearItemDetailsCache,
 	getCachedItemDetails,
 	saveItemsBulk,
 	getAllStoredItems,

--- a/frontend/src/offline/items.js
+++ b/frontend/src/offline/items.js
@@ -159,6 +159,36 @@ export function saveItemDetailsCache(profileName, priceList, items) {
 	}
 }
 
+export function clearItemDetailsCache(profileName = null, priceList = null) {
+	try {
+		const cache = memory.item_details_cache || {};
+
+		if (!profileName) {
+			memory.item_details_cache = {};
+			persist("item_details_cache", memory.item_details_cache);
+			return;
+		}
+
+		if (!cache[profileName]) {
+			return;
+		}
+
+		if (!priceList) {
+			delete cache[profileName];
+		} else if (cache[profileName][priceList]) {
+			delete cache[profileName][priceList];
+			if (Object.keys(cache[profileName]).length === 0) {
+				delete cache[profileName];
+			}
+		}
+
+		memory.item_details_cache = cache;
+		persist("item_details_cache", memory.item_details_cache);
+	} catch (e) {
+		console.error("Failed to clear item details cache", e);
+	}
+}
+
 export async function getCachedItemDetails(profileName, priceList, itemCodes, ttl = 15 * 60 * 1000) {
 	try {
 		const cache = memory.item_details_cache || {};

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -609,6 +609,7 @@ import {
 	clearStoredItems,
 	getLocalStockCache,
 	setLocalStockCache,
+	clearLocalStockCache,
 	initPromise,
 	memoryInitPromise,
 	checkDbHealth,
@@ -619,6 +620,7 @@ import {
 	isStockCacheReady,
 	getCachedItemDetails,
 	saveItemDetailsCache,
+	clearItemDetailsCache,
 	saveItemGroups,
 	getCachedItemGroups,
 	getItemsLastSync,
@@ -1741,13 +1743,25 @@ export default {
 			});
 		},
 		async forceReloadItems() {
+			if (isOffline()) {
+				frappe.msgprint(__("Cannot reload items while offline."));
+				return;
+			}
+
 			console.log("[ItemsSelector] forceReloadItems called");
-			// Clear cached price list items so the reload always
-			// fetches the latest data from the server
-			await clearPriceListCache();
-			console.log("[ItemsSelector] price list cache cleared");
 			await this.ensureStorageHealth();
 			console.log("[ItemsSelector] storage health ensured");
+
+			if (typeof this.clearAllCaches === "function") {
+				await this.clearAllCaches();
+			}
+
+			await clearStoredItems();
+			await clearPriceListCache();
+			clearLocalStockCache();
+			clearItemDetailsCache(this.pos_profile?.name, this.active_price_list);
+			setItemsLastSync(null);
+			console.log("[ItemsSelector] item caches cleared");
 
 			// When no search term is entered, reset the search so
 			// we fetch the entire item list from the server.
@@ -1759,6 +1773,11 @@ export default {
 
 			console.log("[ItemsSelector] loading items from server");
 			await this.get_items(true);
+
+			if (Array.isArray(this.displayedItems) && this.displayedItems.length) {
+				// Benchmark: refresh visible item details only to avoid large payloads on full reload.
+				await this.update_items_details(this.displayedItems, { forceRefresh: true });
+			}
 			console.log("[ItemsSelector] forceReloadItems finished");
 		},
 		async verifyServerItemCount() {


### PR DESCRIPTION
### Motivation

- Implement a full online-only reload so clicking reload refreshes items, stock and price-list rates and replaces stale cache entries. 
- Ensure the UI shows new rates/stock after reload by repopulating item detail caches for visible items. 
- Prevent cache-reset reload when offline to avoid data loss and user confusion. 
- Keep the reload work scoped to visible items where possible for performance.

### Description

- Added `clearItemDetailsCache(profileName, priceList)` in `frontend/src/offline/items.js` and exported it from `frontend/src/offline/index.js` to allow targeted clearing of cached item detail entries. 
- Updated `ItemsSelector.vue` to block reload when `isOffline()` and, when online, to call `clearAllCaches()` (if available) and then `clearStoredItems()`, `clearPriceListCache()`, `clearLocalStockCache()`, `clearItemDetailsCache(this.pos_profile?.name, this.active_price_list)`, and `setItemsLastSync(null)` before fetching fresh items. 
- After fetching from server the code refreshes visible item details via `update_items_details(this.displayedItems, { forceRefresh: true })` to repopulate caches with current rates and stock. 
- Minor performance note added to refresh only visible item details to avoid large payloads on full reload.

### Testing

- Ran code formatting with `yarn format` which succeeded. 
- Ran linting with `yarn -s eslint frontend/src` which reported existing repo-wide lint issues (vendor files and missing globals) and is not failing due to these changes. 
- Ran unit tests with `yarn --cwd frontend test` (Vitest) where 25 tests were executed, 23 passed and 2 failed, with failures related to environment constraints (IndexedDB API missing) and existing test mocks in `invoiceItemMethods.spec.js`. 
- Manual console messages added in `forceReloadItems` to help observe cache clearing and reload flow during runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b4db612888326af4a7187cb0b1d55)