### PR TITLE
fix: Replace deprecated frappe.get_list count query with frappe.db.count

### DIFF
--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -1301,13 +1301,7 @@ def search_invoices_for_return(
             return {"invoices": [], "has_more": False}
 
     # Count total invoices matching the criteria (for has_more flag)
-    total_count_query = frappe.get_list(
-        doctype,
-        filters=filters,
-        fields=["count(name) as total_count"],
-        as_list=False,
-    )
-    total_count = total_count_query[0].total_count if total_count_query else 0
+    total_count = frappe.db.count(doctype, filters=filters)
 
     # Get invoices matching all criteria with pagination
     invoices_list = frappe.get_list(


### PR DESCRIPTION
Fixes SQL validation error in search_invoices_for_return function. Frappe no longer allows raw SQL functions in get_list fields parameter. Using frappe.db.count() is the recommended approach for counting records.