### PR TITLE
feat: add transaction ID reference fields and supplier price list sup…

### DIFF
--- a/frontend/src/posapp/components/pos/items/ItemCard.vue
+++ b/frontend/src/posapp/components/pos/items/ItemCard.vue
@@ -100,7 +100,14 @@ const props = defineProps({
 const emit = defineEmits(["click", "dragstart", "dragend"]);
 
 const primaryCurrency = computed(() => {
-	if (props.context === "purchase") return props.posProfile.currency;
+	if (props.context === "purchase") {
+		return (
+			props.item.original_currency ||
+			props.item.currency ||
+			props.item.price_list_currency ||
+			props.posProfile.currency
+		);
+	}
 	return (
 		props.item.original_currency ||
 		props.item.currency ||
@@ -111,7 +118,7 @@ const primaryCurrency = computed(() => {
 
 const primaryRate = computed(() => {
 	if (props.context === "purchase") {
-		return props.item.rate || props.item.standard_rate || 0;
+		return props.item.original_rate ?? props.item.rate ?? props.item.standard_rate ?? 0;
 	}
 	return props.item.original_rate ?? props.item.rate ?? 0;
 });

--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -91,37 +91,37 @@
 								:context="context"
 								:selected-currency="selected_currency"
 								:hide-qty-decimals="hide_qty_decimals"
-								:get-last-invoice-rate="getLastInvoiceRate"
-								:is-item-highlighted="isItemHighlighted"
-								:currency-symbol="currencySymbol"
-								:format-currency="memoizedFormatCurrency"
-								:format-number="memoizedFormatNumber"
-								:rate-precision="ratePrecision"
-								:is-negative="isNegative"
-								:no-items-title="__('No items found')"
-								:no-items-subtitle="__('Try adjusting your search or filters')"
-								:clear-search-label="__('Clear Search')"
-								@select-item="select_item"
-								@dragstart="onDragStart"
-								@dragend="onDragEnd"
-								@virtual-range-update="onVirtualRangeUpdate"
-								@clear-search="clearSearch"
-							/>
-							<ItemsSelectorTable
-								v-else
-								ref="itemsTable"
-								:headers="headers"
-								:displayed-items="displayedItems"
-								:header-props="headerProps"
-								:context="context"
-								:pos-profile="pos_profile"
-								:selected-currency="selected_currency"
-								:hide-qty-decimals="hide_qty_decimals"
-								:currency-symbol="currencySymbol"
-								:format-currency="memoizedFormatCurrency"
-								:format-number="memoizedFormatNumber"
-								:rate-precision="ratePrecision"
-								:get-last-invoice-rate="getLastInvoiceRate"
+						:get-last-invoice-rate="getLastRateForContext"
+						:is-item-highlighted="isItemHighlighted"
+						:currency-symbol="currencySymbol"
+						:format-currency="memoizedFormatCurrency"
+						:format-number="memoizedFormatNumber"
+						:rate-precision="ratePrecision"
+						:is-negative="isNegative"
+						:no-items-title="__('No items found')"
+						:no-items-subtitle="__('Try adjusting your search or filters')"
+						:clear-search-label="__('Clear Search')"
+						@select-item="select_item"
+						@dragstart="onDragStart"
+						@dragend="onDragEnd"
+						@virtual-range-update="onVirtualRangeUpdate"
+						@clear-search="clearSearch"
+					/>
+					<ItemsSelectorTable
+						v-else
+						ref="itemsTable"
+						:headers="headers"
+						:displayed-items="displayedItems"
+						:header-props="headerProps"
+						:context="context"
+						:pos-profile="pos_profile"
+						:selected-currency="selected_currency"
+						:hide-qty-decimals="hide_qty_decimals"
+						:currency-symbol="currencySymbol"
+						:format-currency="memoizedFormatCurrency"
+						:format-number="memoizedFormatNumber"
+						:rate-precision="ratePrecision"
+						:get-last-invoice-rate="getLastRateForContext"
 								:is-negative="isNegative"
 								:item-class="getItemRowClass"
 								:row-props="getItemRowProps"
@@ -210,6 +210,7 @@ import { useItemAddition } from "../../../composables/pos/items/useItemAddition"
 import { useItemSelection } from "../../../composables/pos/items/useItemSelection";
 import { useItemSelectorLayout } from "../../../composables/pos/items/useItemSelectorLayout";
 import { useLastInvoiceRate } from "../../../composables/pos/items/useLastInvoiceRate";
+import { useLastBuyingRate } from "../../../composables/pos/items/useLastBuyingRate";
 import { useItemSync } from "../../../composables/pos/items/useItemSync";
 import { useItemStorageSafety } from "../../../composables/pos/items/useItemStorageSafety";
 import { useItemsSelectorSearch } from "../../../composables/pos/items/useItemsSelectorSearch";
@@ -521,6 +522,22 @@ const { getLastInvoiceRate, scheduleLastInvoiceRateRefresh, clearLastInvoiceRate
 	show_last_invoice_rate: () => show_last_invoice_rate.value,
 	autoRefresh: true,
 });
+
+const selectedSupplier = ref<string | null>(null);
+
+const { getLastBuyingRate, scheduleLastBuyingRateRefresh, clearLastBuyingRateCache } = useLastBuyingRate({
+	pos_profile: () => pos_profile.value,
+	supplier: () => selectedSupplier.value,
+	displayedItems: () => displayedItems.value,
+	show_last_buying_rate: () => true,
+});
+
+const getLastRateForContext = (item: any) => {
+	if (props.context === "purchase") {
+		return getLastBuyingRate(item);
+	}
+	return getLastInvoiceRate(item);
+};
 
 const {
 	isOverflowing,
@@ -894,6 +911,19 @@ onMounted(async () => {
 		eventBus.on("update_customer_price_list", (priceList) => {
 			syncSelectorPriceList(priceList);
 		});
+		eventBus.on("update_buying_price_list", (data) => {
+			if (data && typeof data === "object") {
+				if (data.price_list) syncSelectorPriceList(data.price_list);
+				selectedSupplier.value = data.supplier || null;
+				scheduleLastBuyingRateRefresh();
+			} else if (typeof data === "string") {
+				syncSelectorPriceList(data);
+				selectedSupplier.value = null;
+				scheduleLastBuyingRateRefresh();
+			} else {
+				selectedSupplier.value = null;
+			}
+		});
 		eventBus.on("focus_item_search", requestItemSearchFocus);
 		eventBus.on("remote_stock_adjustment", handleRemoteStockAdjustment);
 	}
@@ -968,6 +998,7 @@ onBeforeUnmount(() => {
 	if (eventBus) {
 		eventBus.off("update_currency");
 		eventBus.off("update_customer_price_list");
+		eventBus.off("update_buying_price_list");
 		eventBus.off("focus_item_search", requestItemSearchFocus);
 		eventBus.off("remote_stock_adjustment", handleRemoteStockAdjustment);
 	}
@@ -1297,6 +1328,7 @@ defineExpose({
 	virtualScrollBuffer,
 	selected_currency,
 	getLastInvoiceRate,
+	getLastRateForContext,
 	isItemHighlighted,
 	isNegative,
 	headerProps,

--- a/frontend/src/posapp/components/pos/items/ItemsSelectorTable.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelectorTable.vue
@@ -74,16 +74,48 @@
 						{{ formatCurrency(item.rate, selectedCurrency, ratePrecision(item.rate)) }}
 					</div>
 				</div>
-				<div v-else class="text-primary">
-					{{ currencySymbol(posProfile.currency) }}
+			<div v-else>
+				<div class="text-primary">
+					{{
+						currencySymbol(
+							item.original_currency ||
+								item.currency ||
+								item.price_list_currency ||
+								posProfile.currency,
+						)
+					}}
 					{{
 						formatCurrency(
-							item.rate || item.standard_rate || 0,
-							posProfile.currency,
-							ratePrecision(item.rate || item.standard_rate || 0),
+							item.original_rate ?? item.rate ?? item.standard_rate ?? 0,
+							item.original_currency ||
+								item.currency ||
+								item.price_list_currency ||
+								posProfile.currency,
+							ratePrecision(item.original_rate ?? item.rate ?? item.standard_rate ?? 0),
 						)
 					}}
 				</div>
+				<div
+					v-if="getLastInvoiceRate(item)"
+					class="text-caption d-flex align-center last-rate-inline"
+				>
+					<v-icon size="14" class="mr-1" color="secondary">mdi-history</v-icon>
+					<span class="mr-1">{{ __("Last") }}:</span>
+					<span class="font-weight-medium">
+						{{ currencySymbol(getLastInvoiceRate(item).currency || posProfile.currency) }}
+						{{
+							formatCurrency(
+								getLastInvoiceRate(item).rate,
+								getLastInvoiceRate(item).currency || posProfile.currency,
+								ratePrecision(getLastInvoiceRate(item).rate || 0),
+							)
+						}}
+						<span v-if="getLastInvoiceRate(item).uom" class="last-rate-uom">
+							/{{ getLastInvoiceRate(item).uom }}
+						</span>
+					</span>
+				</div>
+			</div>
 			</template>
 			<template v-slot:item.actual_qty="{ item }">
 				<span class="golden--text" :class="{ 'negative-number': isNegative(item.actual_qty) }">

--- a/frontend/src/posapp/components/pos/purchase/PurchaseOrders.vue
+++ b/frontend/src/posapp/components/pos/purchase/PurchaseOrders.vue
@@ -47,7 +47,7 @@
 						<PurchaseItemsTable
 							:headers="itemHeaders"
 							:items="purchaseItems"
-							:currencySymbol="currencySymbol(supplierCurrency)"
+							:currencySymbol="currencySymbol(priceListCurrency || supplierCurrency)"
 							:totalAmount="totalAmount"
 							:receiveNow="receiveNow"
 							:formatCurrency="formatCurrency"
@@ -112,7 +112,7 @@ import PurchasePaymentDialog from "./PurchasePaymentDialog.vue";
 import SupplierDialog from "../dialogs/purchase/SupplierDialog.vue";
 import PurchaseHeader from "./PurchaseHeader.vue";
 import PurchaseItemsTable from "./PurchaseItemsTable.vue";
-import { ref, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, watch, onMounted, onBeforeUnmount, inject } from "vue";
 
 export default {
 	mixins: [format],
@@ -127,6 +127,7 @@ export default {
 		const uiStore = useUIStore();
 		const toastStore = useToastStore();
 		const itemsStore = useItemsStore();
+		const eventBus = inject("eventBus");
 
 		const pos_profile = ref({});
 		const receiveNow = ref(false);
@@ -139,10 +140,13 @@ export default {
 			scheduleDate,
 			createInvoice,
 			supplierCurrency,
+			supplierPriceList,
+			priceListCurrency,
 			totalAmount,
 			submitLoading,
 			errorMessage,
 			onAddItem,
+			fetchSupplierInfo,
 			updateItemUom,
 			updateItemQty,
 			updateItemRate,
@@ -362,12 +366,19 @@ export default {
 				},
 				{ immediate: true },
 			);
-			watch(supplier, (val) => {
+			watch(supplier, async (val) => {
 				if (val) {
-					const s = supplierOptions.value.find((o) => o.name === val);
-					supplierCurrency.value = s?.default_currency || pos_profile.value.currency;
+					const info = await fetchSupplierInfo(val);
+					if (info?.buying_price_list) {
+						await itemsStore.updatePriceList(info.buying_price_list);
+					}
+					eventBus?.emit?.("update_buying_price_list", {
+						price_list: info?.buying_price_list || null,
+						supplier: val,
+					});
 				} else {
 					supplierCurrency.value = pos_profile.value.currency;
+					eventBus?.emit?.("update_buying_price_list", null);
 				}
 			});
 
@@ -385,6 +396,7 @@ export default {
 		});
 
 		onBeforeUnmount(() => {
+			eventBus?.emit?.("update_buying_price_list", null);
 			if (pos_profile.value?.selling_price_list)
 				itemsStore.updatePriceList(pos_profile.value.selling_price_list);
 		});
@@ -399,10 +411,13 @@ export default {
 			scheduleDate,
 			createInvoice,
 			supplierCurrency,
+			supplierPriceList,
+			priceListCurrency,
 			totalAmount,
 			submitLoading,
 			errorMessage,
 			onAddItem,
+			fetchSupplierInfo,
 			updateItemUom,
 			updateItemQty,
 			updateItemRate,

--- a/frontend/src/posapp/components/pos/shell/PayView.vue
+++ b/frontend/src/posapp/components/pos/shell/PayView.vue
@@ -165,6 +165,8 @@
 					<PayTotalsSidebar
 						v-model:exchange-rate="exchangeRate"
 						v-model:auto-allocate-payment-amount="autoAllocatePaymentAmount"
+						v-model:reference-no="referenceNo"
+						v-model:reference-date="referenceDate"
 						:pos-profile="pos_profile"
 						:total-selected-invoices="total_selected_invoices"
 						:selected-invoices-count="selected_invoices.length"
@@ -309,6 +311,8 @@ export default {
 		const autoAllocatePaymentAmount = ref(true);
 		const exchangeRate = ref(null);
 		const companyCurrency = ref(null);
+		const referenceNo = ref("");
+		const referenceDate = ref("");
 		const exchangeRateLoading = ref(false);
 		const exchangeRateError = ref(null);
 		const payment_method_currencies = ref({});
@@ -613,6 +617,8 @@ export default {
 			postingDate,
 			exchangeRate,
 			invoiceTotalCurrency,
+			referenceNo,
+			referenceDate,
 			payment_methods,
 			selected_invoices,
 			selected_payments,
@@ -876,6 +882,8 @@ export default {
 		async function syncCustomerPaymentContext(normalized, { forceReload = false } = {}) {
 			if (!normalized) {
 				customer_name.value = "";
+				referenceNo.value = "";
+				referenceDate.value = "";
 				clearSelections();
 				outstanding_invoices.value = [];
 				unallocated_payments.value = [];
@@ -1086,6 +1094,8 @@ export default {
 			autoAllocatePaymentAmount,
 			exchangeRate,
 			companyCurrency,
+			referenceNo,
+			referenceDate,
 			exchangeRateLoading,
 			exchangeRateError,
 			payment_method_currencies,

--- a/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
+++ b/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
@@ -135,24 +135,30 @@
         </v-row>
 
         <v-divider></v-divider>
+        <h4 class="text-primary">{{ __("Transaction ID") }}</h4>
         <v-row>
-            <v-col md="7">
-                <h4 class="text-primary mt-1">{{ __("Difference:") }}</h4>
-            </v-col>
-            <v-col md="5">
+            <v-col md="6" cols="12">
                 <v-text-field
-                    class="p-0 m-0 pos-themed-input"
                     density="compact"
-                    color="primary"
+                    variant="outlined"
                     hide-details
-                    :model-value="formatCurrency(totalOfDiff)"
-                    readonly
-                    flat
-                    :prefix="currencySymbol(invoiceTotalCurrency)"
+                    class="pos-themed-input"
+                    v-model="internalReferenceNo"
+                    :label="__('Cheque/Reference No')"
+                ></v-text-field>
+            </v-col>
+            <v-col md="6" cols="12">
+                <v-text-field
+                    density="compact"
+                    variant="outlined"
+                    hide-details
+                    type="date"
+                    class="pos-themed-input"
+                    v-model="internalReferenceDate"
+                    :label="__('Cheque/Reference Date')"
                 ></v-text-field>
             </v-col>
         </v-row>
-
         <v-row class="mt-2">
             <v-col cols="12">
                 <v-switch
@@ -204,12 +210,16 @@ const props = defineProps({
     },
     currencySymbol: Function,
     formatCurrency: Function,
-    getPaymentMethodCurrency: Function
+    getPaymentMethodCurrency: Function,
+    referenceNo: String,
+    referenceDate: String,
 });
 
 const emit = defineEmits([
     'update:exchangeRate',
     'update:autoAllocatePaymentAmount',
+    'update:referenceNo',
+    'update:referenceDate',
     'validate-exchange-rate',
     'fetch-exchange-rate'
 ]);
@@ -222,4 +232,14 @@ const internalExchangeRate = computed({
 const internalAutoAllocatePaymentAmount = computed(
     () => props.autoAllocatePaymentAmount ?? true,
 );
+
+const internalReferenceNo = computed({
+    get: () => props.referenceNo,
+    set: (val) => emit('update:referenceNo', val),
+});
+
+const internalReferenceDate = computed({
+    get: () => props.referenceDate,
+    set: (val) => emit('update:referenceDate', val),
+});
 </script>

--- a/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
+++ b/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
@@ -135,6 +135,25 @@
         </v-row>
 
         <v-divider></v-divider>
+        <v-row>
+            <v-col md="7">
+                <h4 class="text-primary mt-1">{{ __("Difference:") }}</h4>
+            </v-col>
+            <v-col md="5">
+                <v-text-field
+                    class="p-0 m-0 pos-themed-input"
+                    density="compact"
+                    color="primary"
+                    hide-details
+                    :model-value="formatCurrency(totalOfDiff)"
+                    readonly
+                    flat
+                    :prefix="currencySymbol(invoiceTotalCurrency)"
+                ></v-text-field>
+            </v-col>
+        </v-row>
+
+        <v-divider></v-divider>
         <h4 class="text-primary">{{ __("Transaction ID") }}</h4>
         <v-row>
             <v-col md="6" cols="12">

--- a/frontend/src/posapp/composables/pos/items/useLastBuyingRate.ts
+++ b/frontend/src/posapp/composables/pos/items/useLastBuyingRate.ts
@@ -1,0 +1,120 @@
+import { ref, watch, onUnmounted } from "vue";
+import { debounce } from "lodash";
+
+type LastBuyingRate = {
+	rate?: number;
+	currency?: string;
+	uom?: string;
+	source?: string;
+};
+
+type LastBuyingRatesMap = Record<string, LastBuyingRate>;
+
+type MaybeRefLike<T> = T | { value: T } | (() => T);
+
+declare const frappe: any;
+
+const unwrapValue = <T>(source: MaybeRefLike<T> | undefined): T | undefined => {
+	if (typeof source === "function") {
+		return (source as () => T)();
+	}
+	if (source && typeof source === "object" && "value" in source) {
+		return (source as { value: T }).value;
+	}
+	return source as T | undefined;
+};
+
+interface UseLastBuyingRateContext {
+	pos_profile?: MaybeRefLike<{ company?: string } | null>;
+	supplier?: MaybeRefLike<any>;
+	displayedItems?: MaybeRefLike<Array<{ item_code?: string }>>;
+	show_last_buying_rate?: MaybeRefLike<boolean>;
+}
+
+export function useLastBuyingRate(context: UseLastBuyingRateContext = {}) {
+	const { pos_profile, supplier, displayedItems, show_last_buying_rate } = context;
+
+	const lastBuyingRates = ref<LastBuyingRatesMap>({});
+	const lastBuyingRateCache = new Map<string, LastBuyingRatesMap>();
+	const lastBuyingRateLoading = ref(false);
+
+	const scheduler = debounce(() => {
+		fetchLastBuyingRates();
+	}, 500);
+
+	const getLastBuyingRate = (item: any): LastBuyingRate | null => {
+		if (!item?.item_code) return null;
+		return lastBuyingRates.value[item.item_code] || null;
+	};
+
+	const fetchLastBuyingRates = async () => {
+		const supplierVal = unwrapValue(supplier);
+		if (!supplierVal) {
+			lastBuyingRates.value = {};
+			return;
+		}
+
+		const itemsVal = unwrapValue(displayedItems);
+		if (!itemsVal || itemsVal.length === 0) {
+			lastBuyingRates.value = {};
+			return;
+		}
+
+		const itemCodes = itemsVal
+			.map((i: any) => i.item_code)
+			.filter(Boolean);
+
+		if (itemCodes.length === 0) return;
+
+		const cacheKey = `${supplierVal}`;
+		const cached = lastBuyingRateCache.get(cacheKey);
+		if (cached) {
+			const missingCodes = itemCodes.filter(
+				(code: string) => !(code in cached),
+			);
+			if (missingCodes.length === 0) {
+				lastBuyingRates.value = cached;
+				return;
+			}
+		}
+
+		lastBuyingRateLoading.value = true;
+		try {
+			const profile = unwrapValue(pos_profile);
+			const { message } = await frappe.call({
+				method: "posawesome.posawesome.api.purchase_orders.get_last_buying_rate",
+				args: {
+					supplier: supplierVal,
+					item_codes: JSON.stringify(itemCodes),
+					company: profile?.company || null,
+				},
+			});
+
+			const merged = { ...(cached || {}), ...(message || {}) };
+			lastBuyingRateCache.set(cacheKey, merged);
+			lastBuyingRates.value = merged;
+		} catch (e) {
+			console.error("Failed to fetch last buying rates", e);
+		} finally {
+			lastBuyingRateLoading.value = false;
+		}
+	};
+
+	const scheduleLastBuyingRateRefresh = () => {
+		scheduler();
+	};
+
+	const clearLastBuyingRateCache = () => {
+		lastBuyingRateCache.clear();
+		lastBuyingRates.value = {};
+	};
+
+	return {
+		lastBuyingRates,
+		lastBuyingRateLoading,
+		getLastBuyingRate,
+		fetchLastBuyingRates,
+		scheduleLastBuyingRateRefresh,
+		clearLastBuyingRateCache,
+	};
+}

--- a/frontend/src/posapp/composables/pos/payments/usePosPaySubmission.ts
+++ b/frontend/src/posapp/composables/pos/payments/usePosPaySubmission.ts
@@ -16,6 +16,8 @@ type PosPaySubmissionArgs = {
 	postingDate?: Ref<string | null>;
 	exchangeRate: Ref<number>;
 	invoiceTotalCurrency: Ref<string>;
+	referenceNo: Ref<string>;
+	referenceDate: Ref<string>;
 	autoAllocatePaymentAmount: Ref<boolean>;
 	payment_methods: Ref<any[]>;
 	selected_invoices: Ref<any[]>;
@@ -49,6 +51,8 @@ export function usePosPaySubmission({
 	postingDate,
 	exchangeRate,
 	invoiceTotalCurrency,
+	referenceNo,
+	referenceDate,
 	autoAllocatePaymentAmount,
 	payment_methods,
 	selected_invoices,
@@ -82,6 +86,8 @@ export function usePosPaySubmission({
 		const finalizeSubmission = () => {
 			clearSelections();
 			resetPaymentMethodAmounts();
+			referenceNo.value = "";
+			referenceDate.value = "";
 			customerName.value = party;
 			get_outstanding_invoices();
 			get_unallocated_payments();
@@ -127,19 +133,21 @@ export function usePosPaySubmission({
 					0,
 				);
 
-			const payload = {
-				customer: party,
-				party,
-				party_type: resolvedPartyType,
-				payment_type: resolvedPaymentType,
-				company: company.value,
-				currency: invoiceTotalCurrency.value,
-				posting_date: postingDate?.value || null,
-				exchange_rate: exchangeRate.value || null,
-				pos_opening_shift_name: posOpeningShift.value.name,
-				pos_profile_name: posProfile.value.name,
-				pos_profile: posProfile.value,
-				payment_methods: payment_methods.value.filter(
+		const payload = {
+			customer: party,
+			party,
+			party_type: resolvedPartyType,
+			payment_type: resolvedPaymentType,
+			company: company.value,
+			currency: invoiceTotalCurrency.value,
+			posting_date: postingDate?.value || null,
+			exchange_rate: exchangeRate.value || null,
+			reference_no: referenceNo?.value?.trim() || null,
+			reference_date: referenceDate?.value?.trim() || null,
+			pos_opening_shift_name: posOpeningShift.value.name,
+			pos_profile_name: posProfile.value.name,
+			pos_profile: posProfile.value,
+			payment_methods: payment_methods.value.filter(
 					(m: any) => flt(m.amount) > 0,
 				),
 				selected_invoices: selectedInvoicesForPayload,

--- a/frontend/src/posapp/composables/pos/payments/usePurchaseOrder.ts
+++ b/frontend/src/posapp/composables/pos/payments/usePurchaseOrder.ts
@@ -42,6 +42,8 @@ export function usePurchaseOrder(options: {
 	const scheduleDate = ref<string | null>(null);
 	const createInvoice = ref(false);
 	const supplierCurrency = ref<string | null>(null);
+	const supplierPriceList = ref<string | null>(null);
+	const priceListCurrency = ref<string | null>(null);
 	const submitLoading = ref(false);
 	const errorMessage = ref("");
 
@@ -54,6 +56,30 @@ export function usePurchaseOrder(options: {
 
 	const generateLineId = () => {
 		return `po_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+	};
+
+	const fetchSupplierInfo = async (supplierName: string) => {
+		if (!supplierName) {
+			supplierPriceList.value = null;
+			priceListCurrency.value = null;
+			return null;
+		}
+		try {
+			const { message } = await frappe.call({
+				method: "posawesome.posawesome.api.purchase_orders.get_supplier_info",
+				args: { supplier: supplierName },
+			});
+			if (message) {
+				supplierPriceList.value = message.buying_price_list || null;
+				priceListCurrency.value = message.price_list_currency || null;
+				supplierCurrency.value =
+					message.default_currency || posProfile.value?.currency || null;
+			}
+			return message;
+		} catch (e) {
+			console.error("Failed to fetch supplier info", e);
+			return null;
+		}
 	};
 
 	const onAddItem = async (item: any) => {
@@ -91,6 +117,26 @@ export function usePurchaseOrder(options: {
 				const uomData = item.item_uoms.find((u: any) => u.uom === uom);
 				if (uomData) {
 					conversion_factor = uomData.conversion_factor;
+				}
+			}
+
+			// Try fetching price from the active buying price list
+			const activePriceList = supplierPriceList.value || itemsStore.activePriceList;
+			if (activePriceList) {
+				try {
+					const { message } = await frappe.call({
+						method: "posawesome.posawesome.api.items.get_price_for_uom",
+						args: {
+							item_code: item.item_code,
+							price_list: activePriceList,
+							uom: uom,
+						},
+					});
+					if (message !== undefined && message !== null && message > 0) {
+						rate = message;
+					}
+				} catch (e) {
+					console.warn("Failed to fetch buying price for item", e);
 				}
 			}
 
@@ -132,7 +178,7 @@ export function usePurchaseOrder(options: {
 
 		let priceFound = false;
 		try {
-			const priceList = itemsStore.activePriceList;
+			const priceList = supplierPriceList.value || itemsStore.activePriceList;
 			if (priceList) {
 				const { message } = await frappe.call({
 					method: "posawesome.posawesome.api.items.get_price_for_uom",
@@ -185,6 +231,8 @@ export function usePurchaseOrder(options: {
 
 	const resetForm = () => {
 		supplier.value = null;
+		supplierPriceList.value = null;
+		priceListCurrency.value = null;
 		purchaseItems.value = [];
 		errorMessage.value = "";
 		submitLoading.value = false;
@@ -207,10 +255,13 @@ export function usePurchaseOrder(options: {
 		scheduleDate,
 		createInvoice,
 		supplierCurrency,
+		supplierPriceList,
+		priceListCurrency,
 		totalAmount,
 		submitLoading,
 		errorMessage,
 		onAddItem,
+		fetchSupplierInfo,
 		updateItemUom,
 		updateItemQty,
 		updateItemRate,

--- a/posawesome/posawesome/api/payment_processing/processor.py
+++ b/posawesome/posawesome/api/payment_processing/processor.py
@@ -306,8 +306,8 @@ def process_pos_payment(payload):
                     payment_type=payment_type,
                     exchange_rate=data.get("exchange_rate"),
                     posting_date=posting_date,
-                    reference_no=pos_opening_shift_name,
-                    reference_date=posting_date,
+                    reference_no=data.get("reference_no") or pos_opening_shift_name,
+                    reference_date=data.get("reference_date") or posting_date,
                     cost_center=data.pos_profile.get("cost_center"),
                     submit=0,
                 )

--- a/posawesome/posawesome/api/purchase_orders.py
+++ b/posawesome/posawesome/api/purchase_orders.py
@@ -83,13 +83,30 @@ def _resolve_buying_price_list():
     buying_price_list = frappe.db.get_single_value("Buying Settings", "buying_price_list")
     if not buying_price_list:
         buying_price_list = frappe.db.get_value("Price List", {"buying": 1}, "name")
-    
+
     if not buying_price_list:
         # Fallback to standard default if exists
         if frappe.db.exists("Price List", "Standard Buying"):
             buying_price_list = "Standard Buying"
-            
+
     return buying_price_list
+
+
+def _resolve_supplier_buying_price_list(supplier):
+    """Resolve buying price list for a specific supplier.
+    Checks Supplier-level default_price_list first, then falls back
+    to the generic buying price list from Buying Settings.
+    """
+    if not supplier:
+        return _resolve_buying_price_list()
+
+    supplier_price_list = frappe.db.get_value("Supplier", supplier, "default_price_list")
+    if supplier_price_list:
+        is_buying = frappe.db.get_value("Price List", supplier_price_list, "buying")
+        if is_buying:
+            return supplier_price_list
+
+    return _resolve_buying_price_list()
 
 
 def _upsert_item_price(item_code, price_list, rate, uom=None, buying=False, selling=False):
@@ -259,6 +276,101 @@ def search_suppliers(search_text=None, limit=20):
 @frappe.whitelist()
 def get_buying_price_list():
     return _resolve_buying_price_list()
+
+
+@frappe.whitelist()
+def get_supplier_info(supplier):
+    """Get supplier details including the effective buying price list."""
+    supplier = _resolve_supplier(supplier)
+    if not supplier:
+        frappe.throw(_("Supplier not found."))
+
+    supplier_doc = frappe.get_doc("Supplier", supplier)
+    buying_price_list = _resolve_supplier_buying_price_list(supplier)
+
+    price_list_currency = None
+    if buying_price_list:
+        price_list_currency = frappe.db.get_value("Price List", buying_price_list, "currency")
+
+    return {
+        "supplier": supplier,
+        "supplier_name": supplier_doc.supplier_name,
+        "supplier_group": supplier_doc.supplier_group,
+        "default_currency": supplier_doc.default_currency,
+        "buying_price_list": buying_price_list,
+        "price_list_currency": price_list_currency,
+    }
+
+
+@frappe.whitelist()
+def get_last_buying_rate(supplier, item_codes):
+    """Get the last buying rate for items from the price list and recent Purchase Invoices."""
+    if isinstance(item_codes, str):
+        try:
+            item_codes = json.loads(item_codes)
+        except Exception:
+            item_codes = [item_codes]
+
+    if not item_codes or not supplier:
+        return {}
+
+    result = {}
+    buying_price_list = _resolve_supplier_buying_price_list(supplier)
+
+    # Get rates from the buying price list
+    price_list_rates = frappe.get_all(
+        "Item Price",
+        filters={
+            "price_list": buying_price_list,
+            "item_code": ["in", item_codes],
+            "buying": 1,
+        },
+        fields=["item_code", "price_list_rate", "uom", "currency"],
+    )
+
+    for row in price_list_rates:
+        code = row.get("item_code")
+        if code and code not in result:
+            price_list_currency = row.get("currency")
+            if not price_list_currency and buying_price_list:
+                price_list_currency = frappe.db.get_value(
+                    "Price List", buying_price_list, "currency"
+                )
+            result[code] = {
+                "rate": row.get("price_list_rate", 0),
+                "currency": price_list_currency,
+                "uom": row.get("uom"),
+                "source": "price_list",
+            }
+
+    # Get last buying rate from recent Purchase Invoices for this supplier
+    if supplier:
+        last_pi_items = frappe.db.sql(
+            """
+            SELECT pii.item_code, pii.rate, pii.uom, pi.currency
+            FROM `tabPurchase Invoice Item` pii
+            JOIN `tabPurchase Invoice` pi ON pi.name = pii.parent
+            WHERE pi.supplier = %s
+              AND pi.docstatus = 1
+              AND pii.item_code IN %s
+            ORDER BY pi.posting_date DESC, pi.creation DESC
+            LIMIT 50
+            """,
+            (supplier, tuple(item_codes)),
+            as_dict=True,
+        )
+
+        for row in last_pi_items:
+            code = row.get("item_code")
+            if code and code not in result:
+                result[code] = {
+                    "rate": row.get("rate", 0),
+                    "currency": row.get("currency"),
+                    "uom": row.get("uom"),
+                    "source": "last_invoice",
+                }
+
+    return result
 
 
 @frappe.whitelist()
@@ -462,8 +574,8 @@ def create_purchase_order(data):
         # Fallback to company currency if supplier has no default
         supplier_currency = frappe.get_value("Company", company, "default_currency")
 
-    # Validate price list currency matches (RECOMMENDED)
-    buying_price_list = _resolve_buying_price_list()
+    # Resolve buying price list: prefer supplier-specific, then payload override, then default
+    buying_price_list = payload.get("buying_price_list") or _resolve_supplier_buying_price_list(supplier)
     price_list_currency = frappe.get_value("Price List", buying_price_list, "currency")
 
     # If currencies don't match, try to find a matching one


### PR DESCRIPTION
…port

PR #2958 - Transaction ID Reference Fields:
- Add reference_no and reference_date fields to PayView.vue
- Add Transaction ID UI section in PayTotalsSidebar.vue with Cheque/Reference No and Date inputs
- Extend usePosPaySubmission composable to accept and pass reference fields
- Clear reference fields on customer change and after successful payment submission
- Update payment_processing/processor.py to use reference_no and reference_date from payload

PR #2959 - Supplier Price List Support:
- Create useLastBuyingRate composable for fetching/caching supplier-specific buying rates
- Update ItemCard.vue to use proper currency/rate fallbacks for purchase context
- Update ItemsSelector.vue with useLastBuyingRate integration and update_buying_price_list event handling
- Update ItemsSelectorTable.vue to display purchase rates with supplier currency support
- Add fetchSupplierInfo function to usePurchaseOrder.ts for supplier price list resolution
- Update PurchaseOrders.vue to emit buying price list events on supplier selection
- Add get_supplier_info and get_last_buying_rate API endpoints in purchase_orders.py
- Add _resolve_supplier_buying_price_list to check supplier's default_price_list first

Technical Details:
- Reference fields are passed through the entire payment flow and saved to Payment Entry documents
- Supplier price list resolution checks Supplier.default_price_list before falling back to Buying Settings
- Last buying rates are fetched from both Item Price records and recent Purchase Invoices
- Event bus pattern used to sync buying price list changes between PurchaseOrders and ItemsSelector