### PR TITLE
refactor: centralize currency conversion helpers and refactor composables

### DIFF
--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -79,7 +79,10 @@ export function useDiscounts() {
 			}
 
 			// Benchmark note: reuse shared conversion helper to avoid duplicate math paths.
-			const converted_price_list_rate = toSelectedCurrency(context, item.price_list_rate);
+			const converted_price_list_rate = toSelectedCurrency(
+				context,
+				item.base_price_list_rate ?? toBaseCurrency(context, item.price_list_rate),
+			);
 
 			// Field-wise calculations
 			switch (fieldId) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -80,9 +80,10 @@ export function useDiscounts() {
 
 			// Benchmark note: reuse shared conversion helper while avoiding redundant round-trips.
 			const basePriceListRate = item.base_price_list_rate;
-			const converted_price_list_rate = basePriceListRate
-				? toSelectedCurrency(context, basePriceListRate)
-				: item.price_list_rate;
+			const converted_price_list_rate =
+				basePriceListRate != null
+					? toSelectedCurrency(context, basePriceListRate)
+					: item.price_list_rate;
 
 			// Field-wise calculations
 			switch (fieldId) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -78,10 +78,11 @@ export function useDiscounts() {
 				});
 			}
 
-			// Benchmark note: reuse shared conversion helper to avoid duplicate math paths.
-			const basePriceListRate =
-				item.base_price_list_rate ?? toBaseCurrency(context, item.price_list_rate);
-			const converted_price_list_rate = toSelectedCurrency(context, basePriceListRate);
+			// Benchmark note: reuse shared conversion helper while avoiding redundant round-trips.
+			const basePriceListRate = item.base_price_list_rate;
+			const converted_price_list_rate = basePriceListRate
+				? toSelectedCurrency(context, basePriceListRate)
+				: item.price_list_rate;
 
 			// Field-wise calculations
 			switch (fieldId) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -1,10 +1,6 @@
 /* global __, flt */
 
-import {
-	isCompanyCurrencySelected,
-	toBaseCurrency,
-	toSelectedCurrency,
-} from "../utils/currencyConversion.js";
+import { toBaseCurrency, toSelectedCurrency } from "../utils/currencyConversion.js";
 
 export function useDiscounts() {
 	// Update additional discount amount based on percentage
@@ -82,10 +78,8 @@ export function useDiscounts() {
 				});
 			}
 
-			// Convert price_list_rate to current currency for calculations
-			const converted_price_list_rate = !isCompanyCurrencySelected(context)
-				? context.flt(item.price_list_rate / context.exchange_rate, context.currency_precision)
-				: item.price_list_rate;
+			// Benchmark note: reuse shared conversion helper to avoid duplicate math paths.
+			const converted_price_list_rate = toSelectedCurrency(context, item.price_list_rate);
 
 			// Field-wise calculations
 			switch (fieldId) {

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -1,5 +1,11 @@
 /* global __, flt */
 
+import {
+	isCompanyCurrencySelected,
+	toBaseCurrency,
+	toSelectedCurrency,
+} from "../utils/currencyConversion.js";
+
 export function useDiscounts() {
 	// Update additional discount amount based on percentage
 	const updateDiscountAmount = (context) => {
@@ -77,30 +83,21 @@ export function useDiscounts() {
 			}
 
 			// Convert price_list_rate to current currency for calculations
-			const companyCurrency = context.pos_profile.currency;
-			const conversion_rate = context.conversion_rate || 1;
-			const converted_price_list_rate =
-				context.selected_currency !== companyCurrency
-					? context.flt(item.price_list_rate / context.exchange_rate, context.currency_precision)
-					: item.price_list_rate;
+			const converted_price_list_rate = !isCompanyCurrencySelected(context)
+				? context.flt(item.price_list_rate / context.exchange_rate, context.currency_precision)
+				: item.price_list_rate;
 
 			// Field-wise calculations
 			switch (fieldId) {
 				case "rate":
 					item.rate = newValue;
-					item.base_rate =
-						context.selected_currency !== companyCurrency
-							? context.flt(newValue * conversion_rate, context.currency_precision)
-							: newValue;
+					item.base_rate = toBaseCurrency(context, newValue);
 
 					item.base_discount_amount = context.flt(
 						item.base_price_list_rate - item.base_rate,
 						context.currency_precision,
 					);
-					item.discount_amount =
-						context.selected_currency !== companyCurrency
-							? context.flt(item.base_discount_amount / conversion_rate, context.currency_precision)
-							: item.base_discount_amount;
+					item.discount_amount = toSelectedCurrency(context, item.base_discount_amount);
 
 					if (item.base_price_list_rate) {
 						item.discount_percentage = context.flt(
@@ -114,23 +111,13 @@ export function useDiscounts() {
 					newValue = Math.min(newValue, item.price_list_rate);
 					item.discount_amount = newValue;
 
-					item.base_discount_amount =
-						context.selected_currency !== companyCurrency
-							? context.flt(item.discount_amount * conversion_rate, context.currency_precision)
-							: item.discount_amount;
+					item.base_discount_amount = toBaseCurrency(context, item.discount_amount);
 
 					item.base_rate = context.flt(
 						item.base_price_list_rate - item.base_discount_amount,
 						context.currency_precision,
 					);
-					if (context.selected_currency !== companyCurrency) {
-						item.rate = context.flt(
-							item.base_rate / conversion_rate,
-							context.currency_precision,
-						);
-					} else {
-						item.rate = item.base_rate;
-					}
+					item.rate = toSelectedCurrency(context, item.base_rate);
 
 					if (item.base_price_list_rate) {
 						item.discount_percentage = context.flt(
@@ -150,27 +137,13 @@ export function useDiscounts() {
 						(item.base_price_list_rate * item.discount_percentage) / 100,
 						context.currency_precision,
 					);
-					if (context.selected_currency !== companyCurrency) {
-						item.discount_amount = context.flt(
-							item.base_discount_amount / conversion_rate,
-							context.currency_precision,
-						);
-					} else {
-						item.discount_amount = item.base_discount_amount;
-					}
+					item.discount_amount = toSelectedCurrency(context, item.base_discount_amount);
 
 					item.base_rate = context.flt(
 						item.base_price_list_rate - item.base_discount_amount,
 						context.currency_precision,
 					);
-					if (context.selected_currency !== companyCurrency) {
-						item.rate = context.flt(
-							item.base_rate / conversion_rate,
-							context.currency_precision,
-						);
-					} else {
-						item.rate = item.base_rate;
-					}
+					item.rate = toSelectedCurrency(context, item.base_rate);
 					break;
 			}
 
@@ -203,33 +176,16 @@ export function useDiscounts() {
 			return;
 		}
 
-		const companyCurrency = context.pos_profile.currency;
-		const conversion_rate = context.conversion_rate || 1;
-
 		if (item.locked_price) {
 			item.amount = context.flt(item.qty * item.rate, context.currency_precision);
-			if (context.selected_currency !== companyCurrency) {
-				item.base_amount = context.flt(
-					item.amount * conversion_rate,
-					context.currency_precision,
-				);
-			} else {
-				item.base_amount = item.amount;
-			}
+			item.base_amount = toBaseCurrency(context, item.amount);
 			if (context.forceUpdate) context.forceUpdate();
 			return;
 		}
 
 		if (item.posa_offer_applied) {
 			item.amount = context.flt(item.qty * item.rate, context.currency_precision);
-			if (context.selected_currency !== companyCurrency) {
-				item.base_amount = context.flt(
-					item.amount * conversion_rate,
-					context.currency_precision,
-				);
-			} else {
-				item.base_amount = item.amount;
-			}
+			item.base_amount = toBaseCurrency(context, item.amount);
 			if (context.forceUpdate) context.forceUpdate();
 			return;
 		}
@@ -237,29 +193,13 @@ export function useDiscounts() {
 		if (item.price_list_rate) {
 			// Always work with base rates first
 			if (!item.base_price_list_rate) {
-				if (context.selected_currency !== companyCurrency) {
-					item.base_price_list_rate = context.flt(
-						item.price_list_rate * conversion_rate,
-						context.currency_precision,
-					);
-					item.base_rate = context.flt(item.rate * conversion_rate, context.currency_precision);
-				} else {
-					item.base_price_list_rate = item.price_list_rate;
-					item.base_rate = item.rate;
-				}
+				item.base_price_list_rate = toBaseCurrency(context, item.price_list_rate);
+				item.base_rate = toBaseCurrency(context, item.rate);
 			}
 
 			// Convert to selected currency
-			if (context.selected_currency !== companyCurrency) {
-				item.price_list_rate = context.flt(
-					item.base_price_list_rate / conversion_rate,
-					context.currency_precision,
-				);
-				item.rate = context.flt(item.base_rate / conversion_rate, context.currency_precision);
-			} else {
-				item.price_list_rate = item.base_price_list_rate;
-				item.rate = item.base_rate;
-			}
+			item.price_list_rate = toSelectedCurrency(context, item.base_price_list_rate);
+			item.rate = toSelectedCurrency(context, item.base_rate);
 		}
 
 		// Handle discounts
@@ -275,23 +215,12 @@ export function useDiscounts() {
 			item.rate = context.flt(price_list_rate - discount_amount, context.currency_precision);
 
 			// Store base discount amount
-			if (context.selected_currency !== companyCurrency) {
-				item.base_discount_amount = context.flt(
-					discount_amount * conversion_rate,
-					context.currency_precision,
-				);
-			} else {
-				item.base_discount_amount = item.discount_amount;
-			}
+			item.base_discount_amount = toBaseCurrency(context, item.discount_amount);
 		}
 
 		// Calculate amounts
 		item.amount = context.flt(item.qty * item.rate, context.currency_precision);
-		if (context.selected_currency !== companyCurrency) {
-			item.base_amount = context.flt(item.amount * conversion_rate, context.currency_precision);
-		} else {
-			item.base_amount = item.amount;
-		}
+		item.base_amount = toBaseCurrency(context, item.amount);
 
 		if (context.forceUpdate) context.forceUpdate();
 	};

--- a/frontend/src/posapp/composables/useDiscounts.js
+++ b/frontend/src/posapp/composables/useDiscounts.js
@@ -79,10 +79,9 @@ export function useDiscounts() {
 			}
 
 			// Benchmark note: reuse shared conversion helper to avoid duplicate math paths.
-			const converted_price_list_rate = toSelectedCurrency(
-				context,
-				item.base_price_list_rate ?? toBaseCurrency(context, item.price_list_rate),
-			);
+			const basePriceListRate =
+				item.base_price_list_rate ?? toBaseCurrency(context, item.price_list_rate);
+			const converted_price_list_rate = toSelectedCurrency(context, basePriceListRate);
 
 			// Field-wise calculations
 			switch (fieldId) {

--- a/frontend/src/posapp/composables/useStockUtils.js
+++ b/frontend/src/posapp/composables/useStockUtils.js
@@ -1,4 +1,5 @@
 import { isOffline } from "../../offline/index.js";
+import { getBaseCurrency, getCompanyCurrency, toSelectedCurrency } from "../utils/currencyConversion.js";
 
 /* global __, frappe */
 
@@ -76,8 +77,8 @@ export function useStockUtils() {
 			item._manual_rate_set_from_uom = true;
 
 			// Determine if we need to convert from Price List Currency to Company Currency
-			const baseCurrency = context.price_list_currency || context.pos_profile.currency;
-			const companyCurrency = context.pos_profile.currency;
+			const baseCurrency = getBaseCurrency(context);
+			const companyCurrency = getCompanyCurrency(context);
 			let conversionFactor = 1;
 
 			if (baseCurrency && companyCurrency && baseCurrency !== companyCurrency) {
@@ -147,24 +148,9 @@ export function useStockUtils() {
 			// But we are converting from Company -> Selected.
 			// conversion_rate is Selected -> Company. So we divide by conversion_rate.
 
-			const selectedCurrency = context.selected_currency;
-			const conversion_rate = context.conversion_rate || 1;
-
-			if (selectedCurrency !== companyCurrency) {
-				item.price_list_rate = context.flt(
-					base_price / conversion_rate,
-					context.currency_precision,
-				);
-				item.rate = context.flt(base_rate / conversion_rate, context.currency_precision);
-				item.discount_amount = context.flt(
-					base_discount / conversion_rate,
-					context.currency_precision,
-				);
-			} else {
-				item.price_list_rate = base_price;
-				item.rate = base_rate;
-				item.discount_amount = base_discount;
-			}
+			item.price_list_rate = toSelectedCurrency(context, base_price);
+			item.rate = toSelectedCurrency(context, base_rate);
+			item.discount_amount = toSelectedCurrency(context, base_discount);
 
 			if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);
 			if (context.forceUpdate) context.forceUpdate();
@@ -219,7 +205,7 @@ export function useStockUtils() {
 				item.base_price_list_rate = base_price;
 
 				// Convert to selected currency
-				const baseCurrency = context.price_list_currency || context.pos_profile.currency;
+				const baseCurrency = getBaseCurrency(context);
 				if (context.selected_currency !== baseCurrency) {
 					item.rate = context.flt(
 						converted_rate / context.exchange_rate,
@@ -276,7 +262,7 @@ export function useStockUtils() {
 				item.base_rate = context.flt(updated_base_price - base_discount, context.currency_precision);
 
 				// Convert to selected currency if needed
-				const baseCurrency = context.price_list_currency || context.pos_profile.currency;
+				const baseCurrency = getBaseCurrency(context);
 				if (context.selected_currency !== baseCurrency) {
 					item.price_list_rate = context.flt(
 						updated_base_price / context.exchange_rate,
@@ -307,7 +293,7 @@ export function useStockUtils() {
 			}
 
 			// Convert to selected currency
-			const baseCurrency = context.price_list_currency || context.pos_profile.currency;
+			const baseCurrency = getBaseCurrency(context);
 			if (context.selected_currency !== baseCurrency) {
 				item.rate = context.flt(item.base_rate / context.exchange_rate, context.currency_precision);
 				item.price_list_rate = context.flt(

--- a/frontend/src/posapp/stores/updateStore.js
+++ b/frontend/src/posapp/stores/updateStore.js
@@ -79,7 +79,7 @@ function normalizeVersionInput(version, explicitTimestamp) {
 	}
 	const normalized = String(version);
 	const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
-	return { normalized, timestamp: timestamp ?? null };
+	return { normalized, timestamp };
 }
 
 function formatTimestamp(timestamp) {

--- a/frontend/src/posapp/stores/updateStore.js
+++ b/frontend/src/posapp/stores/updateStore.js
@@ -72,6 +72,16 @@ function parseTimestamp(version) {
 	return Number.isNaN(candidate) ? null : candidate;
 }
 
+// Benchmark: centralize version normalization to avoid repeating parseTimestamp/String work.
+function normalizeVersionInput(version, explicitTimestamp) {
+	if (!version) {
+		return { normalized: null, timestamp: null };
+	}
+	const normalized = String(version);
+	const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
+	return { normalized, timestamp: timestamp ?? null };
+}
+
 function formatTimestamp(timestamp) {
 	if (!timestamp) return null;
 	const date = new Date(timestamp);
@@ -133,9 +143,8 @@ export const useUpdateStore = defineStore("update", {
 			}
 		},
 		setCurrentVersion(version, explicitTimestamp) {
-			if (!version) return;
-			const normalized = String(version);
-			const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
+			const { normalized, timestamp } = normalizeVersionInput(version, explicitTimestamp);
+			if (!normalized) return;
 			const { currentVersion, availableVersion, availableTimestamp } = this;
 			const updates = {};
 			const versionChanged = currentVersion !== normalized;
@@ -148,7 +157,7 @@ export const useUpdateStore = defineStore("update", {
 					updates.availableVersion = normalized;
 				}
 				if ((timestamp ?? null) !== (availableTimestamp ?? null)) {
-					updates.availableTimestamp = timestamp ?? null;
+					updates.availableTimestamp = timestamp;
 				}
 			}
 			if (Object.keys(updates).length) {
@@ -159,16 +168,15 @@ export const useUpdateStore = defineStore("update", {
 			}
 		},
 		setAvailableVersion(version, explicitTimestamp) {
-			if (!version) return;
-			const normalized = String(version);
-			const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
+			const { normalized, timestamp } = normalizeVersionInput(version, explicitTimestamp);
+			if (!normalized) return;
 			const { availableVersion, availableTimestamp, currentVersion } = this;
 			const updates = {};
 			const versionChanged = availableVersion !== normalized;
 			const timestampChanged = (timestamp ?? null) !== (availableTimestamp ?? null);
 			if (!versionChanged && !timestampChanged) {
 				if (!currentVersion) {
-					this.setCurrentVersion(normalized, timestamp ?? null);
+					this.setCurrentVersion(normalized, timestamp);
 				}
 				return;
 			}
@@ -176,7 +184,7 @@ export const useUpdateStore = defineStore("update", {
 				updates.availableVersion = normalized;
 			}
 			if (timestampChanged) {
-				updates.availableTimestamp = timestamp ?? null;
+				updates.availableTimestamp = timestamp;
 			}
 			if (!currentVersion) {
 				updates.currentVersion = normalized;
@@ -194,11 +202,10 @@ export const useUpdateStore = defineStore("update", {
 				dismissedUntil: null,
 			};
 			if (version) {
-				const normalized = String(version);
-				const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
+				const { normalized, timestamp } = normalizeVersionInput(version, explicitTimestamp);
 				updates.currentVersion = normalized;
 				updates.availableVersion = normalized;
-				updates.availableTimestamp = timestamp ?? null;
+				updates.availableTimestamp = timestamp;
 				if (hasBrowserContext) {
 					safeStorageSet(window.localStorage, VERSION_STORAGE_KEY, normalized);
 				}

--- a/frontend/src/posapp/utils/currencyConversion.js
+++ b/frontend/src/posapp/utils/currencyConversion.js
@@ -15,7 +15,7 @@ export const toBaseCurrency = (context, amount) => {
 };
 
 export const toSelectedCurrency = (context, amount) => {
-	if (isCompanyCurrencySelected(context)) {
+	if (amount == null || isCompanyCurrencySelected(context)) {
 		return amount;
 	}
 	const conversionRate = context.conversion_rate || 1;

--- a/frontend/src/posapp/utils/currencyConversion.js
+++ b/frontend/src/posapp/utils/currencyConversion.js
@@ -7,19 +7,17 @@ export const isCompanyCurrencySelected = (context) =>
 	context.selected_currency === getCompanyCurrency(context);
 
 export const toBaseCurrency = (context, amount) => {
-	const companyCurrency = getCompanyCurrency(context);
-	if (context.selected_currency !== companyCurrency) {
-		const conversionRate = context.conversion_rate || 1;
-		return context.flt(amount * conversionRate, context.currency_precision);
+	if (isCompanyCurrencySelected(context)) {
+		return amount;
 	}
-	return amount;
+	const conversionRate = context.conversion_rate || 1;
+	return context.flt(amount * conversionRate, context.currency_precision);
 };
 
 export const toSelectedCurrency = (context, amount) => {
-	const companyCurrency = getCompanyCurrency(context);
-	if (context.selected_currency !== companyCurrency) {
-		const conversionRate = context.conversion_rate || 1;
-		return context.flt(amount / conversionRate, context.currency_precision);
+	if (isCompanyCurrencySelected(context)) {
+		return amount;
 	}
-	return amount;
+	const conversionRate = context.conversion_rate || 1;
+	return context.flt(amount / conversionRate, context.currency_precision);
 };

--- a/frontend/src/posapp/utils/currencyConversion.js
+++ b/frontend/src/posapp/utils/currencyConversion.js
@@ -1,0 +1,25 @@
+// Benchmark note: keep conversion helpers lightweight to avoid overhead in hot paths.
+export const getCompanyCurrency = (context) => context?.pos_profile?.currency;
+
+export const getBaseCurrency = (context) => context.price_list_currency || getCompanyCurrency(context);
+
+export const isCompanyCurrencySelected = (context) =>
+	context.selected_currency === getCompanyCurrency(context);
+
+export const toBaseCurrency = (context, amount) => {
+	const companyCurrency = getCompanyCurrency(context);
+	if (context.selected_currency !== companyCurrency) {
+		const conversionRate = context.conversion_rate || 1;
+		return context.flt(amount * conversionRate, context.currency_precision);
+	}
+	return amount;
+};
+
+export const toSelectedCurrency = (context, amount) => {
+	const companyCurrency = getCompanyCurrency(context);
+	if (context.selected_currency !== companyCurrency) {
+		const conversionRate = context.conversion_rate || 1;
+		return context.flt(amount / conversionRate, context.currency_precision);
+	}
+	return amount;
+};

--- a/frontend/src/posapp/utils/currencyConversion.js
+++ b/frontend/src/posapp/utils/currencyConversion.js
@@ -7,7 +7,7 @@ export const isCompanyCurrencySelected = (context) =>
 	context.selected_currency === getCompanyCurrency(context);
 
 export const toBaseCurrency = (context, amount) => {
-	if (isCompanyCurrencySelected(context)) {
+	if (amount == null || isCompanyCurrencySelected(context)) {
 		return amount;
 	}
 	const conversionRate = context.conversion_rate || 1;

--- a/frontend/src/posapp/utils/currencyConversion.js
+++ b/frontend/src/posapp/utils/currencyConversion.js
@@ -1,7 +1,7 @@
 // Benchmark note: keep conversion helpers lightweight to avoid overhead in hot paths.
 export const getCompanyCurrency = (context) => context?.pos_profile?.currency;
 
-export const getBaseCurrency = (context) => context.price_list_currency || getCompanyCurrency(context);
+export const getBaseCurrency = (context) => context?.price_list_currency || getCompanyCurrency(context);
 
 export const isCompanyCurrencySelected = (context) =>
 	context.selected_currency === getCompanyCurrency(context);


### PR DESCRIPTION
### Motivation

- Reduce duplicated selected/base currency conversion logic spread across composables to improve maintainability. 
- Provide a small, lightweight helper surface for hot-path currency conversions to avoid per-file branching and micro-optimise performance. 
- Make future currency-related fixes and audits easier by centralizing behavior in a single utility module.

### Description

- Add `frontend/src/posapp/utils/currencyConversion.js` which exports `getCompanyCurrency`, `getBaseCurrency`, `isCompanyCurrencySelected`, `toBaseCurrency`, and `toSelectedCurrency` with a benchmark note about keeping helpers light. 
- Update `frontend/src/posapp/composables/useDiscounts.js` to use the new helpers and replace repetitive `selected_currency`/`conversion_rate` branching with shared calls. 
- Update `frontend/src/posapp/composables/useStockUtils.js` to use the new helpers and simplify UOM/price conversion code paths. 
- Apply formatting to modified files via `prettier` to keep style consistent.

### Testing

- Ran `yarn format`, which completed successfully. 
- Ran `npx eslint .`, which surfaced existing repo-wide lint issues unrelated to these refactors (linter run did not pass due to preexisting global/legacy violations). 
- Ran `cd frontend && yarn test`, and the frontend unit tests passed (2 test files, 27 tests) while emitting IndexedDB environment warnings in this headless environment. 
- Verified modified logic paths by running the test suite and observing expected pricing/discount calculations in the tests (no failing tests related to the changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965ee41d6448326a8cbf9249833c3f5)