### PR TITLE
Migrate remaining POS UI components and dialogs to <script setup> (Composition API)

### DIFF
--- a/frontend/src/posapp/components/OfflineInvoices.vue
+++ b/frontend/src/posapp/components/OfflineInvoices.vue
@@ -193,83 +193,114 @@
 	</v-row>
 </template>
 
-<script>
-import format from "../format";
+<script setup>
+import { ref, watch } from "vue";
+import { formatUtils } from "../format";
 import {
 	getOfflineInvoices,
 	deleteOfflineInvoice,
 	getPendingOfflineInvoiceCount,
 } from "../../offline/index.js";
 
-export default {
+defineOptions({
 	name: "OfflineInvoicesDialog",
-	mixins: [format],
-	props: {
-		modelValue: Boolean,
-		posProfile: {
-			type: Object,
-			default: () => ({}),
-		},
+});
+
+const props = defineProps({
+	modelValue: Boolean,
+	posProfile: {
+		type: Object,
+		default: () => ({}),
 	},
-	emits: ["update:modelValue", "deleted", "sync-all"],
-	data() {
-		return {
-			dialog: this.modelValue,
-			invoices: [],
-			headers: [
-				{
-					title: this.__("Customer"),
-					value: "customer",
-					align: "start",
-					width: "35%",
-				},
-				{
-					title: this.__("Date"),
-					value: "posting_date",
-					align: "center",
-					width: "20%",
-				},
-				{
-					title: this.__("Amount"),
-					value: "grand_total",
-					align: "end",
-					width: "25%",
-				},
-				{
-					title: this.__("Actions"),
-					value: "actions",
-					align: "center",
-					width: "20%",
-					sortable: false,
-				},
-			],
-		};
+});
+
+const emit = defineEmits(["update:modelValue", "deleted", "sync-all"]);
+const __ = window.__ || ((text) => text);
+const get_currency_symbol = window.get_currency_symbol;
+const currency_precision = ref(2);
+
+const dialog = ref(props.modelValue);
+const invoices = ref([]);
+const headers = [
+	{
+		title: __("Customer"),
+		value: "customer",
+		align: "start",
+		width: "35%",
 	},
-	watch: {
-		modelValue(val) {
-			this.dialog = val;
-			if (val) {
-				this.loadInvoices();
-			}
-		},
-		dialog(val) {
-			this.$emit("update:modelValue", val);
-		},
+	{
+		title: __("Date"),
+		value: "posting_date",
+		align: "center",
+		width: "20%",
 	},
-	methods: {
-		loadInvoices() {
-			this.invoices = getOfflineInvoices();
-		},
-		removeInvoice(index) {
-			if (!this.posProfile.posa_allow_delete_offline_invoice) {
-				return;
-			}
-			deleteOfflineInvoice(index);
-			this.loadInvoices();
-			this.$emit("deleted", getPendingOfflineInvoiceCount());
-		},
+	{
+		title: __("Amount"),
+		value: "grand_total",
+		align: "end",
+		width: "25%",
 	},
-};
+	{
+		title: __("Actions"),
+		value: "actions",
+		align: "center",
+		width: "20%",
+		sortable: false,
+	},
+];
+
+watch(
+	() => props.modelValue,
+	(val) => {
+		dialog.value = val;
+		if (val) {
+			loadInvoices();
+		}
+	},
+);
+
+watch(dialog, (val) => {
+	emit("update:modelValue", val);
+});
+
+function formatCurrency(value, precision) {
+	if (value === null || value === undefined) {
+		value = 0;
+	}
+	let number = Number(formatUtils.fromArabicNumerals(String(value)).replace(/,/g, ""));
+	if (isNaN(number)) number = 0;
+	let prec = precision != null ? Number(precision) : Number(currency_precision.value) || 2;
+	if (!Number.isInteger(prec) || prec < 0 || prec > 20) {
+		prec = Math.min(Math.max(parseInt(prec) || 2, 0), 20);
+	}
+
+	const locale = formatUtils.getNumberLocale();
+	let formatted = number.toLocaleString(locale, {
+		minimumFractionDigits: prec,
+		maximumFractionDigits: prec,
+		useGrouping: true,
+	});
+
+	formatted = formatUtils.toArabicNumerals(formatted);
+	return formatted;
+}
+
+function currencySymbol(currency) {
+	return get_currency_symbol?.(currency);
+}
+
+function loadInvoices() {
+	invoices.value = getOfflineInvoices();
+}
+
+function removeInvoice(index) {
+	if (!props.posProfile.posa_allow_delete_offline_invoice) {
+		return;
+	}
+	deleteOfflineInvoice(index);
+	loadInvoices();
+	emit("deleted", getPendingOfflineInvoiceCount());
+}
 </script>
 
 <style>

--- a/frontend/src/posapp/components/navbar/AboutDialog.vue
+++ b/frontend/src/posapp/components/navbar/AboutDialog.vue
@@ -91,70 +91,75 @@
 	</v-dialog>
 </template>
 
-<script>
+<script setup>
+/* global frappe */
+import { computed, ref, watch } from "vue";
 import { formatBuildVersion } from "../../stores/updateStore.js";
 
-const BUILD_VERSION = typeof __BUILD_VERSION__ !== "undefined" ? __BUILD_VERSION__ : null;
-
-export default {
+defineOptions({
 	name: "AboutDialog",
-	props: {
-		modelValue: Boolean,
+});
+
+const BUILD_VERSION = typeof __BUILD_VERSION__ !== "undefined" ? __BUILD_VERSION__ : null;
+const __ = window.__ || ((text) => text);
+
+const props = defineProps({
+	modelValue: Boolean,
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const dialogOpen = ref(props.modelValue);
+const loadingAppInfo = ref(false);
+const appInfoError = ref(false);
+const appInfo = ref([]);
+const buildVersion = ref(BUILD_VERSION);
+
+const formattedBuildVersion = computed(() =>
+	buildVersion.value ? formatBuildVersion(buildVersion.value) : null,
+);
+
+watch(
+	() => props.modelValue,
+	(val) => {
+		dialogOpen.value = val;
+		if (val) {
+			loadAppInfo();
+		}
 	},
-	data() {
-		return {
-			dialogOpen: this.modelValue,
-			loadingAppInfo: false,
-			appInfoError: false,
-			appInfo: [],
-			buildVersion: BUILD_VERSION,
-		};
-	},
-	computed: {
-		formattedBuildVersion() {
-			return this.buildVersion ? formatBuildVersion(this.buildVersion) : null;
-		},
-	},
-	watch: {
-		modelValue(val) {
-			this.dialogOpen = val;
-			if (val) {
-				this.loadAppInfo();
+);
+
+watch(dialogOpen, (val) => {
+	emit("update:modelValue", val);
+});
+
+function close() {
+	dialogOpen.value = false;
+}
+
+function loadAppInfo() {
+	loadingAppInfo.value = true;
+	appInfoError.value = false;
+
+	frappe.call({
+		method: "posawesome.posawesome.api.utilities.get_app_info",
+		callback: (r) => {
+			loadingAppInfo.value = false;
+			if (Array.isArray(r.message.apps)) {
+				appInfo.value = r.message.apps;
+				if (r.message.build_version) {
+					buildVersion.value = r.message.build_version;
+				}
+			} else {
+				appInfoError.value = true;
 			}
 		},
-		dialogOpen(val) {
-			this.$emit("update:modelValue", val);
+		error: () => {
+			loadingAppInfo.value = false;
+			appInfoError.value = true;
 		},
-	},
-	methods: {
-		close() {
-			this.dialogOpen = false;
-		},
-		loadAppInfo() {
-			this.loadingAppInfo = true;
-			this.appInfoError = false;
-
-			frappe.call({
-				method: "posawesome.posawesome.api.utilities.get_app_info",
-				callback: (r) => {
-					this.loadingAppInfo = false;
-					if (Array.isArray(r.message.apps)) {
-						this.appInfo = r.message.apps;
-						if (r.message.build_version) {
-							this.buildVersion = r.message.build_version;
-						}
-					} else {
-						this.appInfoError = true;
-					}
-				},
-				error: () => {
-					this.loadingAppInfo = false;
-					this.appInfoError = true;
-				},
-			});
-		},
-	},
-};
+	});
+}
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/navbar/CacheUsageMeter.vue
+++ b/frontend/src/posapp/components/navbar/CacheUsageMeter.vue
@@ -79,63 +79,68 @@
 	</div>
 </template>
 
-<script>
-export default {
+<script setup>
+import { computed } from "vue";
+
+defineOptions({
 	name: "CacheUsageMeter",
-	props: {
-		cacheUsage: {
-			type: Number,
-			default: 0,
-		},
-		cacheUsageLoading: {
-			type: Boolean,
-			default: false,
-		},
-		cacheUsageDetails: {
-			type: Object,
-			default: () => ({
-				total: 0,
-				indexedDB: 0,
-				localStorage: 0,
-			}),
-		},
+});
+
+const props = defineProps({
+	cacheUsage: {
+		type: Number,
+		default: 0,
 	},
-	computed: {
-		cacheUsageColor() {
-			// Return color based on cache usage percentage
-			if (this.cacheUsage < 50) return "success";
-			if (this.cacheUsage < 80) return "warning";
-			return "error";
-		},
-		cacheBarGradient() {
-			if (this.cacheUsage < 50) {
-				return "linear-gradient(90deg, #43e97b 0%, #38f9d7 100%)";
-			} else if (this.cacheUsage < 80) {
-				return "linear-gradient(90deg, #f7971e 0%, #ffd200 100%)";
-			} else {
-				return "linear-gradient(90deg, #f953c6 0%, #b91d73 100%)";
-			}
-		},
-		cacheUsageLabel() {
-			return `${this.cacheUsage}% ${this.__("cache used")}`;
-		},
+	cacheUsageLoading: {
+		type: Boolean,
+		default: false,
 	},
-	methods: {
-		refreshCacheUsage() {
-			if (this.cacheUsageLoading) {
-				return;
-			}
-			this.$emit("refresh");
-		},
-		formatBytes(bytes) {
-			if (bytes === 0) return "0 Bytes";
-			const k = 1024;
-			const sizes = ["Bytes", "KB", "MB", "GB"];
-			const i = Math.floor(Math.log(bytes) / Math.log(k));
-			return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
-		},
+	cacheUsageDetails: {
+		type: Object,
+		default: () => ({
+			total: 0,
+			indexedDB: 0,
+			localStorage: 0,
+		}),
 	},
-};
+});
+
+const emit = defineEmits(["refresh"]);
+const __ = window.__ || ((text) => text);
+
+const cacheUsageColor = computed(() => {
+	// Return color based on cache usage percentage
+	if (props.cacheUsage < 50) return "success";
+	if (props.cacheUsage < 80) return "warning";
+	return "error";
+});
+
+const cacheBarGradient = computed(() => {
+	if (props.cacheUsage < 50) {
+		return "linear-gradient(90deg, #43e97b 0%, #38f9d7 100%)";
+	}
+	if (props.cacheUsage < 80) {
+		return "linear-gradient(90deg, #f7971e 0%, #ffd200 100%)";
+	}
+	return "linear-gradient(90deg, #f953c6 0%, #b91d73 100%)";
+});
+
+const cacheUsageLabel = computed(() => `${props.cacheUsage}% ${__("cache used")}`);
+
+function refreshCacheUsage() {
+	if (props.cacheUsageLoading) {
+		return;
+	}
+	emit("refresh");
+}
+
+function formatBytes(bytes) {
+	if (bytes === 0) return "0 Bytes";
+	const k = 1024;
+	const sizes = ["Bytes", "KB", "MB", "GB"];
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+}
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/navbar/NavbarDrawer.vue
+++ b/frontend/src/posapp/components/navbar/NavbarDrawer.vue
@@ -47,82 +47,84 @@
 	</v-navigation-drawer>
 </template>
 
-<script>
+<script setup>
+import { computed, ref, watch } from "vue";
 import { useRtl } from "../../composables/useRtl.js";
 
-export default {
+defineOptions({
 	name: "NavbarDrawer",
-	setup() {
-		const { isRtl, rtlStyles, rtlClasses } = useRtl();
-		return {
-			isRtl,
-			rtlStyles,
-			rtlClasses,
-		};
+});
+
+const props = defineProps({
+	drawer: Boolean,
+	company: String,
+	companyImg: String,
+	items: Array,
+	item: Number,
+	isDark: Boolean,
+});
+
+const emit = defineEmits(["update:drawer", "update:item"]);
+const { isRtl, rtlClasses } = useRtl();
+
+const mini = ref(false);
+const drawerOpen = ref(props.drawer);
+const activeItem = ref(props.item);
+const showSport = ref(true);
+let closeTimeout = null;
+
+const scrimColor = computed(() => {
+	// Use an opaque background in light mode so that
+	// underlying content doesn't show through the drawer
+	return props.isDark ? true : "rgba(255,255,255,1)";
+});
+
+watch(
+	() => props.drawer,
+	(val) => {
+		drawerOpen.value = val;
+		if (val) {
+			mini.value = false;
+		}
 	},
-	props: {
-		drawer: Boolean,
-		company: String,
-		companyImg: String,
-		items: Array,
-		item: Number,
-		isDark: Boolean,
+);
+
+watch(drawerOpen, (val) => {
+	document.body.style.overflow = val ? "hidden" : "";
+	emit("update:drawer", val);
+});
+
+watch(
+	() => props.item,
+	(val) => {
+		activeItem.value = val;
 	},
-	data() {
-		return {
-			mini: false,
-			drawerOpen: this.drawer,
-			activeItem: this.item,
-			showSport: true,
-		};
-	},
-	computed: {
-		scrimColor() {
-			// Use an opaque background in light mode so that
-			// underlying content doesn't show through the drawer
-			return this.isDark ? true : "rgba(255,255,255,1)";
-		},
-	},
-	watch: {
-		drawer(val) {
-			this.drawerOpen = val;
-			if (val) {
-				this.mini = false;
-			}
-		},
-		drawerOpen(val) {
-			document.body.style.overflow = val ? "hidden" : "";
-			this.$emit("update:drawer", val);
-		},
-		item(val) {
-			this.activeItem = val;
-		},
-		activeItem(val) {
-			this.$emit("update:item", val);
-		},
-	},
-	mounted() {},
-	methods: {
-		handleMouseLeave() {
-			if (!this.drawerOpen) return;
-			clearTimeout(this._closeTimeout);
-			this._closeTimeout = setTimeout(() => {
-				this.drawerOpen = false;
-				this.mini = true;
-			}, 250);
-		},
-		handleItemClick() {
-			// Close drawer after selection if mobile
-			if (window.innerWidth < 1024) {
-				this.closeDrawer();
-			}
-		},
-		closeDrawer() {
-			this.drawerOpen = false;
-			this.mini = true;
-		},
-	},
-};
+);
+
+watch(activeItem, (val) => {
+	emit("update:item", val);
+});
+
+function handleMouseLeave() {
+	if (!drawerOpen.value) return;
+	clearTimeout(closeTimeout);
+	closeTimeout = setTimeout(() => {
+		drawerOpen.value = false;
+		mini.value = true;
+	}, 250);
+}
+
+function handleItemClick() {
+	// Close drawer after selection if mobile
+	if (window.innerWidth < 1024) {
+		closeDrawer();
+	}
+}
+
+function closeDrawer() {
+	drawerOpen.value = false;
+	mini.value = true;
+}
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/navbar/NavbarInfoGadgets.vue
+++ b/frontend/src/posapp/components/navbar/NavbarInfoGadgets.vue
@@ -42,15 +42,15 @@
 	</div>
 </template>
 
-<script>
-export default {
+<script setup>
+import { ref } from "vue";
+
+defineOptions({
 	name: "NavbarInfoGadgets",
-	data() {
-		return {
-			menu: false,
-		};
-	},
-};
+});
+
+const __ = window.__ || ((text) => text);
+const menu = ref(false);
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/navbar/NotificationBell.vue
+++ b/frontend/src/posapp/components/navbar/NotificationBell.vue
@@ -79,49 +79,49 @@
 	</div>
 </template>
 
-<script>
-export default {
+<script setup>
+import { ref, watch } from "vue";
+
+defineOptions({
 	name: "NotificationBell",
-	props: {
-		notifications: {
-			type: Array,
-			default: () => [],
-		},
-		unreadCount: {
-			type: Number,
-			default: 0,
-		},
+});
+
+const props = defineProps({
+	notifications: {
+		type: Array,
+		default: () => [],
 	},
-	data() {
-		return {
-			open: false,
-		};
+	unreadCount: {
+		type: Number,
+		default: 0,
 	},
-	watch: {
-		open(val) {
-			if (val) {
-				this.$emit("mark-read");
-			}
-		},
-	},
-	methods: {
-		clearAll() {
-			this.$emit("clear");
-		},
-		formatTimestamp(ts) {
-			if (!ts) {
-				return "";
-			}
-			try {
-				const date = new Date(ts);
-				return date.toLocaleString();
-			} catch {
-				return ts;
-			}
-		},
-	},
-	emits: ["mark-read", "clear"],
-};
+});
+
+const emit = defineEmits(["mark-read", "clear"]);
+const __ = window.__ || ((text) => text);
+const open = ref(false);
+
+watch(open, (value) => {
+	if (value) {
+		emit("mark-read");
+	}
+});
+
+function clearAll() {
+	emit("clear");
+}
+
+function formatTimestamp(ts) {
+	if (!ts) {
+		return "";
+	}
+	try {
+		const date = new Date(ts);
+		return date.toLocaleString();
+	} catch {
+		return ts;
+	}
+}
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/navbar/StatusIndicator.vue
+++ b/frontend/src/posapp/components/navbar/StatusIndicator.vue
@@ -17,150 +17,155 @@
 	</div>
 </template>
 
-<script>
+<script setup>
+import { computed } from "vue";
+
+defineOptions({
+	name: "StatusIndicator",
+});
+
+const props = defineProps({
+	networkOnline: Boolean,
+	serverOnline: Boolean,
+	serverConnecting: Boolean,
+	isIpHost: Boolean,
+});
+
+const __ = window.__ || ((text) => text);
 const DEBUG = false;
 
-export default {
-	name: "StatusIndicator",
-	props: {
-		networkOnline: Boolean,
-		serverOnline: Boolean,
-		serverConnecting: Boolean,
-		isIpHost: Boolean,
-	},
-	computed: {
-		/**
-		 * Determines the color of the status icon based on current network and server connectivity.
-		 * @returns {string} A Vuetify color string ('green', 'red').
-		 */
-		statusColor() {
-			// Enhanced debugging with more context
-			if (DEBUG) {
-				console.log(
-					"StatusIndicator - Network:",
-					this.networkOnline,
-					"Server:",
-					this.serverOnline,
-					"Connecting:",
-					this.serverConnecting,
-					"IP Host:",
-					this.isIpHost,
-					"Host:",
-					window.location.hostname,
-				);
-			}
+const statusColor = computed(() => {
+	/**
+	 * Determines the color of the status icon based on current network and server connectivity.
+	 * @returns {string} A Vuetify color string ('green', 'red').
+	 */
+	if (DEBUG) {
+		console.log(
+			"StatusIndicator - Network:",
+			props.networkOnline,
+			"Server:",
+			props.serverOnline,
+			"Connecting:",
+			props.serverConnecting,
+			"IP Host:",
+			props.isIpHost,
+			"Host:",
+			window.location.hostname,
+		);
+	}
 
-			// Show yellow/orange when connecting
-			if (this.serverConnecting) {
-				return "orange";
-			}
+	// Show yellow/orange when connecting
+	if (props.serverConnecting) {
+		return "orange";
+	}
 
-			// For IP hosts (localhost, 127.0.0.1, IP addresses), prioritize network status
-			if (this.isIpHost) {
-				return this.networkOnline ? "green" : "red";
-			}
+	// For IP hosts (localhost, 127.0.0.1, IP addresses), prioritize network status
+	if (props.isIpHost) {
+		return props.networkOnline ? "green" : "red";
+	}
 
-			// For domain hosts, require both network and server connectivity
-			if (this.networkOnline && this.serverOnline) {
-				return "green";
-			}
+	// For domain hosts, require both network and server connectivity
+	if (props.networkOnline && props.serverOnline) {
+		return "green";
+	}
 
-			// Network online but server offline
-			if (this.networkOnline && !this.serverOnline) {
-				return "orange";
-			}
+	// Network online but server offline
+	if (props.networkOnline && !props.serverOnline) {
+		return "orange";
+	}
 
-			// Network offline
-			return "red";
-		},
-		/**
-		 * Determines the Material Design Icon to display based on network and server status.
-		 * @returns {string} A Material Design Icon class string.
-		 */
-		statusIcon() {
-			if (DEBUG) {
-				console.log(
-					"StatusIndicator - Determining icon for network:",
-					this.networkOnline,
-					"server:",
-					this.serverOnline,
-					"connecting:",
-					this.serverConnecting,
-				);
-			}
+	// Network offline
+	return "red";
+});
 
-			// Show loading icon when connecting
-			if (this.serverConnecting) {
-				return "mdi-wifi-sync";
-			}
+const statusIcon = computed(() => {
+	/**
+	 * Determines the Material Design Icon to display based on network and server status.
+	 * @returns {string} A Material Design Icon class string.
+	 */
+	if (DEBUG) {
+		console.log(
+			"StatusIndicator - Determining icon for network:",
+			props.networkOnline,
+			"server:",
+			props.serverOnline,
+			"connecting:",
+			props.serverConnecting,
+		);
+	}
 
-			// For IP hosts, show based on network status
-			if (this.isIpHost) {
-				return this.networkOnline ? "mdi-wifi" : "mdi-wifi-off";
-			}
+	// Show loading icon when connecting
+	if (props.serverConnecting) {
+		return "mdi-wifi-sync";
+	}
 
-			// Full connectivity
-			if (this.networkOnline && this.serverOnline) {
-				return "mdi-wifi";
-			}
+	// For IP hosts, show based on network status
+	if (props.isIpHost) {
+		return props.networkOnline ? "mdi-wifi" : "mdi-wifi-off";
+	}
 
-			// Network online but server issues
-			if (this.networkOnline && !this.serverOnline) {
-				return "mdi-wifi-strength-alert-outline";
-			}
+	// Full connectivity
+	if (props.networkOnline && props.serverOnline) {
+		return "mdi-wifi";
+	}
 
-			// Network offline
-			return "mdi-wifi-off";
-		},
-		/**
-		 * Provides a descriptive text for the tooltip that appears when hovering over the status icon.
-		 * This text is also used for the `title` attribute of the button.
-		 * @returns {string} A localized status message.
-		 */
-		statusText() {
-			const hostname = window.location.hostname;
-			const hostType = this.isIpHost ? "Local/IP Host" : "Domain Host";
+	// Network online but server issues
+	if (props.networkOnline && !props.serverOnline) {
+		return "mdi-wifi-strength-alert-outline";
+	}
 
-			if (this.serverConnecting) {
-				return this.__(`Connecting to server... (${hostType}: ${hostname})`);
-			}
+	// Network offline
+	return "mdi-wifi-off";
+});
 
-			if (!this.networkOnline) {
-				return this.__(`No Internet Connection (${hostType}: ${hostname})`);
-			}
+const statusText = computed(() => {
+	/**
+	 * Provides a descriptive text for the tooltip that appears when hovering over the status icon.
+	 * This text is also used for the `title` attribute of the button.
+	 * @returns {string} A localized status message.
+	 */
+	const hostname = window.location.hostname;
+	const hostType = props.isIpHost ? "Local/IP Host" : "Domain Host";
 
-			if (this.isIpHost) {
-				return this.__(`Connected to ${hostname}`);
-			}
+	if (props.serverConnecting) {
+		return __(`Connecting to server... (${hostType}: ${hostname})`);
+	}
 
-			if (this.serverOnline) {
-				return this.__(`Connected to Server (${hostname})`);
-			}
+	if (!props.networkOnline) {
+		return __(`No Internet Connection (${hostType}: ${hostname})`);
+	}
 
-			return this.__(`Server Offline (${hostname})`);
-		},
-		/**
-		 * Short, user-friendly connectivity label for the navbar.
-		 * @returns {string}
-		 */
-		connectivityLabel() {
-			if (this.serverConnecting) {
-				return this.__("Connecting");
-			}
+	if (props.isIpHost) {
+		return __(`Connected to ${hostname}`);
+	}
 
-			if (!this.networkOnline) {
-				return this.__("Offline");
-			}
+	if (props.serverOnline) {
+		return __(`Connected to Server (${hostname})`);
+	}
 
-			if (this.networkOnline && this.serverOnline) {
-				return this.__("Online");
-			}
+	return __(`Server Offline (${hostname})`);
+});
 
-			// Network is available but server is not responding
-			return this.__("Limited");
-		},
-	},
-};
+const connectivityLabel = computed(() => {
+	/**
+	 * Short, user-friendly connectivity label for the navbar.
+	 * @returns {string}
+	 */
+	if (props.serverConnecting) {
+		return __("Connecting");
+	}
+
+	if (!props.networkOnline) {
+		return __("Offline");
+	}
+
+	if (props.networkOnline && props.serverOnline) {
+		return __("Online");
+	}
+
+	// Network is available but server is not responding
+	return __("Limited");
+});
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/pos/CancelSaleDialog.vue
+++ b/frontend/src/posapp/components/pos/CancelSaleDialog.vue
@@ -15,12 +15,7 @@
 			</v-card-text>
 			<v-card-actions>
 				<v-spacer></v-spacer>
-				<v-btn
-					ref="confirmBtn"
-					color="error"
-					autofocus
-					@click="onConfirm"
-				>
+				<v-btn ref="confirmBtn" color="error" autofocus @click="onConfirm">
 					{{ __("Yes, Cancel sale") }}
 				</v-btn>
 				<v-btn color="warning" @click="$emit('update:modelValue', false)">{{ __("Back") }}</v-btn>
@@ -29,27 +24,35 @@
 	</v-dialog>
 </template>
 
-<script>
-export default {
-	props: {
-		modelValue: Boolean,
+<script setup>
+import { nextTick, ref, watch } from "vue";
+
+defineOptions({
+	name: "CancelSaleDialog",
+});
+
+const props = defineProps({
+	modelValue: Boolean,
+});
+
+const emit = defineEmits(["update:modelValue", "confirm"]);
+const confirmBtn = ref(null);
+const __ = window.__ || ((text) => text);
+
+function onConfirm() {
+	emit("confirm");
+}
+
+watch(
+	() => props.modelValue,
+	(val) => {
+		if (val) {
+			nextTick(() => {
+				setTimeout(() => {
+					confirmBtn.value?.$el?.focus();
+				}, 100);
+			});
+		}
 	},
-	emits: ["update:modelValue", "confirm"],
-	methods: {
-		onConfirm() {
-			this.$emit("confirm");
-		},
-	},
-	watch: {
-		modelValue(val) {
-			if (val) {
-				this.$nextTick(() => {
-					setTimeout(() => {
-						this.$refs.confirmBtn?.$el?.focus();
-					}, 100);
-				});
-			}
-		},
-	},
-};
+);
 </script>

--- a/frontend/src/posapp/components/pos/CartItemRow.vue
+++ b/frontend/src/posapp/components/pos/CartItemRow.vue
@@ -123,7 +123,7 @@
 				>
 					<v-icon size="small">mdi-chevron-left</v-icon>
 				</v-btn>
-				
+
 				<div
 					v-if="!isEditingUom"
 					class="posa-cart-table__editor-display"
@@ -327,224 +327,248 @@
 	</tr>
 </template>
 
-<script>
-/* global __ */
-export default {
+<script setup>
+import { computed, nextTick, ref } from "vue";
+
+defineOptions({
 	name: "CartItemRow",
-	props: {
-		item: {
-			type: Object,
-			required: true,
-		},
-		posProfile: {
-			type: Object,
-			required: true,
-		},
-		isReturnInvoice: Boolean,
-		invoiceType: String,
-		displayCurrency: String,
-		formatFloat: Function,
-		formatCurrency: Function,
-		currencySymbol: Function,
-		isNumber: Function,
-		isNegative: Function,
-		hideQtyDecimals: Boolean,
-		isRTL: Boolean,
-		// Column visibility flags to avoid passing full headers array
-		showUom: Boolean,
-		showPriceListRate: Boolean,
-		showDiscountPercent: Boolean,
-		showDiscountAmount: Boolean,
-		showOffer: Boolean,
-	},
-	data() {
-		return {
-			isEditingQty: false,
-			editingQtyValue: "",
-			isEditingUom: false,
-			isEditingRate: false,
-			editingRateValue: "",
-			isEditingDiscountPercent: false,
-			editingDiscountPercentValue: "",
-			isEditingDiscountAmount: false,
-			editingDiscountAmountValue: "",
-		};
-	},
-	computed: {
-		memoDeps() {
-			return [
-				this.item.qty,
-				this.item.rate,
-				this.item.amount,
-				this.item.discount_amount,
-				this.item.discount_percentage,
-				this.item.uom,
-				this.item.item_name,
-				this.item.name_overridden,
-				this.item.pricing_rule_badge,
-				this.item.batch_no_is_expired,
-				this.item.posa_is_offer,
-				this.item.posa_offer_applied,
-				this.item.is_free_item,
-				this.item.price_list_rate,
-				// Include edit states to ensure UI updates when switching modes
-				this.isEditingQty,
-				this.isEditingRate,
-				this.isEditingUom,
-				this.isEditingDiscountPercent,
-				this.isEditingDiscountAmount,
-			];
-		},
-		qtyLength() {
-			return String(Math.abs(this.item.qty || 0)).replace(".", "").length;
-		},
-		disableDecrement() {
-			return (
-				!!this.item.posa_is_replace ||
-				(this.isReturnInvoice &&
-					(this.item.is_free_item || this.item.posa_is_offer || this.item.posa_is_replace))
-			);
-		},
-		disableIncrement() {
-			return (
-				!!this.item.posa_is_replace ||
-				this.item.disable_increment ||
-				(this.isReturnInvoice &&
-					(this.item.is_free_item || this.item.posa_is_offer || this.item.posa_is_replace))
-			);
-		},
-		disableInput() {
-			return (
-				this.isReturnInvoice &&
-				(this.item.is_free_item || this.item.posa_is_offer || this.item.posa_is_replace)
-			);
-		},
-		disableRateEdit() {
-			return (
-				!this.posProfile.posa_allow_user_to_edit_rate ||
-				!!this.item.posa_is_replace ||
-				!!this.item.posa_offer_applied
-			);
-		},
-		disableDiscountEdit() {
-			return (
-				!this.posProfile.posa_allow_user_to_edit_item_discount ||
-				!!this.item.posa_is_replace ||
-				!!this.item.posa_offer_applied
-			);
-		},
-	},
-	methods: {
-		openQtyEdit() {
-			this.isEditingQty = true;
-			this.editingQtyValue = "";
-			this.$nextTick(() => {
-				this.$refs.qtyInput?.focus();
-			});
-		},
-		closeQtyEdit() {
-			if (this.isEditingQty) {
-				if (this.editingQtyValue !== "" && this.editingQtyValue != null) {
-					const newQty = parseFloat(this.editingQtyValue);
-					// Emit event to update parent state
-					const val = !newQty || newQty <= 0 ? 1 : newQty;
-					this.$emit("update-qty", this.item, val);
-				}
-				this.isEditingQty = false;
-				this.editingQtyValue = "";
-			}
-		},
-		handleMinusClick() {
-			this.$emit("minus-click", this.item);
-		},
-		changeUom(direction) {
-			const uoms = this.item.item_uoms.map((u) => u.uom);
-			const currentIndex = uoms.indexOf(this.item.uom);
-			let newIndex = currentIndex + direction;
+});
 
-			if (newIndex < 0) {
-				newIndex = uoms.length - 1;
-			} else if (newIndex >= uoms.length) {
-				newIndex = 0;
-			}
-
-			const newUom = uoms[newIndex];
-			if (newUom !== this.item.uom) {
-				this.$emit("calc-uom", this.item, newUom);
-			}
-		},
-		handleUomSelect(newUom) {
-			if (newUom && newUom !== this.item.uom) {
-				this.$emit("calc-uom", this.item, newUom);
-			}
-			// Find the correct component instance to blur - ref is local now
-			this.$refs.uomSelect?.blur();
-		},
-		openRateEdit() {
-			if (this.disableRateEdit) return;
-			this.isEditingRate = true;
-			this.editingRateValue = "";
-			this.$nextTick(() => {
-				this.$refs.rateInput?.focus();
-			});
-		},
-		closeRateEdit() {
-			if (this.isEditingRate) {
-				if (this.editingRateValue !== "" && this.editingRateValue != null) {
-					const newRate = parseFloat(this.editingRateValue);
-					if (Number.isFinite(newRate) && newRate !== this.item.rate) {
-						// We need to pass the "event-like" object that useDiscounts expects or handle it in parent
-						// For isolation, let's emit value and let parent handler construct event if needed
-						// But ItemsTable methods expect (item, value, event)
-						this.$emit("update-rate", this.item, newRate);
-					}
-				}
-				this.isEditingRate = false;
-				this.editingRateValue = "";
-			}
-		},
-		openDiscountPercentEdit() {
-			if (this.disableDiscountEdit) return;
-			this.isEditingDiscountPercent = true;
-			this.editingDiscountPercentValue = "";
-			this.$nextTick(() => {
-				this.$refs.discountPercentInput?.focus();
-			});
-		},
-		closeDiscountPercentEdit() {
-			if (this.isEditingDiscountPercent) {
-				if (this.editingDiscountPercentValue !== "" && this.editingDiscountPercentValue != null) {
-					const newDiscount = parseFloat(this.editingDiscountPercentValue);
-					if (Number.isFinite(newDiscount) && newDiscount !== this.item.discount_percentage) {
-						this.$emit("update-discount-percent", this.item, newDiscount);
-					}
-				}
-				this.isEditingDiscountPercent = false;
-				this.editingDiscountPercentValue = "";
-			}
-		},
-		openDiscountAmountEdit() {
-			if (this.disableDiscountEdit) return;
-			this.isEditingDiscountAmount = true;
-			this.editingDiscountAmountValue = "";
-			this.$nextTick(() => {
-				this.$refs.discountAmountInput?.focus();
-			});
-		},
-		closeDiscountAmountEdit() {
-			if (this.isEditingDiscountAmount) {
-				if (this.editingDiscountAmountValue !== "" && this.editingDiscountAmountValue != null) {
-					const newDiscount = parseFloat(this.editingDiscountAmountValue);
-					if (Number.isFinite(newDiscount) && newDiscount !== this.item.discount_amount) {
-						this.$emit("update-discount-amount", this.item, newDiscount);
-					}
-				}
-				this.isEditingDiscountAmount = false;
-				this.editingDiscountAmountValue = "";
-			}
-		},
+const props = defineProps({
+	item: {
+		type: Object,
+		required: true,
 	},
-};
+	posProfile: {
+		type: Object,
+		required: true,
+	},
+	isReturnInvoice: Boolean,
+	invoiceType: String,
+	displayCurrency: String,
+	formatFloat: Function,
+	formatCurrency: Function,
+	currencySymbol: Function,
+	isNumber: Function,
+	isNegative: Function,
+	hideQtyDecimals: Boolean,
+	isRTL: Boolean,
+	// Column visibility flags to avoid passing full headers array
+	showUom: Boolean,
+	showPriceListRate: Boolean,
+	showDiscountPercent: Boolean,
+	showDiscountAmount: Boolean,
+	showOffer: Boolean,
+});
+
+const emit = defineEmits([
+	"open-name-dialog",
+	"reset-item-name",
+	"add-one",
+	"update-qty",
+	"minus-click",
+	"calc-uom",
+	"update-rate",
+	"update-discount-percent",
+	"update-discount-amount",
+]);
+
+const __ = window.__ || ((text) => text);
+
+const isEditingQty = ref(false);
+const editingQtyValue = ref("");
+const isEditingUom = ref(false);
+const isEditingRate = ref(false);
+const editingRateValue = ref("");
+const isEditingDiscountPercent = ref(false);
+const editingDiscountPercentValue = ref("");
+const isEditingDiscountAmount = ref(false);
+const editingDiscountAmountValue = ref("");
+
+const qtyInput = ref(null);
+const rateInput = ref(null);
+const discountPercentInput = ref(null);
+const discountAmountInput = ref(null);
+const uomSelect = ref(null);
+
+const memoDeps = computed(() => [
+	props.item.qty,
+	props.item.rate,
+	props.item.amount,
+	props.item.discount_amount,
+	props.item.discount_percentage,
+	props.item.uom,
+	props.item.item_name,
+	props.item.name_overridden,
+	props.item.pricing_rule_badge,
+	props.item.batch_no_is_expired,
+	props.item.posa_is_offer,
+	props.item.posa_offer_applied,
+	props.item.is_free_item,
+	props.item.price_list_rate,
+	// Include edit states to ensure UI updates when switching modes
+	isEditingQty.value,
+	isEditingRate.value,
+	isEditingUom.value,
+	isEditingDiscountPercent.value,
+	isEditingDiscountAmount.value,
+]);
+
+const qtyLength = computed(() => String(Math.abs(props.item.qty || 0)).replace(".", "").length);
+
+const disableDecrement = computed(
+	() =>
+		!!props.item.posa_is_replace ||
+		(props.isReturnInvoice &&
+			(props.item.is_free_item || props.item.posa_is_offer || props.item.posa_is_replace)),
+);
+
+const disableIncrement = computed(
+	() =>
+		!!props.item.posa_is_replace ||
+		props.item.disable_increment ||
+		(props.isReturnInvoice &&
+			(props.item.is_free_item || props.item.posa_is_offer || props.item.posa_is_replace)),
+);
+
+const disableInput = computed(
+	() =>
+		props.isReturnInvoice &&
+		(props.item.is_free_item || props.item.posa_is_offer || props.item.posa_is_replace),
+);
+
+const disableRateEdit = computed(
+	() =>
+		!props.posProfile.posa_allow_user_to_edit_rate ||
+		!!props.item.posa_is_replace ||
+		!!props.item.posa_offer_applied,
+);
+
+const disableDiscountEdit = computed(
+	() =>
+		!props.posProfile.posa_allow_user_to_edit_item_discount ||
+		!!props.item.posa_is_replace ||
+		!!props.item.posa_offer_applied,
+);
+
+function openQtyEdit() {
+	isEditingQty.value = true;
+	editingQtyValue.value = "";
+	nextTick(() => {
+		qtyInput.value?.focus();
+	});
+}
+
+function closeQtyEdit() {
+	if (isEditingQty.value) {
+		if (editingQtyValue.value !== "" && editingQtyValue.value != null) {
+			const newQty = parseFloat(editingQtyValue.value);
+			// Emit event to update parent state
+			const val = !newQty || newQty <= 0 ? 1 : newQty;
+			emit("update-qty", props.item, val);
+		}
+		isEditingQty.value = false;
+		editingQtyValue.value = "";
+	}
+}
+
+function handleMinusClick() {
+	emit("minus-click", props.item);
+}
+
+function changeUom(direction) {
+	const uoms = props.item.item_uoms.map((u) => u.uom);
+	const currentIndex = uoms.indexOf(props.item.uom);
+	let newIndex = currentIndex + direction;
+
+	if (newIndex < 0) {
+		newIndex = uoms.length - 1;
+	} else if (newIndex >= uoms.length) {
+		newIndex = 0;
+	}
+
+	const newUom = uoms[newIndex];
+	if (newUom !== props.item.uom) {
+		emit("calc-uom", props.item, newUom);
+	}
+}
+
+function handleUomSelect(newUom) {
+	if (newUom && newUom !== props.item.uom) {
+		emit("calc-uom", props.item, newUom);
+	}
+	// Find the correct component instance to blur - ref is local now
+	uomSelect.value?.blur();
+}
+
+function openRateEdit() {
+	if (disableRateEdit.value) return;
+	isEditingRate.value = true;
+	editingRateValue.value = "";
+	nextTick(() => {
+		rateInput.value?.focus();
+	});
+}
+
+function closeRateEdit() {
+	if (isEditingRate.value) {
+		if (editingRateValue.value !== "" && editingRateValue.value != null) {
+			const newRate = parseFloat(editingRateValue.value);
+			if (Number.isFinite(newRate) && newRate !== props.item.rate) {
+				// We need to pass the "event-like" object that useDiscounts expects or handle it in parent
+				// For isolation, let's emit value and let parent handler construct event if needed
+				// But ItemsTable methods expect (item, value, event)
+				emit("update-rate", props.item, newRate);
+			}
+		}
+		isEditingRate.value = false;
+		editingRateValue.value = "";
+	}
+}
+
+function openDiscountPercentEdit() {
+	if (disableDiscountEdit.value) return;
+	isEditingDiscountPercent.value = true;
+	editingDiscountPercentValue.value = "";
+	nextTick(() => {
+		discountPercentInput.value?.focus();
+	});
+}
+
+function closeDiscountPercentEdit() {
+	if (isEditingDiscountPercent.value) {
+		if (editingDiscountPercentValue.value !== "" && editingDiscountPercentValue.value != null) {
+			const newDiscount = parseFloat(editingDiscountPercentValue.value);
+			if (Number.isFinite(newDiscount) && newDiscount !== props.item.discount_percentage) {
+				emit("update-discount-percent", props.item, newDiscount);
+			}
+		}
+		isEditingDiscountPercent.value = false;
+		editingDiscountPercentValue.value = "";
+	}
+}
+
+function openDiscountAmountEdit() {
+	if (disableDiscountEdit.value) return;
+	isEditingDiscountAmount.value = true;
+	editingDiscountAmountValue.value = "";
+	nextTick(() => {
+		discountAmountInput.value?.focus();
+	});
+}
+
+function closeDiscountAmountEdit() {
+	if (isEditingDiscountAmount.value) {
+		if (editingDiscountAmountValue.value !== "" && editingDiscountAmountValue.value != null) {
+			const newDiscount = parseFloat(editingDiscountAmountValue.value);
+			if (Number.isFinite(newDiscount) && newDiscount !== props.item.discount_amount) {
+				emit("update-discount-amount", props.item, newDiscount);
+			}
+		}
+		isEditingDiscountAmount.value = false;
+		editingDiscountAmountValue.value = "";
+	}
+}
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/pos/InvoiceSummary.vue
+++ b/frontend/src/posapp/components/pos/InvoiceSummary.vue
@@ -124,207 +124,197 @@
 	</v-card>
 </template>
 
-<script>
+<script setup>
+import { computed, ref, watch } from "vue";
 import { loadItemSelectorSettings } from "../../utils/itemSelectorSettings.js";
 import InvoiceActionButtons from "./InvoiceActionButtons.vue";
 
-export default {
-	components: {
-		InvoiceActionButtons,
+defineOptions({
+	name: "InvoiceSummary",
+});
+
+const props = defineProps({
+	pos_profile: Object,
+	total_qty: [Number, String],
+	additional_discount: Number,
+	additional_discount_percentage: Number,
+	total_items_discount_amount: Number,
+	subtotal: Number,
+	displayCurrency: String,
+	formatFloat: Function,
+	formatCurrency: Function,
+	currencySymbol: Function,
+	discount_percentage_offer_name: [String, Number],
+	isNumber: Function,
+});
+
+const emit = defineEmits([
+	"update:additional_discount",
+	"update:additional_discount_percentage",
+	"update_discount_umount",
+	"save-and-clear",
+	"load-drafts",
+	"select-order",
+	"select-purchase-order",
+	"cancel-sale",
+	"open-returns",
+	"print-draft",
+	"apply-offers",
+	"show-payment",
+]);
+
+const saveLoading = ref(false);
+const loadDraftsLoading = ref(false);
+const selectOrderLoading = ref(false);
+const selectPurchaseOrderLoading = ref(false);
+const cancelLoading = ref(false);
+const returnsLoading = ref(false);
+const printLoading = ref(false);
+const applyOffersLoading = ref(false);
+const paymentLoading = ref(false);
+const isEditingAdditionalDiscount = ref(false);
+const isEditingAdditionalDiscountPercentage = ref(false);
+
+const additionalDiscountDisplay = ref(normalizeDiscountDisplay(props.additional_discount));
+const additionalDiscountPercentageDisplay = ref(
+	normalizeDiscountDisplay(props.additional_discount_percentage),
+);
+
+const hide_qty_decimals = computed(() => {
+	const opts = loadItemSelectorSettings();
+	return !!opts?.hide_qty_decimals;
+});
+
+watch(
+	() => props.additional_discount,
+	(value) => {
+		if (!isEditingAdditionalDiscount.value) {
+			additionalDiscountDisplay.value = normalizeDiscountDisplay(value);
+		}
 	},
-	props: {
-		pos_profile: Object,
-		total_qty: [Number, String],
-		additional_discount: Number,
-		additional_discount_percentage: Number,
-		total_items_discount_amount: Number,
-		subtotal: Number,
-		displayCurrency: String,
-		formatFloat: Function,
-		formatCurrency: Function,
-		currencySymbol: Function,
-		discount_percentage_offer_name: [String, Number],
-		isNumber: Function,
+);
+
+watch(
+	() => props.additional_discount_percentage,
+	(value) => {
+		if (!isEditingAdditionalDiscountPercentage.value) {
+			additionalDiscountPercentageDisplay.value = normalizeDiscountDisplay(value);
+		}
 	},
-	data() {
-		return {
-			// Loading states for better UX
-			saveLoading: false,
-			loadDraftsLoading: false,
-			selectOrderLoading: false,
-			selectPurchaseOrderLoading: false,
-			cancelLoading: false,
-			returnsLoading: false,
-			printLoading: false,
-			applyOffersLoading: false,
-			paymentLoading: false,
-			additionalDiscountDisplay: null,
-			additionalDiscountPercentageDisplay: null,
-			isEditingAdditionalDiscount: false,
-			isEditingAdditionalDiscountPercentage: false,
-		};
-	},
-	emits: [
-		"update:additional_discount",
-		"update:additional_discount_percentage",
-		"update_discount_umount",
-		"save-and-clear",
-		"load-drafts",
-		"select-order",
-		"select-purchase-order",
-		"cancel-sale",
-		"open-returns",
-		"print-draft",
-		"apply-offers",
-		"show-payment",
-	],
-	computed: {
-		hide_qty_decimals() {
-			const opts = loadItemSelectorSettings();
-			return !!opts?.hide_qty_decimals;
-		},
-	},
-	watch: {
-		additional_discount(value) {
-			if (!this.isEditingAdditionalDiscount) {
-				this.additionalDiscountDisplay = this.normalizeDiscountDisplay(value);
-			}
-		},
-		additional_discount_percentage(value) {
-			if (!this.isEditingAdditionalDiscountPercentage) {
-				this.additionalDiscountPercentageDisplay = this.normalizeDiscountDisplay(value);
-			}
-		},
-	},
-	created() {
-		this.additionalDiscountDisplay = this.normalizeDiscountDisplay(this.additional_discount);
-		this.additionalDiscountPercentageDisplay = this.normalizeDiscountDisplay(
-			this.additional_discount_percentage,
-		);
-	},
-	methods: {
-		normalizeDiscountDisplay(value) {
-			if (value === 0 || value === "0") {
-				return "";
-			}
-			return value;
-		},
-		// Debounced handlers for better performance
-		handleAdditionalDiscountUpdate(value) {
-			this.$emit("update:additional_discount", value);
-		},
+);
 
-		handleAdditionalDiscountFocus() {
-			this.isEditingAdditionalDiscount = true;
-		},
+function normalizeDiscountDisplay(value) {
+	if (value === 0 || value === "0") {
+		return "";
+	}
+	return value;
+}
 
-		handleAdditionalDiscountBlur() {
-			this.isEditingAdditionalDiscount = false;
-		},
+// Debounced handlers for better performance
+function handleAdditionalDiscountUpdate(value) {
+	emit("update:additional_discount", value);
+}
 
-		focusAdditionalDiscountField() {
-			const field = this.$refs.additionalDiscountField;
-			const input = field?.$el?.querySelector?.("input");
-			if (input?.disabled) {
-				return;
-			}
-			input?.focus?.();
-		},
+function handleAdditionalDiscountFocus() {
+	isEditingAdditionalDiscount.value = true;
+}
 
-		handleAdditionalDiscountPercentageUpdate(value) {
-			this.$emit("update:additional_discount_percentage", value);
-		},
+function handleAdditionalDiscountBlur() {
+	isEditingAdditionalDiscount.value = false;
+}
 
-		handleAdditionalDiscountPercentageFocus() {
-			this.isEditingAdditionalDiscountPercentage = true;
-		},
+function handleAdditionalDiscountPercentageUpdate(value) {
+	emit("update:additional_discount_percentage", value);
+}
 
-		handleAdditionalDiscountPercentageBlur() {
-			this.isEditingAdditionalDiscountPercentage = false;
-		},
+function handleAdditionalDiscountPercentageFocus() {
+	isEditingAdditionalDiscountPercentage.value = true;
+}
 
-		async handleSaveAndClear() {
-			this.saveLoading = true;
-			try {
-				await this.$emit("save-and-clear");
-			} finally {
-				this.saveLoading = false;
-			}
-		},
+function handleAdditionalDiscountPercentageBlur() {
+	isEditingAdditionalDiscountPercentage.value = false;
+}
 
-		async handleLoadDrafts() {
-			this.loadDraftsLoading = true;
-			try {
-				await this.$emit("load-drafts");
-			} finally {
-				this.loadDraftsLoading = false;
-			}
-		},
+async function handleSaveAndClear() {
+	saveLoading.value = true;
+	try {
+		await emit("save-and-clear");
+	} finally {
+		saveLoading.value = false;
+	}
+}
 
-		async handleSelectOrder() {
-			this.selectOrderLoading = true;
-			try {
-				await this.$emit("select-order");
-			} finally {
-				this.selectOrderLoading = false;
-			}
-		},
+async function handleLoadDrafts() {
+	loadDraftsLoading.value = true;
+	try {
+		await emit("load-drafts");
+	} finally {
+		loadDraftsLoading.value = false;
+	}
+}
 
-		async handleSelectPurchaseOrder() {
-			this.selectPurchaseOrderLoading = true;
-			try {
-				await this.$emit("select-purchase-order");
-			} finally {
-				this.selectPurchaseOrderLoading = false;
-			}
-		},
+async function handleSelectOrder() {
+	selectOrderLoading.value = true;
+	try {
+		await emit("select-order");
+	} finally {
+		selectOrderLoading.value = false;
+	}
+}
 
-		async handleCancelSale() {
-			this.cancelLoading = true;
-			try {
-				await this.$emit("cancel-sale");
-			} finally {
-				this.cancelLoading = false;
-			}
-		},
+async function handleSelectPurchaseOrder() {
+	selectPurchaseOrderLoading.value = true;
+	try {
+		await emit("select-purchase-order");
+	} finally {
+		selectPurchaseOrderLoading.value = false;
+	}
+}
 
-		async handleOpenReturns() {
-			this.returnsLoading = true;
-			try {
-				await this.$emit("open-returns");
-			} finally {
-				this.returnsLoading = false;
-			}
-		},
+async function handleCancelSale() {
+	cancelLoading.value = true;
+	try {
+		await emit("cancel-sale");
+	} finally {
+		cancelLoading.value = false;
+	}
+}
 
-		async handlePrintDraft() {
-			this.printLoading = true;
-			try {
-				await this.$emit("print-draft");
-			} finally {
-				this.printLoading = false;
-			}
-		},
+async function handleOpenReturns() {
+	returnsLoading.value = true;
+	try {
+		await emit("open-returns");
+	} finally {
+		returnsLoading.value = false;
+	}
+}
 
-		async handleApplyOffers() {
-			this.applyOffersLoading = true;
-			try {
-				await this.$emit("apply-offers");
-			} finally {
-				this.applyOffersLoading = false;
-			}
-		},
+async function handlePrintDraft() {
+	printLoading.value = true;
+	try {
+		await emit("print-draft");
+	} finally {
+		printLoading.value = false;
+	}
+}
 
-		async handleShowPayment() {
-			this.paymentLoading = true;
-			try {
-				await this.$emit("show-payment");
-			} finally {
-				this.paymentLoading = false;
-			}
-		},
-	},
-};
+async function handleApplyOffers() {
+	applyOffersLoading.value = true;
+	try {
+		await emit("apply-offers");
+	} finally {
+		applyOffersLoading.value = false;
+	}
+}
+
+async function handleShowPayment() {
+	paymentLoading.value = true;
+	try {
+		await emit("show-payment");
+	} finally {
+		paymentLoading.value = false;
+	}
+}
 </script>
 
 <style scoped>
@@ -332,8 +322,6 @@ export default {
 	background-color: var(--pos-card-bg) !important;
 	transition: all 0.3s ease;
 }
-
-
 
 /* Enhanced field styling */
 .summary-field {
@@ -350,6 +338,4 @@ export default {
 		font-size: 0.875rem;
 	}
 }
-
-
 </style>

--- a/frontend/src/posapp/components/pos/LoadingOverlay.vue
+++ b/frontend/src/posapp/components/pos/LoadingOverlay.vue
@@ -21,37 +21,39 @@
 	</v-overlay>
 </template>
 
-<script>
-export default {
+<script setup>
+defineOptions({
 	name: "LoadingOverlay",
-	props: {
-		loading: {
-			type: Boolean,
-			default: false,
-		},
-		message: {
-			type: String,
-			default: "",
-		},
-		progress: {
-			type: Number,
-			default: 0,
-		},
-		sources: {
-			type: Object,
-			default: () => ({}),
-		},
-		sourceMessages: {
-			type: Object,
-			default: () => ({}),
-		},
+});
+
+const props = defineProps({
+	loading: {
+		type: Boolean,
+		default: false,
 	},
-	methods: {
-		getLabel(name) {
-			return this.sourceMessages[name] || name;
-		},
+	message: {
+		type: String,
+		default: "",
 	},
-};
+	progress: {
+		type: Number,
+		default: 0,
+	},
+	sources: {
+		type: Object,
+		default: () => ({}),
+	},
+	sourceMessages: {
+		type: Object,
+		default: () => ({}),
+	},
+});
+
+const __ = window.__ || ((text) => text);
+
+function getLabel(name) {
+	return props.sourceMessages[name] || name;
+}
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/pos/Mpesa-Payments.vue
+++ b/frontend/src/posapp/components/pos/Mpesa-Payments.vue
@@ -83,135 +83,156 @@
 	</v-row>
 </template>
 
-<script>
-/* global __, frappe */
-export default {
-	data: () => ({
-		dialog: false,
-		singleSelect: true,
-		selected: [],
-		dialog_data: "",
-		company: "",
-		customer: "",
-		mode_of_payment: "",
-		full_name: "",
-		mobile_no: "",
-		isLoading: false,
-		isSubmitting: false,
-		errorMessage: "",
-		headers: [
-			{
-				title: __("Full Name"),
-				value: "full_name",
-				align: "start",
-				sortable: true,
-			},
-			{
-				title: __("Mobile No"),
-				value: "mobile_no",
-				align: "start",
-				sortable: true,
-			},
-			{
-				title: __("Amount"),
-				value: "amount",
-				align: "start",
-				sortable: true,
-			},
-			{
-				title: __("Date"),
-				align: "start",
-				sortable: true,
-				value: "posting_date",
-			},
-		],
-	}),
-	computed: {},
-	watch: {},
-	methods: {
-		close_dialog() {
-			this.dialog = false;
-		},
-		search_by_enter(e) {
-			if (e.keyCode === 13) {
-				this.search();
-			}
-		},
-		async search() {
-			if (this.isLoading || this.isSubmitting) {
-				return;
-			}
+<script setup>
+import { inject, onBeforeUnmount, onMounted, ref } from "vue";
+import { formatUtils } from "../../format";
 
-			this.errorMessage = "";
-			this.isLoading = true;
+defineOptions({
+	name: "MpesaPayments",
+});
 
-			try {
-				const { message } = await frappe.call({
-					method: "posawesome.posawesome.api.m_pesa.get_mpesa_draft_payments",
-					args: {
-						company: this.company,
-						mode_of_payment: this.mode_of_payment,
-						mobile_no: this.mobile_no,
-						full_name: this.full_name,
-					},
-				});
+const frappe = window.frappe;
+const __ = window.__ || ((text) => text);
+const eventBus = inject("eventBus");
 
-				this.dialog_data = message;
-			} catch (error) {
-				console.error("Failed to search M-Pesa payments:", error);
-				this.errorMessage = __("Unable to fetch M-Pesa payments");
-			} finally {
-				this.isLoading = false;
-			}
-		},
-		async submit_dialog() {
-			if (this.isSubmitting || this.selected.length === 0) {
-				return;
-			}
+const dialog = ref(false);
+const selected = ref([]);
+const dialog_data = ref("");
+const company = ref("");
+const customer = ref("");
+const mode_of_payment = ref("");
+const full_name = ref("");
+const mobile_no = ref("");
+const isLoading = ref(false);
+const isSubmitting = ref(false);
+const errorMessage = ref("");
 
-			this.errorMessage = "";
-			this.isSubmitting = true;
-
-			try {
-				const selected_payment = this.selected[0].name;
-				const { message } = await frappe.call({
-					method: "posawesome.posawesome.api.m_pesa.submit_mpesa_payment",
-					args: {
-						mpesa_payment: selected_payment,
-						customer: this.customer,
-					},
-				});
-
-				this.eventBus.emit("set_mpesa_payment", message);
-				this.dialog = false;
-			} catch (error) {
-				console.error("Failed to submit M-Pesa payment:", error);
-				this.errorMessage = __("Unable to submit the selected payment");
-			} finally {
-				this.isSubmitting = false;
-			}
-		},
-		formatCurrency(value) {
-			return this.$options.mixins[0].methods.formatCurrency.call(this, value, 2);
-		},
+const headers = [
+	{
+		title: __("Full Name"),
+		value: "full_name",
+		align: "start",
+		sortable: true,
 	},
-	created: function () {
-		this.eventBus.on("open_mpesa_payments", (data) => {
-			this.dialog = true;
-			this.full_name = "";
-			this.mobile_no = "";
-			this.company = data.company;
-			this.customer = data.customer;
-			this.mode_of_payment = data.mode_of_payment;
-			this.dialog_data = "";
-			this.selected = [];
-			this.errorMessage = "";
-			this.isLoading = false;
-			this.isSubmitting = false;
+	{
+		title: __("Mobile No"),
+		value: "mobile_no",
+		align: "start",
+		sortable: true,
+	},
+	{
+		title: __("Amount"),
+		value: "amount",
+		align: "start",
+		sortable: true,
+	},
+	{
+		title: __("Date"),
+		align: "start",
+		sortable: true,
+		value: "posting_date",
+	},
+];
+
+function close_dialog() {
+	dialog.value = false;
+}
+
+async function search() {
+	if (isLoading.value || isSubmitting.value) {
+		return;
+	}
+
+	errorMessage.value = "";
+	isLoading.value = true;
+
+	try {
+		const { message } = await frappe.call({
+			method: "posawesome.posawesome.api.m_pesa.get_mpesa_draft_payments",
+			args: {
+				company: company.value,
+				mode_of_payment: mode_of_payment.value,
+				mobile_no: mobile_no.value,
+				full_name: full_name.value,
+			},
 		});
-	},
-	beforeUnmount() {
-		this.eventBus.off("open_mpesa_payments");
-	},
-};
+
+		dialog_data.value = message;
+	} catch (error) {
+		console.error("Failed to search M-Pesa payments:", error);
+		errorMessage.value = __("Unable to fetch M-Pesa payments");
+	} finally {
+		isLoading.value = false;
+	}
+}
+
+async function submit_dialog() {
+	if (isSubmitting.value || selected.value.length === 0) {
+		return;
+	}
+
+	errorMessage.value = "";
+	isSubmitting.value = true;
+
+	try {
+		const selected_payment = selected.value[0].name;
+		const { message } = await frappe.call({
+			method: "posawesome.posawesome.api.m_pesa.submit_mpesa_payment",
+			args: {
+				mpesa_payment: selected_payment,
+				customer: customer.value,
+			},
+		});
+
+		eventBus?.emit("set_mpesa_payment", message);
+		dialog.value = false;
+	} catch (error) {
+		console.error("Failed to submit M-Pesa payment:", error);
+		errorMessage.value = __("Unable to submit the selected payment");
+	} finally {
+		isSubmitting.value = false;
+	}
+}
+
+function formatCurrency(value) {
+	if (value === null || value === undefined) {
+		value = 0;
+	}
+	let number = Number(formatUtils.fromArabicNumerals(String(value)).replace(/,/g, ""));
+	if (isNaN(number)) number = 0;
+	let prec = 2;
+	if (!Number.isInteger(prec) || prec < 0 || prec > 20) {
+		prec = Math.min(Math.max(parseInt(prec) || 2, 0), 20);
+	}
+
+	const locale = formatUtils.getNumberLocale();
+	let formatted = number.toLocaleString(locale, {
+		minimumFractionDigits: prec,
+		maximumFractionDigits: prec,
+		useGrouping: true,
+	});
+
+	formatted = formatUtils.toArabicNumerals(formatted);
+	return formatted;
+}
+
+onMounted(() => {
+	eventBus?.on("open_mpesa_payments", (data) => {
+		dialog.value = true;
+		full_name.value = "";
+		mobile_no.value = "";
+		company.value = data.company;
+		customer.value = data.customer;
+		mode_of_payment.value = data.mode_of_payment;
+		dialog_data.value = "";
+		selected.value = [];
+		errorMessage.value = "";
+		isLoading.value = false;
+		isSubmitting.value = false;
+	});
+});
+
+onBeforeUnmount(() => {
+	eventBus?.off("open_mpesa_payments");
+});
 </script>

--- a/frontend/src/posapp/components/pos/OpeningDialog.vue
+++ b/frontend/src/posapp/components/pos/OpeningDialog.vue
@@ -132,8 +132,9 @@
 	</v-row>
 </template>
 
-<script>
-import format from "../../format";
+<script setup>
+/* global frappe */
+import { onMounted, ref, watch } from "vue";
 import {
 	getOpeningDialogStorage,
 	setOpeningDialogStorage,
@@ -142,172 +143,167 @@ import {
 	checkDbHealth,
 } from "../../../offline/index.js";
 
-export default {
-	mixins: [format],
-	props: ["dialog"],
+defineOptions({
+	name: "OpeningDialog",
+});
 
-	data() {
-		return {
-			isOpen: this.dialog ? this.dialog : false,
-			dialog_data: {},
-			is_loading: false,
-			companies: [],
-			company: "",
-			pos_profiles_data: [],
-			pos_profiles: [],
-			pos_profile: "",
-			payments_method_data: [],
-			payments_methods: [],
-			payments_methods_headers: [
-				{
-					title: __("Mode of Payment"),
-					align: "start",
-					sortable: false,
-					value: "mode_of_payment",
-				},
-				{
-					title: __("Opening Amount"),
-					value: "amount",
-					align: "center",
-					sortable: false,
-				},
-			],
-			itemsPerPage: 100,
-			max25chars: (v) => v.length <= 12 || "Input too long!",
-			pagination: {},
-			snack: false,
-			snackColor: "",
-			snackText: "",
-		};
+const props = defineProps({
+	dialog: Boolean,
+});
+
+const emit = defineEmits(["close", "register"]);
+const __ = window.__ || ((text) => text);
+const get_currency_symbol = window.get_currency_symbol;
+
+const isOpen = ref(props.dialog ? props.dialog : false);
+const is_loading = ref(false);
+const companies = ref([]);
+const company = ref("");
+const pos_profiles_data = ref([]);
+const pos_profiles = ref([]);
+const pos_profile = ref("");
+const payments_method_data = ref([]);
+const payments_methods = ref([]);
+const payments_methods_headers = [
+	{
+		title: __("Mode of Payment"),
+		align: "start",
+		sortable: false,
+		value: "mode_of_payment",
 	},
-
-	watch: {
-		company(val) {
-			this.pos_profiles = [];
-			this.pos_profiles_data.forEach((element) => {
-				if (element.company === val) {
-					this.pos_profiles.push(element.name);
-				}
-				if (this.pos_profiles.length) {
-					this.pos_profile = this.pos_profiles[0];
-				} else {
-					this.pos_profile = "";
-				}
-			});
-		},
-
-		pos_profile(val) {
-			this.payments_methods = [];
-			this.payments_method_data.forEach((element) => {
-				if (element.parent === val) {
-					this.payments_methods.push({
-						mode_of_payment: element.mode_of_payment,
-						amount: 0,
-						currency: element.currency,
-					});
-				}
-			});
-		},
+	{
+		title: __("Opening Amount"),
+		value: "amount",
+		align: "center",
+		sortable: false,
 	},
+];
+const itemsPerPage = ref(100);
+const max25chars = (v) => v.length <= 12 || "Input too long!";
 
-	methods: {
-		close_opening_dialog() {
-			this.$emit("close");
-		},
+const currencySymbol = (currency) => get_currency_symbol?.(currency);
 
-		async get_opening_dialog_data() {
-			const vm = this;
-			await initPromise;
-			await checkDbHealth();
+watch(
+	() => props.dialog,
+	(val) => {
+		isOpen.value = val ? val : false;
+	},
+);
 
-			// Load cached data first for offline usage
-			const cached = getOpeningDialogStorage();
-			if (cached) {
+watch(company, (val) => {
+	pos_profiles.value = [];
+	pos_profiles_data.value.forEach((element) => {
+		if (element.company === val) {
+			pos_profiles.value.push(element.name);
+		}
+		if (pos_profiles.value.length) {
+			pos_profile.value = pos_profiles.value[0];
+		} else {
+			pos_profile.value = "";
+		}
+	});
+});
+
+watch(pos_profile, (val) => {
+	payments_methods.value = [];
+	payments_method_data.value.forEach((element) => {
+		if (element.parent === val) {
+			payments_methods.value.push({
+				mode_of_payment: element.mode_of_payment,
+				amount: 0,
+				currency: element.currency,
+			});
+		}
+	});
+});
+
+function close_opening_dialog() {
+	emit("close");
+}
+
+async function get_opening_dialog_data() {
+	await initPromise;
+	await checkDbHealth();
+
+	// Load cached data first for offline usage
+	const cached = getOpeningDialogStorage();
+	if (cached) {
+		try {
+			companies.value = cached.companies.map((c) => c.name);
+			pos_profiles_data.value = cached.pos_profiles_data || [];
+			payments_method_data.value = cached.payments_method || [];
+			company.value = companies.value[0] || "";
+		} catch (e) {
+			console.error("Failed to parse opening dialog cache", e);
+		}
+	}
+
+	frappe.call({
+		method: "posawesome.posawesome.api.shifts.get_opening_dialog_data",
+		args: {},
+		callback: function (r) {
+			if (r.message) {
+				companies.value = r.message.companies.map((element) => element.name);
+				pos_profiles_data.value = r.message.pos_profiles_data;
+				payments_method_data.value = r.message.payments_method;
+				company.value = companies.value[0] || "";
 				try {
-					vm.companies = cached.companies.map((c) => c.name);
-					vm.pos_profiles_data = cached.pos_profiles_data || [];
-					vm.payments_method_data = cached.payments_method || [];
-					vm.company = vm.companies[0] || "";
+					setOpeningDialogStorage(r.message);
 				} catch (e) {
-					console.error("Failed to parse opening dialog cache", e);
+					console.error("Failed to cache opening dialog data", e);
 				}
 			}
-
-			frappe.call({
-				method: "posawesome.posawesome.api.shifts.get_opening_dialog_data",
-				args: {},
-				callback: function (r) {
-					if (r.message) {
-						vm.companies = r.message.companies.map((element) => element.name);
-						vm.pos_profiles_data = r.message.pos_profiles_data;
-						vm.payments_method_data = r.message.payments_method;
-						vm.company = vm.companies[0] || "";
-						try {
-							setOpeningDialogStorage(r.message);
-						} catch (e) {
-							console.error("Failed to cache opening dialog data", e);
-						}
-					}
-				},
-			});
 		},
+	});
+}
 
-		submit_dialog() {
-			if (!this.payments_methods.length || !this.company || !this.pos_profile) {
-				return;
+function submit_dialog() {
+	if (!payments_methods.value.length || !company.value || !pos_profile.value) {
+		return;
+	}
+
+	is_loading.value = true;
+
+	return frappe
+		.call("posawesome.posawesome.api.shifts.create_opening_voucher", {
+			pos_profile: pos_profile.value,
+			company: company.value,
+			balance_details: payments_methods.value,
+		})
+		.then((r) => {
+			if (r.message) {
+				emit("register", r.message);
+				try {
+					setOpeningStorage(r.message);
+				} catch (e) {
+					console.error("Failed to cache opening data", e);
+				}
+				// Close handles hiding the dialog, parent handles logic
+				emit("close");
+				is_loading.value = false;
 			}
+		});
+}
 
-			this.is_loading = true;
-			const vm = this;
+function go_desk() {
+	frappe.set_route("/");
+	location.reload();
+}
 
-			return frappe
-				.call("posawesome.posawesome.api.shifts.create_opening_voucher", {
-					pos_profile: this.pos_profile,
-					company: this.company,
-					balance_details: this.payments_methods,
-				})
-				.then((r) => {
-					if (r.message) {
-						vm.$emit("register", r.message);
-						try {
-							setOpeningStorage(r.message);
-						} catch (e) {
-							console.error("Failed to cache opening data", e);
-						}
-						// Close handles hiding the dialog, parent handles logic
-						vm.$emit("close");
-						vm.is_loading = false;
-					}
-				});
-		},
+function logout() {
+	const redirectTarget = "/app/posapp";
+	const loginPath = `/login?redirect-to=${encodeURIComponent(redirectTarget)}`;
+	frappe.call("logout").finally(() => {
+		const loginUrl =
+			frappe?.utils?.get_url?.(loginPath) ??
+			(frappe?.urllib?.get_base_url?.() ? `${frappe.urllib.get_base_url()}${loginPath}` : loginPath);
+		window.location.href = loginUrl;
+	});
+}
 
-		go_desk() {
-			frappe.set_route("/");
-			location.reload();
-		},
-
-		logout() {
-			const redirectTarget = "/app/posapp";
-			const loginPath = `/login?redirect-to=${encodeURIComponent(redirectTarget)}`;
-			frappe.call("logout").finally(() => {
-				const loginUrl =
-					frappe?.utils?.get_url?.(loginPath) ??
-					(frappe?.urllib?.get_base_url?.()
-						? `${frappe.urllib.get_base_url()}${loginPath}`
-						: loginPath);
-				window.location.href = loginUrl;
-			});
-		},
-	},
-
-	mounted() {
-		this.get_opening_dialog_data();
-	},
-
-	beforeUnmount() {
-		// Clean up event listeners if any were added
-	},
-};
+onMounted(() => {
+	get_opening_dialog_data();
+});
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/pos/PurchasePaymentDialog.vue
+++ b/frontend/src/posapp/components/pos/PurchasePaymentDialog.vue
@@ -1,6 +1,6 @@
 <template>
 	<v-dialog v-model="dialog" max-width="600px" persistent>
-		<v-card class="pos-themed-card" style="max-height: 80vh; overflow: hidden;">
+		<v-card class="pos-themed-card" style="max-height: 80vh; overflow: hidden">
 			<v-card-title class="bg-primary text-white d-flex align-center py-3">
 				<span class="text-h6">{{ __("Payment") }}</span>
 				<v-spacer></v-spacer>
@@ -9,7 +9,7 @@
 				</span>
 			</v-card-title>
 
-			<v-card-text class="pa-0 overflow-y-auto" style="max-height: 60vh;">
+			<v-card-text class="pa-0 overflow-y-auto" style="max-height: 60vh">
 				<!-- Payment Summary -->
 				<v-row v-if="totalAmount > 0" class="pa-3 ma-0" dense>
 					<v-col cols="6">
@@ -45,10 +45,10 @@
 
 				<!-- Payment Inputs -->
 				<div class="pa-3">
-					<v-row 
-						v-for="(payment, index) in paymentLines" 
-						:key="payment.mode_of_payment" 
-						class="payments pa-1 ma-0 align-center" 
+					<v-row
+						v-for="(payment, index) in paymentLines"
+						:key="payment.mode_of_payment"
+						class="payments pa-1 ma-0 align-center"
 						dense
 					>
 						<v-col cols="6">
@@ -209,229 +209,261 @@
 	</v-dialog>
 </template>
 
-<script>
-/* global __, frappe */
-import format from "../../format";
+<script setup>
+/* global frappe */
+import { computed, ref, watch } from "vue";
+import { formatUtils } from "../../format";
 import { getSmartTenderSuggestions } from "../../../utils/smartTender.js";
 
-export default {
+defineOptions({
 	name: "PurchasePaymentDialog",
-	mixins: [format],
-	props: {
-		modelValue: Boolean,
-		totalAmount: {
-			type: Number,
-			required: true,
-		},
-		currency: {
-			type: String,
-			default: "",
-		},
-		posProfile: {
-			type: Object,
-			required: true,
-		},
-		createInvoice: {
-			type: Boolean,
-			default: false,
-		},
+});
+
+const __ = window.__ || ((text) => text);
+
+const props = defineProps({
+	modelValue: Boolean,
+	totalAmount: {
+		type: Number,
+		required: true,
 	},
-	emits: ["update:modelValue", "submit"],
-	data() {
-		return {
-			paymentLines: [],
-			printFormats: [],
-			selectedPrintFormat: null,
-			printInvoice: this.createInvoice,
-			loading: false,
-			cashMOP: null, // Will be set to the cash mode of payment
-		};
+	currency: {
+		type: String,
+		default: "",
 	},
-	computed: {
-		dialog: {
-			get() {
-				return this.modelValue;
-			},
-			set(val) {
-				this.$emit("update:modelValue", val);
-			},
-		},
-		paidAmount() {
-			return this.paymentLines.reduce((sum, p) => sum + (parseFloat(p.amount) || 0), 0);
-		},
-		remainingAmount() {
-			return this.totalAmount - this.paidAmount;
-		},
-		isPaymentValid() {
-			// For purchases, we typically want exact payment or overpayment (change)
-			// Or we could allow partial payments if configured
-			return this.paidAmount > 0 && this.remainingAmount <= 0;
-		},
+	posProfile: {
+		type: Object,
+		required: true,
 	},
-	watch: {
-		dialog(val) {
-			if (val) {
-				this.printInvoice = this.createInvoice;
-				this.initializePayments();
-				this.fetchPrintFormats();
-				this.loading = false;
-			}
-		},
-		printInvoice() {
-			this.fetchPrintFormats();
-		},
+	createInvoice: {
+		type: Boolean,
+		default: false,
 	},
-	methods: {
-		initializePayments() {
-			const modes = this.posProfile.payments || [];
-			this.paymentLines = modes.map((m) => ({
-				mode_of_payment: m.mode_of_payment,
-				amount: 0,
-				default: m.default,
-				type: m.type,
-			}));
+});
 
-			// Identify cash payment method
-			this.cashMOP = this.paymentLines.find(p => 
-				p.mode_of_payment.toLowerCase().includes('cash') || p.type === 'Cash'
-			);
+const emit = defineEmits(["update:modelValue", "submit"]);
+const currency_precision = ref(2);
 
-			// Auto-fill default payment method if exists
-			const defaultMode = this.paymentLines.find((p) => p.default) || this.paymentLines[0];
-			if (defaultMode) {
-				defaultMode.amount = this.totalAmount;
-			}
-		},
-		set_full_amount(payment) {
-			// Reset all other payments
-			this.paymentLines.forEach((p) => {
-				if (p !== payment) {
-					p.amount = 0;
-				}
-			});
-			// Set this payment to total amount
-			payment.amount = this.totalAmount;
-		},
-		set_rest_amount(payment) {
-			// If payment is 0 and there's remaining amount, auto-fill
-			if (payment.amount === 0 && this.remainingAmount > 0) {
-				payment.amount = this.remainingAmount;
-			}
-		},
-		handlePaymentAmountChange(payment, event) {
-			const val = parseFloat(event) || 0;
-			payment.amount = val;
-			
-			// Auto-balance: if this payment exceeds remaining, reduce others
-			if (this.remainingAmount < 0) {
-				this.autoBalancePayments(payment);
-			}
-		},
-		setPaymentToDenomination(payment, amount) {
-			payment.amount = amount;
-			// Auto-balance other payments if needed
-			if (this.remainingAmount < 0) {
-				this.autoBalancePayments(payment);
-			}
-		},
-		autoBalancePayments(excludePayment) {
-			const excess = Math.abs(this.remainingAmount);
-			if (excess <= 0) return;
+const paymentLines = ref([]);
+const printFormats = ref([]);
+const selectedPrintFormat = ref(null);
+const printInvoice = ref(props.createInvoice);
+const loading = ref(false);
 
-			// Find other payments with amount > 0 to reduce
-			const otherPayments = this.paymentLines.filter(
-				(p) => p !== excludePayment && parseFloat(p.amount) > 0
-			);
-
-			// Sort by amount descending to reduce larger chunks first
-			otherPayments.sort((a, b) => parseFloat(b.amount) - parseFloat(a.amount));
-
-			let remainingExcess = excess;
-
-			for (const other of otherPayments) {
-				if (remainingExcess <= 0) break;
-				
-				const otherAmount = parseFloat(other.amount) || 0;
-				const reduction = Math.min(otherAmount, remainingExcess);
-				
-				other.amount = this.flt(otherAmount - reduction, this.currency_precision);
-				remainingExcess = this.flt(remainingExcess - reduction, this.currency_precision);
-			}
-		},
-		isCashLikePayment(payment) {
-			if (!payment) return false;
-			
-			// Check if it's the configured cash MOP or contains "cash" in name
-			const configuredCashMOP = String(this.posProfile?.posa_cash_mode_of_payment || "").toLowerCase();
-			const mode = String(payment.mode_of_payment || "").toLowerCase();
-			const type = String(payment.type || "").toLowerCase();
-			
-			if (type === "cash") return true;
-			if (configuredCashMOP && mode === configuredCashMOP) return true;
-			return mode.includes("cash");
-		},
-		getVisibleDenominations(payment) {
-			if (!this.isCashLikePayment(payment)) return [];
-			
-			const currentTotalPaid = this.paidAmount;
-			const currentPaymentAmount = parseFloat(payment.amount) || 0;
-			const otherPayments = currentTotalPaid - currentPaymentAmount;
-			const amountToPay = this.totalAmount - otherPayments;
-
-			if (amountToPay <= 0) return [];
-
-			return getSmartTenderSuggestions(amountToPay, this.currency);
-		},
-		currencySymbol(curr) {
-			return curr || "";
-		},
-		close() {
-			this.dialog = false;
-		},
-		submit(doPrint) {
-			this.loading = true;
-			const payments = this.paymentLines
-				.filter((p) => p.amount > 0)
-				.map((p) => ({
-					mode_of_payment: p.mode_of_payment,
-					amount: p.amount,
-				}));
-			
-			this.$emit("submit", {
-				payments,
-				print: doPrint,
-				print_format: this.selectedPrintFormat,
-				print_invoice: this.printInvoice,
-			});
-		},
-		async fetchPrintFormats() {
-			try {
-				const doctype = this.printInvoice ? "Purchase Invoice" : "Purchase Order";
-				const { message } = await frappe.call({
-					method: "posawesome.posawesome.api.print_formats.get_print_formats",
-					args: {
-						doctype: doctype,
-					},
-				});
-				this.printFormats = message || [];
-				this.selectedPrintFormat = null;
-
-				if (this.printFormats.length) {
-					if (
-						this.posProfile.print_format &&
-						this.printFormats.includes(this.posProfile.print_format)
-					) {
-						this.selectedPrintFormat = this.posProfile.print_format;
-					} else {
-						this.selectedPrintFormat = this.printFormats[0];
-					}
-				}
-			} catch (e) {
-				console.error("Failed to fetch print formats", e);
-			}
-		},
+const dialog = computed({
+	get() {
+		return props.modelValue;
 	},
+	set(val) {
+		emit("update:modelValue", val);
+	},
+});
+
+const paidAmount = computed(() =>
+	paymentLines.value.reduce((sum, p) => sum + (parseFloat(p.amount) || 0), 0),
+);
+
+const remainingAmount = computed(() => props.totalAmount - paidAmount.value);
+
+const isPaymentValid = computed(() => paidAmount.value > 0 && remainingAmount.value <= 0);
+
+watch(
+	() => props.modelValue,
+	(val) => {
+		if (val) {
+			printInvoice.value = props.createInvoice;
+			initializePayments();
+			fetchPrintFormats();
+			loading.value = false;
+		}
+	},
+);
+
+watch(printInvoice, () => {
+	fetchPrintFormats();
+});
+
+const flt = (value, precision, number_format, rounding_method) => {
+	if (!precision && precision != 0) {
+		precision = currency_precision.value || 2;
+	}
+	if (!rounding_method) {
+		rounding_method = "Banker's Rounding (legacy)";
+	}
+	return window.flt(value, precision, number_format, rounding_method);
 };
+
+function formatCurrency(value, precision) {
+	if (value === null || value === undefined) {
+		value = 0;
+	}
+	let number = Number(formatUtils.fromArabicNumerals(String(value)).replace(/,/g, ""));
+	if (isNaN(number)) number = 0;
+	let prec = precision != null ? Number(precision) : Number(currency_precision.value) || 2;
+	if (!Number.isInteger(prec) || prec < 0 || prec > 20) {
+		prec = Math.min(Math.max(parseInt(prec) || 2, 0), 20);
+	}
+
+	const locale = formatUtils.getNumberLocale();
+	let formatted = number.toLocaleString(locale, {
+		minimumFractionDigits: prec,
+		maximumFractionDigits: prec,
+		useGrouping: true,
+	});
+
+	formatted = formatUtils.toArabicNumerals(formatted);
+	return formatted;
+}
+
+function initializePayments() {
+	const modes = props.posProfile.payments || [];
+	paymentLines.value = modes.map((m) => ({
+		mode_of_payment: m.mode_of_payment,
+		amount: 0,
+		default: m.default,
+		type: m.type,
+	}));
+
+	// Auto-fill default payment method if exists
+	const defaultMode = paymentLines.value.find((p) => p.default) || paymentLines.value[0];
+	if (defaultMode) {
+		defaultMode.amount = props.totalAmount;
+	}
+}
+
+function set_full_amount(payment) {
+	// Reset all other payments
+	paymentLines.value.forEach((p) => {
+		if (p !== payment) {
+			p.amount = 0;
+		}
+	});
+	// Set this payment to total amount
+	payment.amount = props.totalAmount;
+}
+
+function set_rest_amount(payment) {
+	// If payment is 0 and there's remaining amount, auto-fill
+	if (payment.amount === 0 && remainingAmount.value > 0) {
+		payment.amount = remainingAmount.value;
+	}
+}
+
+function handlePaymentAmountChange(payment, event) {
+	const val = parseFloat(event) || 0;
+	payment.amount = val;
+
+	// Auto-balance: if this payment exceeds remaining, reduce others
+	if (remainingAmount.value < 0) {
+		autoBalancePayments(payment);
+	}
+}
+
+function setPaymentToDenomination(payment, amount) {
+	payment.amount = amount;
+	// Auto-balance other payments if needed
+	if (remainingAmount.value < 0) {
+		autoBalancePayments(payment);
+	}
+}
+
+function autoBalancePayments(excludePayment) {
+	const excess = Math.abs(remainingAmount.value);
+	if (excess <= 0) return;
+
+	// Find other payments with amount > 0 to reduce
+	const otherPayments = paymentLines.value.filter((p) => p !== excludePayment && parseFloat(p.amount) > 0);
+
+	// Sort by amount descending to reduce larger chunks first
+	otherPayments.sort((a, b) => parseFloat(b.amount) - parseFloat(a.amount));
+
+	let remainingExcess = excess;
+
+	for (const other of otherPayments) {
+		if (remainingExcess <= 0) break;
+
+		const otherAmount = parseFloat(other.amount) || 0;
+		const reduction = Math.min(otherAmount, remainingExcess);
+
+		other.amount = flt(otherAmount - reduction, currency_precision.value);
+		remainingExcess = flt(remainingExcess - reduction, currency_precision.value);
+	}
+}
+
+function isCashLikePayment(payment) {
+	if (!payment) return false;
+
+	// Check if it's the configured cash MOP or contains "cash" in name
+	const configuredCashMOP = String(props.posProfile?.posa_cash_mode_of_payment || "").toLowerCase();
+	const mode = String(payment.mode_of_payment || "").toLowerCase();
+	const type = String(payment.type || "").toLowerCase();
+
+	if (type === "cash") return true;
+	if (configuredCashMOP && mode === configuredCashMOP) return true;
+	return mode.includes("cash");
+}
+
+function getVisibleDenominations(payment) {
+	if (!isCashLikePayment(payment)) return [];
+
+	const currentTotalPaid = paidAmount.value;
+	const currentPaymentAmount = parseFloat(payment.amount) || 0;
+	const otherPayments = currentTotalPaid - currentPaymentAmount;
+	const amountToPay = props.totalAmount - otherPayments;
+
+	if (amountToPay <= 0) return [];
+
+	return getSmartTenderSuggestions(amountToPay, props.currency);
+}
+
+function currencySymbol(curr) {
+	return curr || "";
+}
+
+function close() {
+	dialog.value = false;
+}
+
+function submit(doPrint) {
+	loading.value = true;
+	const payments = paymentLines.value
+		.filter((p) => p.amount > 0)
+		.map((p) => ({
+			mode_of_payment: p.mode_of_payment,
+			amount: p.amount,
+		}));
+
+	emit("submit", {
+		payments,
+		print: doPrint,
+		print_format: selectedPrintFormat.value,
+		print_invoice: printInvoice.value,
+	});
+}
+
+async function fetchPrintFormats() {
+	try {
+		const doctype = printInvoice.value ? "Purchase Invoice" : "Purchase Order";
+		const { message } = await frappe.call({
+			method: "posawesome.posawesome.api.print_formats.get_print_formats",
+			args: {
+				doctype: doctype,
+			},
+		});
+		printFormats.value = message || [];
+		selectedPrintFormat.value = null;
+
+		if (printFormats.value.length) {
+			if (props.posProfile.print_format && printFormats.value.includes(props.posProfile.print_format)) {
+				selectedPrintFormat.value = props.posProfile.print_format;
+			} else {
+				selectedPrintFormat.value = printFormats.value[0];
+			}
+		}
+	} catch (e) {
+		console.error("Failed to fetch print formats", e);
+	}
+}
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/pos/ScanErrorDialog.vue
+++ b/frontend/src/posapp/components/pos/ScanErrorDialog.vue
@@ -31,28 +31,33 @@
 	</v-dialog>
 </template>
 
-<script>
-export default {
-	props: {
-		modelValue: {
-			type: Boolean,
-			default: false,
-		},
-		message: {
-			type: String,
-			default: "",
-		},
-		code: {
-			type: String,
-			default: "",
-		},
-		details: {
-			type: String,
-			default: "",
-		},
+<script setup>
+defineOptions({
+	name: "ScanErrorDialog",
+});
+
+defineProps({
+	modelValue: {
+		type: Boolean,
+		default: false,
 	},
-	emits: ["update:modelValue", "acknowledge"],
-};
+	message: {
+		type: String,
+		default: "",
+	},
+	code: {
+		type: String,
+		default: "",
+	},
+	details: {
+		type: String,
+		default: "",
+	},
+});
+
+defineEmits(["update:modelValue", "acknowledge"]);
+
+const __ = window.__ || ((text) => text);
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/reports/Reports.vue
+++ b/frontend/src/posapp/components/reports/Reports.vue
@@ -9,10 +9,8 @@
 	</v-container>
 </template>
 
-<script>
-import { defineComponent } from 'vue';
-
-export default defineComponent({
+<script setup>
+defineOptions({
 	name: "Reports",
 });
 </script>

--- a/frontend/src/posapp/components/ui/LoadingOverlay.vue
+++ b/frontend/src/posapp/components/ui/LoadingOverlay.vue
@@ -7,25 +7,22 @@
 	</transition>
 </template>
 
-<script>
+<script setup>
 import { computed } from "vue";
 import { useLoading } from "../../composables/useLoading.js";
 
-export default {
+defineOptions({
 	name: "LoadingOverlay",
-	props: {
-		visible: { type: Boolean, default: undefined },
-		message: { type: String, default: "" },
-	},
-	setup(props) {
-		const { overlayVisible } = useLoading();
-		const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-		const isVisible = computed(() =>
-			props.visible !== undefined ? props.visible : overlayVisible.value,
-		);
-		return { isVisible, prefersReduced };
-	},
-};
+});
+
+const props = defineProps({
+	visible: { type: Boolean, default: undefined },
+	message: { type: String, default: "" },
+});
+
+const { overlayVisible } = useLoading();
+const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+const isVisible = computed(() => (props.visible !== undefined ? props.visible : overlayVisible.value));
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/ui/Skeleton.vue
+++ b/frontend/src/posapp/components/ui/Skeleton.vue
@@ -2,27 +2,26 @@
 	<div :class="['skeleton', { shimmer: !prefersReduced }]" :style="style"></div>
 </template>
 
-<script>
+<script setup>
 import { computed } from "vue";
 import "../../styles/shimmer.css";
 
-export default {
+defineOptions({
 	name: "Skeleton",
-	props: {
-		type: { type: String, default: "rect" },
-		width: { type: [String, Number], default: "100%" },
-		height: { type: [String, Number], default: "1rem" },
-	},
-	setup(props) {
-		const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-		const style = computed(() => ({
-			width: typeof props.width === "number" ? `${props.width}px` : props.width,
-			height: typeof props.height === "number" ? `${props.height}px` : props.height,
-			borderRadius: props.type === "circle" ? "50%" : "4px",
-		}));
-		return { style, prefersReduced };
-	},
-};
+});
+
+const props = defineProps({
+	type: { type: String, default: "rect" },
+	width: { type: [String, Number], default: "100%" },
+	height: { type: [String, Number], default: "1rem" },
+});
+
+const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+const style = computed(() => ({
+	width: typeof props.width === "number" ? `${props.width}px` : props.width,
+	height: typeof props.height === "number" ? `${props.height}px` : props.height,
+	borderRadius: props.type === "circle" ? "50%" : "4px",
+}));
 </script>
 
 <style scoped>

--- a/frontend/src/posapp/components/ui/UpdatePrompt.vue
+++ b/frontend/src/posapp/components/ui/UpdatePrompt.vue
@@ -30,48 +30,38 @@
 	</v-snackbar>
 </template>
 
-<script>
-import { computed, watch, ref } from "vue";
+<script setup>
+import { computed, ref, watch } from "vue";
 import { useUpdateStore } from "../../stores/updateStore.js";
 import { useRtl } from "../../composables/useRtl.js";
 
-export default {
+defineOptions({
 	name: "UpdatePrompt",
-	setup() {
-		const updateStore = useUpdateStore();
-		const { isRtl } = useRtl();
-		const visible = ref(false);
+});
 
-		watch(
-			() => updateStore.shouldPrompt,
-			(shouldShow) => {
-				visible.value = shouldShow;
-			},
-			{ immediate: true },
-		);
+const updateStore = useUpdateStore();
+const { isRtl } = useRtl();
+const visible = ref(false);
 
-		const label = computed(() => updateStore.formattedAvailableVersion);
-
-		function reload() {
-			updateStore.resetSnooze();
-			updateStore.reloadNow();
-		}
-
-		function snooze() {
-			updateStore.snooze();
-			visible.value = false;
-		}
-
-		return {
-			updateStore,
-			visible,
-			label,
-			reload,
-			snooze,
-			isRtl,
-		};
+watch(
+	() => updateStore.shouldPrompt,
+	(shouldShow) => {
+		visible.value = shouldShow;
 	},
-};
+	{ immediate: true },
+);
+
+const label = computed(() => updateStore.formattedAvailableVersion);
+
+function reload() {
+	updateStore.resetSnooze();
+	updateStore.reloadNow();
+}
+
+function snooze() {
+	updateStore.snooze();
+	visible.value = false;
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
### Motivation
- Modernize and standardize the frontend by migrating remaining Options API components to the Composition API using `<script setup>` for clearer, smaller components and consistent patterns. 
- Reduce implicit mixin usage and inline component state by converting `props`, `emits`, `data` and `computed` logic to `defineProps`, `defineEmits`, `ref` and `computed` so future refactors are easier. 
- Prepare the codebase for incremental improvements (type-checking, tree-shaking and composable reuse) by aligning components to the newer Vue 3 recommended style.

### Description
- Converted many navbar/ui helper components to `<script setup>` and composition primitives, including `StatusIndicator.vue`, `CacheUsageMeter.vue`, `NavbarInfoGadgets.vue`, `NotificationBell.vue`, `AboutDialog.vue`, `NavbarDrawer.vue`, `Reports.vue`, `Skeleton.vue`, `ui/LoadingOverlay.vue`, and `ui/UpdatePrompt.vue`. 
- Migrated several POS dialogs/rows and offline UI to `<script setup>`, notably `OfflineInvoices.vue`, `CancelSaleDialog.vue`, `CartItemRow.vue`, `InvoiceSummary.vue`, `pos/LoadingOverlay.vue`, `Mpesa-Payments.vue`, `OpeningDialog.vue`, `PurchasePaymentDialog.vue` and `ScanErrorDialog.vue`, moving state to `ref`/`computed` and replacing Options API lifecycle with Composition equivalents. 
- Replaced mixin-based formatter usage in components with local usage of `formatUtils` where needed and kept behavior and templates intact (props/emits preserved). 
- Ran automated formatting (`prettier`) and applied minor defensive updates (clamping precisions, safe fallbacks for `window.__`), while preserving existing UX and business logic.

### Testing
- `yarn --cwd frontend format` ran successfully and formatted the modified files. 
- `yarn --cwd frontend eslint .` was executed but failed with existing repository lint issues (many pre-existing errors reported); migration did not introduce new lint configuration changes. 
- `yarn --cwd frontend test` (Vitest) ran and revealed environment-related failures: one test suite failed due to missing test environment resources (IndexedDB API unavailable in the runner, missing static `jsbarcode` copy and a missing `toastStore.js` import), while other suites (e.g., `pricingEngine.spec.js`) passed; tests cannot be fully validated in this headless environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837bd2a5708326a583fadef335509e)