### PR TITLE
fix: add flt fallback in setBatchQty to prevent 'flt is not a functio…

### DIFF
--- a/frontend/src/posapp/composables/pos/shared/useBatchSerial.ts
+++ b/frontend/src/posapp/composables/pos/shared/useBatchSerial.ts
@@ -91,7 +91,9 @@ export function useBatchSerial() {
 
 		if (
 			sanitizedSelection.length !== currentSelection.length ||
-			sanitizedSelection.some((serial, index) => serial !== currentSelection[index])
+			sanitizedSelection.some(
+				(serial, index) => serial !== currentSelection[index],
+			)
 		) {
 			item.serial_no_selected = sanitizedSelection;
 		}
@@ -217,6 +219,7 @@ export function useBatchSerial() {
 		update = true,
 		context: any,
 	) => {
+		const flt = context.flt || ((v: unknown) => Number(v));
 		const normalized_batch_data: any[] = getBatchAvailability(
 			item,
 			context,
@@ -269,7 +272,7 @@ export function useBatchSerial() {
 				const baseCurrency =
 					context.price_list_currency || context.pos_profile.currency;
 				if (context.selected_currency !== baseCurrency) {
-					item.batch_price = context.flt(
+					item.batch_price = flt(
 						batch_to_use.batch_price / context.exchange_rate,
 						context.currency_precision,
 					);
@@ -295,11 +298,11 @@ export function useBatchSerial() {
 				item.base_discount_amount = 0;
 
 				// Calculate final amounts
-				item.amount = context.flt(
+				item.amount = flt(
 					item.qty * item.rate,
 					context.currency_precision,
 				);
-				item.base_amount = context.flt(
+				item.base_amount = flt(
 					item.qty * item.base_rate,
 					context.currency_precision,
 				);


### PR DESCRIPTION
add flt fallback in setBatchQty to prevent 'flt is not a function' error

The setBatchQty function in useBatchSerial.ts was calling context.flt()
directly without checking if it exists, causing errors when the composable
is called from contexts that don't have flt available.

Fix: Added local flt variable with fallback to Number() when context.flt
is not available, following the same pattern used in useItemCurrency.ts:88:
  const flt = context.flt || ((v: unknown) => Number(v));

Other files using this pattern:
- useItemCurrency.ts:88 - same fallback pattern
- useStockUtils.ts - uses context.flt directly (expects flt from component)
- useDiscounts.ts - uses context.flt directly (expects flt from component)

The fix ensures setBatchQty works both:
1. When called from Invoice component (has mixin format with flt)
2. When called from composables without direct flt access"