### PR TITLE
feat: add transaction ID reference fields to payment processing

### DIFF
--- a/frontend/src/posapp/components/pos/shell/PayView.vue
+++ b/frontend/src/posapp/components/pos/shell/PayView.vue
@@ -642,6 +642,8 @@ export default {
 		async function syncCustomerPaymentContext(normalized, { forceReload = false } = {}) {
 			if (!normalized) {
 				customer_name.value = "";
+				referenceNo.value = "";
+				referenceDate.value = "";
 				clearSelections();
 				outstanding_invoices.value = [];
 				unallocated_payments.value = [];

--- a/frontend/src/posapp/components/pos/shell/PayView.vue
+++ b/frontend/src/posapp/components/pos/shell/PayView.vue
@@ -1,9 +1,6 @@
 <template>
 	<div fluid :class="rtlClasses">
-		<AppLoadingOverlay
-			:visible="isPaymentRouteLocked"
-			:message="paymentsLoadingMessage"
-		/>
+		<AppLoadingOverlay :visible="isPaymentRouteLocked" :message="paymentsLoadingMessage" />
 		<v-row v-show="!dialog">
 			<v-col md="8" cols="12" class="pb-2 pr-0">
 				<v-card
@@ -81,6 +78,8 @@
 					<PayTotalsSidebar
 						v-model:exchange-rate="exchangeRate"
 						v-model:auto-allocate-payment-amount="autoAllocatePaymentAmount"
+						v-model:reference-no="referenceNo"
+						v-model:reference-date="referenceDate"
 						:pos-profile="pos_profile"
 						:total-selected-invoices="total_selected_invoices"
 						:selected-invoices-count="selected_invoices.length"
@@ -199,6 +198,8 @@ export default {
 		const autoAllocatePaymentAmount = ref(true);
 		const exchangeRate = ref(null);
 		const companyCurrency = ref(null);
+		const referenceNo = ref("");
+		const referenceDate = ref("");
 		const exchangeRateLoading = ref(false);
 		const exchangeRateError = ref(null);
 		const payment_method_currencies = ref({});
@@ -450,9 +451,7 @@ export default {
 				isCustomerBackgroundLoading: !!isCustomerBackgroundLoading.value,
 			}),
 		);
-		const paymentsLoadingMessage = computed(() =>
-			buildPaymentRouteLoadingMessage(loadProgress.value),
-		);
+		const paymentsLoadingMessage = computed(() => buildPaymentRouteLoadingMessage(loadProgress.value));
 
 		const { isSubmitting, processPayment } = usePosPaySubmission({
 			customerName: customer_name,
@@ -461,6 +460,8 @@ export default {
 			posOpeningShift: pos_opening_shift,
 			exchangeRate,
 			invoiceTotalCurrency,
+			referenceNo,
+			referenceDate,
 			payment_methods,
 			selected_invoices,
 			selected_payments,
@@ -563,8 +564,7 @@ export default {
 			pos_profile.value = data.pos_profile;
 			pos_opening_shift.value = data.pos_opening_shift;
 			company.value = data.company?.name || data.pos_profile?.company || "";
-			companyCurrency.value =
-				data.company?.default_currency || data.pos_profile?.currency || null;
+			companyCurrency.value = data.company?.default_currency || data.pos_profile?.currency || null;
 			uiStore.setRegisterData(data);
 			proxy?.eventBus?.emit("payments_register_pos_profile", data);
 			set_payment_methods();
@@ -604,10 +604,7 @@ export default {
 				console.error("Error checking opening entry", e);
 				const cached =
 					cachedOpening ||
-					getValidCachedOpeningForCurrentUser(
-						getOpeningStorage(),
-						frappe?.session?.user,
-					);
+					getValidCachedOpeningForCurrentUser(getOpeningStorage(), frappe?.session?.user);
 				if (cached) {
 					await applyOpeningData(cached);
 					return;
@@ -739,10 +736,9 @@ export default {
 			isPaymentRouteLocked,
 			(locked) => {
 				if (locked) return;
-				void syncCustomerPaymentContext(
-					selectedCustomer.value || customer_name.value || "",
-					{ forceReload: true },
-				);
+				void syncCustomerPaymentContext(selectedCustomer.value || customer_name.value || "", {
+					forceReload: true,
+				});
 			},
 			{ immediate: true },
 		);
@@ -784,6 +780,8 @@ export default {
 			autoAllocatePaymentAmount,
 			exchangeRate,
 			companyCurrency,
+			referenceNo,
+			referenceDate,
 			exchangeRateLoading,
 			exchangeRateError,
 			payment_method_currencies,

--- a/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
+++ b/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
@@ -1,225 +1,258 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
-    <div class="totals-wrapper">
-        <h4 class="text-primary">Totals</h4>
-        <v-row>
-            <v-col md="7" class="mt-1">
-                <span>{{ __("Total Invoices:") }}</span>
-            </v-col>
-            <v-col md="5">
-                <v-text-field
-                    class="p-0 m-0 pos-themed-input"
-                    density="compact"
-                    color="primary"
-                    hide-details
-                    :model-value="formatCurrency(totalSelectedInvoices)"
-                    readonly
-                    flat
-                    :prefix="currencySymbol(invoiceTotalCurrency)"
-                ></v-text-field>
-                <small v-if="selectedInvoicesCount" class="text-primary"
-                    >{{ selectedInvoicesCount }} invoice(s) selected</small
-                >
-            </v-col>
-        </v-row>
+	<div class="totals-wrapper">
+		<h4 class="text-primary">Totals</h4>
+		<v-row>
+			<v-col md="7" class="mt-1">
+				<span>{{ __("Total Invoices:") }}</span>
+			</v-col>
+			<v-col md="5">
+				<v-text-field
+					class="p-0 m-0 pos-themed-input"
+					density="compact"
+					color="primary"
+					hide-details
+					:model-value="formatCurrency(totalSelectedInvoices)"
+					readonly
+					flat
+					:prefix="currencySymbol(invoiceTotalCurrency)"
+				></v-text-field>
+				<small v-if="selectedInvoicesCount" class="text-primary"
+					>{{ selectedInvoicesCount }} invoice(s) selected</small
+				>
+			</v-col>
+		</v-row>
 
-        <v-row v-if="totalSelectedPayments">
-            <v-col md="7" class="mt-1"
-                ><span>{{ __("Total Payments:") }}</span></v-col
-            >
-            <v-col md="5">
-                <v-text-field
-                    class="p-0 m-0 pos-themed-input"
-                    density="compact"
-                    color="primary"
-                    hide-details
-                    :model-value="formatCurrency(totalSelectedPayments)"
-                    readonly
-                    flat
-                    :prefix="currencySymbol(paymentTotalCurrency)"
-                ></v-text-field>
-            </v-col>
-        </v-row>
+		<v-row v-if="totalSelectedPayments">
+			<v-col md="7" class="mt-1"
+				><span>{{ __("Total Payments:") }}</span></v-col
+			>
+			<v-col md="5">
+				<v-text-field
+					class="p-0 m-0 pos-themed-input"
+					density="compact"
+					color="primary"
+					hide-details
+					:model-value="formatCurrency(totalSelectedPayments)"
+					readonly
+					flat
+					:prefix="currencySymbol(paymentTotalCurrency)"
+				></v-text-field>
+			</v-col>
+		</v-row>
 
-        <v-row v-if="totalSelectedMpesa">
-            <v-col md="7" class="mt-1"
-                ><span>{{ __("Total Mpesa:") }}</span></v-col
-            >
-            <v-col md="5">
-                <v-text-field
-                    class="p-0 m-0 pos-themed-input"
-                    density="compact"
-                    color="primary"
-                    hide-details
-                    :model-value="formatCurrency(totalSelectedMpesa)"
-                    readonly
-                    flat
-                    :prefix="currencySymbol(mpesaTotalCurrency)"
-                ></v-text-field>
-            </v-col>
-        </v-row>
+		<v-row v-if="totalSelectedMpesa">
+			<v-col md="7" class="mt-1"
+				><span>{{ __("Total Mpesa:") }}</span></v-col
+			>
+			<v-col md="5">
+				<v-text-field
+					class="p-0 m-0 pos-themed-input"
+					density="compact"
+					color="primary"
+					hide-details
+					:model-value="formatCurrency(totalSelectedMpesa)"
+					readonly
+					flat
+					:prefix="currencySymbol(mpesaTotalCurrency)"
+				></v-text-field>
+			</v-col>
+		</v-row>
 
-        <v-divider v-if="paymentMethods.length"></v-divider>
-        <div v-if="posProfile.posa_allow_make_new_payments">
-            <h4 class="text-primary">Make New Payment</h4>
-            <v-row
-                v-if="filteredPaymentMethods.length"
-                v-for="method in filteredPaymentMethods"
-                :key="method.row_id"
-            >
-                <v-col md="7"
-                    ><span class="mt-1">{{ __(method.mode_of_payment) }}:</span>
-                </v-col>
-                <v-col md="5">
-                    <div class="d-flex align-center">
-                        <div class="mr-1 text-primary">
-                            {{ currencySymbol(getPaymentMethodCurrency(method.mode_of_payment)) }}
-                        </div>
-                        <v-text-field
-                            class="p-0 m-0 pos-themed-input"
-                            density="compact"
-                            color="primary"
-                            hide-details
-                            v-model="method.amount"
-                            type="number"
-                            flat
-                        ></v-text-field>
-                    </div>
-                </v-col>
-            </v-row>
-        </div>
+		<v-divider v-if="paymentMethods.length"></v-divider>
+		<div v-if="posProfile.posa_allow_make_new_payments">
+			<h4 class="text-primary">Make New Payment</h4>
+			<v-row
+				v-if="filteredPaymentMethods.length"
+				v-for="method in filteredPaymentMethods"
+				:key="method.row_id"
+			>
+				<v-col md="7"
+					><span class="mt-1">{{ __(method.mode_of_payment) }}:</span>
+				</v-col>
+				<v-col md="5">
+					<div class="d-flex align-center">
+						<div class="mr-1 text-primary">
+							{{ currencySymbol(getPaymentMethodCurrency(method.mode_of_payment)) }}
+						</div>
+						<v-text-field
+							class="p-0 m-0 pos-themed-input"
+							density="compact"
+							color="primary"
+							hide-details
+							v-model="method.amount"
+							type="number"
+							flat
+						></v-text-field>
+					</div>
+				</v-col>
+			</v-row>
+		</div>
 
-        <v-divider v-if="requiresExchangeRate"></v-divider>
-        <v-row v-if="requiresExchangeRate" class="mb-2">
-            <v-col md="7" class="mt-1">
-                <span class="text-primary">
-                    {{ __("Exchange Rate") }} (1 {{ invoiceTotalCurrency }} = ? {{ companyCurrency }}):
-                </span>
-            </v-col>
-            <v-col md="5">
-                <div class="d-flex align-center">
-                    <div class="mr-1 text-primary">
-                        {{ currencySymbol(companyCurrency) }}
-                    </div>
-                    <v-text-field
-                        class="p-0 m-0 pos-themed-input"
-                        density="compact"
-                        color="primary"
-                        hide-details
-                        v-model="internalExchangeRate"
-                        type="number"
-                        step="0.01"
-                        flat
-                        @update:model-value="$emit('validate-exchange-rate')"
-                        :loading="exchangeRateLoading"
-                        :error="!!exchangeRateError"
-                        :hint="exchangeRateError"
-                        persistent-hint
-                    ></v-text-field>
-                    <v-btn
-                        icon
-                        size="small"
-                        variant="text"
-                        color="primary"
-                        @click="$emit('fetch-exchange-rate')"
-                        :loading="exchangeRateLoading"
-                        :title="__('Refresh Exchange Rate')"
-                    >
-                        <v-icon>mdi-refresh</v-icon>
-                    </v-btn>
-                </div>
-                <small class="text-caption text-medium-emphasis">
-                    1 {{ invoiceTotalCurrency }} = {{ formatCurrency(internalExchangeRate || 0) }} {{ companyCurrency }}
-                </small>
-            </v-col>
-        </v-row>
+		<v-divider v-if="requiresExchangeRate"></v-divider>
+		<v-row v-if="requiresExchangeRate" class="mb-2">
+			<v-col md="7" class="mt-1">
+				<span class="text-primary">
+					{{ __("Exchange Rate") }} (1 {{ invoiceTotalCurrency }} = ? {{ companyCurrency }}):
+				</span>
+			</v-col>
+			<v-col md="5">
+				<div class="d-flex align-center">
+					<div class="mr-1 text-primary">
+						{{ currencySymbol(companyCurrency) }}
+					</div>
+					<v-text-field
+						class="p-0 m-0 pos-themed-input"
+						density="compact"
+						color="primary"
+						hide-details
+						v-model="internalExchangeRate"
+						type="number"
+						step="0.01"
+						flat
+						@update:model-value="$emit('validate-exchange-rate')"
+						:loading="exchangeRateLoading"
+						:error="!!exchangeRateError"
+						:hint="exchangeRateError"
+						persistent-hint
+					></v-text-field>
+					<v-btn
+						icon
+						size="small"
+						variant="text"
+						color="primary"
+						@click="$emit('fetch-exchange-rate')"
+						:loading="exchangeRateLoading"
+						:title="__('Refresh Exchange Rate')"
+					>
+						<v-icon>mdi-refresh</v-icon>
+					</v-btn>
+				</div>
+				<small class="text-caption text-medium-emphasis">
+					1 {{ invoiceTotalCurrency }} = {{ formatCurrency(internalExchangeRate || 0) }}
+					{{ companyCurrency }}
+				</small>
+			</v-col>
+		</v-row>
 
-        <v-divider></v-divider>
-        <v-row>
-            <v-col md="7">
-                <h4 class="text-primary mt-1">{{ __("Difference:") }}</h4>
-            </v-col>
-            <v-col md="5">
-                <v-text-field
-                    class="p-0 m-0 pos-themed-input"
-                    density="compact"
-                    color="primary"
-                    hide-details
-                    :model-value="formatCurrency(totalOfDiff)"
-                    readonly
-                    flat
-                    :prefix="currencySymbol(invoiceTotalCurrency)"
-                ></v-text-field>
-            </v-col>
-        </v-row>
+		<v-divider></v-divider>
+		<v-row>
+			<v-col md="7">
+				<h4 class="text-primary mt-1">{{ __("Difference:") }}</h4>
+			</v-col>
+			<v-col md="5">
+				<v-text-field
+					class="p-0 m-0 pos-themed-input"
+					density="compact"
+					color="primary"
+					hide-details
+					:model-value="formatCurrency(totalOfDiff)"
+					readonly
+					flat
+					:prefix="currencySymbol(invoiceTotalCurrency)"
+				></v-text-field>
+			</v-col>
+		</v-row>
 
-        <v-row class="mt-2">
-            <v-col cols="12">
-                <v-switch
-                    :model-value="internalAutoAllocatePaymentAmount"
-                    color="primary"
-                    hide-details
-                    inset
-                    :label="__('Auto Allocate Payment Amount')"
-                    data-test="auto-allocate-payment-toggle"
-                    @update:model-value="
-                        emit('update:autoAllocatePaymentAmount', Boolean($event))
-                    "
-                />
-                <small class="text-caption text-medium-emphasis">
-                    {{
-                        __(
-                            "Unselected payments stay unallocated first, then auto reconcile after submit.",
-                        )
-                    }}
-                </small>
-            </v-col>
-        </v-row>
-    </div>
+		<v-divider></v-divider>
+		<h4 class="text-primary">{{ __("Transaction ID") }}</h4>
+		<v-row>
+			<v-col md="6" cols="12">
+				<v-text-field
+					density="compact"
+					variant="outlined"
+					hide-details
+					class="pos-themed-input"
+					v-model="internalReferenceNo"
+					:label="__('Cheque/Reference No')"
+				></v-text-field>
+			</v-col>
+			<v-col md="6" cols="12">
+				<v-text-field
+					density="compact"
+					variant="outlined"
+					hide-details
+					type="date"
+					class="pos-themed-input"
+					v-model="internalReferenceDate"
+					:label="__('Cheque/Reference Date')"
+				></v-text-field>
+			</v-col>
+		</v-row>
+
+		<v-row class="mt-2">
+			<v-col cols="12">
+				<v-switch
+					:model-value="internalAutoAllocatePaymentAmount"
+					color="primary"
+					hide-details
+					inset
+					:label="__('Auto Allocate Payment Amount')"
+					data-test="auto-allocate-payment-toggle"
+					@update:model-value="emit('update:autoAllocatePaymentAmount', Boolean($event))"
+				/>
+				<small class="text-caption text-medium-emphasis">
+					{{ __("Unselected payments stay unallocated first, then auto reconcile after submit.") }}
+				</small>
+			</v-col>
+		</v-row>
+	</div>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed } from "vue";
 
 const props = defineProps({
-    posProfile: Object,
-    totalSelectedInvoices: Number,
-    selectedInvoicesCount: Number,
-    totalSelectedPayments: Number,
-    totalSelectedMpesa: Number,
-    paymentMethods: Array,
-    filteredPaymentMethods: Array,
-    invoiceTotalCurrency: String,
-    paymentTotalCurrency: String,
-    mpesaTotalCurrency: String,
-    companyCurrency: String,
-    exchangeRate: Number,
-    exchangeRateLoading: Boolean,
-    exchangeRateError: String,
-    requiresExchangeRate: Boolean,
-    totalOfDiff: Number,
-    autoAllocatePaymentAmount: {
-        type: Boolean,
-        default: true,
-    },
-    currencySymbol: Function,
-    formatCurrency: Function,
-    getPaymentMethodCurrency: Function
+	posProfile: Object,
+	totalSelectedInvoices: Number,
+	selectedInvoicesCount: Number,
+	totalSelectedPayments: Number,
+	totalSelectedMpesa: Number,
+	paymentMethods: Array,
+	filteredPaymentMethods: Array,
+	invoiceTotalCurrency: String,
+	paymentTotalCurrency: String,
+	mpesaTotalCurrency: String,
+	companyCurrency: String,
+	exchangeRate: Number,
+	exchangeRateLoading: Boolean,
+	exchangeRateError: String,
+	requiresExchangeRate: Boolean,
+	totalOfDiff: Number,
+	autoAllocatePaymentAmount: {
+		type: Boolean,
+		default: true,
+	},
+	currencySymbol: Function,
+	formatCurrency: Function,
+	getPaymentMethodCurrency: Function,
+	referenceNo: String,
+	referenceDate: String,
 });
 
 const emit = defineEmits([
-    'update:exchangeRate',
-    'update:autoAllocatePaymentAmount',
-    'validate-exchange-rate',
-    'fetch-exchange-rate'
+	"update:exchangeRate",
+	"update:autoAllocatePaymentAmount",
+	"update:referenceNo",
+	"update:referenceDate",
+	"validate-exchange-rate",
+	"fetch-exchange-rate",
 ]);
 
 const internalExchangeRate = computed({
-    get: () => props.exchangeRate,
-    set: (val) => emit('update:exchangeRate', val)
+	get: () => props.exchangeRate,
+	set: (val) => emit("update:exchangeRate", val),
 });
 
-const internalAutoAllocatePaymentAmount = computed(
-    () => props.autoAllocatePaymentAmount ?? true,
-);
+const internalAutoAllocatePaymentAmount = computed(() => props.autoAllocatePaymentAmount ?? true);
+
+const internalReferenceNo = computed({
+	get: () => props.referenceNo,
+	set: (val) => emit("update:referenceNo", val),
+});
+
+const internalReferenceDate = computed({
+	get: () => props.referenceDate,
+	set: (val) => emit("update:referenceDate", val),
+});
 </script>

--- a/frontend/src/posapp/composables/pos/payments/usePosPaySubmission.ts
+++ b/frontend/src/posapp/composables/pos/payments/usePosPaySubmission.ts
@@ -12,6 +12,8 @@ type PosPaySubmissionArgs = {
 	posOpeningShift: Ref<any>;
 	exchangeRate: Ref<number>;
 	invoiceTotalCurrency: Ref<string>;
+	referenceNo: Ref<string>;
+	referenceDate: Ref<string>;
 	autoAllocatePaymentAmount: Ref<boolean>;
 	payment_methods: Ref<any[]>;
 	selected_invoices: Ref<any[]>;
@@ -41,6 +43,8 @@ export function usePosPaySubmission({
 	posOpeningShift,
 	exchangeRate,
 	invoiceTotalCurrency,
+	referenceNo,
+	referenceDate,
 	autoAllocatePaymentAmount,
 	payment_methods,
 	selected_invoices,
@@ -125,6 +129,8 @@ export function usePosPaySubmission({
 				pos_opening_shift_name: posOpeningShift.value.name,
 				pos_profile_name: posProfile.value.name,
 				pos_profile: posProfile.value,
+				reference_no: referenceNo?.value || null,
+				reference_date: referenceDate?.value || null,
 				payment_methods: payment_methods.value.filter(
 					(m: any) => flt(m.amount) > 0,
 				),
@@ -183,7 +189,9 @@ export function usePosPaySubmission({
 					__("Auto reconciliation completed after payment submit.");
 				eventBus.emit("show_message", {
 					title: `${__("Payment submitted.")} ${autoReconcileSummary}`,
-					color: autoReconcileResult?.total_allocated ? "success" : "info",
+					color: autoReconcileResult?.total_allocated
+						? "success"
+						: "info",
 				});
 			}
 

--- a/frontend/src/posapp/composables/pos/payments/usePosPaySubmission.ts
+++ b/frontend/src/posapp/composables/pos/payments/usePosPaySubmission.ts
@@ -76,6 +76,8 @@ export function usePosPaySubmission({
 		const finalizeSubmission = () => {
 			clearSelections();
 			resetPaymentMethodAmounts();
+			referenceNo.value = "";
+			referenceDate.value = "";
 			customerName.value = customer;
 			get_outstanding_invoices();
 			get_unallocated_payments();
@@ -129,8 +131,8 @@ export function usePosPaySubmission({
 				pos_opening_shift_name: posOpeningShift.value.name,
 				pos_profile_name: posProfile.value.name,
 				pos_profile: posProfile.value,
-				reference_no: referenceNo?.value || null,
-				reference_date: referenceDate?.value || null,
+				reference_no: referenceNo?.value?.trim() || null,
+				reference_date: referenceDate?.value?.trim() || null,
 				payment_methods: payment_methods.value.filter(
 					(m: any) => flt(m.amount) > 0,
 				),

--- a/posawesome/posawesome/api/payment_processing/processor.py
+++ b/posawesome/posawesome/api/payment_processing/processor.py
@@ -299,8 +299,8 @@ def process_pos_payment(payload):
                     mode_of_payment=mode_of_payment,
                     exchange_rate=data.get("exchange_rate"),
                     posting_date=today,
-                    reference_no=pos_opening_shift_name,
-                    reference_date=today,
+                    reference_no=data.get("reference_no") or pos_opening_shift_name,
+                    reference_date=data.get("reference_date") or today,
                     cost_center=data.pos_profile.get("cost_center"),
                     submit=0,
                 )


### PR DESCRIPTION
- Add reference_no and reference_date inputs to PayTotalsSidebar
- Pass reference data through usePosPaySubmission composable
- Update processor.py to use custom reference_no/date in Payment Entry
- Fallback to POS shift name and today if fields left empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment sidebar now includes a new Transaction ID section where users can enter cheque/reference numbers and corresponding dates. This reference information is automatically captured during payment processing and included with all payment submissions, enabling better transaction tracking and record-keeping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->