### PR TITLE
Respect POS Profile and Allow Negative Stock when adding items (fix out-of-stock blocking)

### DIFF
--- a/frontend/src/posapp/composables/useItemAddition.js
+++ b/frontend/src/posapp/composables/useItemAddition.js
@@ -2,6 +2,7 @@ import { nextTick } from "vue";
 import _ from "lodash";
 import { useBundles } from "./useBundles.js";
 import { withPerf } from "../utils/perf.js";
+import { parseBooleanSetting } from "../utils/stock.js";
 
 /* global frappe, __ */
 
@@ -388,13 +389,19 @@ export function useItemAddition() {
 
 	// Add item to invoice
 	const addItem = withPerf("pos:add-item", async function addItemMeasured(item, context) {
-		const blockSale = context.pos_profile?.posa_block_sale_beyond_available_qty;
+		const blockSale = parseBooleanSetting(context.pos_profile?.posa_block_sale_beyond_available_qty);
 		const allowNegativeStock =
-			item.allow_negative_stock === 1 ||
-			item.allow_negative_stock === true ||
-			item.allow_negative_stock === "1";
+			parseBooleanSetting(context.stock_settings?.allow_negative_stock) ||
+			parseBooleanSetting(item.allow_negative_stock);
 
-		if (item.is_stock_item && item.actual_qty <= 0 && !allowNegativeStock) {
+		if (blockSale && item.is_stock_item && item.actual_qty <= 0 && !allowNegativeStock) {
+			console.debug("POS stock gate: item blocked", {
+				item_code: item.item_code,
+				actual_qty: item.actual_qty,
+				block_sale_beyond_available_qty: blockSale,
+				allow_negative_stock: allowNegativeStock,
+				item_allow_negative_stock: parseBooleanSetting(item.allow_negative_stock),
+			});
 			context.eventBus.emit("show_message", {
 				title: __("Item is out of stock"),
 				text: __("Cannot add an item with zero or negative quantity."),


### PR DESCRIPTION
### Motivation
- POS was blocking adding items when `actual_qty <= 0` even if the POS Profile `posa_block_sale_beyond_available_qty` was disabled or negative stock was allowed. 
- The goal is to only block item addition when the POS Profile blocks sales beyond available stock and negative stock is not permitted globally or at item level. 

### Description
- Updated `frontend/src/posapp/composables/useItemAddition.js` to import `parseBooleanSetting` and use it to evaluate `blockSale` and `allowNegativeStock` from both `context.stock_settings` and the item. 
- Changed the pre-add gating so an item is blocked only when `blockSale && item.is_stock_item && item.actual_qty <= 0 && !allowNegativeStock`, and added a similar guard for the quantity-exceeds-available check (`blockSale && !allowNegativeStock`). 
- Added a small `console.debug` log to emit the evaluated flags and item stock data when the gate blocks an item to aid debugging. 

### Testing
- Ran formatting with `yarn format`, which completed successfully. 
- Ran lint with `npx eslint frontend/src`, which failed due to existing repository lint violations unrelated to this change. 
- Ran unit tests with `cd frontend && yarn test`, which failed in the headless environment due to missing IndexedDB and produced 2 failing tests in `tests/invoiceItemMethods.spec.js` (test-environment and existing-mock issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7317ae348326be687994d18ca67c)