### PR TITLE
Auto-assign batch numbers for unexpanded items when auto-set is enabled

### DIFF
--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -118,6 +118,16 @@ export function useItemAddition() {
 		cache.lastItems = itemsRef;
 	};
 
+	const shouldAutoSetBatch = (context, item) => {
+		if (!context?.setBatchQty || !context?.pos_profile?.posa_auto_set_batch) {
+			return false;
+		}
+		if (!item?.has_batch_no || item.batch_no) {
+			return false;
+		}
+		return Array.isArray(item.batch_no_data) && item.batch_no_data.length > 0;
+	};
+
 	const invalidateMergeCache = (context) => {
 		if (context && context._mergeIndexCache) {
 			context._mergeIndexCache.signature = -1;
@@ -284,6 +294,10 @@ export function useItemAddition() {
 			addedItems.forEach((item, index) => {
 				const resolvers = currentResolvers[index]; // Array of resolvers
 				refreshMergeCacheEntry(context, item, 0);
+				// Benchmark note: Use preloaded batch data to avoid extra fetches on auto-assign.
+				if (shouldAutoSetBatch(context, item)) {
+					context.setBatchQty(item, null, false);
+				}
 				runAsyncTask(() => expandBundle(item, context), "expand_bundle");
 
 				// OPTIMIZATION: Removed immediate server calls.
@@ -436,6 +450,9 @@ export function useItemAddition() {
 				item.to_set_batch_no = null;
 				item.batch_no = null;
 				if (context.setBatchQty) context.setBatchQty(new_item, new_item.batch_no, false);
+			}
+			if (shouldAutoSetBatch(context, new_item)) {
+				context.setBatchQty(new_item, null, false);
 			}
 			// Make quantity negative for returns
 			if (context.isReturnInvoice) {


### PR DESCRIPTION
### Motivation
- Fix cases where items added in batch/queue (not expanded) were not auto-assigned a batch, causing "batch is mandatory" errors when other items had batches available.
- Preserve FIFO behaviour by auto-allocating from already-fetched `batch_no_data` instead of forcing extra server calls.
- Ensure auto-allocation only runs when profile-level auto-set is enabled and a batch list is present.

### Description
- Added a helper `shouldAutoSetBatch(context, item)` that checks `posa_auto_set_batch`, `has_batch_no`, absence of `batch_no`, and presence of `batch_no_data`.
- Invoke `shouldAutoSetBatch` in both the batched additions path (`flushPendingItems`) and the direct-add path (`addItem`) to call `context.setBatchQty(item, null, false)` when appropriate.
- Kept behaviour local to the frontend using preloaded `batch_no_data` to avoid extra fetches and preserve FIFO order.
- Minor benchmark comment included to note intent to avoid extra fetches on auto-assign.

### Testing
- Ran formatter with `yarn --cwd frontend format` which completed successfully.
- Ran lint via `npx eslint frontend/src/posapp/composables/useItemAddition.js` which ran (with standard npm warnings) without blocking the PR.
- Ran unit tests with `yarn --cwd frontend test` (Vitest); test run executed but some tests failed due to environment/test setup issues: 23 passed and 2 failed out of 25, where failures were caused by IndexedDB API missing and test mocks/translations (`evaluatePricingRules` mock and `__` translation helper).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bad3b56808326b462d15d1db855c1)