### PR TITLE
Fix alt shortcut detection for non-Latin layouts

### DIFF
--- a/frontend/src/posapp/components/pos/invoiceShortcuts.js
+++ b/frontend/src/posapp/components/pos/invoiceShortcuts.js
@@ -7,6 +7,11 @@ const consumeEvent = (event) => {
 const isDigit = (event, digit) =>
 	event.key === String(digit) || event.code === `Digit${digit}` || event.code === `Numpad${digit}`;
 const isBackquote = (event) => event.key === "`" || event.code === "Backquote";
+const isLetter = (event, letter) => {
+	const normalized = letter.toLowerCase();
+	const keyValue = event.key?.toLowerCase?.();
+	return keyValue === normalized || event.code === `Key${letter.toUpperCase()}`;
+};
 
 export default {
 	async handleInvoiceShortcut(event) {
@@ -15,7 +20,6 @@ export default {
 		}
 
 		const key = event.key;
-		const keyLower = key.toLowerCase();
 
 		if (key === "F4") {
 			consumeEvent(event);
@@ -128,31 +132,31 @@ export default {
 			return;
 		}
 
-		if (keyLower === "q") {
+		if (isLetter(event, "q")) {
 			consumeEvent(event);
 			this.focusItemTableField("qty");
 			return;
 		}
 
-		if (keyLower === "a") {
+		if (isLetter(event, "a")) {
 			consumeEvent(event);
 			this.focusAdditionalDiscountField?.();
 			return;
 		}
 
-		if (keyLower === "u") {
+		if (isLetter(event, "u")) {
 			consumeEvent(event);
 			this.focusItemTableField("uom");
 			return;
 		}
 
-		if (keyLower === "r") {
+		if (isLetter(event, "r")) {
 			consumeEvent(event);
 			this.focusItemTableField("rate");
 			return;
 		}
 
-		if (keyLower === "e") {
+		if (isLetter(event, "e")) {
 			consumeEvent(event);
 			const firstItem = this.items?.[0];
 			if (firstItem) {
@@ -161,7 +165,7 @@ export default {
 			return;
 		}
 
-		if (keyLower === "f") {
+		if (isLetter(event, "f")) {
 			consumeEvent(event);
 			const input = this.$refs.itemSearchField;
 			if (input?.focus) {
@@ -172,37 +176,39 @@ export default {
 			return;
 		}
 
-		if (keyLower === "l") {
+		if (isLetter(event, "l")) {
 			consumeEvent(event);
 			this.get_draft_invoices?.();
 			return;
 		}
 
-		if (keyLower === "m") {
+		if (isLetter(event, "m")) {
 			consumeEvent(event);
 			this.eventBus.emit("toggle_item_selector_settings");
 			return;
 		}
 
-		if (keyLower === "s") {
+		if (isLetter(event, "s")) {
 			consumeEvent(event);
 			this.save_and_clear_invoice?.();
 			return;
 		}
 
-		if (keyLower === "d") {
+		if (isLetter(event, "d")) {
 			consumeEvent(event);
 			this.show_payment?.();
 			return;
 		}
 
-		if (keyLower === "x" || keyLower === "p") {
+		const isPaymentShortcut = isLetter(event, "x");
+		const isPrintShortcut = isLetter(event, "p");
+		if (isPaymentShortcut || isPrintShortcut) {
 			if (this.paymentVisible) {
 				return;
 			}
 			consumeEvent(event);
 
-			const shouldPrint = keyLower === "p";
+			const shouldPrint = isPrintShortcut;
 			const shouldSubmit = window.confirm(
 				__("Payments are not open. Do you want to open payments and submit?"),
 			);


### PR DESCRIPTION
### Motivation
- Alt+letter shortcuts in the POS invoice screen do not work when the keyboard layout is non-Latin (e.g. Arabic) because `event.key` reflects the character in the active layout. 
- Use of `event.code` (physical key name) ensures Alt+letter shortcuts behave consistently across layouts. 

### Description
- Added an `isLetter(event, letter)` helper that compares `event.key` (fallback) and `event.code` (`KeyX` style) to detect letter shortcuts reliably. 
- Replaced `keyLower === "..."` checks with `isLetter(...)` for all letter-based invoice shortcuts and adjusted payment/print shortcut logic to use the new checks. 
- Modified `frontend/src/posapp/components/pos/invoiceShortcuts.js` to implement these changes and kept existing behavior (consuming events and invoking the same handlers). 

### Testing
- Ran formatting with `cd frontend && yarn format` which completed successfully. 
- Ran lint with `cd frontend && yarn eslint .` which failed due to pre-existing lint errors in the repository (not introduced by this change). 
- Ran tests with `cd frontend && yarn test` which exercised the suite but reported failures: IndexedDB is missing in the test environment and two unit tests failed (mock export and missing `__` translation in tests), unrelated to the shortcut detection change.
