### PR TITLE
Increase mobile menu button size

### DIFF
--- a/frontend/src/posapp/components/navbar/NavbarMenu.vue
+++ b/frontend/src/posapp/components/navbar/NavbarMenu.vue
@@ -614,12 +614,12 @@ export default {
 /* Mobile Menu Button Styles */
 .mobile-menu-btn {
 	margin: 0 !important;
-	padding: 6px !important;
-	border-radius: 12px !important;
-	min-width: 36px !important;
-	max-width: 36px !important;
-	width: 36px !important;
-	height: 36px !important;
+	padding: 8px !important;
+	border-radius: 14px !important;
+	min-width: 44px !important;
+	max-width: 44px !important;
+	width: 44px !important;
+	height: 44px !important;
 	background: rgba(25, 118, 210, 0.08) !important;
 	border: 1px solid rgba(25, 118, 210, 0.12) !important;
 }


### PR DESCRIPTION
### Motivation

- Mobile (Android) users reported the navbar menu button appeared too small and hard to tap. 
- Increase hit area and improve accessibility/usability on small devices. 

### Description

- Enlarged the mobile menu button CSS in `frontend/src/posapp/components/navbar/NavbarMenu.vue` by updating `.mobile-menu-btn` padding to `8px`, `border-radius` to `14px`, and width/height (and min/max-width) to `44px`.
- No functional logic changes were made; this is a visual/UX-only update.
- Kept styling consistent with existing navbar theme and hover behavior.

### Testing

- Ran formatter with `yarn --cwd frontend format` and it completed successfully.
- Ran linter with `yarn --cwd frontend eslint .` which failed due to pre-existing, repo-wide lint errors unrelated to this change.
- Ran unit tests with `yarn --cwd frontend test`; test run completed but reported 2 failing tests (25 tests total: 23 passed, 2 failed) due to environment issues (missing IndexedDB API in the test environment and an existing mock export issue) unrelated to the UI sizing change.
- Manual UI screenshot verification was not possible in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696485df48e083268b11149be43b51a3)