### PR TITLE
Auto-assign batch numbers for outgoing invoices on submit

### DIFF
--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -402,6 +402,37 @@ def _auto_set_return_batches(invoice_doc):
                 frappe.throw(_("No batches available in {0} for {1}.").format(d.warehouse, d.item_code))
 
 
+def _auto_set_outgoing_batches(invoice_doc):
+    """Automatically set batch numbers for outgoing invoice items."""
+
+    if not invoice_doc or invoice_doc.is_return:
+        return
+
+    pos_profile = invoice_doc.get("pos_profile")
+    if not pos_profile:
+        return
+
+    auto_set = cint(frappe.get_cached_value("POS Profile", pos_profile, "posa_auto_set_batch") or 0)
+    if not auto_set:
+        return
+
+    for d in invoice_doc.items:
+        qty = d.get("stock_qty") or d.get("transfer_qty") or d.get("qty") or 0
+        if flt(qty) <= 0:
+            continue
+        if d.get("batch_no"):
+            continue
+        warehouse = d.get("warehouse")
+        if not warehouse:
+            continue
+        has_batch = frappe.get_cached_value("Item", d.item_code, "has_batch_no")
+        if not cint(has_batch):
+            continue
+
+        # Benchmark note: assign batch numbers server-side to avoid UI expand-only auto-selection.
+        d.batch_no = get_batch_no(d.item_code, warehouse, qty, True, d.get("serial_no"))
+
+
 @frappe.whitelist()
 def validate_cart_items(items, pos_profile=None):
     """Validate cart items for available stock.
@@ -966,6 +997,7 @@ def submit_invoice(invoice, data, submit_in_background=False):
     payments = invoice_doc.payments
 
     _auto_set_return_batches(invoice_doc)
+    _auto_set_outgoing_batches(invoice_doc)
 
     # if frappe.get_value("POS Profile", invoice_doc.pos_profile, "posa_auto_set_batch"):
     #     set_batch_nos(invoice_doc, "warehouse", throw=True)
@@ -1037,6 +1069,7 @@ def submit_in_background_job(kwargs):
         frappe.flags.ignore_account_permission = True
 
         # Re-run validations that may be impacted while queued (stock, credit limits)
+        _auto_set_outgoing_batches(invoice_doc)
         _validate_stock_on_invoice(invoice_doc)
         if hasattr(invoice_doc, "validate_credit_limit"):
             invoice_doc.validate_credit_limit()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -436,7 +436,7 @@ def _auto_set_outgoing_batches(invoice_doc):
 def _resolve_batch_no(item_code, warehouse, qty, serial_no=None):
     """Resolve batch number across ERPNext signature variants."""
     try:
-        return get_batch_no(
+        batch_no = get_batch_no(
             {
                 "item_code": item_code,
                 "warehouse": warehouse,
@@ -446,7 +446,20 @@ def _resolve_batch_no(item_code, warehouse, qty, serial_no=None):
             }
         )
     except TypeError:
-        return get_batch_no(item_code, warehouse, qty, True, serial_no)
+        batch_no = get_batch_no(item_code, warehouse, qty, True, serial_no)
+    return _normalize_batch_no(batch_no)
+
+
+def _normalize_batch_no(batch_no):
+    """Return a string batch number or None when the response is not usable."""
+
+    if isinstance(batch_no, dict):
+        batch_no = batch_no.get("batch_no")
+
+    if isinstance(batch_no, str):
+        return batch_no or None
+
+    return None
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020, Youssef Restom and contributors
 # For license information, please see license.txt
 
-import inspect
 import json
 
 import frappe
@@ -436,9 +435,9 @@ def _auto_set_outgoing_batches(invoice_doc):
 
 def _resolve_batch_no(item_code, warehouse, qty, serial_no=None):
     """Resolve batch number across ERPNext signature variants."""
-
-    params = list(inspect.signature(get_batch_no).parameters.values())
-    if len(params) == 1:
+    try:
+        return get_batch_no(item_code, warehouse, qty, True, serial_no)
+    except TypeError:
         return get_batch_no(
             {
                 "item_code": item_code,
@@ -448,7 +447,6 @@ def _resolve_batch_no(item_code, warehouse, qty, serial_no=None):
                 "serial_no": serial_no,
             }
         )
-    return get_batch_no(item_code, warehouse, qty, True, serial_no)
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -436,8 +436,6 @@ def _auto_set_outgoing_batches(invoice_doc):
 def _resolve_batch_no(item_code, warehouse, qty, serial_no=None):
     """Resolve batch number across ERPNext signature variants."""
     try:
-        return get_batch_no(item_code, warehouse, qty, True, serial_no)
-    except TypeError:
         return get_batch_no(
             {
                 "item_code": item_code,
@@ -447,6 +445,8 @@ def _resolve_batch_no(item_code, warehouse, qty, serial_no=None):
                 "serial_no": serial_no,
             }
         )
+    except TypeError:
+        return get_batch_no(item_code, warehouse, qty, True, serial_no)
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020, Youssef Restom and contributors
 # For license information, please see license.txt
 
+import inspect
 import json
 
 import frappe
@@ -430,13 +431,24 @@ def _auto_set_outgoing_batches(invoice_doc):
             continue
 
         # Benchmark note: assign batch numbers server-side to avoid UI expand-only auto-selection.
-        d.batch_no = get_batch_no(
-            item_code=d.item_code,
-            warehouse=warehouse,
-            qty=qty,
-            throw=True,
-            serial_no=d.get("serial_no"),
+        d.batch_no = _resolve_batch_no(d.item_code, warehouse, qty, d.get("serial_no"))
+
+
+def _resolve_batch_no(item_code, warehouse, qty, serial_no=None):
+    """Resolve batch number across ERPNext signature variants."""
+
+    params = list(inspect.signature(get_batch_no).parameters.values())
+    if len(params) == 1:
+        return get_batch_no(
+            {
+                "item_code": item_code,
+                "warehouse": warehouse,
+                "qty": qty,
+                "throw": True,
+                "serial_no": serial_no,
+            }
         )
+    return get_batch_no(item_code, warehouse, qty, True, serial_no)
 
 
 @frappe.whitelist()

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -430,7 +430,13 @@ def _auto_set_outgoing_batches(invoice_doc):
             continue
 
         # Benchmark note: assign batch numbers server-side to avoid UI expand-only auto-selection.
-        d.batch_no = get_batch_no(d.item_code, warehouse, qty, True, d.get("serial_no"))
+        d.batch_no = get_batch_no(
+            item_code=d.item_code,
+            warehouse=warehouse,
+            qty=qty,
+            throw=True,
+            serial_no=d.get("serial_no"),
+        )
 
 
 @frappe.whitelist()


### PR DESCRIPTION
### Motivation
- Some invoice items that require a batch were failing submission when the row was not expanded because `batch_no` was not set client-side.  
- The POS profile supports an `auto_set_batch` option that should auto-select batches for outgoing items without requiring the UI to be expanded.  
- Assigning batches server-side during submit avoids race conditions and extra UI interactions.  

### Description
- Added a new helper ` _auto_set_outgoing_batches` in `posawesome/posawesome/api/invoices.py` that selects a batch using `get_batch_no` when `posa_auto_set_batch` is enabled.  
- Invoked the helper from the synchronous submission flow (`submit_invoice`) so outgoing items get batch numbers before stock validation.  
- Also invoked the helper inside the background submission job (`submit_in_background_job`) to ensure queued submissions receive batches before final validation and submit.  
- Kept a short benchmark/note in the code to document the server-side assignment optimization to avoid UI-only auto-selection cycles.  

### Testing
- Ran formatting check with `npx prettier --check "frontend/src/**/*.{js,vue,css,scss,html}"` which succeeded.  
- Ran linting with `npx eslint frontend/src` which reported repository-wide lint errors (existing unrelated frontend issues), so lint did not pass cleanly.  
- Attempted to run the app test suite with `bench --site mysite.local run-tests --app posawesome` but the `bench` command is not available in this environment so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d11635c048326992b32753ab47f5f)