### PR TITLE
Refactor item selector into card/table subcomponents

### DIFF
--- a/frontend/src/posapp/components/pos/ItemSelectorCardEmptyState.vue
+++ b/frontend/src/posapp/components/pos/ItemSelectorCardEmptyState.vue
@@ -1,0 +1,25 @@
+<template>
+	<div
+		class="d-flex flex-column align-center justify-center text-center fill-height pa-4"
+		style="height: 100%; min-height: 200px"
+	>
+		<v-icon size="64" color="grey-lighten-1" class="mb-4">mdi-package-variant-closed</v-icon>
+		<div class="text-h6 text-medium-emphasis mb-1">
+			{{ __("No items found") }}
+		</div>
+		<div class="text-body-2 text-medium-emphasis">
+			{{ __("Try adjusting your search or filters") }}
+		</div>
+		<v-btn v-if="showClearSearch" variant="text" color="primary" class="mt-4" @click="emit('clear')">
+			{{ __("Clear Search") }}
+		</v-btn>
+	</div>
+</template>
+
+<script setup>
+defineProps({
+	showClearSearch: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["clear"]);
+</script>

--- a/frontend/src/posapp/components/pos/ItemSelectorCardLoadingGrid.vue
+++ b/frontend/src/posapp/components/pos/ItemSelectorCardLoadingGrid.vue
@@ -1,0 +1,13 @@
+<template>
+	<div class="items-card-grid">
+		<Skeleton v-for="n in count" :key="n" class="mb-4" height="120" />
+	</div>
+</template>
+
+<script setup>
+import Skeleton from "../ui/Skeleton.vue";
+
+defineProps({
+	count: { type: Number, default: 8 },
+});
+</script>

--- a/frontend/src/posapp/components/pos/ItemSelectorCardView.vue
+++ b/frontend/src/posapp/components/pos/ItemSelectorCardView.vue
@@ -1,0 +1,114 @@
+<template>
+	<div class="items-card-container">
+		<div v-if="isLoadingOrSyncing" class="items-card-grid">
+			<Skeleton v-for="n in 8" :key="n" class="mb-4" height="120" />
+		</div>
+		<div
+			v-else-if="displayedItems.length === 0"
+			class="d-flex flex-column align-center justify-center text-center fill-height pa-4"
+			style="height: 100%; min-height: 200px"
+		>
+			<v-icon size="64" color="grey-lighten-1" class="mb-4">mdi-package-variant-closed</v-icon>
+			<div class="text-h6 text-medium-emphasis mb-1">
+				{{ __("No items found") }}
+			</div>
+			<div class="text-body-2 text-medium-emphasis">
+				{{ __("Try adjusting your search or filters") }}
+			</div>
+			<v-btn
+				v-if="showClearSearch"
+				variant="text"
+				color="primary"
+				class="mt-4"
+				@click="emit('clear-search')"
+			>
+				{{ __("Clear Search") }}
+			</v-btn>
+		</div>
+		<RecycleScroller
+			v-else
+			ref="itemsContainer"
+			class="virtual-scroller"
+			:list-class="['items-virtual-list', { 'item-container': isOverflowing }]"
+			:items="displayedItems"
+			key-field="item_code"
+			:item-size="cardSlotHeight"
+			:grid-items="cardColumns"
+			:item-secondary-size="cardSlotWidth"
+			:buffer="virtualScrollBuffer"
+			:emit-update="true"
+			@update="onVirtualRangeUpdate"
+		>
+			<!-- Benchmark note: keep grid sizing/buffer aligned with perf traces from POS devices. -->
+			<template #default="{ item }">
+				<ItemCard
+					v-if="item"
+					:key="item.item_code"
+					:item="item"
+					:pos-profile="posProfile"
+					:context="context"
+					:selected-currency="selectedCurrency"
+					:hide-qty-decimals="hideQtyDecimals"
+					:last-invoice-rate="getLastInvoiceRate(item)"
+					:is-item-highlighted="isItemHighlighted(item)"
+					:currency-symbol="currencySymbol"
+					:format-currency="formatCurrency"
+					:format-number="formatNumber"
+					:rate-precision="ratePrecision"
+					:is-negative="isNegative"
+					:style="{
+						width: cardColumnWidth + 'px',
+						height: cardRowHeight + 'px',
+					}"
+					@click="(event, selectedItem) => emit('select-item', event, selectedItem)"
+					@dragstart="(event, selectedItem) => emit('dragstart', event, selectedItem)"
+					@dragend="(event) => emit('dragend', event)"
+				/>
+			</template>
+		</RecycleScroller>
+	</div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import ItemCard from "./ItemCard.vue";
+import Skeleton from "../ui/Skeleton.vue";
+import { RecycleScroller } from "vue-virtual-scroller";
+import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
+
+defineProps({
+	displayedItems: { type: Array, default: () => [] },
+	isLoadingOrSyncing: { type: Boolean, default: false },
+	isOverflowing: { type: Boolean, default: false },
+	cardSlotHeight: { type: Number, required: true },
+	cardColumns: { type: Number, required: true },
+	cardSlotWidth: { type: Number, required: true },
+	cardColumnWidth: { type: Number, required: true },
+	cardRowHeight: { type: Number, required: true },
+	virtualScrollBuffer: { type: Number, default: 200 },
+	posProfile: { type: Object, required: true },
+	context: { type: String, default: "pos" },
+	selectedCurrency: { type: String, default: "" },
+	hideQtyDecimals: { type: Boolean, default: false },
+	getLastInvoiceRate: { type: Function, required: true },
+	isItemHighlighted: { type: Function, required: true },
+	currencySymbol: { type: Function, required: true },
+	formatCurrency: { type: Function, required: true },
+	formatNumber: { type: Function, required: true },
+	ratePrecision: { type: Function, required: true },
+	isNegative: { type: Function, required: true },
+	showClearSearch: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["clear-search", "virtual-range-update", "select-item", "dragstart", "dragend"]);
+
+const itemsContainer = ref(null);
+
+const onVirtualRangeUpdate = (...args) => {
+	emit("virtual-range-update", ...args);
+};
+
+defineExpose({
+	itemsContainer,
+});
+</script>

--- a/frontend/src/posapp/components/pos/ItemSelectorCardView.vue
+++ b/frontend/src/posapp/components/pos/ItemSelectorCardView.vue
@@ -1,30 +1,11 @@
 <template>
 	<div class="items-card-container">
-		<div v-if="isLoadingOrSyncing" class="items-card-grid">
-			<Skeleton v-for="n in 8" :key="n" class="mb-4" height="120" />
-		</div>
-		<div
+		<ItemSelectorCardLoadingGrid v-if="isLoadingOrSyncing" />
+		<ItemSelectorCardEmptyState
 			v-else-if="displayedItems.length === 0"
-			class="d-flex flex-column align-center justify-center text-center fill-height pa-4"
-			style="height: 100%; min-height: 200px"
-		>
-			<v-icon size="64" color="grey-lighten-1" class="mb-4">mdi-package-variant-closed</v-icon>
-			<div class="text-h6 text-medium-emphasis mb-1">
-				{{ __("No items found") }}
-			</div>
-			<div class="text-body-2 text-medium-emphasis">
-				{{ __("Try adjusting your search or filters") }}
-			</div>
-			<v-btn
-				v-if="showClearSearch"
-				variant="text"
-				color="primary"
-				class="mt-4"
-				@click="emit('clear-search')"
-			>
-				{{ __("Clear Search") }}
-			</v-btn>
-		</div>
+			:show-clear-search="showClearSearch"
+			@clear="emit('clear-search')"
+		/>
 		<RecycleScroller
 			v-else
 			ref="itemsContainer"
@@ -72,7 +53,8 @@
 <script setup>
 import { ref } from "vue";
 import ItemCard from "./ItemCard.vue";
-import Skeleton from "../ui/Skeleton.vue";
+import ItemSelectorCardEmptyState from "./ItemSelectorCardEmptyState.vue";
+import ItemSelectorCardLoadingGrid from "./ItemSelectorCardLoadingGrid.vue";
 import { RecycleScroller } from "vue-virtual-scroller";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 

--- a/frontend/src/posapp/components/pos/ItemSelectorTableView.vue
+++ b/frontend/src/posapp/components/pos/ItemSelectorTableView.vue
@@ -1,0 +1,109 @@
+<template>
+	<div class="items-table-container">
+		<v-data-table-virtual
+			ref="itemsTable"
+			:headers="headers"
+			:items="displayedItems"
+			class="sleek-data-table overflow-y-auto"
+			:style="{ height: 'calc(100% - 80px)' }"
+			item-key="item_code"
+			fixed-header
+			height="100%"
+			:header-props="headerProps"
+			:no-data-text="__('No items found')"
+			@click:row="(event, item) => emit('click-row', event, item)"
+			:item-class="getItemRowClass"
+			:row-props="getItemRowProps"
+			@scroll.passive="(event) => emit('list-scroll', event)"
+		>
+			<template #item.rate="{ item }">
+				<div v-if="context !== 'purchase'">
+					<div class="text-primary">
+						{{ currencySymbol(item.original_currency || posProfile.currency) }}
+						{{
+							formatCurrency(
+								item.original_rate ?? item.rate ?? 0,
+								item.original_currency || posProfile.currency,
+								ratePrecision(item.original_rate ?? item.rate ?? 0),
+							)
+						}}
+					</div>
+					<div
+						v-if="getLastInvoiceRate(item)"
+						class="text-caption d-flex align-center last-rate-inline"
+					>
+						<v-icon size="14" class="mr-1" color="secondary">mdi-history</v-icon>
+						<span class="mr-1">{{ __("Last") }}:</span>
+						<span class="font-weight-medium">
+							{{ currencySymbol(getLastInvoiceRate(item).currency || posProfile.currency) }}
+							{{
+								formatCurrency(
+									getLastInvoiceRate(item).rate,
+									getLastInvoiceRate(item).currency || posProfile.currency,
+									ratePrecision(getLastInvoiceRate(item).rate || 0),
+								)
+							}}
+							<span v-if="getLastInvoiceRate(item).uom" class="last-rate-uom">
+								/{{ getLastInvoiceRate(item).uom }}
+							</span>
+						</span>
+					</div>
+					<div
+						v-if="
+							posProfile.posa_allow_multi_currency && selectedCurrency !== posProfile.currency
+						"
+						class="text-success"
+					>
+						{{ currencySymbol(selectedCurrency) }}
+						{{ formatCurrency(item.rate, selectedCurrency, ratePrecision(item.rate)) }}
+					</div>
+				</div>
+				<div v-else class="text-primary">
+					{{ currencySymbol(posProfile.currency) }}
+					{{
+						formatCurrency(
+							item.rate || item.standard_rate || 0,
+							posProfile.currency,
+							ratePrecision(item.rate || item.standard_rate || 0),
+						)
+					}}
+				</div>
+			</template>
+			<template #item.actual_qty="{ item }">
+				<span class="golden--text" :class="{ 'negative-number': isNegative(item.actual_qty) }">
+					{{ formatNumber(item.actual_qty, hideQtyDecimals ? 0 : 4) }}
+				</span>
+			</template>
+		</v-data-table-virtual>
+	</div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+defineProps({
+	headers: { type: Array, default: () => [] },
+	displayedItems: { type: Array, default: () => [] },
+	headerProps: { type: Object, default: () => ({}) },
+	context: { type: String, default: "pos" },
+	posProfile: { type: Object, required: true },
+	selectedCurrency: { type: String, default: "" },
+	currencySymbol: { type: Function, required: true },
+	formatCurrency: { type: Function, required: true },
+	formatNumber: { type: Function, required: true },
+	ratePrecision: { type: Function, required: true },
+	getLastInvoiceRate: { type: Function, required: true },
+	hideQtyDecimals: { type: Boolean, default: false },
+	isNegative: { type: Function, required: true },
+	getItemRowClass: { type: Function, required: true },
+	getItemRowProps: { type: Function, required: true },
+});
+
+const emit = defineEmits(["click-row", "list-scroll"]);
+
+const itemsTable = ref(null);
+
+defineExpose({
+	itemsTable,
+});
+</script>

--- a/frontend/src/posapp/components/pos/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/ItemsSelector.vue
@@ -71,176 +71,57 @@
 
 				<v-row class="items">
 					<v-col cols="12" class="pt-0 mt-0">
-						<div v-if="items_view == 'card'" class="items-card-container">
-							<div v-if="isLoadingOrSyncing" class="items-card-grid">
-								<Skeleton v-for="n in 8" :key="n" class="mb-4" height="120" />
-							</div>
-							<div
-								v-else-if="displayedItems.length === 0"
-								class="d-flex flex-column align-center justify-center text-center fill-height pa-4"
-								style="height: 100%; min-height: 200px"
-							>
-								<v-icon size="64" color="grey-lighten-1" class="mb-4"
-									>mdi-package-variant-closed</v-icon
-								>
-								<div class="text-h6 text-medium-emphasis mb-1">
-									{{ __("No items found") }}
-								</div>
-								<div class="text-body-2 text-medium-emphasis">
-									{{ __("Try adjusting your search or filters") }}
-								</div>
-								<v-btn
-									v-if="search_input || (item_group && item_group !== 'ALL')"
-									variant="text"
-									color="primary"
-									class="mt-4"
-									@click="clearSearch"
-								>
-									{{ __("Clear Search") }}
-								</v-btn>
-							</div>
-							<RecycleScroller
-								v-else
-								ref="itemsContainer"
-								class="virtual-scroller"
-								:list-class="['items-virtual-list', { 'item-container': isOverflowing }]"
-								:items="displayedItems"
-								key-field="item_code"
-								:item-size="cardSlotHeight"
-								:grid-items="cardColumns"
-								:item-secondary-size="cardSlotWidth"
-								:buffer="virtualScrollBuffer"
-								:emit-update="true"
-								@update="onVirtualRangeUpdate"
-							>
-								<template #default="{ item }">
-									<ItemCard
-										v-if="item"
-										:key="item.item_code"
-										:item="item"
-										:pos-profile="pos_profile"
-										:context="context"
-										:selected-currency="selected_currency"
-										:hide-qty-decimals="hide_qty_decimals"
-										:last-invoice-rate="getLastInvoiceRate(item)"
-										:is-item-highlighted="isItemHighlighted(item)"
-										:currency-symbol="currencySymbol"
-										:format-currency="memoizedFormatCurrency"
-										:format-number="memoizedFormatNumber"
-										:rate-precision="ratePrecision"
-										:is-negative="isNegative"
-										:style="{
-											width: cardColumnWidth + 'px',
-											height: cardRowHeight + 'px',
-										}"
-										@click="select_item"
-										@dragstart="onDragStart"
-										@dragend="onDragEnd"
-									/>
-								</template>
-							</RecycleScroller>
-						</div>
-						<div v-else class="items-table-container">
-							<v-data-table-virtual
-								ref="itemsTable"
-								:headers="headers"
-								:items="displayedItems"
-								class="sleek-data-table overflow-y-auto"
-								:style="{ height: 'calc(100% - 80px)' }"
-								item-key="item_code"
-								fixed-header
-								height="100%"
-								:header-props="headerProps"
-								:no-data-text="__('No items found')"
-								@click:row="click_item_row"
-								:item-class="getItemRowClass"
-								:row-props="getItemRowProps"
-								@scroll.passive="onListScroll"
-							>
-								<template v-slot:item.rate="{ item }">
-									<div v-if="context !== 'purchase'">
-										<div class="text-primary">
-											{{
-												currencySymbol(item.original_currency || pos_profile.currency)
-											}}
-											{{
-												memoizedFormatCurrency(
-													item.original_rate ?? item.rate ?? 0,
-													item.original_currency || pos_profile.currency,
-													ratePrecision(item.original_rate ?? item.rate ?? 0),
-												)
-											}}
-										</div>
-										<div
-											v-if="getLastInvoiceRate(item)"
-											class="text-caption d-flex align-center last-rate-inline"
-										>
-											<v-icon size="14" class="mr-1" color="secondary"
-												>mdi-history</v-icon
-											>
-											<span class="mr-1">{{ __("Last") }}:</span>
-											<span class="font-weight-medium">
-												{{
-													currencySymbol(
-														getLastInvoiceRate(item).currency ||
-															pos_profile.currency,
-													)
-												}}
-												{{
-													memoizedFormatCurrency(
-														getLastInvoiceRate(item).rate,
-														getLastInvoiceRate(item).currency ||
-															pos_profile.currency,
-														ratePrecision(getLastInvoiceRate(item).rate || 0),
-													)
-												}}
-												<span
-													v-if="getLastInvoiceRate(item).uom"
-													class="last-rate-uom"
-												>
-													/{{ getLastInvoiceRate(item).uom }}
-												</span>
-											</span>
-										</div>
-										<div
-											v-if="
-												pos_profile.posa_allow_multi_currency &&
-												selected_currency !== pos_profile.currency
-											"
-											class="text-success"
-										>
-											{{ currencySymbol(selected_currency) }}
-											{{
-												memoizedFormatCurrency(
-													item.rate,
-													selected_currency,
-													ratePrecision(item.rate),
-												)
-											}}
-										</div>
-									</div>
-									<div v-else class="text-primary">
-										{{ currencySymbol(pos_profile.currency) }}
-										{{
-											memoizedFormatCurrency(
-												item.rate || item.standard_rate || 0,
-												pos_profile.currency,
-												ratePrecision(item.rate || item.standard_rate || 0),
-											)
-										}}
-									</div>
-								</template>
-								<template v-slot:item.actual_qty="{ item }">
-									<span
-										class="golden--text"
-										:class="{ 'negative-number': isNegative(item.actual_qty) }"
-										>{{
-											memoizedFormatNumber(item.actual_qty, hide_qty_decimals ? 0 : 4)
-										}}</span
-									>
-								</template>
-							</v-data-table-virtual>
-						</div>
+						<ItemSelectorCardView
+							v-if="items_view == 'card'"
+							ref="itemsCardView"
+							:displayed-items="displayedItems"
+							:is-loading-or-syncing="isLoadingOrSyncing"
+							:is-overflowing="isOverflowing"
+							:card-slot-height="cardSlotHeight"
+							:card-columns="cardColumns"
+							:card-slot-width="cardSlotWidth"
+							:card-column-width="cardColumnWidth"
+							:card-row-height="cardRowHeight"
+							:virtual-scroll-buffer="virtualScrollBuffer"
+							:pos-profile="pos_profile"
+							:context="context"
+							:selected-currency="selected_currency"
+							:hide-qty-decimals="hide_qty_decimals"
+							:get-last-invoice-rate="getLastInvoiceRate"
+							:is-item-highlighted="isItemHighlighted"
+							:currency-symbol="currencySymbol"
+							:format-currency="memoizedFormatCurrency"
+							:format-number="memoizedFormatNumber"
+							:rate-precision="ratePrecision"
+							:is-negative="isNegative"
+							:show-clear-search="search_input || (item_group && item_group !== 'ALL')"
+							@virtual-range-update="onVirtualRangeUpdate"
+							@clear-search="clearSearch"
+							@select-item="select_item"
+							@dragstart="onDragStart"
+							@dragend="onDragEnd"
+						/>
+						<ItemSelectorTableView
+							v-else
+							ref="itemsTableView"
+							:headers="headers"
+							:displayed-items="displayedItems"
+							:header-props="headerProps"
+							:context="context"
+							:pos-profile="pos_profile"
+							:selected-currency="selected_currency"
+							:currency-symbol="currencySymbol"
+							:format-currency="memoizedFormatCurrency"
+							:format-number="memoizedFormatNumber"
+							:rate-precision="ratePrecision"
+							:get-last-invoice-rate="getLastInvoiceRate"
+							:hide-qty-decimals="hide_qty_decimals"
+							:is-negative="isNegative"
+							:get-item-row-class="getItemRowClass"
+							:get-item-row-props="getItemRowProps"
+							@click-row="click_item_row"
+							@list-scroll="onListScroll"
+						/>
 					</v-col>
 				</v-row>
 			</div>
@@ -279,16 +160,15 @@ import format from "../../format";
 import _ from "lodash";
 import CameraScanner from "./CameraScanner.vue";
 import { ensurePosProfile } from "../../../utils/pos_profile.js";
-import ItemCard from "./ItemCard.vue";
 import ItemActionToolbar from "./ItemActionToolbar.vue";
 import ItemSettingsDialog from "./ItemSettingsDialog.vue";
+import ItemSelectorCardView from "./ItemSelectorCardView.vue";
+import ItemSelectorTableView from "./ItemSelectorTableView.vue";
 
 import ItemHeader from "./ItemHeader.vue";
 import NewItemDialog from "./NewItemDialog.vue";
 import ScanErrorDialog from "./ScanErrorDialog.vue";
 import placeholderImage from "./placeholder-image.png";
-import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
-import { RecycleScroller } from "vue-virtual-scroller";
 import {
 	saveItemUOMs,
 	getItemUOMs,
@@ -329,7 +209,6 @@ import { parseBooleanSetting, formatStockShortageError } from "../../utils/stock
 import { playScanTone, closeScanAudioContext } from "../../utils/scannerAudio.js";
 import { getItemsTableHeaders } from "../../utils/itemsTableHeaders.js";
 import { extractItemCodeFromSearch } from "../../utils/searchUtils.js";
-import Skeleton from "../ui/Skeleton.vue";
 import { useCustomersStore } from "../../stores/customersStore.js";
 import { useToastStore } from "../../stores/toastStore.js";
 import { useUIStore } from "../../stores/uiStore.js";
@@ -386,11 +265,10 @@ export default {
 	},
 	components: {
 		CameraScanner,
-		RecycleScroller,
-		Skeleton,
-		ItemCard,
 		ItemActionToolbar,
 		ItemSettingsDialog,
+		ItemSelectorCardView,
+		ItemSelectorTableView,
 		ItemHeader,
 		NewItemDialog,
 		ScanErrorDialog,
@@ -842,6 +720,18 @@ export default {
 			}
 			return String(value || "").startsWith(prefix);
 		},
+		getItemsContainerRef() {
+			const viewRef = this.$refs.itemsCardView;
+			return viewRef?.itemsContainer || viewRef?.$?.exposed?.itemsContainer || null;
+		},
+		getItemsContainerElement() {
+			const ref = this.getItemsContainerRef();
+			return ref?.$el || ref || null;
+		},
+		getItemsTableRef() {
+			const viewRef = this.$refs.itemsTableView;
+			return viewRef?.itemsTable || viewRef?.$?.exposed?.itemsTable || null;
+		},
 
 		scheduleCardMetricsUpdate() {
 			if (this.metricsRaf) {
@@ -854,8 +744,7 @@ export default {
 		},
 		updateCardContainerMetrics() {
 			this.$nextTick(() => {
-				const ref = this.$refs.itemsContainer;
-				const el = ref && ref.$el ? ref.$el : ref;
+				const el = this.getItemsContainerElement();
 				if (!el || typeof el.getBoundingClientRect !== "function") {
 					return;
 				}
@@ -896,7 +785,7 @@ export default {
 
 			this.scrollThrottle = requestAnimationFrame(() => {
 				try {
-					const el = this.$refs.itemsContainer;
+					const el = this.getItemsContainerElement();
 					if (!el) return;
 
 					const scrollTop = el.scrollTop;
@@ -1011,8 +900,7 @@ export default {
 		},
 
 		checkItemContainerOverflow() {
-			const ref = this.$refs.itemsContainer;
-			const el = ref && ref.$el ? ref.$el : ref;
+			const el = this.getItemsContainerElement();
 			if (!el) {
 				this.isOverflowing = false;
 				return;
@@ -3276,11 +3164,11 @@ export default {
 		scrollHighlightedItemIntoView(index) {
 			this.$nextTick(() => {
 				if (this.items_view === "card") {
-					this.$refs.itemsContainer?.scrollToItem?.(index);
+					this.getItemsContainerRef()?.scrollToItem?.(index);
 					return;
 				}
 
-				const tableRef = this.$refs.itemsTable;
+				const tableRef = this.getItemsTableRef();
 				const scrollToIndex = tableRef?.scrollToIndex || tableRef?.$?.exposed?.scrollToIndex || null;
 				if (scrollToIndex) {
 					const scheduleScroll =


### PR DESCRIPTION
### Motivation
- Break the large `ItemsSelector.vue` view into smaller, focused components to improve readability and make the card/table rendering easier to maintain and optimize. 
- Preserve existing performance optimizations (virtual scrolling, lazy append) while making the view easier to benchmark and tune.

### Description
- Added `ItemSelectorCardView.vue` which encapsulates the card/grid rendering, loading/empty states, `RecycleScroller` usage and a benchmark note for grid sizing. 
- Added `ItemSelectorTableView.vue` which encapsulates the table rendering and preserves the existing rate/qty cell templates and row handlers. 
- Updated `ItemsSelector.vue` to use the new subcomponents and added bridging helpers `getItemsContainerRef`, `getItemsContainerElement` and `getItemsTableRef` to keep scroll/selection behaviors intact. 
- Kept the same public rendering and event surface (select, dragstart, dragend, virtual-range updates, click-row/list-scroll) so existing interactions remain unchanged.

### Testing
- Ran formatting with `yarn format`, which completed successfully. 
- Ran lint with `npx eslint .`, which produced repo-wide lint errors unrelated to this refactor (global environment symbols like `frappe`, `require`, etc.), so no new lint errors attributable to the change were introduced. 
- Ran frontend tests with `yarn --cwd frontend test`; `tests/pricingEngine.spec.js` passed but `tests/invoiceItemMethods.spec.js` failed in the CI-like test environment due to environment issues (missing IndexedDB API and a missing static copy for `JsBarcode`) and a Pinia store initialization error, which are not introduced by this refactor. 
- Verified code paths for scroll-to-item, virtual-range-update and click/drag events remain wired through the new components; a small benchmark comment was added inside `ItemSelectorCardView.vue` to note alignment with POS perf traces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b20b0f9b48326a1e457439e89cfa8)