### PR TITLE
Preserve ItemsSelector scroll position on add/resize/zoom

### DIFF
--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -29,6 +29,7 @@
 				'selection mx-auto my-0 py-0 mt-3 pos-card dynamic-card resizable pos-themed-card',
 				rtlClasses,
 			]"
+			ref="itemsSelectorCard"
 			:style="{
 				height: responsiveStyles['--container-height'],
 				maxHeight: responsiveStyles['--container-height'],
@@ -758,6 +759,10 @@ export default {
 		lastScrollTop: 0,
 		scrollThrottle: null,
 		searchDebounce: null,
+		scrollRestoreToken: 0,
+		resizeObserver: null,
+		resizeObserverRaf: null,
+		lastKnownMaxHeight: null,
 		// Prevent repeated server fetches when local storage is empty
 		fallbackAttempted: false,
 		cardContainerWidth: 0,
@@ -1283,7 +1288,7 @@ export default {
 
 			this.scrollThrottle = requestAnimationFrame(() => {
 				try {
-					const el = this.$refs.itemsContainer;
+					const el = this.getItemsScrollElement();
 					if (!el) return;
 
 					const scrollTop = el.scrollTop;
@@ -1303,6 +1308,118 @@ export default {
 					this.scrollThrottle = null;
 				}
 			});
+		},
+		resolveElement(ref) {
+			const el = ref?.$el || ref?.$?.el || ref;
+			return el && el instanceof HTMLElement ? el : null;
+		},
+		getCardScrollElement() {
+			const ref = this.$refs.itemsContainer;
+			return this.resolveElement(ref);
+		},
+		getListScrollElement() {
+			const ref = this.$refs.itemsTable;
+			const baseEl = this.resolveElement(ref);
+			if (!baseEl) {
+				return null;
+			}
+			return (
+				baseEl.querySelector(".v-table__wrapper") ||
+				baseEl.querySelector(".v-data-table-virtual__wrapper") ||
+				baseEl
+			);
+		},
+		getItemsScrollElement() {
+			// Use the real scroll container so we don't restore on a non-scrollable wrapper.
+			return this.items_view === "card" ? this.getCardScrollElement() : this.getListScrollElement();
+		},
+		captureScrollPosition() {
+			const el = this.getItemsScrollElement();
+			if (!el) {
+				return null;
+			}
+			const top = el.scrollTop || 0;
+			this.lastScrollTop = top;
+			return {
+				top,
+				view: this.items_view,
+			};
+		},
+		applyScrollPosition(snapshot) {
+			if (!snapshot) {
+				return;
+			}
+			const { top, view } = snapshot;
+			if (view && view !== this.items_view) {
+				return;
+			}
+			if (view === "card") {
+				const scroller = this.$refs.itemsContainer;
+				if (scroller?.scrollToPosition) {
+					scroller.scrollToPosition(top);
+					return;
+				}
+			}
+			const el = this.getItemsScrollElement();
+			if (el) {
+				el.scrollTop = top;
+			}
+		},
+		waitForFrame() {
+			return new Promise((resolve) => {
+				requestAnimationFrame(() => resolve());
+			});
+		},
+		scheduleScrollRestore(snapshot) {
+			if (!snapshot) {
+				return;
+			}
+			const token = ++this.scrollRestoreToken;
+			this.$nextTick(() => {
+				// Wait for DOM + virtual scroller recalculation to settle before restoring.
+				requestAnimationFrame(() => {
+					requestAnimationFrame(() => {
+						if (token !== this.scrollRestoreToken) {
+							return;
+						}
+						this.applyScrollPosition(snapshot);
+					});
+				});
+			});
+		},
+		async restoreScrollPosition(snapshot) {
+			if (!snapshot) {
+				return;
+			}
+			const token = ++this.scrollRestoreToken;
+			await this.$nextTick();
+			await this.waitForFrame();
+			await this.waitForFrame();
+			if (token !== this.scrollRestoreToken) {
+				return;
+			}
+			this.applyScrollPosition(snapshot);
+		},
+		setupItemsResizeObserver() {
+			if (typeof ResizeObserver === "undefined") {
+				return;
+			}
+			const target = this.resolveElement(this.$refs.itemsSelectorCard);
+			if (!target) {
+				return;
+			}
+			const scheduleResize = () => {
+				if (this.resizeObserverRaf) {
+					cancelAnimationFrame(this.resizeObserverRaf);
+				}
+				this.resizeObserverRaf = requestAnimationFrame(() => {
+					this.resizeObserverRaf = null;
+					const scrollSnapshot = this.captureScrollPosition();
+					this.checkItemContainerOverflow(scrollSnapshot);
+				});
+			};
+			this.resizeObserver = new ResizeObserver(scheduleResize);
+			this.resizeObserver.observe(target);
 		},
 		markStorageUnavailable(localOnly = false) {
 			if (localOnly) {
@@ -1397,7 +1514,8 @@ export default {
 			});
 		},
 
-		checkItemContainerOverflow() {
+		checkItemContainerOverflow(scrollSnapshot = null) {
+			const snapshot = scrollSnapshot || this.captureScrollPosition();
 			const ref = this.$refs.itemsContainer;
 			const el = ref && ref.$el ? ref.$el : ref;
 			if (!el) {
@@ -1415,9 +1533,14 @@ export default {
 			const headerHeight = stickyHeader ? stickyHeader.offsetHeight : 0;
 			const availableHeight = containerHeight - headerHeight;
 
-			el.style.maxHeight = `${availableHeight}px`;
+			const nextMaxHeight = `${availableHeight}px`;
+			if (this.lastKnownMaxHeight !== nextMaxHeight) {
+				el.style.maxHeight = nextMaxHeight;
+				this.lastKnownMaxHeight = nextMaxHeight;
+			}
 			this.isOverflowing = el.scrollHeight > availableHeight;
 			this.scheduleCardMetricsUpdate();
+			this.scheduleScrollRestore(snapshot);
 		},
 
 		async fetchItemDetails(items) {
@@ -2111,8 +2234,10 @@ export default {
 			// Add item to cart
 			const payload = { ...item };
 			delete payload._barcode_qty;
+			const scrollSnapshot = this.captureScrollPosition();
 			this.eventBus.emit("add_item", payload);
 			this.qty = 1;
+			await this.restoreScrollPosition(scrollSnapshot);
 		},
 
 		/**
@@ -4902,6 +5027,7 @@ export default {
 		// Apply the configured items per page on mount
 		this.itemsPerPage = this.items_per_page;
 		window.addEventListener("resize", this.checkItemContainerOverflow);
+		this.setupItemsResizeObserver();
 		this.$nextTick(() => {
 			this.checkItemContainerOverflow();
 			this.scheduleCardMetricsUpdate();
@@ -4973,6 +5099,14 @@ export default {
 		this.eventBus.off("select_top_item");
 		this.eventBus.off("toggle_item_selector_settings");
 		window.removeEventListener("resize", this.checkItemContainerOverflow);
+		if (this.resizeObserver) {
+			this.resizeObserver.disconnect();
+			this.resizeObserver = null;
+		}
+		if (this.resizeObserverRaf) {
+			cancelAnimationFrame(this.resizeObserverRaf);
+			this.resizeObserverRaf = null;
+		}
 		if (this.metricsRaf) {
 			cancelAnimationFrame(this.metricsRaf);
 			this.metricsRaf = null;


### PR DESCRIPTION
### Motivation
- Prevent the items list from jumping to the top when a user clicks an item or when the container is resized/zoomed. 
- The reset was caused by targeting the wrong scroll element and restoring too early while the virtual scroller/layout was recalculating. 
- Keep behavior consistent between card (virtual scroller) and table/list views while not touching `ItemsTable` which already behaves correctly. 
- Use native browser APIs and frame timing (`ResizeObserver`, `requestAnimationFrame`, `nextTick`) to make restores robust across zoom/layout changes.

### Description
- Added stable scroll utilities (`getItemsScrollElement`, `captureScrollPosition`, `applyScrollPosition`, `scheduleScrollRestore`, `restoreScrollPosition`) and used two RAFs + `nextTick` to restore after virtual-scroller recalculation. 
- Wired a `ResizeObserver` on the selector card (`ref="itemsSelectorCard"`) with a debounced RAF callback to capture/restore scroll on container/zoom/resize. 
- Hardened overflow handling in `checkItemContainerOverflow()` to compute available height, only update `el.style.maxHeight` when it actually changes, and schedule scroll restore after layout settles. 
- Captured scroll before item add and restore after emitting `add_item`, and switched card scroll handlers to operate on the real scroll container; no new deps added (only native APIs).

### Testing
- Ran code formatting with `prettier --write` on `ItemsSelector.vue` which completed successfully. 
- Ran `prettier --check` which initially reported style issues before formatting (fixed). 
- Ran `eslint` which reported an existing Vuetify deprecation error (`@input` -> `@update:modelValue`) unrelated to the scroll changes. 
- Ran the test suite (`vitest`) which failed in this environment due to IndexedDB MissingAPI (test environment) and two unrelated unit test failures; scroll-related changes did not introduce additional test errors beyond environment/test-suite preconditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69608582e2648326b055012bf0a89b16)