### PR TITLE
Refactor update store version normalization

### DIFF
--- a/frontend/src/posapp/stores/updateStore.js
+++ b/frontend/src/posapp/stores/updateStore.js
@@ -79,7 +79,7 @@ function normalizeVersionInput(version, explicitTimestamp) {
 	}
 	const normalized = String(version);
 	const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
-	return { normalized, timestamp: timestamp ?? null };
+	return { normalized, timestamp };
 }
 
 function formatTimestamp(timestamp) {

--- a/frontend/src/posapp/stores/updateStore.js
+++ b/frontend/src/posapp/stores/updateStore.js
@@ -72,6 +72,16 @@ function parseTimestamp(version) {
 	return Number.isNaN(candidate) ? null : candidate;
 }
 
+// Benchmark: centralize version normalization to avoid repeating parseTimestamp/String work.
+function normalizeVersionInput(version, explicitTimestamp) {
+	if (!version) {
+		return { normalized: null, timestamp: null };
+	}
+	const normalized = String(version);
+	const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
+	return { normalized, timestamp: timestamp ?? null };
+}
+
 function formatTimestamp(timestamp) {
 	if (!timestamp) return null;
 	const date = new Date(timestamp);
@@ -133,9 +143,8 @@ export const useUpdateStore = defineStore("update", {
 			}
 		},
 		setCurrentVersion(version, explicitTimestamp) {
-			if (!version) return;
-			const normalized = String(version);
-			const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
+			const { normalized, timestamp } = normalizeVersionInput(version, explicitTimestamp);
+			if (!normalized) return;
 			const { currentVersion, availableVersion, availableTimestamp } = this;
 			const updates = {};
 			const versionChanged = currentVersion !== normalized;
@@ -148,7 +157,7 @@ export const useUpdateStore = defineStore("update", {
 					updates.availableVersion = normalized;
 				}
 				if ((timestamp ?? null) !== (availableTimestamp ?? null)) {
-					updates.availableTimestamp = timestamp ?? null;
+					updates.availableTimestamp = timestamp;
 				}
 			}
 			if (Object.keys(updates).length) {
@@ -159,16 +168,15 @@ export const useUpdateStore = defineStore("update", {
 			}
 		},
 		setAvailableVersion(version, explicitTimestamp) {
-			if (!version) return;
-			const normalized = String(version);
-			const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
+			const { normalized, timestamp } = normalizeVersionInput(version, explicitTimestamp);
+			if (!normalized) return;
 			const { availableVersion, availableTimestamp, currentVersion } = this;
 			const updates = {};
 			const versionChanged = availableVersion !== normalized;
 			const timestampChanged = (timestamp ?? null) !== (availableTimestamp ?? null);
 			if (!versionChanged && !timestampChanged) {
 				if (!currentVersion) {
-					this.setCurrentVersion(normalized, timestamp ?? null);
+					this.setCurrentVersion(normalized, timestamp);
 				}
 				return;
 			}
@@ -176,7 +184,7 @@ export const useUpdateStore = defineStore("update", {
 				updates.availableVersion = normalized;
 			}
 			if (timestampChanged) {
-				updates.availableTimestamp = timestamp ?? null;
+				updates.availableTimestamp = timestamp;
 			}
 			if (!currentVersion) {
 				updates.currentVersion = normalized;
@@ -194,11 +202,10 @@ export const useUpdateStore = defineStore("update", {
 				dismissedUntil: null,
 			};
 			if (version) {
-				const normalized = String(version);
-				const timestamp = explicitTimestamp ?? parseTimestamp(normalized);
+				const { normalized, timestamp } = normalizeVersionInput(version, explicitTimestamp);
 				updates.currentVersion = normalized;
 				updates.availableVersion = normalized;
-				updates.availableTimestamp = timestamp ?? null;
+				updates.availableTimestamp = timestamp;
 				if (hasBrowserContext) {
 					safeStorageSet(window.localStorage, VERSION_STORAGE_KEY, normalized);
 				}


### PR DESCRIPTION
### Motivation

- Reduce duplication by centralizing version normalization and timestamp parsing logic used across the update store.  
- Make version/timestamp handling consistent between `setCurrentVersion`, `setAvailableVersion` and `markUpdateApplied`.  
- Improve maintainability and make future changes to normalization/parsing easier to apply in one place.  
- Note a micro-benchmark intent (comment) to avoid repeated `String`/`parseTimestamp` work.

### Description

- Added a new helper `normalizeVersionInput(version, explicitTimestamp)` that returns `{ normalized, timestamp }`.  
- Updated `setCurrentVersion`, `setAvailableVersion` and `markUpdateApplied` in `frontend/src/posapp/stores/updateStore.js` to use `normalizeVersionInput`.  
- Standardized timestamp null handling so comparisons and stored values are consistent.  
- Left a brief comment documenting the benchmark/intent behind centralizing normalization.

### Testing

- Ran code formatting via `yarn format` which completed successfully.  
- Ran linting with `npx eslint .` which fails due to existing repository-wide `no-undef` / `no-unused-vars` issues unrelated to this change.  
- Ran frontend unit tests with `yarn --cwd frontend test` (Vitest) which passed, with IndexedDB MissingAPI warnings in this environment.  
- Ran backend tests with `pytest` which failed in this environment due to a missing `frappe` dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965fcb1859c832683b34d979a6b4ba4)