### PR TITLE
Add offline guard to item search clear reloads

### DIFF
--- a/frontend/src/posapp/composables/useItemSearchTriggers.js
+++ b/frontend/src/posapp/composables/useItemSearchTriggers.js
@@ -1,6 +1,6 @@
 import { ref, nextTick } from "vue";
-import _ from "lodash";
-import { shouldReloadOnSearchClear } from "../../utils/searchUtils.js";
+import { shouldReloadOnSearchClear } from "../utils/searchUtils.js";
+import { isOffline } from "../../offline/index.js";
 
 /**
  * useItemSearchTriggers
@@ -98,6 +98,11 @@ export function useItemSearchTriggers({
 
         if (isBackgroundLoading.value) {
             // Defer reload
+            release();
+            return;
+        }
+
+        if (typeof isOffline === "function" && isOffline()) {
             release();
             return;
         }


### PR DESCRIPTION
### Motivation
- Prevent forced server reloads when the app is offline and remove an unused import to keep the composable aligned with existing utilities.

### Description
- Import `isOffline` from `frontend/src/offline/index.js`, remove the unused `lodash` import, and add an early-return offline check in `clearSearch` to avoid calling `get_items(true)` when offline.

### Testing
- `cd frontend && yarn format` completed successfully.
- `cd frontend && npx eslint .` failed due to existing repository lint errors (many `no-undef` / `no-unused-vars`) not introduced by this change.
- `cd frontend && yarn test` ran `vitest` where one suite failed due to IndexedDB/Pinia runtime errors and a missing static-copy asset while other suites passed.
- `cd frontend && yarn build` failed on an unresolved `@mdi/font/css/materialdesignicons.css` dependency which is unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c5e3f48d083269053d9ed915e06c6)