### PR TITLE
Improve mobile navbar menu scrolling

### DIFF
--- a/frontend/src/posapp/components/navbar/NavbarMenu.vue
+++ b/frontend/src/posapp/components/navbar/NavbarMenu.vue
@@ -664,6 +664,8 @@ export default {
 .menu-card-compact {
 	border-radius: 20px;
 	overflow: hidden;
+	display: flex;
+	flex-direction: column;
 	background: rgba(255, 255, 255, 0.9);
 	border: 1px solid rgba(255, 255, 255, 0.2);
 	box-shadow:
@@ -699,6 +701,8 @@ export default {
 .menu-list-compact {
 	padding: 8px 6px 12px;
 	background: #ffffff;
+	flex: 1 1 auto;
+	overflow-y: auto;
 }
 
 /* Compact Menu Items */
@@ -861,6 +865,7 @@ export default {
 		min-width: 240px;
 		max-width: 260px;
 		border-radius: 14px;
+		max-height: 80vh;
 	}
 
 	.menu-item-compact {
@@ -891,6 +896,7 @@ export default {
 	.menu-card-compact {
 		min-width: 220px;
 		max-width: 240px;
+		max-height: 80vh;
 	}
 
 	.menu-item-compact {


### PR DESCRIPTION
### Motivation
- Mobile/Android three-dot (overflow) menu was being clipped and only showed a single item, making the menu unusable on small screens. 
- Provide a scrollable menu container so the full list of actions is reachable on small viewports. 
- Keep the menu visually contained on screen by capping height to avoid overflowing the viewport. 

### Description
- Updated `frontend/src/posapp/components/navbar/NavbarMenu.vue` to make `.menu-card-compact` a vertical flex container and to let its list grow/shrink. 
- Made `.menu-list-compact` flexible (`flex: 1 1 auto`) and added `overflow-y: auto` so the list can scroll when content is long. 
- Added `max-height: 80vh` to the mobile media queries (`@media (max-width: 768px)` and `@media (max-width: 480px)`) to cap the card height on small screens. 
- No JavaScript/behavior changes were made; this is a layout/CSS-only fix. 

### Testing
- Ran `yarn format` and it completed successfully. 
- Ran `npx eslint frontend/src` which failed due to pre-existing lint errors across the repository (not introduced by this change). 
- Ran `cd frontend && yarn test` where unit tests executed but the run failed due to unrelated environment issues and two failing tests (IndexedDB missing in the environment and a mocked export issue), so tests did not fully pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69648ad711248326b03befbfac98d6b8)