### PR TITLE
fix: convert dict to frappe._dict for ERPNext v15+ compatibility

### DIFF
--- a/posawesome/posawesome/api/item_processing/details.py
+++ b/posawesome/posawesome/api/item_processing/details.py
@@ -43,6 +43,13 @@ def get_items_details(pos_profile, items_data, price_list=None, customer=None):
 def get_item_detail(item, doc=None, warehouse=None, price_list=None, company=None):
     from erpnext.stock.get_item_details import get_item_details
     item = json.loads(item)
+    
+    # Fix for ERPNext v15+ type validation - convert dict to frappe._dict
+    if isinstance(item, dict) and not isinstance(item, frappe._dict):
+        item = frappe._dict(item)
+    if doc and isinstance(doc, dict) and not isinstance(doc, frappe._dict):
+        doc = frappe._dict(doc)
+    
     today = nowdate()
     item_code = item.get("item_code")
     batch_no_data = []


### PR DESCRIPTION
- Add type validation fix for get_item_details API call
- Convert item and doc from plain dict to frappe._dict
- Resolves FrappeTypeError: Argument 'ctx' should be frappe._dict