### PR TITLE
fix: hide ERPNext 16 sidebar in POSAwesome interface

### DIFF
--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -165,11 +165,8 @@ export default {
 		UpdatePrompt,
 	},
 	mounted() {
-		// Wait for Frappe to fully render then remove sidebar
-		setTimeout(() => {
-			this.remove_frappe_nav();
-			this.setup_sidebar_observer();
-		}, 800);
+		// Poll for Frappe sidebar instead of fixed timeout
+		this.pollForFrappeNav();
 
 		// Rest of your initialization code...
 		window.addEventListener("resize", this.adjust_frappe_sidebar_offset);
@@ -221,6 +218,29 @@ export default {
 		}
 	},
 	methods: {
+		pollForFrappeNav(maxAttempts = 50, interval = 100) {
+			let attempts = 0;
+			const checkAndRemove = () => {
+				attempts++;
+				// Check if any sidebar elements exist
+				const selectors = [
+					".body-sidebar-container", 
+					".body-sidebar", 
+					".desk-sidebar", 
+					".app-sidebar", 
+					".layout-side-section"
+				];
+				const hasSidebar = selectors.some(sel => document.querySelector(sel));
+				
+				if (hasSidebar || attempts >= maxAttempts) {
+					this.remove_frappe_nav();
+					this.setup_sidebar_observer();
+				} else {
+					setTimeout(checkAndRemove, interval);
+				}
+			};
+			checkAndRemove();
+		},
 		setupNetworkListeners,
 		checkNetworkConnectivity,
 		detectHostType,
@@ -545,15 +565,16 @@ export default {
 		},
 
 		setup_sidebar_observer() {
-			// PERFORMANCE FIX: Check added nodes directly instead of re-querying entire document
+			const SIDEBAR_SELECTORS = '.body-sidebar-container, .body-sidebar, .desk-sidebar, .app-sidebar, .layout-side-section';
+			
 			const observer = new MutationObserver((mutations) => {
 				for (const mutation of mutations) {
 					for (const node of mutation.addedNodes) {
 						if (node.nodeType === Node.ELEMENT_NODE) {
 							// Check if the added node itself is a sidebar element or contains one
 							if (
-								node.matches('.body-sidebar-container, .body-sidebar, .desk-sidebar, .app-sidebar, .layout-side-section') ||
-								node.querySelector('.body-sidebar-container, .body-sidebar, .desk-sidebar, .app-sidebar, .layout-side-section')
+								node.matches(SIDEBAR_SELECTORS) ||
+								node.querySelector(SIDEBAR_SELECTORS)
 							) {
 								this.remove_frappe_nav();
 								return; // Exit after handling

--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -86,6 +86,23 @@ import {
 } from "./composables/useNetwork.js";
 import { useRtl } from "./composables/useRtl.js";
 
+/**
+ * Frappe Desk UI selectors to hide in POS view.
+ * Used by: remove_frappe_nav(), pollForFrappeNav(), setup_sidebar_observer()
+ */
+const FRAPPE_NAV_SELECTORS = [
+	".body-sidebar-container",
+	".body-sidebar",
+	".desk-sidebar",
+	".app-sidebar",
+	".layout-side-section",
+	".page-head",
+	".navbar.navbar-default.navbar-fixed-top",
+	".sidebar-overlay",
+];
+
+const FRAPPE_NAV_SELECTOR_STRING = FRAPPE_NAV_SELECTORS.join(", ");
+
 export default {
 	setup() {
 		const { isRtl, rtlStyles, rtlClasses } = useRtl();
@@ -222,15 +239,7 @@ export default {
 			let attempts = 0;
 			const checkAndRemove = () => {
 				attempts++;
-				// Check if any sidebar elements exist
-				const selectors = [
-					".body-sidebar-container", 
-					".body-sidebar", 
-					".desk-sidebar", 
-					".app-sidebar", 
-					".layout-side-section"
-				];
-				const hasSidebar = selectors.some(sel => document.querySelector(sel));
+				const hasSidebar = FRAPPE_NAV_SELECTORS.some((sel) => document.querySelector(sel));
 				
 				if (hasSidebar || attempts >= maxAttempts) {
 					this.remove_frappe_nav();
@@ -543,53 +552,39 @@ export default {
 		},
 
 		remove_frappe_nav() {
-			// Remove sidebar elements immediately
-			const selectors = [
-				".body-sidebar-container",
-				".body-sidebar",
-				".desk-sidebar",
-				".app-sidebar",
-				".layout-side-section",
-				".page-head",
-				".navbar.navbar-default.navbar-fixed-top",
-				".sidebar-overlay"
-			];
-			
-			selectors.forEach(selector => {
+			FRAPPE_NAV_SELECTORS.forEach((selector) => {
 				const elements = document.querySelectorAll(selector);
-				elements.forEach(el => el.remove());
+				elements.forEach((el) => el.remove());
 			});
 			
-			// Force sidebar width to zero
 			document.documentElement.style.setProperty("--posa-desk-sidebar-width", "0px");
 		},
 
 		setup_sidebar_observer() {
-			const SIDEBAR_SELECTORS = '.body-sidebar-container, .body-sidebar, .desk-sidebar, .app-sidebar, .layout-side-section';
-			
+			// Disconnect existing observer if any
+			if (this._sidebarObserver) {
+				this._sidebarObserver.disconnect();
+			}
+
 			const observer = new MutationObserver((mutations) => {
 				for (const mutation of mutations) {
 					for (const node of mutation.addedNodes) {
 						if (node.nodeType === Node.ELEMENT_NODE) {
-							// Check if the added node itself is a sidebar element or contains one
-							if (
-								node.matches(SIDEBAR_SELECTORS) ||
-								node.querySelector(SIDEBAR_SELECTORS)
-							) {
+							if (node.matches(FRAPPE_NAV_SELECTOR_STRING) || 
+								node.querySelector(FRAPPE_NAV_SELECTOR_STRING)) {
 								this.remove_frappe_nav();
-								return; // Exit after handling
+								return;
 							}
 						}
 					}
 				}
 			});
-			
+
 			observer.observe(document.body, {
 				childList: true,
-				subtree: true
+				subtree: true,
 			});
 			
-			// Store reference for cleanup
 			this._sidebarObserver = observer;
 		},
 

--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -166,8 +166,13 @@ export default {
 		UpdatePrompt,
 	},
 	mounted() {
-		this.remove_frappe_nav();
-		this.adjust_frappe_sidebar_offset();
+		// Wait longer for Frappe to fully render
+		setTimeout(() => {
+			this.remove_frappe_nav();
+			this.setup_sidebar_observer();
+		}, 800); // Increased to 800ms
+
+		// Rest of your initialization code...
 		window.addEventListener("resize", this.adjust_frappe_sidebar_offset);
 		initLoadingSources(["init", "items", "customers"]);
 		this.initializeData();
@@ -495,25 +500,48 @@ export default {
 		},
 
 		remove_frappe_nav() {
-			this.$nextTick(() => {
-				$(".page-head").remove();
-				$(".navbar.navbar-default.navbar-fixed-top").remove();
-				this.adjust_frappe_sidebar_offset();
-			});
+			// Remove immediately without waiting for nextTick
+			$(".body-sidebar-container").remove();
+			$(".body-sidebar").remove();
+			$(".desk-sidebar").remove();
+			$(".app-sidebar").remove();
+			$(".layout-side-section").remove();
+			$(".page-head").remove();
+			$(".navbar.navbar-default.navbar-fixed-top").remove();
+			$(".sidebar-overlay").remove();
+			
+			// Force width to 0
+			document.documentElement.style.setProperty("--posa-desk-sidebar-width", "0px");
 		},
+
+		setup_sidebar_observer() {
+			const observer = new MutationObserver((mutations) => {
+				mutations.forEach((mutation) => {
+					if (mutation.addedNodes.length) {
+						// Check if any sidebar element was added back
+						const sidebarExists = 
+							$(".body-sidebar-container").length > 0 ||
+							$(".body-sidebar:visible").length > 0 ||
+							$(".desk-sidebar:visible").length > 0;
+						
+						if (sidebarExists) {
+							this.remove_frappe_nav();
+						}
+					}
+				});
+			});
+			
+			observer.observe(document.body, {
+				childList: true,
+				subtree: true
+			});
+			
+			this._sidebarObserver = observer;
+		},
+
 		adjust_frappe_sidebar_offset() {
-			const sidebar = document.querySelector(
-				".desk-sidebar, .app-sidebar, .sidebar, .side-section, .layout-side-section",
-			);
-			let sidebarWidth = 0;
-			if (sidebar) {
-				const sidebarStyles = window.getComputedStyle(sidebar);
-				const rect = sidebar.getBoundingClientRect();
-				if (sidebarStyles.display !== "none" && rect.width > 0) {
-					sidebarWidth = rect.width;
-				}
-			}
-			document.documentElement.style.setProperty("--posa-desk-sidebar-width", `${sidebarWidth}px`);
+			// Always return 0 since sidebar should be removed
+			document.documentElement.style.setProperty("--posa-desk-sidebar-width", "0px");
 		},
 	},
 	beforeUnmount() {

--- a/frontend/src/posapp/Home.vue
+++ b/frontend/src/posapp/Home.vue
@@ -122,8 +122,7 @@ export default {
 			cacheUsage: 0,
 			cacheUsageLoading: false,
 			cacheUsageDetails: { total: 0, indexedDB: 0, localStorage: 0 },
-
-			// Loading progress handled via utility
+			_sidebarObserver: null, // Store observer reference
 		};
 	},
 	computed: {
@@ -166,11 +165,11 @@ export default {
 		UpdatePrompt,
 	},
 	mounted() {
-		// Wait longer for Frappe to fully render
+		// Wait for Frappe to fully render then remove sidebar
 		setTimeout(() => {
 			this.remove_frappe_nav();
 			this.setup_sidebar_observer();
-		}, 800); // Increased to 800ms
+		}, 800);
 
 		// Rest of your initialization code...
 		window.addEventListener("resize", this.adjust_frappe_sidebar_offset);
@@ -179,6 +178,7 @@ export default {
 		this.setupNetworkListeners();
 		this.setupEventListeners();
 		this.handleRefreshCacheUsage();
+		
 		const customersStore = useCustomersStore();
 		const { loadProgress, customersLoaded } = storeToRefs(customersStore);
 		this.$watch(
@@ -197,6 +197,28 @@ export default {
 			},
 			{ immediate: true },
 		);
+	},
+	beforeUnmount() {
+		// Clean up event bus listeners
+		if (this.eventBus) {
+			this.eventBus.off("pending_invoices_changed");
+			this.eventBus.off("data-loaded");
+			this.eventBus.off("register_pos_profile");
+			this.eventBus.off("set_last_invoice");
+			this.eventBus.off("data-load-progress");
+			this.eventBus.off("print_last_invoice");
+			this.eventBus.off("sync_invoices");
+			this.eventBus.off("open_purchase_orders");
+		}
+		
+		// Remove resize listener
+		window.removeEventListener("resize", this.adjust_frappe_sidebar_offset);
+		
+		// CRITICAL FIX: Disconnect MutationObserver to prevent memory leak
+		if (this._sidebarObserver) {
+			this._sidebarObserver.disconnect();
+			this._sidebarObserver = null;
+		}
 	},
 	methods: {
 		setupNetworkListeners,
@@ -272,6 +294,7 @@ export default {
 				this.eventBus.on("data-loaded", (name) => {
 					markSourceLoaded(name);
 				});
+				
 				this.eventBus.on("data-load-progress", ({ name, progress }) => {
 					setSourceProgress(name, progress);
 				});
@@ -500,35 +523,44 @@ export default {
 		},
 
 		remove_frappe_nav() {
-			// Remove immediately without waiting for nextTick
-			$(".body-sidebar-container").remove();
-			$(".body-sidebar").remove();
-			$(".desk-sidebar").remove();
-			$(".app-sidebar").remove();
-			$(".layout-side-section").remove();
-			$(".page-head").remove();
-			$(".navbar.navbar-default.navbar-fixed-top").remove();
-			$(".sidebar-overlay").remove();
+			// Remove sidebar elements immediately
+			const selectors = [
+				".body-sidebar-container",
+				".body-sidebar",
+				".desk-sidebar",
+				".app-sidebar",
+				".layout-side-section",
+				".page-head",
+				".navbar.navbar-default.navbar-fixed-top",
+				".sidebar-overlay"
+			];
 			
-			// Force width to 0
+			selectors.forEach(selector => {
+				const elements = document.querySelectorAll(selector);
+				elements.forEach(el => el.remove());
+			});
+			
+			// Force sidebar width to zero
 			document.documentElement.style.setProperty("--posa-desk-sidebar-width", "0px");
 		},
 
 		setup_sidebar_observer() {
+			// PERFORMANCE FIX: Check added nodes directly instead of re-querying entire document
 			const observer = new MutationObserver((mutations) => {
-				mutations.forEach((mutation) => {
-					if (mutation.addedNodes.length) {
-						// Check if any sidebar element was added back
-						const sidebarExists = 
-							$(".body-sidebar-container").length > 0 ||
-							$(".body-sidebar:visible").length > 0 ||
-							$(".desk-sidebar:visible").length > 0;
-						
-						if (sidebarExists) {
-							this.remove_frappe_nav();
+				for (const mutation of mutations) {
+					for (const node of mutation.addedNodes) {
+						if (node.nodeType === Node.ELEMENT_NODE) {
+							// Check if the added node itself is a sidebar element or contains one
+							if (
+								node.matches('.body-sidebar-container, .body-sidebar, .desk-sidebar, .app-sidebar, .layout-side-section') ||
+								node.querySelector('.body-sidebar-container, .body-sidebar, .desk-sidebar, .app-sidebar, .layout-side-section')
+							) {
+								this.remove_frappe_nav();
+								return; // Exit after handling
+							}
 						}
 					}
-				});
+				}
 			});
 			
 			observer.observe(document.body, {
@@ -536,6 +568,7 @@ export default {
 				subtree: true
 			});
 			
+			// Store reference for cleanup
 			this._sidebarObserver = observer;
 		},
 
@@ -543,18 +576,6 @@ export default {
 			// Always return 0 since sidebar should be removed
 			document.documentElement.style.setProperty("--posa-desk-sidebar-width", "0px");
 		},
-	},
-	beforeUnmount() {
-		if (this.eventBus) {
-			this.eventBus.off("pending_invoices_changed");
-			this.eventBus.off("data-loaded");
-		}
-		window.removeEventListener("resize", this.adjust_frappe_sidebar_offset);
-	},
-	created: function () {
-		setTimeout(() => {
-			this.remove_frappe_nav();
-		}, 1000);
 	},
 };
 </script>

--- a/frontend/src/posapp/styles/theme.css
+++ b/frontend/src/posapp/styles/theme.css
@@ -454,79 +454,55 @@
 
 
 /* ==========================================================================
-   FORCE-HIDE FRAPPE DESK ELEMENTS IN POSAWESOME
+   POSAwesome - Hide Frappe Desk Elements in POS View
+   Target only when in POSApp route to avoid affecting ERPNext functionality
    ========================================================================== */
 
-/* 
-   CRITICAL: These rules are NOT scoped to .posapp
-   They apply globally to the POS page route
-*/
-
-/* Hide the entire sidebar container and its contents */
+/* Only apply when in POSApp page route - ensures ERPNext 15/16 compatibility */
 body[data-page-route="posapp"] .body-sidebar-container,
 body[data-page-route="posapp"] .body-sidebar,
-body[data-page-route="posapp"] .body-sidebar-placeholder,
-body[data-page-route="posapp"] .overlay {
-    display: none !important;
-    visibility: hidden !important;
-    width: 0 !important;
-    height: 0 !important;
-    overflow: hidden !important;
-    position: absolute !important;
-    left: -9999px !important;
-    opacity: 0 !important;
-    pointer-events: none !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    max-width: 0 !important;
-    max-height: 0 !important;
-    clip-path: inset(100%) !important;
-    clip: rect(0, 0, 0, 0) !important;
-}
-
-/* Remove all sidebar-related elements */
 body[data-page-route="posapp"] .desk-sidebar,
 body[data-page-route="posapp"] .app-sidebar,
 body[data-page-route="posapp"] .layout-side-section,
 body[data-page-route="posapp"] .page-head,
 body[data-page-route="posapp"] .navbar.navbar-default.navbar-fixed-top,
-body[data-page-route="posapp"] .offcanvas_left_sidebar,
-body[data-page-route="posapp"] .sidebar-overlay,
-body[data-page-route="posapp"] .offcanvas-backdrop {
+body[data-page-route="posapp"] .sidebar-overlay {
     display: none !important;
-    visibility: hidden !important;
-    width: 0 !important;
-    height: 0 !important;
-    overflow: hidden !important;
-    position: absolute !important;
-    left: -9999px !important;
-    opacity: 0 !important;
-    pointer-events: none !important;
 }
 
-/* Ensure POS takes full viewport */
+/* Ensure POSApp takes full width without sidebar offset */
 body[data-page-route="posapp"] {
-    overflow-x: hidden !important;
+    --posa-desk-sidebar-width: 0px !important;
+    --sidebar-width: 0px !important;
 }
 
-body[data-page-route="posapp"] .main-section,
-body[data-page-route="posapp"] .page-content,
-body[data-page-route="posapp"] .page-body,
-body[data-page-route="posapp"] .page-wrapper {
-    padding-left: 0 !important;
-    margin-left: 0 !important;
-    width: 100vw !important;
-    max-width: 100vw !important;
-    overflow-x: hidden !important;
-}
-
-/* Reset padding for POS container */
+/* Remove padding/margin that Frappe adds for sidebar */
 body[data-page-route="posapp"] .container1 {
     padding-inline-start: 0 !important;
+    margin-inline-start: 0 !important;
 }
 
-/* Hide footer */
-body[data-page-route="posapp"] .footer,
-body[data-page-route="posapp"] .page-footer {
-    display: none !important;
+/* Ensure content fills the entire viewport */
+body[data-page-route="posapp"] .main-content {
+    width: 100vw !important;
+    max-width: 100vw !important;
+}
+
+/* Hide any remaining Frappe UI elements that might appear */
+body[data-page-route="posapp"] .page-container,
+body[data-page-route="posapp"] .content.page-wrapper {
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+/* Override Frappe's layout constraints */
+body[data-page-route="posapp"] #body {
+    display: block !important;
+    height: 100vh !important;
+    overflow: hidden !important;
+}
+
+/* Ensure no residual sidebar space */
+body[data-page-route="posapp"] .desk-container {
+    padding-left: 0 !important;
 }

--- a/frontend/src/posapp/styles/theme.css
+++ b/frontend/src/posapp/styles/theme.css
@@ -451,3 +451,82 @@
 [data-theme="dark"] .dp__action_cancel {
 	color: var(--pos-text-secondary) !important;
 }
+
+
+/* ==========================================================================
+   FORCE-HIDE FRAPPE DESK ELEMENTS IN POSAWESOME
+   ========================================================================== */
+
+/* 
+   CRITICAL: These rules are NOT scoped to .posapp
+   They apply globally to the POS page route
+*/
+
+/* Hide the entire sidebar container and its contents */
+body[data-page-route="posapp"] .body-sidebar-container,
+body[data-page-route="posapp"] .body-sidebar,
+body[data-page-route="posapp"] .body-sidebar-placeholder,
+body[data-page-route="posapp"] .overlay {
+    display: none !important;
+    visibility: hidden !important;
+    width: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+    position: absolute !important;
+    left: -9999px !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    max-width: 0 !important;
+    max-height: 0 !important;
+    clip-path: inset(100%) !important;
+    clip: rect(0, 0, 0, 0) !important;
+}
+
+/* Remove all sidebar-related elements */
+body[data-page-route="posapp"] .desk-sidebar,
+body[data-page-route="posapp"] .app-sidebar,
+body[data-page-route="posapp"] .layout-side-section,
+body[data-page-route="posapp"] .page-head,
+body[data-page-route="posapp"] .navbar.navbar-default.navbar-fixed-top,
+body[data-page-route="posapp"] .offcanvas_left_sidebar,
+body[data-page-route="posapp"] .sidebar-overlay,
+body[data-page-route="posapp"] .offcanvas-backdrop {
+    display: none !important;
+    visibility: hidden !important;
+    width: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+    position: absolute !important;
+    left: -9999px !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+}
+
+/* Ensure POS takes full viewport */
+body[data-page-route="posapp"] {
+    overflow-x: hidden !important;
+}
+
+body[data-page-route="posapp"] .main-section,
+body[data-page-route="posapp"] .page-content,
+body[data-page-route="posapp"] .page-body,
+body[data-page-route="posapp"] .page-wrapper {
+    padding-left: 0 !important;
+    margin-left: 0 !important;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    overflow-x: hidden !important;
+}
+
+/* Reset padding for POS container */
+body[data-page-route="posapp"] .container1 {
+    padding-inline-start: 0 !important;
+}
+
+/* Hide footer */
+body[data-page-route="posapp"] .footer,
+body[data-page-route="posapp"] .page-footer {
+    display: none !important;
+}


### PR DESCRIPTION
- Remove Frappe's .body-sidebar-container from POS view
- Use CSS targeting body[data-page-route='posapp'] for reliable hiding
- Add MutationObserver to catch dynamically re-added sidebar elements
- Clean up Vue lifecycle hooks (remove created, fix beforeUnmount)
- Force zero width on sidebar offset variable

@defendicon make sure It Will NOT Affect ERPNext 15 Functionality before merege