### PR TITLE
Fix invoice summary buttons cutoff by using flexbox layout

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1,24 +1,17 @@
 <template>
 	<!-- Main Invoice Wrapper -->
-	<div class="pa-0">
+	<div class="pa-0 d-flex flex-column h-100">
 		<!-- Cancel Sale Confirmation Dialog -->
 		<CancelSaleDialog v-model="cancel_dialog" @confirm="cancel_invoice" />
 
 		<!-- Main Invoice Card (contains all invoice content) -->
 		<v-card
 			ref="invoiceCard"
-			:style="{
-				height: invoiceHeight || 'var(--container-height)',
-				maxHeight: invoiceHeight || 'var(--container-height)',
-				resize: 'vertical',
-				overflow: 'auto',
-			}"
-			:class="['cards my-0 py-0 mt-3 resizable', 'pos-themed-card', { 'return-mode': isReturnInvoice }]"
-			@mouseup="saveInvoiceHeight($refs.invoiceCard)"
-			@touchend="saveInvoiceHeight($refs.invoiceCard)"
+			class="cards my-0 py-0 mt-3 flex-grow-1 d-flex flex-column overflow-hidden pos-themed-card"
+			:class="{ 'return-mode': isReturnInvoice }"
 		>
 			<!-- Dynamic padding wrapper -->
-			<div class="dynamic-padding">
+			<div class="dynamic-padding d-flex flex-column h-100 overflow-hidden">
 				<v-alert
 					type="info"
 					density="compact"
@@ -105,7 +98,7 @@
 				/>
 
 				<!-- Items Table Section (Main items list for invoice) -->
-				<div class="items-table-wrapper">
+				<div class="items-table-wrapper flex-grow-1 d-flex flex-column overflow-hidden">
 					<!-- Refactored Action Toolbar -->
 					<InvoiceItemsActionToolbar
 						ref="actionToolbar"
@@ -123,6 +116,7 @@
 
 					<!-- ItemsTable component with reorder event handler -->
 					<ItemsTable
+						class="flex-grow-1"
 						ref="itemsTableRef"
 						:headers="items_headers"
 						v-model:expanded="expanded"
@@ -180,6 +174,7 @@
 
 		<!-- Payment Section -->
 		<InvoiceSummary
+			class="flex-shrink-0"
 			ref="invoiceSummary"
 			:pos_profile="pos_profile"
 			:total_qty="total_qty"
@@ -760,7 +755,6 @@ export default {
 	mounted() {
 		this.setUpdateItemDetail(this.update_item_detail);
 		this.loadColumnPreferences();
-		this.loadInvoiceHeight();
 
 		this.$watch(
 			() => this.uiStore.posProfile,

--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1,9 +1,8 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
-	<div class="pa-0">
+	<div class="pa-0 d-flex flex-column h-100">
 		<v-card
-			class="selection mx-auto pa-1 my-0 mt-3 pos-themed-card"
-			style="max-height: 68vh; height: 68vh"
+			class="selection mx-auto pa-1 my-0 mt-3 pos-themed-card flex-grow-1 d-flex flex-column overflow-hidden"
 		>
 			<v-progress-linear
 				:active="loading"
@@ -12,7 +11,7 @@
 				location="top"
 				color="info"
 			></v-progress-linear>
-			<div ref="paymentContainer" class="overflow-y-auto pa-2" style="max-height: 67vh">
+			<div ref="paymentContainer" class="overflow-y-auto pa-2 flex-grow-1">
 				<!-- Payment Summary (Paid, To Be Paid, Change) -->
 				<PaymentSummary
 					:invoice_doc="invoice_doc"
@@ -187,6 +186,7 @@
 
 		<!-- Action Buttons -->
 		<PaymentActionButtons
+			class="flex-shrink-0"
 			ref="submitButton"
 			:loading="loading"
 			:validatePayment="validatePayment"

--- a/frontend/src/posapp/components/pos/shell/Pos.vue
+++ b/frontend/src/posapp/components/pos/shell/Pos.vue
@@ -57,9 +57,9 @@
 				md="5"
 				sm="5"
 				cols="12"
-				class="pos dynamic-col"
+				class="pos dynamic-col d-flex flex-column h-100"
 			>
-				<Payments></Payments>
+				<Payments class="flex-grow-1"></Payments>
 			</v-col>
 
 			<v-col

--- a/frontend/src/posapp/components/pos/shell/Pos.vue
+++ b/frontend/src/posapp/components/pos/shell/Pos.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="pos-main-container dynamic-container"
+		class="pos-main-container dynamic-container d-flex flex-column h-100"
 		:class="rtlClasses"
 		:style="[responsiveStyles, rtlStyles]"
 	>
@@ -16,7 +16,7 @@
 			@close="closeOpeningDialog"
 			@register="handleRegisterPosData"
 		></OpeningDialog>
-		<v-row v-show="!dialog" dense class="ma-0 dynamic-main-row">
+		<v-row v-show="!dialog" dense class="ma-0 dynamic-main-row flex-grow-1 h-100">
 			<v-col
 				v-show="activeView === 'items'"
 				xl="5"
@@ -24,7 +24,7 @@
 				md="5"
 				sm="5"
 				cols="12"
-				class="pos dynamic-col"
+				class="pos dynamic-col d-flex flex-column h-100"
 			>
 				<ItemsSelector context="pos" />
 			</v-col>
@@ -62,8 +62,15 @@
 				<Payments></Payments>
 			</v-col>
 
-			<v-col xl="7" lg="7" md="7" sm="7" cols="12" class="pos dynamic-col">
-				<Invoice></Invoice>
+			<v-col
+				xl="7"
+				lg="7"
+				md="7"
+				sm="7"
+				cols="12"
+				class="pos dynamic-col d-flex flex-column h-100"
+			>
+				<Invoice class="flex-grow-1"></Invoice>
 			</v-col>
 		</v-row>
 	</div>


### PR DESCRIPTION
The user reported that buttons at the bottom of the invoice section were being cut off.
This was caused by a fixed or manually calculated height for the invoice card that didn't properly account for the summary section or viewport changes.
I refactored the layout to use CSS Flexbox to ensure the invoice section takes the full available height, with the summary pinned to the bottom and the items list taking the remaining space and scrolling if necessary.
I also removed the legacy manual resize logic which conflicted with the responsive design.

---
*PR created automatically by Jules for task [15928852254883378447](https://jules.google.com/task/15928852254883378447) started by @defendicon*