### PR TITLE
fix: resolve currency validation for purchase invoices

### DIFF
--- a/frontend/src/posapp/components/pos/PurchaseOrders.vue
+++ b/frontend/src/posapp/components/pos/PurchaseOrders.vue
@@ -841,6 +841,7 @@ export default {
 					supplier: this.supplier,
 					company: this.pos_profile.company,
 					warehouse: this.warehouse,
+					currency: this.supplierCurrency,
 					transaction_date: this.formatDateForBackend(this.transactionDate),
 					schedule_date: this.formatDateForBackend(this.scheduleDate),
 					receive: this.receiveNow ? 1 : 0,

--- a/posawesome/posawesome/api/purchase_orders.py
+++ b/posawesome/posawesome/api/purchase_orders.py
@@ -112,6 +112,7 @@ def _create_purchase_receipt(po_doc, payload, default_warehouse, transaction_dat
             "supplier": po_doc.supplier,
             "company": po_doc.company,
             "posting_date": receipt_date,
+			"currency": po_doc.currency,
         }
     )
     if default_warehouse:

--- a/posawesome/posawesome/api/purchase_orders.py
+++ b/posawesome/posawesome/api/purchase_orders.py
@@ -588,6 +588,7 @@ def _create_purchase_invoice(po_doc, payload, default_warehouse, transaction_dat
             "company": po_doc.company,
             "posting_date": invoice_date,
             "purchase_order": po_doc.name,
+            "currency": payload.get("currency") or po_doc.currency,
         }
     )
     if default_warehouse:


### PR DESCRIPTION
- Add currency field to purchase order payload in frontend
- Set invoice currency from supplier default (e.g., EUR)
- Fix InvalidCurrency error when creating bills for foreign suppliers
- Ensure PO and PI use consistent currency