### PR TITLE
Fix print view behavior for new-tab mode (strict trigger_print, offline fallback, debug logging)

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -66,7 +66,12 @@ import {
 	isOffline,
 	getLastSyncTotals,
 } from "../offline/index.js";
-import { silentPrint, watchPrintWindow } from "./plugins/print.js";
+import {
+	appendDebugPrintParam,
+	isDebugPrintEnabled,
+	silentPrint,
+	watchPrintWindow,
+} from "./plugins/print.js";
 import {
 	setupNetworkListeners,
 	checkNetworkConnectivity,
@@ -352,7 +357,8 @@ export default {
 			const doctype = this.posProfile.create_pos_invoice_instead_of_sales_invoice
 				? "POS Invoice"
 				: "Sales Invoice";
-			const url =
+			const debugPrint = isDebugPrintEnabled();
+			let url =
 				frappe.urllib.get_base_url() +
 				"/printview?doctype=" +
 				encodeURIComponent(doctype) +
@@ -364,7 +370,15 @@ export default {
 				"&no_letterhead=" +
 				letter_head;
 
-			const printOptions = { allowOfflineFallback: isOffline() };
+			url = appendDebugPrintParam(url, debugPrint);
+			const printOptions = {
+				allowOfflineFallback: isOffline(),
+				debugPrint,
+				debugInfo: {
+					printFormat: print_format,
+					templatePath: "online-printview",
+				},
+			};
 			if (this.posProfile.posa_silent_print) {
 				silentPrint(url, printOptions);
 			} else {

--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -373,6 +373,7 @@ export default {
 			url = appendDebugPrintParam(url, debugPrint);
 			const printOptions = {
 				allowOfflineFallback: isOffline(),
+				triggerPrint: "1",
 				debugPrint,
 				debugInfo: {
 					printFormat: print_format,

--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -81,18 +81,22 @@
 							</v-col>
 							<v-col md="8" cols="12">
 								<div class="text-caption text-medium-emphasis mt-2">
-									<span v-for="(data, key) in outstanding_by_currency" :key="key" class="mr-4">
-									<strong>
-										{{ formatCurrency(data.amount) }} 
-										{{ data.symbol }} 
-										{{ data.party_currency }}
-										<span v-if="data.party_currency !== data.invoice_currency">
-										({{ data.invoice_currency }})
-										</span>
-									</strong>
+									<span
+										v-for="(data, key) in outstanding_by_currency"
+										:key="key"
+										class="mr-4"
+									>
+										<strong>
+											{{ formatCurrency(data.amount) }}
+											{{ data.symbol }}
+											{{ data.party_currency }}
+											<span v-if="data.party_currency !== data.invoice_currency">
+												({{ data.invoice_currency }})
+											</span>
+										</strong>
 									</span>
 								</div>
-								</v-col>
+							</v-col>
 						</v-row>
 
 						<v-row
@@ -144,7 +148,13 @@
 							</template>
 							<template v-slot:item.outstanding_amount="{ item }">
 								<span class="text-primary"
-									>{{ currencySymbol(item?.party_account_currency || item?.currency || pos_profile.currency) }}
+									>{{
+										currencySymbol(
+											item?.party_account_currency ||
+												item?.currency ||
+												pos_profile.currency,
+										)
+									}}
 									{{ formatCurrency(item?.outstanding_amount || 0) }}</span
 								>
 							</template>
@@ -455,7 +465,12 @@ import {
 	getCustomerStorage,
 	getOfflineCustomers,
 } from "../../../offline/index.js";
-import { silentPrint, watchPrintWindow } from "../../plugins/print.js";
+import {
+	appendDebugPrintParam,
+	isDebugPrintEnabled,
+	silentPrint,
+	watchPrintWindow,
+} from "../../plugins/print.js";
 import { useRtl } from "../../composables/useRtl.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
@@ -822,7 +837,7 @@ export default {
 					company: this.company,
 					currency: this.pos_profile.currency,
 					pos_profile: this.pos_profile_search || null,
-					include_all_currencies: true
+					include_all_currencies: true,
 				})
 				.then((r) => {
 					if (r.message) {
@@ -1196,16 +1211,25 @@ export default {
 			}
 
 			// Use simplest URL possible to avoid errors
-			const url =
+			const debugPrint = isDebugPrintEnabled();
+			let url =
 				frappe.urllib.get_base_url() +
 				"/printview?doctype=Payment%20Entry" +
 				"&name=" +
 				payment_name +
 				"&trigger_print=1";
 
+			url = appendDebugPrintParam(url, debugPrint);
 			console.log("Opening printing URL:", url);
 
-			const printOptions = { allowOfflineFallback: isOffline() };
+			const printOptions = {
+				allowOfflineFallback: isOffline(),
+				debugPrint,
+				debugInfo: {
+					printFormat: null,
+					templatePath: "online-printview",
+				},
+			};
 			if (this.pos_profile?.posa_silent_print) {
 				silentPrint(url, printOptions);
 			} else {
@@ -1239,40 +1263,40 @@ export default {
 		// Get unique currencies from invoices
 		invoice_currencies() {
 			const currencies = new Set();
-			this.outstanding_invoices.forEach(inv => {
+			this.outstanding_invoices.forEach((inv) => {
 				currencies.add(inv.currency || this.pos_profile.currency);
 			});
 			return Array.from(currencies).sort();
 		},
-		
+
 		// Summary of outstanding amounts by currency
 		outstanding_by_currency() {
-		const summary = {};
-		this.outstanding_invoices.forEach(inv => {
-			const partyCurr = inv.party_account_currency || inv.currency || this.pos_profile.currency;
-			const invoiceCurr = inv.currency || this.pos_profile.currency;
-			const key = `${partyCurr}-${invoiceCurr}`;
-			
-			if (!summary[key]) {
-			summary[key] = {
-				amount: 0,
-				symbol: this.currencySymbol(partyCurr),
-				party_currency: partyCurr,
-				invoice_currency: invoiceCurr
-			};
-			}
-			summary[key].amount += flt(inv.outstanding_amount || 0);
-		});
-		return summary;
+			const summary = {};
+			this.outstanding_invoices.forEach((inv) => {
+				const partyCurr = inv.party_account_currency || inv.currency || this.pos_profile.currency;
+				const invoiceCurr = inv.currency || this.pos_profile.currency;
+				const key = `${partyCurr}-${invoiceCurr}`;
+
+				if (!summary[key]) {
+					summary[key] = {
+						amount: 0,
+						symbol: this.currencySymbol(partyCurr),
+						party_currency: partyCurr,
+						invoice_currency: invoiceCurr,
+					};
+				}
+				summary[key].amount += flt(inv.outstanding_amount || 0);
+			});
+			return summary;
 		},
-		
+
 		// Filtered invoices based on selected currency
 		filtered_outstanding_invoices() {
-			if (this.currency_filter === 'ALL' || !this.currency_filter) {
+			if (this.currency_filter === "ALL" || !this.currency_filter) {
 				return this.outstanding_invoices;
 			}
-			return this.outstanding_invoices.filter(inv => 
-				(inv.currency || this.pos_profile.currency) === this.currency_filter
+			return this.outstanding_invoices.filter(
+				(inv) => (inv.currency || this.pos_profile.currency) === this.currency_filter,
 			);
 		},
 		total_unallocated_amount() {
@@ -1287,8 +1311,11 @@ export default {
 			return this.selected_invoices.reduce((acc, cur) => {
 				const invoice_currency = cur.currency || this.pos_profile.currency;
 				// Only include if it matches the filter or filter is ALL
-				if (this.currency_filter === 'ALL' || !this.currency_filter || 
-					invoice_currency === this.currency_filter) {
+				if (
+					this.currency_filter === "ALL" ||
+					!this.currency_filter ||
+					invoice_currency === this.currency_filter
+				) {
 					return acc + flt(cur?.outstanding_amount || 0);
 				}
 				return acc;

--- a/frontend/src/posapp/components/payments/Pay.vue
+++ b/frontend/src/posapp/components/payments/Pay.vue
@@ -1224,6 +1224,7 @@ export default {
 
 			const printOptions = {
 				allowOfflineFallback: isOffline(),
+				triggerPrint: "1",
 				debugPrint,
 				debugInfo: {
 					printFormat: null,

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -831,7 +831,12 @@ import {
 } from "../../../offline/index.js";
 
 import renderOfflineInvoiceHTML from "../../../offline_print_template";
-import { silentPrint, watchPrintWindow } from "../../plugins/print.js";
+import {
+	appendDebugPrintParam,
+	isDebugPrintEnabled,
+	silentPrint,
+	watchPrintWindow,
+} from "../../plugins/print.js";
 import { useInvoiceStore } from "../../stores/invoiceStore.js";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { storeToRefs } from "pinia";
@@ -1941,6 +1946,7 @@ export default {
 				this.pos_profile.print_format;
 			const letter_head = this.pos_profile.letter_head || 0;
 			let doctype;
+			const debugPrint = isDebugPrintEnabled();
 
 			if (this.invoiceType === "Quotation") {
 				doctype = "Quotation";
@@ -1951,7 +1957,7 @@ export default {
 			} else {
 				doctype = "Sales Invoice";
 			}
-			const url =
+			let url =
 				frappe.urllib.get_base_url() +
 				"/printview?doctype=" +
 				encodeURIComponent(doctype) +
@@ -1962,12 +1968,25 @@ export default {
 				print_format +
 				"&no_letterhead=" +
 				letter_head;
+			url = appendDebugPrintParam(url, debugPrint);
 			const printOptions = {
 				invoiceDoc: this.invoice_doc,
 				allowOfflineFallback: isOffline(),
+				debugPrint,
+				debugInfo: {
+					printFormat: print_format,
+					templatePath: "online-printview",
+				},
 			};
 
 			if (this.pos_profile.posa_open_print_in_new_tab) {
+				if (isOffline()) {
+					this.open_offline_invoice_preview(this.invoice_doc, {
+						debugPrint,
+						printFormat: print_format,
+					});
+					return;
+				}
 				let newTabUrl =
 					frappe.urllib.get_base_url() +
 					"/printview?doctype=" +
@@ -1985,7 +2004,13 @@ export default {
 					newTabUrl += "&no_letterhead=0";
 				}
 
-				window.open(newTabUrl, "_blank");
+				newTabUrl = appendDebugPrintParam(newTabUrl, debugPrint);
+				// Android Share → Print is more reliable, so keep trigger_print=0 and skip auto-print.
+				const printWindow = window.open(newTabUrl, "_blank");
+				watchPrintWindow(printWindow, {
+					...printOptions,
+					shouldPrint: false,
+				});
 				return;
 			}
 
@@ -2005,6 +2030,26 @@ export default {
 			win.document.close();
 			win.focus();
 			win.print();
+		},
+		// Open offline invoice preview without triggering auto-print (for new-tab mode)
+		async open_offline_invoice_preview(invoice, { debugPrint = false, printFormat = "" } = {}) {
+			if (!invoice) return;
+			const html = await renderOfflineInvoiceHTML(invoice);
+			const win = window.open("", "_blank");
+			if (!win) return;
+			win.document.write(html);
+			win.document.close();
+			win.focus();
+			if (debugPrint) {
+				console.log("[POSAwesome][Print Debug]", {
+					location: win.location?.href || null,
+					online: navigator.onLine,
+					trigger_print: "0",
+					print_format: printFormat || null,
+					template_path: "offline-fallback",
+					should_print: false,
+				});
+			}
 		},
 		// Validate due date (should not be in the past)
 		validate_due_date() {

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1972,6 +1972,7 @@ export default {
 			const printOptions = {
 				invoiceDoc: this.invoice_doc,
 				allowOfflineFallback: isOffline(),
+				triggerPrint: "1",
 				debugPrint,
 				debugInfo: {
 					printFormat: print_format,
@@ -2009,6 +2010,7 @@ export default {
 				const printWindow = window.open(newTabUrl, "_blank");
 				watchPrintWindow(printWindow, {
 					...printOptions,
+					triggerPrint: "0",
 					shouldPrint: false,
 				});
 				return;

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1,4 +1,9 @@
-import { silentPrint } from "../../plugins/print.js";
+import {
+	appendDebugPrintParam,
+	isDebugPrintEnabled,
+	silentPrint,
+	watchPrintWindow,
+} from "../../plugins/print.js";
 import { isOffline } from "../../../offline/index.js";
 import { formatUtils } from "../../format.js";
 /* global __, frappe, flt */
@@ -1549,7 +1554,8 @@ export default {
 		const doctype = this.pos_profile.create_pos_invoice_instead_of_sales_invoice
 			? "POS Invoice"
 			: "Sales Invoice";
-		const url =
+		const debugPrint = isDebugPrintEnabled();
+		let url =
 			frappe.urllib.get_base_url() +
 			"/printview?doctype=" +
 			encodeURIComponent(doctype) +
@@ -1560,18 +1566,27 @@ export default {
 			print_format +
 			"&no_letterhead=" +
 			letter_head;
+		url = appendDebugPrintParam(url, debugPrint);
 
 		if (this.pos_profile.posa_silent_print) {
-			silentPrint(url, { allowOfflineFallback: isOffline() });
+			silentPrint(url, {
+				allowOfflineFallback: isOffline(),
+				debugPrint,
+				debugInfo: {
+					printFormat: print_format,
+					templatePath: "online-printview",
+				},
+			});
 		} else {
 			const printWindow = window.open(url, "Print");
-			printWindow.addEventListener(
-				"load",
-				function () {
-					printWindow.print();
+			watchPrintWindow(printWindow, {
+				allowOfflineFallback: isOffline(),
+				debugPrint,
+				debugInfo: {
+					printFormat: print_format,
+					templatePath: "online-printview",
 				},
-				{ once: true },
-			);
+			});
 		}
 	},
 

--- a/frontend/src/posapp/components/pos/invoiceOfferMethods.js
+++ b/frontend/src/posapp/components/pos/invoiceOfferMethods.js
@@ -1571,6 +1571,7 @@ export default {
 		if (this.pos_profile.posa_silent_print) {
 			silentPrint(url, {
 				allowOfflineFallback: isOffline(),
+				triggerPrint: "1",
 				debugPrint,
 				debugInfo: {
 					printFormat: print_format,
@@ -1581,6 +1582,7 @@ export default {
 			const printWindow = window.open(url, "Print");
 			watchPrintWindow(printWindow, {
 				allowOfflineFallback: isOffline(),
+				triggerPrint: "1",
 				debugPrint,
 				debugInfo: {
 					printFormat: print_format,

--- a/frontend/src/posapp/plugins/print.js
+++ b/frontend/src/posapp/plugins/print.js
@@ -2,6 +2,100 @@ import renderOfflineInvoiceHTML from "../../offline_print_template.js";
 
 const DEFAULT_READY_SELECTORS = ["#print-view", ".print-format"];
 const DEFAULT_TIMEOUT = 10000;
+const DEBUG_PRINT_PARAM = "debug_print";
+const TRIGGER_PRINT_PARAM = "trigger_print";
+
+function getWindowHref(targetWindow) {
+	try {
+		return targetWindow?.location?.href || "";
+	} catch (err) {
+		return "";
+	}
+}
+
+function getSearchParamFromHref(href, param) {
+	if (!href) return null;
+	try {
+		const resolved = new URL(href, window.location.origin);
+		return resolved.searchParams.get(param);
+	} catch (err) {
+		return null;
+	}
+}
+
+function resolveTriggerPrint(targetWindow, options = {}) {
+	if (options.triggerPrint !== undefined && options.triggerPrint !== null) {
+		return String(options.triggerPrint);
+	}
+	return getSearchParamFromHref(getWindowHref(targetWindow), TRIGGER_PRINT_PARAM);
+}
+
+function resolveDebugPrint(targetWindow, options = {}) {
+	if (typeof options.debugPrint === "boolean") {
+		return options.debugPrint;
+	}
+	const href = getWindowHref(targetWindow);
+	if (href) {
+		return getSearchParamFromHref(href, DEBUG_PRINT_PARAM) === "1";
+	}
+	return isDebugPrintEnabled();
+}
+
+function resolveOnlineStatus(targetWindow) {
+	try {
+		return Boolean(targetWindow?.navigator?.onLine);
+	} catch (err) {
+		return Boolean(navigator?.onLine);
+	}
+}
+
+function logPrintDebug(details) {
+	if (!details?.debugPrint) return;
+	const payload = {
+		location: details.location || null,
+		online: details.online,
+		trigger_print: details.triggerPrint,
+		print_format: details.printFormat || null,
+		template_path: details.templatePath || null,
+		should_print: details.shouldPrint,
+	};
+	if (details.note) {
+		payload.note = details.note;
+	}
+	console.log("[POSAwesome][Print Debug]", payload);
+}
+
+function isLoginRedirect(targetWindow) {
+	try {
+		const path = targetWindow?.location?.pathname || "";
+		if (path.includes("login")) return true;
+		const title = targetWindow?.document?.title || "";
+		if (/login|session/i.test(title)) return true;
+		const loginForm = targetWindow?.document?.querySelector("form[action*='login']");
+		return Boolean(loginForm);
+	} catch (err) {
+		return false;
+	}
+}
+
+function showSessionMessage(targetWindow) {
+	if (!targetWindow) return;
+	try {
+		const message =
+			"Unable to load the online print view. Your session may have expired. Please sign in again and re-open the print view.";
+		targetWindow.document.open();
+		targetWindow.document.write(
+			`<div style="font-family:sans-serif;padding:24px;line-height:1.5;">
+				<h2 style="margin:0 0 12px;">Print view unavailable</h2>
+				<p style="margin:0 0 12px;">${message}</p>
+				<p style="margin:0;">Once signed in, retry from POS Awesome.</p>
+			</div>`,
+		);
+		targetWindow.document.close();
+	} catch (err) {
+		console.warn("Unable to show session warning in print window", err);
+	}
+}
 
 function waitForDocumentSelectors(targetWindow, selectors, timeout) {
 	return new Promise((resolve, reject) => {
@@ -107,7 +201,7 @@ function waitForDocumentSelectors(targetWindow, selectors, timeout) {
 	});
 }
 
-async function fallbackToOfflinePrint(invoiceDoc, existingWindow) {
+async function fallbackToOfflinePrint(invoiceDoc, existingWindow, options = {}) {
 	if (!invoiceDoc) {
 		return false;
 	}
@@ -138,8 +232,20 @@ async function fallbackToOfflinePrint(invoiceDoc, existingWindow) {
 
 		target.document.write(html);
 		target.document.close();
-		target.focus();
-		target.print();
+		const shouldPrint = options.shouldPrint ?? true;
+		logPrintDebug({
+			debugPrint: resolveDebugPrint(target, options),
+			location: getWindowHref(target),
+			online: resolveOnlineStatus(target),
+			triggerPrint: resolveTriggerPrint(target, options),
+			printFormat: options?.debugInfo?.printFormat,
+			templatePath: "offline-fallback",
+			shouldPrint,
+		});
+		if (shouldPrint) {
+			target.focus();
+			target.print();
+		}
 		return true;
 	} catch (err) {
 		console.error("Offline print fallback failed", err);
@@ -157,9 +263,25 @@ async function ensureReadyAndPrint(targetWindow, options = {}) {
 		timeout = DEFAULT_TIMEOUT,
 		invoiceDoc = null,
 		allowOfflineFallback = true,
+		shouldPrint = true,
 	} = options;
 
 	const readySelectors = Array.isArray(selectors) ? selectors.filter(Boolean) : [selectors].filter(Boolean);
+	const triggerPrintValue = resolveTriggerPrint(targetWindow, options);
+	const resolvedDebugPrint = resolveDebugPrint(targetWindow, options);
+	const resolvedOnline = resolveOnlineStatus(targetWindow);
+	const resolvedShouldPrint = shouldPrint && triggerPrintValue === "1";
+
+	// Benchmark: avoid unnecessary print calls unless trigger_print is explicitly "1" for Android reliability.
+	logPrintDebug({
+		debugPrint: resolvedDebugPrint,
+		location: getWindowHref(targetWindow),
+		online: resolvedOnline,
+		triggerPrint: triggerPrintValue,
+		printFormat: options?.debugInfo?.printFormat,
+		templatePath: "online-printview",
+		shouldPrint: resolvedShouldPrint,
+	});
 
 	try {
 		await waitForDocumentSelectors(
@@ -167,15 +289,35 @@ async function ensureReadyAndPrint(targetWindow, options = {}) {
 			readySelectors.length ? readySelectors : DEFAULT_READY_SELECTORS,
 			timeout,
 		);
-		targetWindow.focus();
-		targetWindow.print();
+		if (resolvedShouldPrint) {
+			targetWindow.focus();
+			targetWindow.print();
+		}
 	} catch (err) {
 		console.warn("Print readiness check failed", err);
+		const wantsSessionMessage = options.showSessionMessage !== false;
+		if (wantsSessionMessage && isLoginRedirect(targetWindow)) {
+			logPrintDebug({
+				debugPrint: resolvedDebugPrint,
+				location: getWindowHref(targetWindow),
+				online: resolvedOnline,
+				triggerPrint: triggerPrintValue,
+				printFormat: options?.debugInfo?.printFormat,
+				templatePath: "login-redirect",
+				shouldPrint: resolvedShouldPrint,
+				note: "Login redirect detected",
+			});
+			showSessionMessage(targetWindow);
+			return;
+		}
 		let usedFallback = false;
 		if (allowOfflineFallback && invoiceDoc) {
-			usedFallback = await fallbackToOfflinePrint(invoiceDoc, targetWindow);
+			usedFallback = await fallbackToOfflinePrint(invoiceDoc, targetWindow, {
+				...options,
+				shouldPrint: resolvedShouldPrint,
+			});
 		}
-		if (!usedFallback) {
+		if (!usedFallback && resolvedShouldPrint) {
 			try {
 				targetWindow.focus();
 				targetWindow.print();
@@ -231,5 +373,27 @@ export function silentPrint(url, options = {}) {
 		if (win) {
 			watchPrintWindow(win, options);
 		}
+	}
+}
+
+export function isDebugPrintEnabled(sourceWindow = window) {
+	try {
+		const href = sourceWindow?.location?.href || "";
+		return getSearchParamFromHref(href, DEBUG_PRINT_PARAM) === "1";
+	} catch (err) {
+		return false;
+	}
+}
+
+export function appendDebugPrintParam(url, debugEnabled = isDebugPrintEnabled()) {
+	if (!url || !debugEnabled) {
+		return url;
+	}
+	try {
+		const resolved = new URL(url, window.location.origin);
+		resolved.searchParams.set(DEBUG_PRINT_PARAM, "1");
+		return resolved.toString();
+	} catch (err) {
+		return url;
 	}
 }

--- a/frontend/src/posapp/plugins/print.js
+++ b/frontend/src/posapp/plugins/print.js
@@ -267,20 +267,26 @@ async function ensureReadyAndPrint(targetWindow, options = {}) {
 	} = options;
 
 	const readySelectors = Array.isArray(selectors) ? selectors.filter(Boolean) : [selectors].filter(Boolean);
-	const triggerPrintValue = resolveTriggerPrint(targetWindow, options);
 	const resolvedDebugPrint = resolveDebugPrint(targetWindow, options);
 	const resolvedOnline = resolveOnlineStatus(targetWindow);
-	const resolvedShouldPrint = shouldPrint && triggerPrintValue === "1";
+	const resolvePrintState = () => {
+		const triggerPrintValue = resolveTriggerPrint(targetWindow, options);
+		return {
+			triggerPrintValue,
+			resolvedShouldPrint: shouldPrint && triggerPrintValue === "1",
+		};
+	};
+	const initialPrintState = resolvePrintState();
 
 	// Benchmark: avoid unnecessary print calls unless trigger_print is explicitly "1" for Android reliability.
 	logPrintDebug({
 		debugPrint: resolvedDebugPrint,
 		location: getWindowHref(targetWindow),
 		online: resolvedOnline,
-		triggerPrint: triggerPrintValue,
+		triggerPrint: initialPrintState.triggerPrintValue,
 		printFormat: options?.debugInfo?.printFormat,
 		templatePath: "online-printview",
-		shouldPrint: resolvedShouldPrint,
+		shouldPrint: initialPrintState.resolvedShouldPrint,
 	});
 
 	try {
@@ -289,6 +295,17 @@ async function ensureReadyAndPrint(targetWindow, options = {}) {
 			readySelectors.length ? readySelectors : DEFAULT_READY_SELECTORS,
 			timeout,
 		);
+		const { triggerPrintValue, resolvedShouldPrint } = resolvePrintState();
+		logPrintDebug({
+			debugPrint: resolvedDebugPrint,
+			location: getWindowHref(targetWindow),
+			online: resolvedOnline,
+			triggerPrint: triggerPrintValue,
+			printFormat: options?.debugInfo?.printFormat,
+			templatePath: "online-printview",
+			shouldPrint: resolvedShouldPrint,
+			note: "Print target ready",
+		});
 		if (resolvedShouldPrint) {
 			targetWindow.focus();
 			targetWindow.print();
@@ -296,6 +313,7 @@ async function ensureReadyAndPrint(targetWindow, options = {}) {
 	} catch (err) {
 		console.warn("Print readiness check failed", err);
 		const wantsSessionMessage = options.showSessionMessage !== false;
+		const { triggerPrintValue, resolvedShouldPrint } = resolvePrintState();
 		if (wantsSessionMessage && isLoginRedirect(targetWindow)) {
 			logPrintDebug({
 				debugPrint: resolvedDebugPrint,

--- a/frontend/src/utils/pos_profile.js
+++ b/frontend/src/utils/pos_profile.js
@@ -1,5 +1,10 @@
 /* global frappe */
-import { getOpeningStorage, setPrintTemplate, setTermsAndConditions } from "../offline/index.js";
+import {
+	getOpeningStorage,
+	setOpeningStorage,
+	setPrintTemplate,
+	setTermsAndConditions,
+} from "../offline/index.js";
 
 async function cachePrintTemplateAndTerms(profile) {
 	if (!profile || typeof frappe === "undefined" || !navigator.onLine) return;
@@ -31,10 +36,43 @@ async function cachePrintTemplateAndTerms(profile) {
 	}
 }
 
+function hasProfileChanged(currentProfile, nextProfile) {
+	if (!nextProfile) return false;
+	if (!currentProfile) return true;
+	if (currentProfile.name !== nextProfile.name) return true;
+	if (currentProfile.modified && nextProfile.modified) {
+		return currentProfile.modified !== nextProfile.modified;
+	}
+	return false;
+}
+
+function updateOpeningStorageProfile(profile) {
+	const cached = getOpeningStorage();
+	if (cached?.pos_profile) {
+		setOpeningStorage({ ...cached, pos_profile: profile });
+	}
+}
+
 export async function ensurePosProfile() {
 	const bootProfile = frappe?.boot?.pos_profile;
 	if (bootProfile && bootProfile.warehouse && bootProfile.selling_price_list) {
 		await cachePrintTemplateAndTerms(bootProfile);
+		if (navigator.onLine) {
+			try {
+				const res = await frappe.call({
+					method: "posawesome.posawesome.api.utils.get_active_pos_profile",
+					args: { user: frappe.session.user },
+				});
+				if (res.message && hasProfileChanged(bootProfile, res.message)) {
+					frappe.boot.pos_profile = res.message;
+					updateOpeningStorageProfile(res.message);
+					await cachePrintTemplateAndTerms(res.message);
+					return res.message;
+				}
+			} catch (e) {
+				console.error("Failed to refresh active POS profile", e);
+			}
+		}
 		return bootProfile;
 	}
 	try {
@@ -44,6 +82,7 @@ export async function ensurePosProfile() {
 		});
 		if (res.message) {
 			frappe.boot.pos_profile = res.message;
+			updateOpeningStorageProfile(res.message);
 			await cachePrintTemplateAndTerms(res.message);
 			return res.message;
 		}


### PR DESCRIPTION
### Motivation

- Prevent Android auto-printing and auto-close problems by making print invocation explicit and reliable. 
- Ensure the new-tab flow opens the server `printview` with the POS Profile selected print format when online, and fall back to the offline template only when offline or server printview cannot be loaded. 
- Add debug-only logging to help reproduce session/format selection issues without affecting normal behavior.

### Description

- Gate automated printing so `window.print()` and any auto-close only run when `trigger_print === "1"` and never when `trigger_print` is missing or `"0"`, implemented in `ensureReadyAndPrint` and related helpers in `frontend/src/posapp/plugins/print.js`.
- Add debug helpers and opt-in query param `debug_print=1` plus `appendDebugPrintParam`/`isDebugPrintEnabled` to surface `location`, `navigator.onLine`, resolved `format`, and `trigger_print` in logs; also detect login/session redirects and show a friendly message instead of silent fallback. (changes in `frontend/src/posapp/plugins/print.js`)
- Make new-tab behavior explicit: when `posa_open_print_in_new_tab` is enabled open the online `printview` with `trigger_print=0` (no auto-print) and attach the print watcher with `shouldPrint: false`, and use an offline preview (no auto-print) if offline. Updated calling code paths to attach debug flags and avoid auto-print in new-tab mode in: `frontend/src/posapp/components/pos/Payments.vue`, `frontend/src/posapp/components/pos/invoiceOfferMethods.js`, `frontend/src/posapp/Home.vue`, and `frontend/src/posapp/components/payments/Pay.vue`.
- Improve POS Profile cache freshness by conditionally refreshing `frappe.pos_profile` when online and writing the refreshed profile into opening storage to avoid stale format selection; implemented in `frontend/src/utils/pos_profile.js`.

Files changed:
- `frontend/src/posapp/plugins/print.js` (main logic: strict trigger handling, debug logging, session message)
- `frontend/src/posapp/components/pos/Payments.vue` (new-tab handling, offline preview)
- `frontend/src/posapp/components/pos/invoiceOfferMethods.js` (reprint paths)
- `frontend/src/posapp/Home.vue` (reprint last invoice)
- `frontend/src/posapp/components/payments/Pay.vue` (payment print URL)
- `frontend/src/utils/pos_profile.js` (cache refresh)

### Testing

- Ran code formatting with `yarn format`; this completed successfully.
- Ran linting with `yarn eslint .`; this failed due to repo-wide lint issues unrelated to the print change (non-browser globals and bundled vendor files), so lint errors persist outside the scope of this PR.
- Ran frontend unit tests with `yarn --cwd frontend test`; the test run failed in this environment because IndexedDB is not available in the test environment and two test failures surfaced (mock/export issues in existing tests), so automated tests could not fully verify runtime behavior here.
