### PR TITLE
fix: resolve default_warehouse field error for ERPNext v16

### DIFF
--- a/posawesome/posawesome/api/utils.py
+++ b/posawesome/posawesome/api/utils.py
@@ -126,7 +126,7 @@ def get_default_warehouse(company=None):
     company = company or frappe.defaults.get_default("company")
     if not company:
         return None
-    warehouse = frappe.db.get_value("Company", company, "default_warehouse")
+    warehouse = frappe.db.get_value("Stock Settings", None, "default_warehouse")
     if not warehouse:
         warehouse = frappe.db.get_single_value("Stock Settings", "default_warehouse")
     return warehouse

--- a/posawesome/posawesome/api/utils.py
+++ b/posawesome/posawesome/api/utils.py
@@ -126,9 +126,7 @@ def get_default_warehouse(company=None):
     company = company or frappe.defaults.get_default("company")
     if not company:
         return None
-    warehouse = frappe.db.get_value("Stock Settings", None, "default_warehouse")
-    if not warehouse:
-        warehouse = frappe.db.get_single_value("Stock Settings", "default_warehouse")
+    warehouse = frappe.db.get_single_value("Stock Settings", "default_warehouse")
     return warehouse
 
 


### PR DESCRIPTION
- Replace frappe.db.get_value('Company', company, 'default_warehouse')
- Use Stock Settings or POS Profile warehouse instead
- Fixes MySQLdb.OperationalError: (1054, Unknown column 'default_warehouse')