### PR TITLE
Clean up item selector refactor leftovers

### DIFF
--- a/frontend/src/posapp/components/pos/ItemActionToolbar.vue
+++ b/frontend/src/posapp/components/pos/ItemActionToolbar.vue
@@ -91,13 +91,13 @@ defineEmits(["update:modelValue", "update:itemsView", "open-offers", "open-coupo
 }
 
 .action-btn-consistent:hover {
-	background-color: rgba(25, 118, 210, 0.1) !important;
+	background-color: rgba(var(--v-theme-primary), 0.1) !important;
 	transform: translateY(-1px) !important;
 }
 
 .view-toggle-btn {
 	height: 32px;
-	border: 1px solid rgba(0, 0, 0, 0.12);
+	border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
 }
 
 .dynamic-padding {

--- a/frontend/src/posapp/components/pos/ItemActionToolbar.vue
+++ b/frontend/src/posapp/components/pos/ItemActionToolbar.vue
@@ -66,8 +66,10 @@
 </template>
 
 <script setup>
-/* global frappe, __ */
-const props = defineProps({
+const __ = window.__;
+const frappe = window.frappe;
+
+defineProps({
 	modelValue: { type: String, default: "ALL" }, // item_group
 	itemsGroup: { type: Array, default: () => [] },
 	itemsView: { type: String, default: "card" },
@@ -77,21 +79,59 @@ const props = defineProps({
 	couponsCount: { type: Number, default: 0 },
 });
 
-const emit = defineEmits([
-	"update:modelValue",
-	"update:itemsView",
-	"open-offers",
-	"open-coupons",
-]);
+defineEmits(["update:modelValue", "update:itemsView", "open-offers", "open-coupons"]);
 </script>
 
 <style scoped>
 .action-btn-consistent {
 	height: 32px !important;
+	margin-top: var(--dynamic-xs) !important;
+	padding: var(--dynamic-xs) var(--dynamic-sm) !important;
+	transition: var(--transition-normal) !important;
+}
+
+.action-btn-consistent:hover {
+	background-color: rgba(25, 118, 210, 0.1) !important;
+	transform: translateY(-1px) !important;
 }
 
 .view-toggle-btn {
 	height: 32px;
 	border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.dynamic-padding {
+	padding: var(--dynamic-sm);
+}
+
+.dynamic-spacing-sm {
+	padding: var(--dynamic-sm) !important;
+}
+
+.cards {
+	background-color: var(--surface-secondary) !important;
+	margin-top: var(--dynamic-sm) !important;
+	padding: var(--dynamic-sm) !important;
+}
+
+@media (max-width: 768px) {
+	.dynamic-padding {
+		padding: var(--dynamic-xs);
+	}
+
+	.dynamic-spacing-sm {
+		padding: var(--dynamic-xs) !important;
+	}
+
+	.action-btn-consistent {
+		padding: var(--dynamic-xs) !important;
+		font-size: 0.875rem !important;
+	}
+}
+
+@media (max-width: 480px) {
+	.cards {
+		padding: var(--dynamic-xs) !important;
+	}
 }
 </style>

--- a/frontend/src/posapp/components/pos/ItemCard.vue
+++ b/frontend/src/posapp/components/pos/ItemCard.vue
@@ -35,10 +35,7 @@
 							{{ formatCurrency(primaryRate, primaryCurrency, primaryPrecision) }}
 						</span>
 					</div>
-					<div
-						v-if="showSecondaryPrice"
-						class="secondary-price"
-					>
+					<div v-if="showSecondaryPrice" class="secondary-price">
 						<span class="currency-symbol">
 							{{ currencySymbol(secondaryCurrency) }}
 						</span>
@@ -55,7 +52,7 @@
 								formatCurrency(
 									lastInvoiceRate.rate,
 									lastInvoiceRate.currency || posProfile.currency,
-									primaryPrecision
+									primaryPrecision,
 								)
 							}}
 							<span v-if="lastInvoiceRate.uom" class="last-rate-uom">
@@ -160,7 +157,7 @@ const onDragEnd = (event) => {
 	will-change: transform;
 	backface-visibility: hidden;
 	transform: translate3d(0, 0, 0);
-    position: relative;
+	position: relative;
 }
 
 .card-item-card:hover {
@@ -299,4 +296,21 @@ const onDragEnd = (event) => {
 	text-transform: uppercase;
 }
 
+@media (max-width: 768px) {
+	.card-item-image-container {
+		height: 100px;
+	}
+
+	.card-item-content {
+		padding: 10px 12px 12px;
+	}
+
+	.card-item-name {
+		font-size: 0.85rem;
+	}
+
+	.card-item-code {
+		font-size: 0.7rem;
+	}
+}
 </style>

--- a/frontend/src/posapp/components/pos/ItemCard.vue
+++ b/frontend/src/posapp/components/pos/ItemCard.vue
@@ -153,7 +153,7 @@ const onDragEnd = (event) => {
 	flex-direction: column;
 	height: 100%;
 	width: 100%;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+	box-shadow: 0 2px 8px rgba(var(--v-theme-on-surface), 0.06);
 	will-change: transform;
 	backface-visibility: hidden;
 	transform: translate3d(0, 0, 0);
@@ -162,17 +162,17 @@ const onDragEnd = (event) => {
 
 .card-item-card:hover {
 	transform: translate3d(0, -2px, 0);
-	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-	border-color: var(--primary-color, #1976d2);
+	box-shadow: 0 8px 24px rgba(var(--v-theme-on-surface), 0.12);
+	border-color: rgb(var(--v-theme-primary));
 }
 
 .card-item-card.item-highlighted {
-	border-color: var(--primary-color, #1976d2);
+	border-color: rgb(var(--v-theme-primary));
 	box-shadow:
-		0 0 0 3px rgba(25, 118, 210, 0.35),
-		0 8px 20px rgba(25, 118, 210, 0.2);
+		0 0 0 3px rgba(var(--v-theme-primary), 0.35),
+		0 8px 20px rgba(var(--v-theme-primary), 0.2);
 	transform: translate3d(0, -2px, 0);
-	background: rgba(25, 118, 210, 0.08);
+	background: rgba(var(--v-theme-primary), 0.08);
 }
 
 .card-item-image-container {
@@ -248,7 +248,7 @@ const onDragEnd = (event) => {
 
 .primary-price {
 	font-weight: 700;
-	color: var(--primary-color, #1976d2);
+	color: rgb(var(--v-theme-primary));
 	font-size: 1rem;
 }
 
@@ -260,7 +260,7 @@ const onDragEnd = (event) => {
 .last-rate-chip {
 	margin-top: 4px;
 	font-size: 0.75rem;
-	color: var(--secondary-color, #757575);
+	color: rgb(var(--v-theme-secondary));
 	background: rgba(var(--v-theme-on-surface), 0.08);
 	padding: 2px 6px;
 	border-radius: 4px;
@@ -288,7 +288,7 @@ const onDragEnd = (event) => {
 }
 
 .stock-amount.negative-number {
-	color: var(--error-color, #d32f2f);
+	color: rgb(var(--v-theme-error));
 }
 
 .stock-uom {

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -30,44 +30,44 @@
 
 			<!-- Add dynamic-padding wrapper like Invoice component -->
 			<div class="dynamic-padding">
-			<ItemHeader
-				v-model:search-input="search_input"
-				v-model:qty-input="debounce_qty"
-				v-model:new-line="new_line"
-				:pos-profile="pos_profile"
-				:scanner-locked="scannerLocked"
-				:enable-background-sync="enable_background_sync"
-				:last-sync-time="formatBackgroundSyncTime()"
-				:context="context"
-				@esc="esc_event"
-				@enter="onEnter"
-				@search-keydown="handleSearchKeydown"
-				@clear-search="clearSearch"
-				@search-input="handleSearchInput"
-				@search-paste="handleSearchPaste"
-				@focus="handleItemSearchFocus"
-				@clear-qty="clearQty"
-				@start-camera="startCameraScanning"
-				@open-new-item="openNewItemDialog"
-				@toggle-settings="toggleItemSettings"
-				@reload-items="forceReloadItems"
-				ref="itemHeader"
-			/>
+				<ItemHeader
+					v-model:search-input="search_input"
+					v-model:qty-input="debounce_qty"
+					v-model:new-line="new_line"
+					:pos-profile="pos_profile"
+					:scanner-locked="scannerLocked"
+					:enable-background-sync="enable_background_sync"
+					:last-sync-time="formatBackgroundSyncTime()"
+					:context="context"
+					@esc="esc_event"
+					@enter="onEnter"
+					@search-keydown="handleSearchKeydown"
+					@clear-search="clearSearch"
+					@search-input="handleSearchInput"
+					@search-paste="handleSearchPaste"
+					@focus="handleItemSearchFocus"
+					@clear-qty="clearQty"
+					@start-camera="startCameraScanning"
+					@open-new-item="openNewItemDialog"
+					@toggle-settings="toggleItemSettings"
+					@reload-items="forceReloadItems"
+					ref="itemHeader"
+				/>
 
-								<ItemSettingsDialog
-			v-model="show_item_settings"
-			:initial-settings="{
-				hide_qty_decimals,
-				hide_zero_rate_items,
-				show_last_invoice_rate,
-				enable_background_sync,
-				background_sync_interval,
-				enable_custom_items_per_page,
-				items_per_page,
-				force_server_items: temp_force_server_items,
-			}"
-			@save="applyItemSettings"
-		/>
+				<ItemSettingsDialog
+					v-model="show_item_settings"
+					:initial-settings="{
+						hide_qty_decimals,
+						hide_zero_rate_items,
+						show_last_invoice_rate,
+						enable_background_sync,
+						background_sync_interval,
+						enable_custom_items_per_page,
+						items_per_page,
+						force_server_items: temp_force_server_items,
+					}"
+					@save="applyItemSettings"
+				/>
 
 				<v-row class="items">
 					<v-col cols="12" class="pt-0 mt-0">
@@ -258,14 +258,7 @@
 		/>
 
 		<!-- New Item Dialog -->
-
-		<!-- New Item Dialog -->
-		<NewItemDialog
-			v-model="newItemDialog"
-			:items-group="items_group"
-			@item-created="handleItemCreated"
-		/>
-
+		<NewItemDialog v-model="newItemDialog" :items-group="items_group" @item-created="handleItemCreated" />
 
 		<!-- Camera Scanner Component -->
 		<CameraScanner
@@ -293,6 +286,7 @@ import ItemSettingsDialog from "./ItemSettingsDialog.vue";
 import ItemHeader from "./ItemHeader.vue";
 import NewItemDialog from "./NewItemDialog.vue";
 import ScanErrorDialog from "./ScanErrorDialog.vue";
+import placeholderImage from "./placeholder-image.png";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 import { RecycleScroller } from "vue-virtual-scroller";
 import {
@@ -364,12 +358,12 @@ export default {
 		const invoiceStore = useInvoiceStore();
 		const { selectedCustomer } = storeToRefs(customersStore);
 
-		const { 
-			showOnlyBarcodeItems: showOnlyBarcodeItemsRef, 
-			memoizedSearch, 
-			clearSearchCache, 
+		const {
+			showOnlyBarcodeItems: showOnlyBarcodeItemsRef,
+			memoizedSearch,
+			clearSearchCache,
 			fetchServerItemsTimestamp,
-			filterAndPaginate
+			filterAndPaginate,
 		} = useItemSearch();
 
 		return {
@@ -387,7 +381,7 @@ export default {
 			memoizedSearch,
 			clearSearchCache,
 			fetchServerItemsTimestamp,
-			filterAndPaginate
+			filterAndPaginate,
 		};
 	},
 	components: {
@@ -734,7 +728,6 @@ export default {
 				}
 			});
 		},
-
 	},
 
 	methods: {
@@ -2835,7 +2828,7 @@ export default {
 					this.queueManualScanFocus();
 					return;
 				}
-				const input = this.$refs.debounce_search;
+				const input = this.getSearchInputField();
 				if (input && typeof input.focus === "function") {
 					input.focus();
 				}
@@ -2843,10 +2836,16 @@ export default {
 		},
 
 		blurItemSearch() {
-			const input = this.$refs.debounce_search;
+			const input = this.getSearchInputField();
 			if (input && typeof input.blur === "function") {
 				input.blur();
 			}
+		},
+		getSearchInputField() {
+			// Benchmark: use exposed ref to avoid DOM querying for focus/blur actions.
+			const header = this.$refs.itemHeader;
+			const inputRef = header?.debounce_search;
+			return inputRef?.value ?? inputRef ?? null;
 		},
 
 		clearQty() {
@@ -4299,14 +4298,6 @@ export default {
 				limit: this.enable_custom_items_per_page ? this.items_per_page : this.itemsPerPage,
 			});
 		},
-		debounce_search: {
-			get() {
-				return this.first_search;
-			},
-			set: _.debounce(function (newValue) {
-				this.first_search = newValue || "";
-			}, 200),
-		},
 		debounce_qty: {
 			get() {
 				// Display the raw quantity while typing to avoid forced decimal format
@@ -4701,90 +4692,6 @@ export default {
 	padding: var(--dynamic-sm);
 }
 
-.manual-scan-container {
-	padding: 16px;
-	border-radius: 12px;
-	border: 1px solid var(--pos-border, rgba(0, 0, 0, 0.08));
-	background-color: var(--pos-card-bg, rgba(255, 255, 255, 0.96));
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
-	transition:
-		background-color 0.2s ease,
-		border-color 0.2s ease;
-}
-
-.manual-scan-text .text-body-2 {
-	color: rgba(0, 0, 0, 0.6);
-}
-
-:deep(.v-theme--dark) .manual-scan-container {
-	background-color: rgba(30, 30, 30, 0.92);
-	border-color: rgba(255, 255, 255, 0.12);
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-
-:deep(.v-theme--dark) .manual-scan-text .text-body-2 {
-	color: rgba(255, 255, 255, 0.7);
-}
-
-.scan-error-dialog {
-	border-radius: 16px;
-}
-
-.scan-error-dialog .scan-error-message {
-	font-weight: 600;
-	font-size: 1.05rem;
-	margin: 0;
-}
-
-.scan-error-dialog .scan-error-code {
-	display: inline-flex;
-	align-items: center;
-	gap: 8px;
-	font-family:
-		"Roboto Mono", "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono",
-		"Courier New", monospace;
-	font-size: 0.95rem;
-	padding: 6px 10px;
-	border-radius: 6px;
-	background-color: rgba(244, 67, 54, 0.12);
-}
-
-.scan-error-dialog .scan-error-details {
-	margin-top: 12px;
-	color: rgba(0, 0, 0, 0.72);
-	line-height: 1.4;
-}
-
-:deep(.v-theme--dark) .scan-error-dialog .scan-error-code {
-	background-color: rgba(244, 67, 54, 0.25);
-	color: #ffebee;
-}
-
-:deep(.v-theme--dark) .scan-error-dialog .scan-error-details {
-	color: rgba(255, 255, 255, 0.7);
-}
-
-.sticky-header {
-	position: sticky;
-	top: 0;
-	z-index: 100;
-	background-color: var(--surface-primary, #fff);
-	padding: var(--dynamic-sm);
-	margin: 0;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-	/* Performance optimizations for theme switching */
-	contain: layout style;
-	will-change: background-color;
-	transition:
-		background-color 0.15s ease,
-		border-color 0.15s ease;
-}
-
-.sticky-header {
-	background-color: var(--pos-card-bg);
-	border-bottom: 1px solid var(--pos-border);
-}
-
 .dynamic-scroll {
 	transition: max-height 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 	padding-bottom: var(--dynamic-sm);
@@ -4796,46 +4703,8 @@ export default {
 	scrollbar-gutter: stable;
 }
 
-.items-grid {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-	gap: var(--dynamic-sm);
-	align-items: start;
-	align-content: start;
-	justify-content: flex-start;
-}
-
-.dynamic-item-card {
-	transition:
-		transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-		box-shadow 0.2s ease;
-	background-color: var(--surface-secondary);
-	display: flex;
-	flex-direction: column;
-	height: auto;
-	max-width: 180px;
-	box-sizing: border-box;
-	will-change: transform;
-	backface-visibility: hidden;
-	transform: translate3d(0, 0, 0);
-}
-
-.dynamic-item-card .v-img {
-	object-fit: contain;
-	will-change: auto;
-}
-
-.dynamic-item-card:hover {
-	transform: translate3d(0, -2px, 0) scale(1.02);
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
 .text-success {
 	color: #4caf50 !important;
-}
-
-.last-sync-label {
-	white-space: nowrap;
 }
 
 /* Enhanced Arabic number support for ItemsSelector */
@@ -4893,20 +4762,6 @@ export default {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	letter-spacing: 0.01em;
-}
-
-/* Enhanced card text for better Arabic number display */
-.dynamic-item-card .v-card-text {
-	font-family:
-		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
-		sans-serif;
-	font-variant-numeric: lining-nums tabular-nums;
-	font-feature-settings:
-		"tnum" 1,
-		"lnum" 1,
-		"kern" 1;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
 }
 
 /* Enhanced Card View Grid Layout - 3 items per row */
@@ -4981,10 +4836,6 @@ export default {
 	background-color: rgba(25, 118, 210, 0.32);
 }
 
-
-
-
-
 .last-rate-inline {
 	color: rgba(0, 0, 0, 0.6);
 	white-space: nowrap;
@@ -4994,8 +4845,6 @@ export default {
 :deep(.v-theme--dark) .last-rate-inline {
 	color: rgba(255, 255, 255, 0.75);
 }
-
-
 
 .sleek-data-table {
 	/* composes: pos-table; */
@@ -5128,43 +4977,14 @@ export default {
 	color: #ffffff;
 }
 
-.settings-container {
-	display: flex;
-	align-items: center;
-}
-
 .truncate {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
-/* Light mode card backgrounds */
-.selection,
-.cards {
+.selection {
 	background-color: var(--surface-secondary) !important;
-}
-
-/* Consistent spacing with navbar and system */
-.dynamic-spacing-sm {
-	padding: var(--dynamic-sm) !important;
-}
-
-.action-btn-consistent {
-	margin-top: var(--dynamic-xs) !important;
-	padding: var(--dynamic-xs) var(--dynamic-sm) !important;
-	transition: var(--transition-normal) !important;
-}
-
-.action-btn-consistent:hover {
-	background-color: rgba(25, 118, 210, 0.1) !important;
-	transform: translateY(-1px) !important;
-}
-
-/* Ensure consistent spacing with navbar pattern */
-.cards {
-	margin-top: var(--dynamic-sm) !important;
-	padding: var(--dynamic-sm) !important;
 }
 
 /* Responsive breakpoints */
@@ -5182,45 +5002,16 @@ export default {
 		padding: var(--dynamic-xs);
 	}
 
-	.dynamic-spacing-sm {
-		padding: var(--dynamic-xs) !important;
-	}
-
-	.action-btn-consistent {
-		padding: var(--dynamic-xs) !important;
-		font-size: 0.875rem !important;
-	}
-
 	.items-card-grid {
 		grid-template-columns: 1fr;
 		gap: 10px;
 		padding: 10px;
-	}
-
-	.card-item-image-container {
-		height: 100px;
-	}
-
-	.card-item-content {
-		padding: 10px 12px 12px;
-	}
-
-	.card-item-name {
-		font-size: 0.85rem;
-	}
-
-	.card-item-code {
-		font-size: 0.7rem;
 	}
 }
 
 @media (max-width: 480px) {
 	.dynamic-padding {
 		padding: var(--dynamic-xs);
-	}
-
-	.cards {
-		padding: var(--dynamic-xs) !important;
 	}
 }
 
@@ -5236,24 +5027,13 @@ export default {
 }
 
 /* Enable hardware acceleration for better performance */
-.items-card-grid,
-.sticky-header {
+.items-card-grid {
 	/* Force hardware acceleration */
 	transform: translate3d(0, 0, 0);
 	-webkit-transform: translate3d(0, 0, 0);
 	/* Improve compositing performance */
 	backface-visibility: hidden;
 	-webkit-backface-visibility: hidden;
-}
-
-/* Optimize theme-sensitive elements */
-[data-theme] .sticky-header {
-	/* Minimize reflow during theme changes */
-	will-change: background-color, border-color, color;
-	transition:
-		background-color 0.15s cubic-bezier(0.4, 0, 0.2, 1),
-		border-color 0.15s cubic-bezier(0.4, 0, 0.2, 1),
-		color 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Optimize scrolling performance */
@@ -5268,7 +5048,7 @@ export default {
 
 /* Disable animations on reduced motion preference */
 @media (prefers-reduced-motion: reduce) {
-	.sticky-header {
+	.items-card-grid {
 		transition: none !important;
 		animation: none !important;
 		transform: none !important;

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -1704,9 +1704,9 @@ export default {
 			const target = targets[targets.length - 1];
 			if (target && this.fly) {
 				const placeholder = document.createElement("div");
+				placeholder.className = "item-fly-placeholder";
 				placeholder.style.width = "40px";
 				placeholder.style.height = "40px";
-				placeholder.style.background = "#ccc";
 				placeholder.style.borderRadius = "50%";
 				placeholder.style.position = "fixed";
 				placeholder.style.top = `${event.clientY - 20}px`;
@@ -3826,23 +3826,34 @@ export default {
 			html += '<div class="item-selection-list">';
 
 			items.forEach((item, index) => {
-				html += `
-		<div class="item-option p-3 mb-2 border rounded cursor-pointer" data-item-index="${index}" style="border: 1px solid #ddd; cursor: pointer;">
-			<div class="d-flex align-items-center">
-			<img src="${item.image || placeholderImage}"
-				style="width: 50px; height: 50px; object-fit: cover; margin-right: 15px;" />
-			<div>
-				<div class="font-weight-bold">${item.item_name}</div>
-				<div class="text-muted small">${item.item_code}</div>
-				<div class="text-primary">${this.format_currency(item.rate, this.pos_profile.currency, this.ratePrecision(item.rate))}</div>
-			</div>
-			</div>
-		</div>
-		`;
+				html += this.buildItemSelectionOption(item, index);
 			});
 
 			html += "</div>";
 			return html;
+		},
+		buildItemSelectionOption(item, index) {
+			const price = this.format_currency(
+				item.rate,
+				this.pos_profile.currency,
+				this.ratePrecision(item.rate),
+			);
+			return `
+		<div class="item-option item-selection-option p-3 mb-2 rounded cursor-pointer" data-item-index="${index}">
+			<div class="d-flex align-items-center">
+				<img
+					class="item-selection-image"
+					src="${item.image || placeholderImage}"
+					alt="${item.item_name}"
+				/>
+				<div>
+					<div class="font-weight-bold">${item.item_name}</div>
+					<div class="text-muted small">${item.item_code}</div>
+					<div class="text-primary">${price}</div>
+				</div>
+			</div>
+		</div>
+		`;
 		},
 		handleItemNotFound(scannedCode) {
 			console.warn("Item not found for scanned code:", scannedCode);
@@ -4698,13 +4709,17 @@ export default {
 	contain: layout style;
 }
 
+.item-fly-placeholder {
+	background-color: rgba(var(--v-theme-on-surface), 0.2);
+}
+
 .item-container {
 	overflow-y: auto;
 	scrollbar-gutter: stable;
 }
 
 .text-success {
-	color: #4caf50 !important;
+	color: rgb(var(--v-theme-success)) !important;
 }
 
 /* Enhanced Arabic number support for ItemsSelector */
@@ -4731,7 +4746,7 @@ export default {
 
 /* Enhanced negative number styling for Arabic context */
 .negative-number {
-	color: #d32f2f !important;
+	color: rgb(var(--v-theme-error)) !important;
 	font-weight: 600;
 	/* Same enhanced font stack for negative numbers */
 	font-family:
@@ -4773,7 +4788,7 @@ export default {
 	height: calc(100% - 80px);
 	overflow-y: auto;
 	scrollbar-width: thin;
-	scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+	scrollbar-color: rgba(var(--v-theme-on-surface), 0.2) transparent;
 	/* Performance optimizations */
 	contain: layout style;
 	will-change: scroll-position;
@@ -4804,7 +4819,7 @@ export default {
 }
 
 .items-card-grid::-webkit-scrollbar-thumb {
-	background-color: rgba(0, 0, 0, 0.2);
+	background-color: rgba(var(--v-theme-on-surface), 0.2);
 	border-radius: 4px;
 }
 
@@ -4827,23 +4842,23 @@ export default {
 }
 
 :deep(.item-row-highlighted) {
-	background-color: rgba(25, 118, 210, 0.32);
+	background-color: rgba(var(--v-theme-primary), 0.32);
 }
 
 :deep(.item-row-highlighted td) {
 	font-weight: 600;
-	color: var(--primary-color, #1976d2);
-	background-color: rgba(25, 118, 210, 0.32);
+	color: rgb(var(--v-theme-primary));
+	background-color: rgba(var(--v-theme-primary), 0.32);
 }
 
 .last-rate-inline {
-	color: rgba(0, 0, 0, 0.6);
+	color: rgba(var(--v-theme-on-surface), 0.6);
 	white-space: nowrap;
 }
 
 :deep(.v-theme--dark) .last-rate-chip,
 :deep(.v-theme--dark) .last-rate-inline {
-	color: rgba(255, 255, 255, 0.75);
+	color: rgba(var(--v-theme-on-surface), 0.75);
 }
 
 .sleek-data-table {
@@ -4860,7 +4875,7 @@ export default {
 }
 
 .sleek-data-table:hover {
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
+	box-shadow: 0 4px 12px rgba(var(--v-theme-on-surface), 0.15) !important;
 }
 
 /* Enhanced table header styling with modern gradients and Arabic support */
@@ -4871,16 +4886,21 @@ export default {
 	letter-spacing: 1px;
 	padding: 16px 20px;
 	transition: all 0.3s ease;
-	border-bottom: 3px solid #1976d2;
-	background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 50%, #dee2e6 100%);
-	color: #2c3e50;
+	border-bottom: 3px solid rgb(var(--v-theme-primary));
+	background: linear-gradient(
+		135deg,
+		rgb(var(--v-theme-surface)) 0%,
+		rgb(var(--v-theme-surface-variant)) 50%,
+		rgb(var(--v-theme-surface)) 100%
+	);
+	color: rgb(var(--v-theme-on-surface));
 	position: sticky !important;
 	top: 0 !important;
 	z-index: 10 !important;
 	backdrop-filter: blur(10px);
 	-webkit-backdrop-filter: blur(10px);
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-	text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8);
+	box-shadow: 0 2px 8px rgba(var(--v-theme-on-surface), 0.1);
+	text-shadow: 0 1px 2px rgba(var(--v-theme-on-surface), 0.2);
 	/* Enhanced Arabic number font stack */
 	font-family:
 		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
@@ -4897,11 +4917,16 @@ export default {
 /* Enhanced dark theme header styling */
 :deep([data-theme="dark"]) .sleek-data-table th,
 :deep(.v-theme--dark) .sleek-data-table th {
-	background: linear-gradient(135deg, #2c3e50 0%, #34495e 50%, #2c3e50 100%) !important;
-	border-bottom: 3px solid #3498db;
-	color: #ecf0f1;
-	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+	background: linear-gradient(
+		135deg,
+		rgb(var(--v-theme-surface)) 0%,
+		rgb(var(--v-theme-surface-variant)) 50%,
+		rgb(var(--v-theme-surface)) 100%
+	) !important;
+	border-bottom: 3px solid rgb(var(--v-theme-primary));
+	color: rgb(var(--v-theme-on-surface));
+	text-shadow: 0 1px 2px rgba(var(--v-theme-on-surface), 0.35);
+	box-shadow: 0 2px 8px rgba(var(--v-theme-on-surface), 0.3);
 }
 
 /* Table wrapper styling */
@@ -4931,21 +4956,21 @@ export default {
 /* Table row styling with gray theme */
 .sleek-data-table :deep(tr) {
 	transition: all 0.2s ease;
-	border-bottom: 1px solid #e0e0e0;
-	background-color: #fafafa;
+	border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+	background-color: rgb(var(--v-theme-surface));
 }
 
 .sleek-data-table :deep(tr:hover) {
-	background-color: #f0f0f0;
+	background-color: rgba(var(--v-theme-on-surface), 0.06);
 	transform: translateY(-1px);
-	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+	box-shadow: 0 2px 5px rgba(var(--v-theme-on-surface), 0.1);
 }
 
 /* Table cell styling with Arabic number support */
 .sleek-data-table :deep(td) {
 	padding: 12px 16px;
 	vertical-align: middle;
-	color: #424242;
+	color: rgb(var(--v-theme-on-surface));
 	/* Enhanced Arabic number font stack */
 	font-family:
 		"SF Pro Display", "Segoe UI", "Roboto", "Helvetica Neue", "Arial", "Noto Sans Arabic", "Tahoma",
@@ -4961,22 +4986,6 @@ export default {
 }
 
 /* Dark theme row styling */
-:deep([data-theme="dark"]) .sleek-data-table tr,
-:deep(.v-theme--dark) .sleek-data-table tr {
-	background-color: #2d2d2d;
-	border-bottom: 1px solid #424242;
-}
-
-:deep([data-theme="dark"]) .sleek-data-table tr:hover,
-:deep(.v-theme--dark) .sleek-data-table tr:hover {
-	background-color: #3d3d3d;
-}
-
-:deep([data-theme="dark"]) .sleek-data-table td,
-:deep(.v-theme--dark) .sleek-data-table td {
-	color: #ffffff;
-}
-
 .truncate {
 	white-space: nowrap;
 	overflow: hidden;
@@ -4985,6 +4994,26 @@ export default {
 
 .selection {
 	background-color: var(--surface-secondary) !important;
+}
+
+.item-selection-option {
+	border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+	transition:
+		border-color 0.2s ease,
+		background-color 0.2s ease;
+}
+
+.item-selection-option:hover {
+	background-color: rgba(var(--v-theme-primary), 0.06);
+	border-color: rgba(var(--v-theme-primary), 0.4);
+}
+
+.item-selection-image {
+	width: 50px;
+	height: 50px;
+	object-fit: cover;
+	margin-right: 15px;
+	background-color: rgb(var(--v-theme-surface-variant));
 }
 
 /* Responsive breakpoints */

--- a/frontend/src/posapp/components/pos/ScanErrorDialog.vue
+++ b/frontend/src/posapp/components/pos/ScanErrorDialog.vue
@@ -1,5 +1,11 @@
 <template>
-	<v-dialog :model-value="modelValue" @update:model-value="$emit('update:modelValue', $event)" persistent max-width="420" content-class="scan-error-dialog">
+	<v-dialog
+		:model-value="modelValue"
+		@update:model-value="$emit('update:modelValue', $event)"
+		persistent
+		max-width="420"
+		content-class="scan-error-dialog"
+	>
 		<v-card>
 			<v-card-title class="d-flex align-center text-error text-h6">
 				<v-icon color="error" class="mr-2">mdi-alert-octagon</v-icon>
@@ -51,15 +57,20 @@ export default {
 
 <style scoped>
 .scan-error-message {
-	font-size: 1.1rem;
-	font-weight: 500;
+	font-size: 1.05rem;
+	font-weight: 600;
+	margin: 0;
 }
 
 .scan-error-code {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
 	padding: 8px 12px;
 	background: var(--v-theme-surface-variant);
 	border-radius: 4px;
 	font-family: monospace;
+	font-size: 0.95rem;
 }
 
 .scan-error-code span {
@@ -69,7 +80,22 @@ export default {
 }
 
 .scan-error-details {
-	color: var(--v-theme-on-surface-variant);
+	color: rgba(0, 0, 0, 0.72);
 	font-size: 0.9rem;
+	line-height: 1.4;
+	margin-top: 12px;
+}
+
+:deep(.scan-error-dialog) {
+	border-radius: 16px;
+}
+
+:deep(.v-theme--dark) .scan-error-dialog .scan-error-code {
+	background-color: rgba(244, 67, 54, 0.25);
+	color: #ffebee;
+}
+
+:deep(.v-theme--dark) .scan-error-dialog .scan-error-details {
+	color: rgba(255, 255, 255, 0.7);
 }
 </style>

--- a/frontend/src/posapp/components/pos/ScanErrorDialog.vue
+++ b/frontend/src/posapp/components/pos/ScanErrorDialog.vue
@@ -80,7 +80,7 @@ export default {
 }
 
 .scan-error-details {
-	color: rgba(0, 0, 0, 0.72);
+	color: rgba(var(--v-theme-on-surface), 0.72);
 	font-size: 0.9rem;
 	line-height: 1.4;
 	margin-top: 12px;
@@ -91,11 +91,11 @@ export default {
 }
 
 :deep(.v-theme--dark) .scan-error-dialog .scan-error-code {
-	background-color: rgba(244, 67, 54, 0.25);
-	color: #ffebee;
+	background-color: rgba(var(--v-theme-error), 0.25);
+	color: rgb(var(--v-theme-on-error));
 }
 
 :deep(.v-theme--dark) .scan-error-dialog .scan-error-details {
-	color: rgba(255, 255, 255, 0.7);
+	color: rgba(var(--v-theme-on-surface), 0.7);
 }
 </style>


### PR DESCRIPTION
### Motivation
- Finish the ItemsSelector refactor by removing/stubbing leftover code that relied on the old monolithic component and wire the split components together reliably. 
- Prevent stale DOM ref usage for search focus/blur and avoid missing assets when rendering item-selection HTML generated from the selector logic.
- Move styling that belongs to toolbar/card/dialog into their owning components to keep `ItemsSelector.vue` focused and reduce visual regressions.

### Description
- Wire search focus/blur to the `ItemHeader` exposed ref by adding `getSearchInputField()` and replacing direct `$refs.debounce_search` usage in `frontend/src/posapp/components/pos/ItemsSelector.vue`.  
- Add `placeholder-image.png` import and use it in selection HTML to avoid undefined image references when generating the item selection markup.  
- Remove a leftover `debounce_search` computed setter from `ItemsSelector.vue` (the component now delegates debounce handling to the header/composable).  
- Relocate and tighten up styles: move toolbar layout/responsive styles into `ItemActionToolbar.vue`, add responsive card tweaks into `ItemCard.vue`, and improve Scan Error dialog styling and dark-theme rules in `ScanErrorDialog.vue`.  
- Minor template/API cleanups: compacted `NewItemDialog` usage, updated component prop/emits handling, and added a micro-benchmark comment where an exposed ref is used to avoid DOM queries.

### Testing
- Ran formatter with `cd frontend && yarn format` (Prettier) which completed successfully.  
- Ran linting with `cd frontend && npx eslint <changed files>` and fixed initial issues; final lint run completed without errors for the modified files.  
- Ran the frontend test suite with `cd frontend && yarn test --run`, which completed but reported one failing suite due to the headless test environment lacking IndexedDB (Dexie MissingAPIError) and a Pinia initialization error in tests, so CI-style unit tests currently do not pass in this environment.  
- Started the dev server (`cd frontend && yarn dev`) and captured a visual smoke-check screenshot of the ItemsSelector to validate UI wiring (manual visual verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b14d3ef888326b39d75cbadf792b2)