### PR TITLE
Fix POS 'block sale beyond available qty' flag parsing

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -4533,7 +4533,7 @@ export default {
 			return 500;
 		},
 		blockSaleBeyondAvailableQty() {
-			return Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty);
+			return parseBooleanSetting(this.pos_profile?.posa_block_sale_beyond_available_qty);
 		},
 		headers() {
 			return this.getItemsHeaders();

--- a/frontend/src/posapp/components/pos/ItemsTable.vue
+++ b/frontend/src/posapp/components/pos/ItemsTable.vue
@@ -558,6 +558,7 @@
 import _ from "lodash";
 import { logComponentRender } from "../../utils/perf.js";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
+import { parseBooleanSetting } from "../../utils/stock.js";
 import CartItemRow from "./CartItemRow.vue";
 export default {
 	name: "ItemsTable",
@@ -708,7 +709,7 @@ export default {
 
 		blockSaleBeyondAvailableQty() {
 			if (["Order", "Quotation"].includes(this.invoiceType)) return false;
-			return !!this.pos_profile?.posa_block_sale_beyond_available_qty;
+			return parseBooleanSetting(this.pos_profile?.posa_block_sale_beyond_available_qty);
 		},
 
 		// Responsive headers based on container size

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -836,6 +836,7 @@ import { useInvoiceStore } from "../../stores/invoiceStore.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
 import stockCoordinator from "../../utils/stockCoordinator.js";
+import { parseBooleanSetting } from "../../utils/stock.js";
 
 export default {
 	// Using format mixin for shared formatting methods
@@ -913,7 +914,7 @@ export default {
 			if (["Order", "Quotation"].includes(this.invoiceType)) {
 				return false;
 			}
-			return Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty);
+			return parseBooleanSetting(this.pos_profile?.posa_block_sale_beyond_available_qty);
 		},
 		// Performance: normalize payment amounts once per reactive update to avoid repeated parsing
 		// across totals, change calculations, and denomination rendering (cuts ~3 O(n) scans per render).

--- a/frontend/src/posapp/components/pos/invoiceComputed.js
+++ b/frontend/src/posapp/components/pos/invoiceComputed.js
@@ -140,7 +140,7 @@ export default {
 		if (["Order", "Quotation"].includes(this.invoiceType)) {
 			return false;
 		}
-		return Boolean(this.pos_profile?.posa_block_sale_beyond_available_qty);
+		return parseBooleanSetting(this.pos_profile?.posa_block_sale_beyond_available_qty);
 	},
 	// Table headers for item table (for another table if needed)
 	itemTableHeaders() {


### PR DESCRIPTION
### Motivation
- Users reported items being blocked from add-to-cart despite `Allow Negative Stock` being enabled and `Block Sale Beyond Available Qty` disabled, indicating a configuration parsing bug. 
- The root cause was inconsistent boolean normalization where truthy string values like `"0"` were evaluated as true by `Boolean()`/`!!` checks. 
- The intent is to ensure POS profile settings are interpreted reliably regardless of string/number representations from the server. 
- This change centralizes use of the existing `parseBooleanSetting` helper to avoid incorrect blocking behavior.

### Description
- Replace `Boolean(...)` / `!!(...)` checks with `parseBooleanSetting(...)` for `posa_block_sale_beyond_available_qty` in `invoiceComputed.js`, `ItemsTable.vue`, `Payments.vue`, and `ItemsSelector.vue`. 
- Add imports for `parseBooleanSetting` where required and keep behavior unaffected for Orders/Quotations. 
- No backend logic changes were made; this is a frontend normalization fix for configuration parsing. 
- Files modified: `frontend/src/posapp/components/pos/invoiceComputed.js`, `ItemsTable.vue`, `Payments.vue`, and `ItemsSelector.vue`.

### Testing
- Ran `npx prettier --check frontend/src/posapp/components/pos/ItemsTable.vue frontend/src/posapp/components/pos/Payments.vue frontend/src/posapp/components/pos/ItemsSelector.vue frontend/src/posapp/components/pos/invoiceComputed.js` and it passed. 
- Ran `npx eslint ...` on the same files which reported one lint error (`vuetify/no-deprecated-events` in `ItemsSelector.vue`). 
- Ran the frontend test suite with `cd frontend && yarn test` which encountered an environment limitation (`IndexedDB API missing`) and resulted in 2 failing unit tests in `tests/invoiceItemMethods.spec.js` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5f0871608326914f0a1fbe4b1223)