### PR TITLE
Fix purchase order profile access and remove duplicate item selector

### DIFF
--- a/frontend/src/posapp/components/pos/PurchaseOrders.vue
+++ b/frontend/src/posapp/components/pos/PurchaseOrders.vue
@@ -307,12 +307,6 @@
 
 					<v-card-actions class="pa-4 border-t">
 						<v-spacer></v-spacer>
-						<ItemsSelector
-							context="purchase"
-							:showOnlyBarcodeItems="false"
-							class="flex-grow-1"
-							@add-item="onAddItem"
-						/>
 						<v-btn
 							:loading="submitLoading"
 							:disabled="submitLoading || !purchaseItems.length"
@@ -470,7 +464,7 @@ export default {
 		submitLoading: false,
 	}),
 	computed: {
-		...mapStores(useItemsStore),
+		...mapStores(useItemsStore, useUIStore),
 		allowCreateSupplier() {
 			return !!this.pos_profile?.posa_allow_create_purchase_suppliers;
 		},
@@ -789,7 +783,7 @@ export default {
 		},
 		async submitSupplier() {
 			if (!this.supplierForm.supplier_name) {
-				this.toastStore.show( {
+				this.toastStore.show({
 					title: __("Supplier name is required"),
 					color: "error",
 				});
@@ -807,7 +801,7 @@ export default {
 					},
 				});
 				if (message && message.name) {
-					this.toastStore.show( {
+					this.toastStore.show({
 						title: __("Supplier created successfully"),
 						color: "success",
 					});
@@ -817,7 +811,7 @@ export default {
 				}
 			} catch (error) {
 				console.error("Failed to create supplier:", error);
-				this.toastStore.show( {
+				this.toastStore.show({
 					title: __("Supplier creation failed"),
 					color: "error",
 				});
@@ -882,7 +876,7 @@ export default {
 					} else if (message.purchase_invoice) {
 						title = __("Purchase order and invoice created");
 					}
-					this.toastStore.show( {
+					this.toastStore.show({
 						title,
 						color: "success",
 					});
@@ -1036,7 +1030,7 @@ export default {
 			(profile) => {
 				if (profile) this.pos_profile = profile || {};
 			},
-			{ deep: true, immediate: true }
+			{ deep: true, immediate: true },
 		);
 	},
 	beforeUnmount() {
@@ -1295,4 +1289,3 @@ export default {
 	font-size: 0.85em;
 }
 </style>
-

--- a/frontend/src/posapp/components/pos/PurchaseOrders.vue
+++ b/frontend/src/posapp/components/pos/PurchaseOrders.vue
@@ -307,12 +307,6 @@
 
 					<v-card-actions class="pa-4 border-t">
 						<v-spacer></v-spacer>
-						<ItemsSelector
-							context="purchase"
-							:showOnlyBarcodeItems="false"
-							class="flex-grow-1"
-							@add-item="onAddItem"
-						/>
 						<v-btn
 							:loading="submitLoading"
 							:disabled="submitLoading || !purchaseItems.length"
@@ -470,7 +464,7 @@ export default {
 		submitLoading: false,
 	}),
 	computed: {
-		...mapStores(useItemsStore),
+		...mapStores(useItemsStore, useUIStore),
 		allowCreateSupplier() {
 			return !!this.pos_profile?.posa_allow_create_purchase_suppliers;
 		},
@@ -789,7 +783,7 @@ export default {
 		},
 		async submitSupplier() {
 			if (!this.supplierForm.supplier_name) {
-				this.toastStore.show( {
+				this.toastStore.show({
 					title: __("Supplier name is required"),
 					color: "error",
 				});
@@ -807,7 +801,7 @@ export default {
 					},
 				});
 				if (message && message.name) {
-					this.toastStore.show( {
+					this.toastStore.show({
 						title: __("Supplier created successfully"),
 						color: "success",
 					});
@@ -817,7 +811,7 @@ export default {
 				}
 			} catch (error) {
 				console.error("Failed to create supplier:", error);
-				this.toastStore.show( {
+				this.toastStore.show({
 					title: __("Supplier creation failed"),
 					color: "error",
 				});
@@ -882,7 +876,7 @@ export default {
 					} else if (message.purchase_invoice) {
 						title = __("Purchase order and invoice created");
 					}
-					this.toastStore.show( {
+					this.toastStore.show({
 						title,
 						color: "success",
 					});
@@ -942,6 +936,7 @@ export default {
 		},
 		handlePaymentSubmit({ payments, print, print_format, print_invoice }) {
 			this.payments = payments;
+			this.paymentDialog = false;
 			this.submitPurchaseOrder(print, print_format, print_invoice);
 		},
 		async loadSupplierGroups() {
@@ -1036,7 +1031,7 @@ export default {
 			(profile) => {
 				if (profile) this.pos_profile = profile || {};
 			},
-			{ deep: true, immediate: true }
+			{ deep: true, immediate: true },
 		);
 	},
 	beforeUnmount() {
@@ -1295,4 +1290,3 @@ export default {
 	font-size: 0.85em;
 }
 </style>
-


### PR DESCRIPTION
### Motivation
- Prevent runtime error when opening Purchase Orders caused by undefined `posProfile` by ensuring the component receives the UI store binding. 
- Remove duplicate item selector placed in the footer that obscured the item table area and caused UI confusion.

### Description
- Wire `useUIStore` into the `PurchaseOrders.vue` component via `mapStores(..., useUIStore)` so `uiStore.posProfile` updates are available and `pos_profile` is set safely. 
- Remove the extra `<ItemsSelector>` instance from the footer to keep the items table area clear. 
- Apply minor formatting cleanup in `PurchaseOrders.vue` (Prettier-adjusted spacing and trailing comma in watcher options).

### Testing
- Ran formatting with `cd frontend && npx prettier --write src/posapp/components/pos/PurchaseOrders.vue` which completed successfully. 
- Ran lint with `cd frontend && npx eslint .` which reported many existing lint errors in vendored/legacy files and global references, so lint did not pass (errors are unrelated to this change). 
- Ran the full test suite with `cd frontend && yarn test --run` where `tests/pricingEngine.spec.js` passed (16 tests) but `tests/invoiceItemMethods.spec.js` failed due to a Pinia initialization error (`TypeError: Cannot read properties of undefined (reading '_s')`) and the test run also exposed environment issues (missing `jsbarcode` asset and IndexedDB unavailable in the CI environment), so overall tests did not fully pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f50ed04883269381f62cada47171)