### PR TITLE
Move new-customer shortcut from F5 to F6

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Notes:
 #### Global (Invoice Screen)
 
 - `F4` profile switch (currently shows “not available” message).
-- `F5` open new customer form.
+- `F6` open new customer form.
 - `F7` open shift details.
 - `F8` POS lock (currently shows “not available” message).
 

--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -26,7 +26,7 @@ export default {
 			return;
 		}
 
-		if (key === "F5") {
+		if (key === "F6") {
 			consumeEvent(event);
 			this.$refs.customerComponent?.openNewCustomer?.();
 			return;


### PR DESCRIPTION
### Motivation

- Change the keyboard binding used to open the new-customer flow from `F5` to `F6` as requested.
- Keep the global invoice shortcut behaviour consistent while avoiding the previous `F5` mapping.

### Description

- Update the invoice shortcuts handler to use `F6` instead of `F5` in `frontend/src/posapp/components/pos/invoiceShortcuts.js` (single-line change in `handleInvoiceShortcut`).
- No other logic, UI, or performance changes were made; only the key checked was updated.
- Committed change with message `Move customer shortcut to F6`.

### Testing

- Ran code formatting with `yarn format`; this completed successfully.
- Ran lint with `npx eslint frontend/src`; this reported many existing lint errors across the codebase (vendored libs and other files) so lint did not pass for the project.
- Ran unit tests with `cd frontend && yarn test`; test run failed due to environment/mocking issues (missing IndexedDB in the test environment and a Vitest mock export error), not related to this single-line shortcut change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5cdd76988326a1b85e6a8e75041a)