### PR TITLE
Validate cached POS profile against user

### DIFF
--- a/frontend/src/posapp/composables/usePosShift.js
+++ b/frontend/src/posapp/composables/usePosShift.js
@@ -3,10 +3,10 @@ import {
 	initPromise,
 	checkDbHealth,
 	getOpeningStorage,
-	setOpeningStorage,
 	clearOpeningStorage,
 	setTaxTemplate,
 } from "../../offline/index.js";
+import { cacheOpeningStorageWithUser, isOpeningStorageValidForUser } from "../../utils/opening_storage.js";
 
 export function usePosShift(openDialog) {
 	const { proxy } = getCurrentInstance();
@@ -15,21 +15,23 @@ export function usePosShift(openDialog) {
 	const pos_profile = ref(null);
 	const pos_opening_shift = ref(null);
 
-	function isOpeningStorageValidForUser(data) {
-		if (!data?.pos_profile) return false;
-		const sessionUser = frappe?.session?.user;
-		if (!sessionUser) return true;
-		const cachedUser = data.cached_user || data.pos_opening_shift?.user;
-		if (!cachedUser) return true;
-		return cachedUser === sessionUser;
-	}
-
-	function cacheOpeningStorage(data) {
-		try {
-			setOpeningStorage({ ...data, cached_user: frappe?.session?.user || null });
-		} catch (e) {
-			console.error("Failed to cache opening data", e);
+	function applyCachedOpeningData(data) {
+		if (!data) return false;
+		if (!isOpeningStorageValidForUser(data)) {
+			clearOpeningStorage();
+			return false;
 		}
+		pos_profile.value = data.pos_profile;
+		pos_opening_shift.value = data.pos_opening_shift;
+		eventBus?.emit("register_pos_profile", data);
+		eventBus?.emit("set_company", data.company);
+		try {
+			frappe.realtime.emit("pos_profile_registered");
+		} catch (e) {
+			console.warn("Realtime emit failed", e);
+		}
+		console.info("LoadPosProfile (cached)");
+		return true;
 	}
 
 	async function check_opening_entry() {
@@ -65,49 +67,19 @@ export function usePosShift(openDialog) {
 						console.warn("Realtime emit failed", e);
 					}
 					console.info("LoadPosProfile");
-					try {
-						cacheOpeningStorage(r.message);
-					} catch (e) {
-						console.error("Failed to cache opening data", e);
-					}
+					cacheOpeningStorageWithUser(r.message);
 				} else {
 					const data = getOpeningStorage();
-					if (data && isOpeningStorageValidForUser(data)) {
-						pos_profile.value = data.pos_profile;
-						pos_opening_shift.value = data.pos_opening_shift;
-						eventBus?.emit("register_pos_profile", data);
-						eventBus?.emit("set_company", data.company);
-						try {
-							frappe.realtime.emit("pos_profile_registered");
-						} catch (e) {
-							console.warn("Realtime emit failed", e);
-						}
-						console.info("LoadPosProfile (cached)");
+					if (applyCachedOpeningData(data)) {
 						return;
-					}
-					if (data && !isOpeningStorageValidForUser(data)) {
-						clearOpeningStorage();
 					}
 					openDialog && openDialog();
 				}
 			})
 			.catch(() => {
 				const data = getOpeningStorage();
-				if (data && isOpeningStorageValidForUser(data)) {
-					pos_profile.value = data.pos_profile;
-					pos_opening_shift.value = data.pos_opening_shift;
-					eventBus?.emit("register_pos_profile", data);
-					eventBus?.emit("set_company", data.company);
-					try {
-						frappe.realtime.emit("pos_profile_registered");
-					} catch (e) {
-						console.warn("Realtime emit failed", e);
-					}
-					console.info("LoadPosProfile (cached)");
+				if (applyCachedOpeningData(data)) {
 					return;
-				}
-				if (data && !isOpeningStorageValidForUser(data)) {
-					clearOpeningStorage();
 				}
 				openDialog && openDialog();
 			});

--- a/frontend/src/posapp/composables/usePosShift.js
+++ b/frontend/src/posapp/composables/usePosShift.js
@@ -15,6 +15,23 @@ export function usePosShift(openDialog) {
 	const pos_profile = ref(null);
 	const pos_opening_shift = ref(null);
 
+	function isOpeningStorageValidForUser(data) {
+		if (!data?.pos_profile) return false;
+		const sessionUser = frappe?.session?.user;
+		if (!sessionUser) return true;
+		const cachedUser = data.cached_user || data.pos_opening_shift?.user;
+		if (!cachedUser) return true;
+		return cachedUser === sessionUser;
+	}
+
+	function cacheOpeningStorage(data) {
+		try {
+			setOpeningStorage({ ...data, cached_user: frappe?.session?.user || null });
+		} catch (e) {
+			console.error("Failed to cache opening data", e);
+		}
+	}
+
 	async function check_opening_entry() {
 		await initPromise;
 		await checkDbHealth();
@@ -49,13 +66,13 @@ export function usePosShift(openDialog) {
 					}
 					console.info("LoadPosProfile");
 					try {
-						setOpeningStorage(r.message);
+						cacheOpeningStorage(r.message);
 					} catch (e) {
 						console.error("Failed to cache opening data", e);
 					}
 				} else {
 					const data = getOpeningStorage();
-					if (data) {
+					if (data && isOpeningStorageValidForUser(data)) {
 						pos_profile.value = data.pos_profile;
 						pos_opening_shift.value = data.pos_opening_shift;
 						eventBus?.emit("register_pos_profile", data);
@@ -68,12 +85,15 @@ export function usePosShift(openDialog) {
 						console.info("LoadPosProfile (cached)");
 						return;
 					}
+					if (data && !isOpeningStorageValidForUser(data)) {
+						clearOpeningStorage();
+					}
 					openDialog && openDialog();
 				}
 			})
 			.catch(() => {
 				const data = getOpeningStorage();
-				if (data) {
+				if (data && isOpeningStorageValidForUser(data)) {
 					pos_profile.value = data.pos_profile;
 					pos_opening_shift.value = data.pos_opening_shift;
 					eventBus?.emit("register_pos_profile", data);
@@ -85,6 +105,9 @@ export function usePosShift(openDialog) {
 					}
 					console.info("LoadPosProfile (cached)");
 					return;
+				}
+				if (data && !isOpeningStorageValidForUser(data)) {
+					clearOpeningStorage();
 				}
 				openDialog && openDialog();
 			});

--- a/frontend/src/utils/opening_storage.js
+++ b/frontend/src/utils/opening_storage.js
@@ -3,7 +3,7 @@ import { setOpeningStorage } from "../offline/index.js";
 
 export function isOpeningStorageValidForUser(data, sessionUser = frappe?.session?.user) {
 	if (!data?.pos_profile) return false;
-	if (!sessionUser) return true;
+	if (!sessionUser) return false;
 	const cachedUser = data.cached_user || data.pos_opening_shift?.user || null;
 	return cachedUser === sessionUser;
 }

--- a/frontend/src/utils/opening_storage.js
+++ b/frontend/src/utils/opening_storage.js
@@ -1,0 +1,17 @@
+/* global frappe */
+import { setOpeningStorage } from "../offline/index.js";
+
+export function isOpeningStorageValidForUser(data, sessionUser = frappe?.session?.user) {
+	if (!data?.pos_profile) return false;
+	if (!sessionUser) return true;
+	const cachedUser = data.cached_user || data.pos_opening_shift?.user || null;
+	return cachedUser === sessionUser;
+}
+
+export function cacheOpeningStorageWithUser(data) {
+	try {
+		setOpeningStorage({ ...data, cached_user: frappe?.session?.user || null });
+	} catch (e) {
+		console.error("Failed to cache opening data", e);
+	}
+}

--- a/frontend/src/utils/pos_profile.js
+++ b/frontend/src/utils/pos_profile.js
@@ -6,6 +6,7 @@ import {
 	setPrintTemplate,
 	setTermsAndConditions,
 } from "../offline/index.js";
+import { isOpeningStorageValidForUser } from "./opening_storage.js";
 
 async function cachePrintTemplateAndTerms(profile) {
 	if (!profile || typeof frappe === "undefined" || !navigator.onLine) return;
@@ -52,15 +53,6 @@ function updateOpeningStorageProfile(profile) {
 	if (cached?.pos_profile) {
 		setOpeningStorage({ ...cached, pos_profile: profile });
 	}
-}
-
-function isOpeningStorageValidForUser(data) {
-	if (!data?.pos_profile) return false;
-	const sessionUser = frappe?.session?.user;
-	if (!sessionUser) return true;
-	const cachedUser = data.cached_user || data.pos_opening_shift?.user;
-	if (!cachedUser) return true;
-	return cachedUser === sessionUser;
 }
 
 export async function ensurePosProfile() {

--- a/frontend/src/utils/pos_profile.js
+++ b/frontend/src/utils/pos_profile.js
@@ -2,6 +2,7 @@
 import {
 	getOpeningStorage,
 	setOpeningStorage,
+	clearOpeningStorage,
 	setPrintTemplate,
 	setTermsAndConditions,
 } from "../offline/index.js";
@@ -53,6 +54,15 @@ function updateOpeningStorageProfile(profile) {
 	}
 }
 
+function isOpeningStorageValidForUser(data) {
+	if (!data?.pos_profile) return false;
+	const sessionUser = frappe?.session?.user;
+	if (!sessionUser) return true;
+	const cachedUser = data.cached_user || data.pos_opening_shift?.user;
+	if (!cachedUser) return true;
+	return cachedUser === sessionUser;
+}
+
 export async function ensurePosProfile() {
 	const bootProfile = frappe?.boot?.pos_profile;
 	if (bootProfile && bootProfile.warehouse && bootProfile.selling_price_list) {
@@ -91,6 +101,12 @@ export async function ensurePosProfile() {
 	}
 	const cached = getOpeningStorage();
 	if (cached && cached.pos_profile) {
+		if (!isOpeningStorageValidForUser(cached)) {
+			clearOpeningStorage();
+			console.warn("Cleared cached POS opening data for mismatched user");
+			await cachePrintTemplateAndTerms(bootProfile);
+			return bootProfile || null;
+		}
 		await cachePrintTemplateAndTerms(cached.pos_profile);
 		return cached.pos_profile;
 	}


### PR DESCRIPTION
### Motivation
- Prevent the POS from loading cached opening data that belongs to a different user, which could cause the UI to pick the wrong POS Profile (leading to incorrect prices/stock).
- Ensure offline fallback only reuses opening data when it was cached for the current session user.

### Description
- Add `cached_user` when persisting opening shift data and introduce `isOpeningStorageValidForUser` helper to validate cached ownership. 
- Replace direct `setOpeningStorage` calls with `cacheOpeningStorage` which saves `cached_user` in `usePosShift.js`.
- Import and use `clearOpeningStorage` to drop mismatched cached opening data instead of reusing it in both `usePosShift.js` and `pos_profile.js`.
- In `ensurePosProfile()` fall back to the boot profile when cached opening data does not match the active user.

### Testing
- Ran formatting with `yarn --cwd frontend format` (succeeded).
- Ran lint with `npx eslint frontend/src` (noted repo-wide lint errors unrelated to this change; lint command failed in this environment).
- Ran frontend unit tests with `yarn --cwd frontend test` (Vitest: 2 files, 27 tests passed).
- Ran backend tests with `python -m pytest` (failed to run in this environment due to missing `frappe` module).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b695fb4e4832690332b1e424e7776)