### PR TITLE
Always expand rows for batch-only items (auto-expand fix)

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1192,7 +1192,7 @@ export default {
 
 		new_item.posa_row_id = this.makeid(20);
 
-		if ((!this.pos_profile.posa_auto_set_batch && new_item.has_batch_no) || new_item.has_serial_no) {
+		if (new_item.has_batch_no || new_item.has_serial_no) {
 			// Store only the item's row ID for the expanded state
 			this.expanded.push(new_item.posa_row_id);
 		}

--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -36,6 +36,8 @@ export function useItemAddition() {
 		}, contextLabel);
 	};
 
+	const shouldExpandItemRow = (item) => Boolean(item?.has_serial_no || item?.has_batch_no);
+
 	// PERF: maintain an O(1) lookup map for mergeable lines to avoid repeated O(n) scans when 100+ items are added
 	const shouldIndexItem = (entry) =>
 		entry && !entry.posa_is_offer && !entry.posa_is_replace && Number.parseFloat(entry.qty) > 0;
@@ -352,7 +354,7 @@ export function useItemAddition() {
 					}
 				}
 
-				if ((!context.pos_profile.posa_auto_set_batch && item.has_batch_no) || item.has_serial_no) {
+				if (shouldExpandItemRow(item)) {
 					nextTick(() => {
 						context.expanded = [item.posa_row_id];
 					});
@@ -755,10 +757,7 @@ export function useItemAddition() {
 		}
 
 		// Only try to expand if new_item exists and should be expanded
-		if (
-			new_item &&
-			((!context.pos_profile.posa_auto_set_batch && new_item.has_batch_no) || new_item.has_serial_no)
-		) {
+		if (new_item && shouldExpandItemRow(new_item)) {
 			context.expanded = [new_item.posa_row_id];
 		}
 	});
@@ -852,7 +851,7 @@ export function useItemAddition() {
 			new_item.serial_no_selected_count = 0;
 		}
 		// Expand row if batch/serial required
-		if ((!context.pos_profile.posa_auto_set_batch && new_item.has_batch_no) || new_item.has_serial_no) {
+		if (shouldExpandItemRow(new_item)) {
 			// Only store the row ID to keep expanded array consistent
 			context.expanded.push(new_item.posa_row_id);
 		}


### PR DESCRIPTION
### Motivation
- Ensure items that require batch selection expand their invoice row so users can choose a batch even when auto-set batch is enabled.
- The previous logic only auto-expanded rows for serial-number items, causing batch-only items with available batches to stay collapsed.

### Description
- Add a shared helper `shouldExpandItemRow` in `useItemAddition.js` that returns true when `has_batch_no` or `has_serial_no` is set.
- Replace the scattered conditional checks with `shouldExpandItemRow` so newly added items and offer-added items auto-expand when appropriate.
- Update `frontend/src/posapp/components/pos/invoiceOfferMethods.js` to match the same expansion behavior.
- Run format and lint fixes for the touched files.

### Testing
- Ran `yarn --cwd frontend format` which completed successfully.
- Ran `npx eslint frontend/src/posapp/composables/useItemAddition.js frontend/src/posapp/components/pos/invoiceOfferMethods.js` which executed (no lint errors reported for the modified files).
- Ran `yarn --cwd frontend test`, which started the test suite but overall failed due to environment and unit test issues; IndexedDB API is missing in the test environment and two unit tests in `tests/invoiceItemMethods.spec.js` failed (mocked `evaluatePricingRules` export missing and `__` translation helper undefined).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba953a0948326bc914b3d476b9772)