### PR TITLE
Auto-assign batch numbers during bulk item detail refreshes

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceItemMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceItemMethods.js
@@ -3521,6 +3521,16 @@ export default {
 					item.allow_negative_stock = updated_item.allow_negative_stock;
 					item.batch_no_data = updated_item.batch_no_data;
 					item.serial_no_data = updated_item.serial_no_data;
+					// Benchmark note: Apply auto-batch assignment during bulk updates to avoid extra UI expand cycles.
+					if (
+						item.has_batch_no &&
+						this.pos_profile?.posa_auto_set_batch &&
+						!item.batch_no &&
+						Array.isArray(item.batch_no_data) &&
+						item.batch_no_data.length > 0
+					) {
+						this.set_batch_qty(item, null, false);
+					}
 
 					if (updated_item.price_list_currency) {
 						item.price_list_currency = updated_item.price_list_currency;


### PR DESCRIPTION
### Motivation
- Fix the submit-time error complaining `Serial No / Batch No are mandatory for Item` when a batch-enabled item is added but its row was not expanded for manual batch selection. 
- The POS has an auto-set-batch option (`posa_auto_set_batch`) that should automatically allocate a batch when batch data is available, including during bulk/detail refreshes. 
- Avoid forcing users to expand rows to prevent missing batch assignments and reduce friction during invoice submission. 

### Description
- In `frontend/src/posapp/components/pos/invoiceItemMethods.js` inside `update_items_details`, added a conditional that calls `this.set_batch_qty(item, null, false)` when `item.has_batch_no` is true, `posa_auto_set_batch` is enabled, `item.batch_no` is empty and `item.batch_no_data` is available. 
- Included a short benchmark comment explaining why auto-assignment is applied during bulk updates to avoid extra UI expand cycles. 
- The change performs batch assignment during background/bulk item detail refresh rather than relying only on row expansion logic. 

### Testing
- Ran formatting with `cd frontend && yarn format`, which completed successfully. 
- Ran lint with `cd frontend && npx eslint .`, which reported existing repository lint errors unrelated to this change (run failed). 
- Ran unit tests with `cd frontend && yarn test --run` (Vitest), which executed tests but the run failed due to environment limitations (`IndexedDB API missing`) and two existing test failures in `invoiceItemMethods` related to mocks. 
- Verified that the modified path was exercised by the test run and no new runtime exceptions were introduced by the change itself (test failures are pre-existing/mocking/environmental).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c8c9a5e048326a899e7de294602ee)