### PR TITLE
fix: multi-currency payment mode selection and UI improvements

### DIFF
--- a/frontend/src/posapp/components/pos/shell/PayView.vue
+++ b/frontend/src/posapp/components/pos/shell/PayView.vue
@@ -180,10 +180,12 @@
 						:get-payment-method-currency="getPaymentMethodCurrency"
 						:party-account="partyAccount"
 						:payment-method-accounts="payment_method_accounts"
+						:available-bank-accounts="available_bank_accounts"
 						:payment-type="paymentEntryType"
 						:invoice-conversion-rate="invoiceConversionRate"
 						@validate-exchange-rate="validateExchangeRate"
 						@fetch-exchange-rate="fetchExchangeRate"
+						@update:bank-account="handleBankAccountChange"
 					/>
 
 					<PayActionButtons
@@ -315,6 +317,7 @@ export default {
 		const exchangeRateError = ref(null);
 		const payment_method_currencies = ref({});
 		const payment_method_accounts = ref({});
+		const available_bank_accounts = ref({});
 		const payment_methods_list = ref([]);
 		const partyAccount = ref(null);
 
@@ -713,6 +716,7 @@ export default {
 				mode_of_payment: m.mode_of_payment,
 				amount: 0,
 				row_id: m.name,
+				bank_account: null,
 			}));
 		};
 
@@ -731,8 +735,29 @@ export default {
 					currencies[mode] = typeof data === "string" ? data : data.account_currency;
 				}
 				payment_method_currencies.value = currencies;
+				// Fetch available accounts for all modes
+				for (const mode of modes) {
+					await fetchAvailableAccounts(mode);
+				}
 			} catch (e) {
 				console.error("Failed to load payment method accounts", e);
+			}
+		};
+
+		const fetchAvailableAccounts = async (mode) => {
+			if (!company.value || !mode) return;
+			try {
+				const r = await frappe.call({
+					method: "posawesome.posawesome.api.payment_processing.utils.get_available_accounts_for_mop",
+					args: { company: company.value, mode_of_payment: mode },
+				});
+				const accounts = r.message || [];
+				available_bank_accounts.value = {
+					...available_bank_accounts.value,
+					[mode]: accounts,
+				};
+			} catch (e) {
+				console.error("Failed to fetch available accounts for", mode, e);
 			}
 		};
 
@@ -754,6 +779,33 @@ export default {
 			} catch (e) {
 				console.error("Failed to fetch party account", e);
 				partyAccount.value = null;
+			}
+		};
+
+		const handleBankAccountChange = (mode, bankAccount) => {
+			const method = payment_methods.value.find((m) => m.mode_of_payment === mode);
+			if (method) {
+				method.bank_account = bankAccount;
+				// Update currency map when account changes
+				if (bankAccount && available_bank_accounts.value[mode]) {
+					const acct = available_bank_accounts.value[mode].find(
+						(a) => a.account === bankAccount,
+					);
+					if (acct) {
+						payment_method_currencies.value = {
+							...payment_method_currencies.value,
+							[mode]: acct.account_currency,
+						};
+						payment_method_accounts.value = {
+							...payment_method_accounts.value,
+							[mode]: {
+								account: acct.account,
+								account_currency: acct.account_currency,
+								account_type: acct.account_type,
+							},
+						};
+					}
+				}
 			}
 		};
 
@@ -1185,6 +1237,9 @@ export default {
 			validateExchangeRate,
 			set_payment_methods,
 			loadPaymentMethodCurrencies,
+			fetchAvailableAccounts,
+			handleBankAccountChange,
+			available_bank_accounts,
 			check_opening_entry,
 			syncPendingPayments,
 			paymentRowClass,

--- a/frontend/src/posapp/components/pos/shell/PayView.vue
+++ b/frontend/src/posapp/components/pos/shell/PayView.vue
@@ -531,18 +531,27 @@ export default {
 			return payment_methods.value;
 		});
 
+		const rateFromCurrencyToCompany = (currency) => {
+			if (!currency || currency === companyCurrencyLocal.value) return 1;
+			if (currency === invoiceTotalCurrency.value) return flt(exchangeRate.value || 1);
+			return flt(invoiceConversionRate.value || exchangeRate.value || 1);
+		};
+
 		const new_payments_detail = computed(() => {
 			if (!filtered_payment_methods.value.length) return [];
-			const rate = flt(exchangeRate.value || 1);
 			return filtered_payment_methods.value
 				.filter((m) => flt(m.amount) > 0)
-				.map((m) => ({
-					mode_of_payment: m.mode_of_payment,
-					paid_amount: flt(m.amount),
-					currency: getPaymentMethodCurrency(m.mode_of_payment),
-					received_amount: flt(m.amount) * rate,
-					exchange_rate: rate,
-				}));
+				.map((m) => {
+					const mopCurrency = getPaymentMethodCurrency(m.mode_of_payment);
+					const rate = rateFromCurrencyToCompany(mopCurrency);
+					return {
+						mode_of_payment: m.mode_of_payment,
+						paid_amount: flt(m.amount),
+						currency: mopCurrency,
+						received_amount: flt(m.amount),
+						exchange_rate: rate,
+					};
+				});
 		});
 
 		const invoiceConversionRate = computed(() => {

--- a/frontend/src/posapp/components/pos/shell/PayView.vue
+++ b/frontend/src/posapp/components/pos/shell/PayView.vue
@@ -165,6 +165,8 @@
 						:total-selected-mpesa="total_selected_mpesa_payments"
 						:payment-methods="payment_methods"
 						:filtered-payment-methods="filtered_payment_methods"
+						:selected-payments-detail="selected_payments_detail"
+						:new-payments-detail="new_payments_detail"
 						:invoice-total-currency="invoiceTotalCurrency"
 						:payment-total-currency="paymentTotalCurrency"
 						:mpesa-total-currency="mpesaTotalCurrency"
@@ -176,6 +178,10 @@
 						:currency-symbol="currencySymbol"
 						:format-currency="formatCurrency"
 						:get-payment-method-currency="getPaymentMethodCurrency"
+						:party-account="partyAccount"
+						:payment-method-accounts="payment_method_accounts"
+						:payment-type="paymentEntryType"
+						:invoice-conversion-rate="invoiceConversionRate"
 						@validate-exchange-rate="validateExchangeRate"
 						@fetch-exchange-rate="fetchExchangeRate"
 					/>
@@ -308,7 +314,9 @@ export default {
 		const exchangeRateLoading = ref(false);
 		const exchangeRateError = ref(null);
 		const payment_method_currencies = ref({});
+		const payment_method_accounts = ref({});
 		const payment_methods_list = ref([]);
+		const partyAccount = ref(null);
 
 		const mpesa_payment_headers = [
 			{ title: __("Payment ID"), align: "start", sortable: true, key: "transid" },
@@ -380,6 +388,7 @@ export default {
 			total_selected_payments,
 			total_selected_mpesa_payments,
 			total_payment_methods,
+			selected_payments_detail,
 			total_of_diff,
 			toggleInvoiceSelection,
 			isInvoiceSelected,
@@ -519,15 +528,30 @@ export default {
 
 		const filtered_payment_methods = computed(() => {
 			if (!payment_methods.value.length) return [];
-			if (!selected_invoices.value.length) return payment_methods.value;
-			const target =
-				selected_invoices.value[0]?.party_account_currency ||
-				selected_invoices.value[0]?.currency ||
-				pos_profile.value.currency;
-			return payment_methods.value.filter(
-				(m) => getPaymentMethodCurrency(m.mode_of_payment) === target,
-			);
+			return payment_methods.value;
 		});
+
+		const new_payments_detail = computed(() => {
+			if (!filtered_payment_methods.value.length) return [];
+			const rate = flt(exchangeRate.value || 1);
+			return filtered_payment_methods.value
+				.filter((m) => flt(m.amount) > 0)
+				.map((m) => ({
+					mode_of_payment: m.mode_of_payment,
+					paid_amount: flt(m.amount),
+					currency: getPaymentMethodCurrency(m.mode_of_payment),
+					received_amount: flt(m.amount) * rate,
+					exchange_rate: rate,
+				}));
+		});
+
+		const invoiceConversionRate = computed(() => {
+			if (selected_invoices.value.length > 0) {
+				return selected_invoices.value[0]?.conversion_rate ?? null;
+			}
+			return null;
+		});
+
 		const postingDateDisplay = computed({
 			get: () => formatDisplayDate(postingDate.value),
 			set: (value) => {
@@ -686,17 +710,42 @@ export default {
 		const loadPaymentMethodCurrencies = async () => {
 			if (!pos_profile.value?.payments?.length || !company.value) return;
 			const modes = pos_profile.value.payments.map((p) => p.mode_of_payment).filter(Boolean);
-			payment_method_currencies.value = await loadPaymentMethodCurrencyMap({
-				company: company.value,
-				offline: isOffline(),
-				fetcher: async () => {
-					const r = await frappe.call({
-						method: "posawesome.posawesome.api.payment_processing.utils.get_mode_of_payment_accounts",
-						args: { company: company.value, mode_of_payments: modes },
-					});
-					return { ...(r.message || {}) };
-				},
-			});
+			try {
+				const r = await frappe.call({
+					method: "posawesome.posawesome.api.payment_processing.utils.get_mode_of_payment_accounts",
+					args: { company: company.value, mode_of_payments: modes },
+				});
+				const accountData = r.message || {};
+				payment_method_accounts.value = accountData;
+				const currencies = {};
+				for (const [mode, data] of Object.entries(accountData)) {
+					currencies[mode] = typeof data === "string" ? data : data.account_currency;
+				}
+				payment_method_currencies.value = currencies;
+			} catch (e) {
+				console.error("Failed to load payment method accounts", e);
+			}
+		};
+
+		const fetchPartyAccount = async () => {
+			if (!customer_name.value || !company.value) {
+				partyAccount.value = null;
+				return;
+			}
+			try {
+				const r = await frappe.call({
+					method: "posawesome.posawesome.api.payment_processing.utils.get_party_account_info",
+					args: {
+						party_type: partyType.value || "Customer",
+						party: customer_name.value,
+						company: company.value,
+					},
+				});
+				partyAccount.value = r.message || null;
+			} catch (e) {
+				console.error("Failed to fetch party account", e);
+				partyAccount.value = null;
+			}
 		};
 
 		const applyOpeningData = async (data) => {
@@ -856,6 +905,8 @@ export default {
 				}
 				customer_name.value = cust;
 			});
+			fetchPartyAccount();
+			loadPaymentMethodCurrencies();
 		}
 		async function syncCustomerPaymentContext(normalized, { forceReload = false } = {}) {
 			if (!normalized) {
@@ -888,6 +939,8 @@ export default {
 			customer_name.value = normalized;
 			if (!companyCurrency.value) await fetchCompanyCurrency();
 			fetch_customer_details();
+			fetchPartyAccount();
+			loadPaymentMethodCurrencies();
 			refreshOutstandingInvoices();
 			get_unallocated_payments();
 			get_draft_mpesa_payments_register(payment_methods_list.value);
@@ -1023,6 +1076,8 @@ export default {
 		watch(company, (newCompany, oldCompany) => {
 			if (isPaymentRouteLocked.value) return;
 			if (!newCompany || newCompany === oldCompany || !customer_name.value) return;
+			fetchPartyAccount();
+			loadPaymentMethodCurrencies();
 			refreshOutstandingInvoices();
 			get_unallocated_payments();
 			get_draft_mpesa_payments_register(payment_methods_list.value);
@@ -1097,6 +1152,7 @@ export default {
 			total_selected_mpesa_payments,
 			total_payment_methods,
 			total_of_diff,
+			invoiceConversionRate,
 			toggleInvoiceSelection,
 			isInvoiceSelected,
 			clearSelections,

--- a/frontend/src/posapp/components/pos_pay/PayInvoicesTable.vue
+++ b/frontend/src/posapp/components/pos_pay/PayInvoicesTable.vue
@@ -5,11 +5,6 @@
 			<v-col md="7" cols="12">
 				<p>
 					<strong>{{ resolvedSectionTitle }}</strong>
-					<span v-if="totalOutstanding" class="text-primary"
-						>{{ __("- Total Outstanding") }} :
-						{{ currencySymbol(posProfile.currency) }}
-						{{ formatCurrency(totalOutstanding) }}</span
-					>
 				</p>
 			</v-col>
 			<v-col md="5" cols="12">
@@ -73,16 +68,16 @@
 				></v-select>
 			</v-col>
 			<v-col md="8" cols="12">
-				<div class="text-caption text-medium-emphasis mt-2">
+				<div class="text-body-2 mt-2">
 					<span v-for="(data, key) in outstandingByCurrency" :key="key" class="mr-4">
-						<strong>
+						<span class="text-primary font-weight-bold">
 							{{ formatCurrency(data.amount) }}
 							{{ data.symbol }}
 							{{ data.party_currency }}
 							<span v-if="data.party_currency !== data.invoice_currency">
 								({{ data.invoice_currency }})
 							</span>
-						</strong>
+						</span>
 					</span>
 				</div>
 			</v-col>

--- a/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
+++ b/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
@@ -165,66 +165,145 @@
 							</template>
 						</div>
 					</div>
-					<div v-if="partyAccount && getPaymentMethodAccount(selectedMop.mode_of_payment)" class="text-caption mb-2">
-						<div class="d-flex align-center mb-1">
-							<span class="text-medium-emphasis" style="min-width: 50px">{{ __("From:") }}</span>
-							<template v-if="paymentType === 'Pay' && bankAccountOptions.length">
-								<v-select
-									:model-value="selectedMop.bank_account || ''"
-									:items="bankAccountOptions"
-									item-title="label"
-									item-value="value"
-									density="compact"
-									variant="outlined"
-									hide-details
-									class="flex-grow-1 ml-1"
-									@update:model-value="onBankAccountChange($event)"
-								>
-									<template #item="{ props, item }">
-										<v-list-item v-bind="props" density="compact">
-											<template #append>
-												<v-chip size="x-small" color="primary" variant="tonal">{{ item.raw.currency }}</v-chip>
-												<v-chip size="x-small" color="secondary" variant="tonal" class="ml-1">{{ item.raw.accountType }}</v-chip>
-											</template>
-										</v-list-item>
-									</template>
-								</v-select>
-							</template>
-							<template v-else>
-								<span class="ml-1 text-truncate">{{ partyAccount.account }}</span>
-								<v-chip size="x-small" color="primary" variant="tonal" class="ml-auto">{{ partyAccount.currency }}</v-chip>
-							</template>
+					<div v-if="partyAccount && getPaymentMethodAccount(selectedMop.mode_of_payment)" class="mb-2">
+						<div class="account-selector-row mb-2">
+							<div class="d-flex align-center">
+								<v-icon size="18" class="mr-2 text-medium-emphasis">mdi-account-arrow-right</v-icon>
+								<span class="text-body-2 text-medium-emphasis">{{ __("Party Account") }}</span>
+							</div>
+							<div class="d-flex align-center ml-auto">
+								<span class="text-truncate text-body-2 font-weight-medium">{{ partyAccount.account }}</span>
+								<v-chip size="x-small" color="primary" variant="tonal" class="ml-2">{{ partyAccount.currency }}</v-chip>
+							</div>
 						</div>
-						<div class="d-flex align-center">
-							<span class="text-medium-emphasis" style="min-width: 50px">{{ __("To:") }}</span>
-							<template v-if="paymentType === 'Receive' && bankAccountOptions.length">
-								<v-select
-									:model-value="selectedMop.bank_account || ''"
-									:items="bankAccountOptions"
-									item-title="label"
-									item-value="value"
-									density="compact"
-									variant="outlined"
-									hide-details
-									class="flex-grow-1 ml-1"
-									@update:model-value="onBankAccountChange($event)"
-								>
-									<template #item="{ props, item }">
-										<v-list-item v-bind="props" density="compact">
-											<template #append>
-												<v-chip size="x-small" color="primary" variant="tonal">{{ item.raw.currency }}</v-chip>
-												<v-chip size="x-small" color="secondary" variant="tonal" class="ml-1">{{ item.raw.accountType }}</v-chip>
-											</template>
-										</v-list-item>
-									</template>
-								</v-select>
-							</template>
-							<template v-else>
-								<span class="ml-1 text-truncate">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account }}</span>
-								<v-chip size="x-small" color="primary" variant="tonal" class="ml-auto">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_currency }}</v-chip>
+						<div class="account-selector-row">
+							<div class="d-flex align-center">
+								<v-icon size="18" class="mr-2 text-medium-emphasis">mdi-bank</v-icon>
+								<span class="text-body-2 text-medium-emphasis">{{ __("Payment Account") }}</span>
+							</div>
+							<template v-if="paymentType === 'Pay' || paymentType === 'Receive'">
+								<template v-if="bankAccountOptions.length">
+									<div class="account-selector-card" @click="openAccountDialog">
+										<div class="d-flex align-center">
+											<span class="text-truncate text-body-2 font-weight-medium">
+												{{ isCustomAccount ? selectedMop.bank_account : defaultBankAccount }}
+											</span>
+											<v-chip v-if="isCustomAccount" size="x-small" color="warning" variant="tonal" class="ml-2">
+												{{ __("Custom") }}
+											</v-chip>
+										</div>
+										<div class="d-flex align-center mt-1">
+											<v-chip size="x-small" :color="getAccountTypeColor(getCurrentSelectedAccountType())" variant="tonal">
+												<v-icon start size="12">{{ getAccountTypeIcon(getCurrentSelectedAccountType()) }}</v-icon>
+												{{ getCurrentSelectedAccountType() }}
+											</v-chip>
+											<v-chip size="x-small" color="primary" variant="tonal" class="ml-1">
+												{{ getCurrentSelectedCurrency() }}
+											</v-chip>
+											<v-icon size="18" class="ml-2 text-medium-emphasis">mdi-chevron-down</v-icon>
+										</div>
+									</div>
+								</template>
+								<template v-else>
+									<span class="text-truncate text-body-2 font-weight-medium">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account }}</span>
+									<v-chip size="x-small" color="primary" variant="tonal" class="ml-2">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_currency }}</v-chip>
+								</template>
 							</template>
 						</div>
 					</div>
+
+					<v-dialog v-model="accountDialogOpen" max-width="500" :scrim="true" class="account-dialog">
+						<v-card class="account-dialog-card">
+							<v-card-title class="d-flex align-center pa-4">
+								<v-icon class="mr-2">mdi-bank</v-icon>
+								<span>{{ __("Select Payment Account") }}</span>
+								<v-spacer></v-spacer>
+								<v-btn icon variant="text" size="small" @click="accountDialogOpen = false">
+									<v-icon>mdi-close</v-icon>
+								</v-btn>
+							</v-card-title>
+							<v-divider></v-divider>
+							<v-card-text class="pa-4">
+								<v-autocomplete
+									v-model="selectedAccountTemp"
+									:items="bankAccountOptions"
+									item-title="label"
+									item-value="value"
+									variant="outlined"
+									density="comfortable"
+									:label="__('Search Account')"
+									prepend-inner-icon="mdi-magnify"
+									hide-no-data
+									return-object
+									clearable
+								>
+									<template #item="{ props, item }">
+										<v-list-item v-bind="props" class="account-list-item">
+											<template #prepend>
+												<v-icon :color="getAccountTypeColor(item.raw.accountType)">
+													{{ getAccountTypeIcon(item.raw.accountType) }}
+												</v-icon>
+											</template>
+											<v-list-item-subtitle>
+												<div class="d-flex align-center">
+													<span class="font-weight-medium">{{ item.raw.label }}</span>
+												</div>
+											</v-list-item-subtitle>
+											<template #append>
+												<div class="d-flex align-center">
+													<v-chip size="small" :color="getAccountTypeColor(item.raw.accountType)" variant="tonal">
+														{{ item.raw.accountType }}
+													</v-chip>
+													<v-chip size="small" color="primary" variant="tonal" class="ml-1">
+														{{ item.raw.currency }}
+													</v-chip>
+												</div>
+											</template>
+										</v-list-item>
+									</template>
+									<template #selection="{ item }">
+										<div class="d-flex align-center">
+											<v-icon :color="getAccountTypeColor(item.raw.accountType)" class="mr-2">
+												{{ getAccountTypeIcon(item.raw.accountType) }}
+											</v-icon>
+											<span>{{ item.raw.label }}</span>
+											<v-chip size="small" :color="getAccountTypeColor(item.raw.accountType)" variant="tonal" class="ml-2">
+												{{ item.raw.accountType }}
+											</v-chip>
+											<v-chip size="small" color="primary" variant="tonal" class="ml-1">
+												{{ item.raw.currency }}
+											</v-chip>
+										</div>
+									</template>
+								</v-autocomplete>
+								<div class="d-flex align-center mt-3">
+									<v-btn
+										variant="tonal"
+										color="warning"
+										size="small"
+										prepend-icon="mdi-refresh"
+										@click="resetToDefault"
+									>
+										{{ __("Reset to Default") }}
+									</v-btn>
+									<v-spacer></v-spacer>
+									<span class="text-caption text-medium-emphasis">
+										{{ __("Default:") }} {{ defaultBankAccount }}
+									</span>
+								</div>
+							</v-card-text>
+							<v-divider></v-divider>
+							<v-card-actions class="pa-4">
+								<v-btn variant="text" @click="accountDialogOpen = false">
+									{{ __("Cancel") }}
+								</v-btn>
+								<v-spacer></v-spacer>
+								<v-btn color="primary" variant="flat" @click="confirmAccountSelection">
+									{{ __("Confirm") }}
+								</v-btn>
+							</v-card-actions>
+						</v-card>
+					</v-dialog>
 					<template v-if="flt(selectedMop.amount) > 0 && newPaymentFields[selectedMop.row_id]">
 						<v-divider class="my-1"></v-divider>
 						<div class="text-caption">
@@ -581,6 +660,74 @@ const onBankAccountChange = (account) => {
 	emit("update:bankAccount", selectedMopName.value, account);
 };
 
+const accountDialogOpen = ref(false);
+const selectedAccountTemp = ref(null);
+
+const currentEditableAccount = computed(() => {
+	if (!selectedMop.value || !props.paymentMethodAccounts) return null;
+	if (props.paymentType === "Receive") {
+		return props.paymentMethodAccounts[selectedMop.value.mode_of_payment];
+	} else {
+		return props.paymentMethodAccounts[selectedMop.value.mode_of_payment];
+	}
+});
+
+const defaultBankAccount = computed(() => {
+	return currentEditableAccount.value?.account || null;
+});
+
+const isCustomAccount = computed(() => {
+	if (!selectedMop.value) return false;
+	return selectedMop.value.bank_account && selectedMop.value.bank_account !== defaultBankAccount.value;
+});
+
+const openAccountDialog = () => {
+	if (!selectedMop.value || !bankAccountOptions.value.length) return;
+	selectedAccountTemp.value = selectedMop.value.bank_account || defaultBankAccount.value || null;
+	accountDialogOpen.value = true;
+};
+
+const confirmAccountSelection = () => {
+	if (selectedAccountTemp.value !== null && selectedAccountTemp.value !== "") {
+		emit("update:bankAccount", selectedMopName.value, selectedAccountTemp.value);
+	}
+	accountDialogOpen.value = false;
+};
+
+const resetToDefault = () => {
+	selectedAccountTemp.value = defaultBankAccount.value;
+};
+
+const getAccountTypeColor = (type) => {
+	if (type === "Bank") return "info";
+	if (type === "Cash") return "success";
+	return "secondary";
+};
+
+const getAccountTypeIcon = (type) => {
+	if (type === "Bank") return "mdi-bank";
+	if (type === "Cash") return "mdi-cash";
+	return "mdi-account";
+};
+
+const getCurrentSelectedAccountType = () => {
+	const account = selectedMop.value?.bank_account || defaultBankAccount.value;
+	if (!account || !bankAccountOptions.value.length) {
+		return currentEditableAccount.value?.account_type || "";
+	}
+	const found = bankAccountOptions.value.find((a) => a.value === account);
+	return found?.accountType || currentEditableAccount.value?.account_type || "";
+};
+
+const getCurrentSelectedCurrency = () => {
+	const account = selectedMop.value?.bank_account || defaultBankAccount.value;
+	if (!account || !bankAccountOptions.value.length) {
+		return currentEditableAccount.value?.account_currency || "";
+	}
+	const found = bankAccountOptions.value.find((a) => a.value === account);
+	return found?.currency || currentEditableAccount.value?.account_currency || "";
+};
+
 const enteredPayments = computed(() => {
 	if (!props.filteredPaymentMethods) return [];
 	return props.filteredPaymentMethods
@@ -672,5 +819,72 @@ defineExpose({
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.account-selector-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 12px;
+	background: rgba(var(--v-theme-surface), 0.5);
+	border-radius: 8px;
+	border: 1px solid rgba(var(--v-border-color), 0.15);
+}
+
+.account-selector-card {
+	display: flex;
+	flex-direction: column;
+	padding: 10px 14px;
+	background: rgba(var(--v-theme-primary), 0.08);
+	border: 1px solid rgba(var(--v-theme-primary), 0.2);
+	border-radius: 10px;
+	cursor: pointer;
+	transition: all 0.2s ease;
+	min-width: 200px;
+	max-width: 280px;
+}
+
+.account-selector-card:hover {
+	background: rgba(var(--v-theme-primary), 0.12);
+	border-color: rgba(var(--v-theme-primary), 0.35);
+	transform: translateY(-1px);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.account-dialog-card {
+	border-radius: 16px;
+	overflow: hidden;
+}
+
+.account-dialog-card .v-card-title {
+	background: rgba(var(--v-theme-primary), 0.05);
+	font-weight: 600;
+}
+
+.account-list-item {
+	border-radius: 8px;
+	margin: 4px 0;
+	transition: background 0.15s ease;
+}
+
+.account-list-item:hover {
+	background: rgba(var(--v-theme-primary), 0.08);
+}
+
+.account-dialog-card :deep(.v-autocomplete) {
+	border-radius: 10px;
+}
+
+@media (max-width: 600px) {
+	.account-selector-row {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 8px;
+	}
+
+	.account-selector-card {
+		width: 100%;
+		max-width: none;
+	}
 }
 </style>

--- a/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
+++ b/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
@@ -168,13 +168,61 @@
 					<div v-if="partyAccount && getPaymentMethodAccount(selectedMop.mode_of_payment)" class="text-caption mb-2">
 						<div class="d-flex align-center mb-1">
 							<span class="text-medium-emphasis" style="min-width: 50px">{{ __("From:") }}</span>
-							<span class="ml-1 text-truncate">{{ partyAccount.account }}</span>
-							<v-chip size="x-small" color="primary" variant="tonal" class="ml-auto">{{ partyAccount.currency }}</v-chip>
+							<template v-if="paymentType === 'Pay' && bankAccountOptions.length">
+								<v-select
+									:model-value="selectedMop.bank_account || ''"
+									:items="bankAccountOptions"
+									item-title="label"
+									item-value="value"
+									density="compact"
+									variant="outlined"
+									hide-details
+									class="flex-grow-1 ml-1"
+									@update:model-value="onBankAccountChange($event)"
+								>
+									<template #item="{ props, item }">
+										<v-list-item v-bind="props" density="compact">
+											<template #append>
+												<v-chip size="x-small" color="primary" variant="tonal">{{ item.raw.currency }}</v-chip>
+												<v-chip size="x-small" color="secondary" variant="tonal" class="ml-1">{{ item.raw.accountType }}</v-chip>
+											</template>
+										</v-list-item>
+									</template>
+								</v-select>
+							</template>
+							<template v-else>
+								<span class="ml-1 text-truncate">{{ partyAccount.account }}</span>
+								<v-chip size="x-small" color="primary" variant="tonal" class="ml-auto">{{ partyAccount.currency }}</v-chip>
+							</template>
 						</div>
 						<div class="d-flex align-center">
 							<span class="text-medium-emphasis" style="min-width: 50px">{{ __("To:") }}</span>
-							<span class="ml-1 text-truncate">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account }}</span>
-							<v-chip size="x-small" color="primary" variant="tonal" class="ml-auto">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_currency }}</v-chip>
+							<template v-if="paymentType === 'Receive' && bankAccountOptions.length">
+								<v-select
+									:model-value="selectedMop.bank_account || ''"
+									:items="bankAccountOptions"
+									item-title="label"
+									item-value="value"
+									density="compact"
+									variant="outlined"
+									hide-details
+									class="flex-grow-1 ml-1"
+									@update:model-value="onBankAccountChange($event)"
+								>
+									<template #item="{ props, item }">
+										<v-list-item v-bind="props" density="compact">
+											<template #append>
+												<v-chip size="x-small" color="primary" variant="tonal">{{ item.raw.currency }}</v-chip>
+												<v-chip size="x-small" color="secondary" variant="tonal" class="ml-1">{{ item.raw.accountType }}</v-chip>
+											</template>
+										</v-list-item>
+									</template>
+								</v-select>
+							</template>
+							<template v-else>
+								<span class="ml-1 text-truncate">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account }}</span>
+								<v-chip size="x-small" color="primary" variant="tonal" class="ml-auto">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_currency }}</v-chip>
+							</template>
 						</div>
 					</div>
 					<template v-if="flt(selectedMop.amount) > 0 && newPaymentFields[selectedMop.row_id]">
@@ -399,6 +447,10 @@ const props = defineProps({
 		type: Object,
 		default: () => ({}),
 	},
+	availableBankAccounts: {
+		type: Object,
+		default: () => ({}),
+	},
 	paymentType: {
 		type: String,
 		default: "Receive",
@@ -414,6 +466,7 @@ const emit = defineEmits([
 	"update:autoAllocatePaymentAmount",
 	"update:referenceNo",
 	"update:referenceDate",
+	"update:bankAccount",
 	"validate-exchange-rate",
 	"fetch-exchange-rate",
 ]);
@@ -511,6 +564,22 @@ watch(
 		}
 	},
 );
+
+const bankAccountOptions = computed(() => {
+	if (!selectedMopName.value || !props.availableBankAccounts) return [];
+	const accounts = props.availableBankAccounts[selectedMopName.value];
+	if (!accounts || !accounts.length) return [];
+	return accounts.map((a) => ({
+		label: `${a.account_name || a.account}  (${a.account_currency})`,
+		value: a.account,
+		currency: a.account_currency,
+		accountType: a.account_type,
+	}));
+});
+
+const onBankAccountChange = (account) => {
+	emit("update:bankAccount", selectedMopName.value, account);
+};
 
 const enteredPayments = computed(() => {
 	if (!props.filteredPaymentMethods) return [];

--- a/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
+++ b/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
@@ -23,7 +23,58 @@
 			</v-col>
 		</v-row>
 
-		<v-row v-if="totalSelectedPayments">
+		<v-row v-if="totalSelectedPayments && selectedPaymentsDetail.length">
+			<v-col cols="12">
+				<h4 class="text-primary mb-1">{{ __("Selected Payments") }}</h4>
+				<div
+					v-for="(pay, idx) in selectedPaymentsDetail"
+					:key="idx"
+					class="selected-payment-block py-1 text-caption"
+				>
+					<div class="d-flex align-center mb-1">
+						<span class="text-body-2 font-weight-medium">{{ __(pay.mode_of_payment) }}</span>
+						<span v-if="pay.account" class="text-medium-emphasis ml-1 text-truncate" style="max-width: 40%">
+							({{ pay.account }})
+						</span>
+					</div>
+					<div class="d-flex align-center mb-1">
+						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Paid (orig):") }}</span>
+						<span class="font-weight-medium text-end" style="min-width: 50%">
+							{{ currencySymbol(pay.currency) }}&nbsp;{{ formatCurrency(pay.paid_amount) }}
+						</span>
+					</div>
+					<div class="d-flex align-center mb-1">
+						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Source Rate:") }}</span>
+						<span class="font-weight-medium text-end" style="min-width: 50%">{{ formatCurrency(pay.exchange_rate) }}</span>
+					</div>
+					<div class="d-flex align-center mb-1">
+						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Unallocated:") }}</span>
+						<span class="font-weight-medium text-end" style="min-width: 50%">
+							{{ currencySymbol(pay.currency) }}&nbsp;{{ formatCurrency(pay.unallocated_amount) }}
+						</span>
+					</div>
+					<div class="d-flex align-center mb-1">
+						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Received:") }}</span>
+						<span class="font-weight-medium text-end" style="min-width: 50%">
+							{{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(pay.received_amount) }}
+						</span>
+					</div>
+					<div class="d-flex align-center mb-1">
+						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Target Rate:") }}</span>
+						<span class="font-weight-medium text-end" style="min-width: 50%">{{ formatCurrency(pay.exchange_rate) }}</span>
+					</div>
+					<v-divider v-if="idx < selectedPaymentsDetail.length - 1" class="my-1"></v-divider>
+				</div>
+				<v-divider class="my-1"></v-divider>
+				<div class="d-flex align-center py-1 font-weight-bold">
+					<span class="text-body-2" style="min-width: 50%">{{ __("Total") }}</span>
+					<span class="text-body-2 text-end" style="min-width: 50%">
+						{{ currencySymbol(paymentTotalCurrency) }}&nbsp;{{ formatCurrency(totalSelectedPayments) }}
+					</span>
+				</div>
+			</v-col>
+		</v-row>
+		<v-row v-else-if="totalSelectedPayments">
 			<v-col md="7" class="mt-1"
 				><span>{{ __("Total Payments:") }}</span></v-col
 			>
@@ -61,32 +112,128 @@
 
 		<v-divider v-if="paymentMethods.length"></v-divider>
 		<div v-if="posProfile.posa_allow_make_new_payments">
-			<h4 class="text-primary">Make New Payment</h4>
-			<v-row
-				v-if="filteredPaymentMethods.length"
-				v-for="method in filteredPaymentMethods"
-				:key="method.row_id"
-			>
-				<v-col md="7"
-					><span class="mt-1">{{ __(method.mode_of_payment) }}:</span>
-				</v-col>
-				<v-col md="5">
-					<div class="d-flex align-center">
-						<div class="mr-1 text-primary">
-							{{ currencySymbol(getPaymentMethodCurrency(method.mode_of_payment)) }}
+			<h4 class="text-primary">{{ __("Make New Payment") }}</h4>
+			<template v-if="filteredPaymentMethods.length">
+				<v-select
+					v-model="selectedMopName"
+					:items="mopOptions"
+					:label="__('Mode of Payment')"
+					density="compact"
+					variant="outlined"
+					hide-details
+					class="mb-3"
+					clearable
+				></v-select>
+				<template v-if="selectedMop">
+					<div class="new-payment-card pa-3 mb-2">
+						<div class="d-flex align-center mb-2">
+							<span class="text-body-2 font-weight-medium">{{ __(selectedMop.mode_of_payment) }}</span>
+							<v-chip
+								v-if="getPaymentMethodAccount(selectedMop.mode_of_payment)?.account_type"
+								size="x-small"
+								color="primary"
+								variant="outlined"
+								class="ml-1"
+							>
+								{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_type }}
+							</v-chip>
 						</div>
-						<v-text-field
-							class="p-0 m-0 pos-themed-input"
-							density="compact"
-							color="primary"
-							hide-details
-							v-model="method.amount"
-							type="number"
-							flat
-						></v-text-field>
+						<div class="d-flex align-center mb-1">
+							<span class="text-caption text-medium-emphasis mr-1">{{ paymentType === "Pay" ? __("Paid:") : __("Recv:") }}</span>
+							<span class="text-h6 font-weight-bold mr-2">
+								{{ currencySymbol(getPaymentMethodCurrency(selectedMop.mode_of_payment)) }}
+							</span>
+							<v-text-field
+								class="paid-amount-input amount-field"
+								density="compact"
+								color="primary"
+								hide-details
+								v-model="selectedMop.amount"
+								type="number"
+								flat
+								variant="outlined"
+							></v-text-field>
+						</div>
+						<div v-if="flt(selectedMop.amount) > 0" class="text-caption text-medium-emphasis mt-1">
+							{{ __("Base:") }} {{ currencySymbol(companyCurrency) }}&nbsp;{{
+								formatCurrency(
+									requiresExchangeRate
+										? flt(selectedMop.amount) * flt(internalExchangeRateValue)
+										: flt(selectedMop.amount)
+								)
+							}}
+							<template v-if="requiresExchangeRate">
+								&nbsp;@ {{ formatCurrency(internalExchangeRateValue) }}
+							</template>
+						</div>
 					</div>
-				</v-col>
-			</v-row>
+					<div v-if="partyAccount && getPaymentMethodAccount(selectedMop.mode_of_payment)" class="text-caption mb-2">
+						<div class="d-flex align-center mb-1">
+							<span class="text-medium-emphasis" style="min-width: 50px">{{ __("From:") }}</span>
+							<span class="ml-1 text-truncate">{{ partyAccount.account }}</span>
+							<v-chip size="x-small" color="primary" variant="tonal" class="ml-auto">{{ partyAccount.currency }}</v-chip>
+						</div>
+						<div class="d-flex align-center">
+							<span class="text-medium-emphasis" style="min-width: 50px">{{ __("To:") }}</span>
+							<span class="ml-1 text-truncate">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account }}</span>
+							<v-chip size="x-small" color="primary" variant="tonal" class="ml-auto">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_currency }}</v-chip>
+						</div>
+					</div>
+					<template v-if="flt(selectedMop.amount) > 0 && newPaymentFields[selectedMop.row_id]">
+						<v-divider class="my-1"></v-divider>
+						<div class="text-caption">
+							<div class="d-flex align-center mb-1">
+								<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Source Ex. Rate:") }}</span>
+								<span class="font-weight-medium text-end" style="min-width: 50%">{{ formatCurrency(newPaymentFields[selectedMop.row_id].sourceRate) }}</span>
+							</div>
+							<div class="d-flex align-center mb-1">
+								<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Base Paid Amt:") }}</span>
+								<span class="font-weight-medium text-end" style="min-width: 50%">
+									{{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(newPaymentFields[selectedMop.row_id].basePaidAmount) }}
+								</span>
+							</div>
+							<div class="d-flex align-center mb-1">
+								<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Target Ex. Rate:") }}</span>
+								<span class="font-weight-medium text-end" style="min-width: 50%">{{ formatCurrency(newPaymentFields[selectedMop.row_id].targetRate) }}</span>
+							</div>
+							<div class="d-flex align-center mb-1">
+								<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Base Recv Amt:") }}</span>
+								<span class="font-weight-medium text-end" style="min-width: 50%">
+									{{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(newPaymentFields[selectedMop.row_id].baseReceivedAmount) }}
+								</span>
+							</div>
+						</div>
+					</template>
+				</template>
+				<div v-if="enteredPayments.length" class="mt-2">
+					<v-divider class="mb-1"></v-divider>
+					<div class="text-caption">
+						<div
+							v-for="entry in enteredPayments"
+							:key="entry.row_id"
+							class="d-flex align-center py-1"
+						>
+							<span class="font-weight-medium" style="min-width: 40%">{{ __(entry.mode_of_payment) }}</span>
+							<span class="text-end" style="min-width: 30%">
+								{{ currencySymbol(getPaymentMethodCurrency(entry.mode_of_payment)) }}&nbsp;{{ formatCurrency(entry.amount) }}
+							</span>
+							<span class="text-medium-emphasis text-end" style="min-width: 30%">
+								({{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(entry.baseAmount) }})
+							</span>
+						</div>
+					</div>
+					<v-divider class="my-1"></v-divider>
+					<div class="d-flex align-center font-weight-bold text-body-2">
+						<span style="min-width: 40%">{{ __("Total") }}</span>
+						<span class="text-end" style="min-width: 30%">
+							{{ currencySymbol(invoiceTotalCurrency) }}&nbsp;{{ formatCurrency(totalNewPayments) }}
+						</span>
+						<span class="text-end" style="min-width: 30%">
+							({{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(totalNewPaymentsBase) }})
+						</span>
+					</div>
+				</div>
+			</template>
 		</div>
 
 		<v-divider v-if="requiresExchangeRate"></v-divider>
@@ -203,9 +350,14 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import { normalizeDateForBackend } from "../../format";
+
+const flt = (value, precision) => {
+	const num = parseFloat(String(value ?? 0).replace(/,/g, ""));
+	return isNaN(num) ? 0 : precision != null ? parseFloat(num.toFixed(precision)) : num;
+};
 
 const props = defineProps({
 	posProfile: Object,
@@ -215,6 +367,14 @@ const props = defineProps({
 	totalSelectedMpesa: Number,
 	paymentMethods: Array,
 	filteredPaymentMethods: Array,
+	selectedPaymentsDetail: {
+		type: Array,
+		default: () => [],
+	},
+	newPaymentsDetail: {
+		type: Array,
+		default: () => [],
+	},
 	invoiceTotalCurrency: String,
 	paymentTotalCurrency: String,
 	mpesaTotalCurrency: String,
@@ -233,6 +393,22 @@ const props = defineProps({
 	getPaymentMethodCurrency: Function,
 	referenceNo: String,
 	referenceDate: String,
+	partyAccount: {
+		type: Object,
+		default: null,
+	},
+	paymentMethodAccounts: {
+		type: Object,
+		default: () => ({}),
+	},
+	paymentType: {
+		type: String,
+		default: "Receive",
+	},
+	invoiceConversionRate: {
+		type: Number,
+		default: null,
+	},
 });
 
 const emit = defineEmits([
@@ -249,7 +425,106 @@ const internalExchangeRate = computed({
 	set: (val) => emit("update:exchangeRate", val),
 });
 
+const internalExchangeRateValue = computed(() => flt(props.exchangeRate || 1));
+
 const internalAutoAllocatePaymentAmount = computed(() => props.autoAllocatePaymentAmount ?? true);
+
+const getPaymentMethodAccount = (mode) => {
+	if (!mode || !props.paymentMethodAccounts) return null;
+	return props.paymentMethodAccounts[mode] || null;
+};
+
+const rateFromCurrencyToCompany = (currency) => {
+	if (!currency || currency === props.companyCurrency) return 1;
+	if (currency === props.invoiceTotalCurrency && flt(props.exchangeRate) > 0) return flt(props.exchangeRate);
+	if (currency === props.invoiceTotalCurrency && flt(props.invoiceConversionRate) > 0) return flt(props.invoiceConversionRate);
+	return 1;
+};
+
+const newPaymentFields = computed(() => {
+	const fields = {};
+	if (!props.filteredPaymentMethods) return fields;
+	for (const method of props.filteredPaymentMethods) {
+		const amt = flt(method.amount);
+		const mopCurr = props.getPaymentMethodCurrency(method.mode_of_payment);
+		const partyCurr = props.partyAccount?.currency || props.invoiceTotalCurrency;
+		const isReceive = props.paymentType === "Receive";
+		const fromCurr = isReceive ? partyCurr : mopCurr;
+		const toCurr = isReceive ? mopCurr : partyCurr;
+		const srcRate = rateFromCurrencyToCompany(fromCurr);
+		const tgtRate = rateFromCurrencyToCompany(toCurr);
+		let paidAmt, recvAmt;
+		if (isReceive) {
+			recvAmt = amt;
+			paidAmt = tgtRate !== 0 ? recvAmt * tgtRate / (srcRate || 1) : 0;
+		} else {
+			paidAmt = amt;
+			recvAmt = srcRate !== 0 ? paidAmt * srcRate / (tgtRate || 1) : 0;
+		}
+		fields[method.row_id] = {
+			paidAmount: paidAmt,
+			receivedAmount: recvAmt,
+			sourceRate: srcRate,
+			targetRate: tgtRate,
+			basePaidAmount: paidAmt * srcRate,
+			baseReceivedAmount: recvAmt * tgtRate,
+			fromCurrency: fromCurr,
+			toCurrency: toCurr,
+		};
+	}
+	return fields;
+});
+
+const selectedMopName = ref(null);
+
+const mopOptions = computed(() => {
+	if (!props.filteredPaymentMethods) return [];
+	return props.filteredPaymentMethods.map((m) => ({
+		title: __(m.mode_of_payment),
+		value: m.mode_of_payment,
+	}));
+});
+
+const selectedMop = computed(() => {
+	if (!selectedMopName.value || !props.filteredPaymentMethods) return null;
+	return props.filteredPaymentMethods.find((m) => m.mode_of_payment === selectedMopName.value) || null;
+});
+
+watch(
+	() => props.invoiceTotalCurrency,
+	(newCurrency) => {
+		if (!props.filteredPaymentMethods?.length || !newCurrency) return;
+		const match = props.filteredPaymentMethods.find(
+			(m) => props.getPaymentMethodCurrency(m.mode_of_payment) === newCurrency,
+		);
+		if (match) {
+			selectedMopName.value = match.mode_of_payment;
+		}
+	},
+);
+
+const enteredPayments = computed(() => {
+	if (!props.filteredPaymentMethods) return [];
+	return props.filteredPaymentMethods
+		.filter((m) => flt(m.amount) > 0)
+		.map((m) => {
+			const fields = newPaymentFields.value[m.row_id] || {};
+			return {
+				row_id: m.row_id,
+				mode_of_payment: m.mode_of_payment,
+				amount: flt(m.amount),
+				baseAmount: fields.basePaidAmount || fields.baseReceivedAmount || flt(m.amount),
+			};
+		});
+});
+
+const totalNewPayments = computed(() => {
+	return enteredPayments.value.reduce((sum, e) => sum + e.amount, 0);
+});
+
+const totalNewPaymentsBase = computed(() => {
+	return enteredPayments.value.reduce((sum, e) => sum + e.baseAmount, 0);
+});
 
 const internalReferenceNo = computed({
 	get: () => props.referenceNo,
@@ -296,5 +571,28 @@ defineExpose({
 	background-color: rgb(var(--v-theme-surface));
 	color: inherit;
 	padding: 0 12px;
+}
+
+.selected-payment-block + .selected-payment-block {
+	border-top: 1px solid rgba(var(--v-border-color), 0.3);
+	margin-top: 2px;
+	padding-top: 6px;
+}
+
+.new-payment-card {
+	border: 1px solid rgba(var(--v-border-color), 0.25);
+	border-radius: 8px;
+	background: rgba(var(--v-theme-surface), 0.6);
+}
+
+.new-payment-card .amount-field :deep(.v-field__input) {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.text-truncate {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 </style>

--- a/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
+++ b/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
@@ -157,13 +157,11 @@
 						<div v-if="flt(selectedMop.amount) > 0" class="text-caption text-medium-emphasis mt-1">
 							{{ __("Base:") }} {{ currencySymbol(companyCurrency) }}&nbsp;{{
 								formatCurrency(
-									requiresExchangeRate
-										? flt(selectedMop.amount) * flt(internalExchangeRateValue)
-										: flt(selectedMop.amount)
+									flt(selectedMop.amount) * flt(selectedMopRate)
 								)
 							}}
-							<template v-if="requiresExchangeRate">
-								&nbsp;@ {{ formatCurrency(internalExchangeRateValue) }}
+							<template v-if="flt(selectedMopRate) !== 1">
+								&nbsp;@ {{ formatCurrency(selectedMopRate) }}
 							</template>
 						</div>
 					</div>
@@ -436,8 +434,13 @@ const getPaymentMethodAccount = (mode) => {
 
 const rateFromCurrencyToCompany = (currency) => {
 	if (!currency || currency === props.companyCurrency) return 1;
-	if (currency === props.invoiceTotalCurrency && flt(props.exchangeRate) > 0) return flt(props.exchangeRate);
-	if (currency === props.invoiceTotalCurrency && flt(props.invoiceConversionRate) > 0) return flt(props.invoiceConversionRate);
+	if (currency === props.invoiceTotalCurrency) {
+		if (flt(props.exchangeRate) > 0) return flt(props.exchangeRate);
+		if (flt(props.invoiceConversionRate) > 0) return flt(props.invoiceConversionRate);
+	}
+	// Fallback for third currencies: use invoice→company rate as best estimate
+	if (flt(props.exchangeRate) > 0) return flt(props.exchangeRate);
+	if (flt(props.invoiceConversionRate) > 0) return flt(props.invoiceConversionRate);
 	return 1;
 };
 
@@ -488,6 +491,12 @@ const mopOptions = computed(() => {
 const selectedMop = computed(() => {
 	if (!selectedMopName.value || !props.filteredPaymentMethods) return null;
 	return props.filteredPaymentMethods.find((m) => m.mode_of_payment === selectedMopName.value) || null;
+});
+
+const selectedMopRate = computed(() => {
+	if (!selectedMop.value) return 1;
+	const mopCurr = props.getPaymentMethodCurrency(selectedMop.value.mode_of_payment);
+	return rateFromCurrencyToCompany(mopCurr);
 });
 
 watch(

--- a/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
+++ b/frontend/src/posapp/components/pos_pay/PayTotalsSidebar.vue
@@ -1,199 +1,243 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
-	<div class="totals-wrapper">
-		<h4 class="text-primary">Totals</h4>
-		<v-row>
-			<v-col md="7" class="mt-1">
-				<span>{{ __("Total Invoices:") }}</span>
-			</v-col>
-			<v-col md="5">
-				<v-text-field
-					class="p-0 m-0 pos-themed-input"
-					density="compact"
-					color="primary"
-					hide-details
-					:model-value="formatCurrency(totalSelectedInvoices)"
-					readonly
-					flat
-					:prefix="currencySymbol(invoiceTotalCurrency)"
-				></v-text-field>
-				<small v-if="selectedInvoicesCount" class="text-primary"
-					>{{ selectedInvoicesCount }} invoice(s) selected</small
-				>
-			</v-col>
-		</v-row>
-
-		<v-row v-if="totalSelectedPayments && selectedPaymentsDetail.length">
-			<v-col cols="12">
-				<h4 class="text-primary mb-1">{{ __("Selected Payments") }}</h4>
-				<div
-					v-for="(pay, idx) in selectedPaymentsDetail"
-					:key="idx"
-					class="selected-payment-block py-1 text-caption"
-				>
-					<div class="d-flex align-center mb-1">
-						<span class="text-body-2 font-weight-medium">{{ __(pay.mode_of_payment) }}</span>
-						<span v-if="pay.account" class="text-medium-emphasis ml-1 text-truncate" style="max-width: 40%">
-							({{ pay.account }})
-						</span>
-					</div>
-					<div class="d-flex align-center mb-1">
-						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Paid (orig):") }}</span>
-						<span class="font-weight-medium text-end" style="min-width: 50%">
-							{{ currencySymbol(pay.currency) }}&nbsp;{{ formatCurrency(pay.paid_amount) }}
-						</span>
-					</div>
-					<div class="d-flex align-center mb-1">
-						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Source Rate:") }}</span>
-						<span class="font-weight-medium text-end" style="min-width: 50%">{{ formatCurrency(pay.exchange_rate) }}</span>
-					</div>
-					<div class="d-flex align-center mb-1">
-						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Unallocated:") }}</span>
-						<span class="font-weight-medium text-end" style="min-width: 50%">
-							{{ currencySymbol(pay.currency) }}&nbsp;{{ formatCurrency(pay.unallocated_amount) }}
-						</span>
-					</div>
-					<div class="d-flex align-center mb-1">
-						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Received:") }}</span>
-						<span class="font-weight-medium text-end" style="min-width: 50%">
-							{{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(pay.received_amount) }}
-						</span>
-					</div>
-					<div class="d-flex align-center mb-1">
-						<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Target Rate:") }}</span>
-						<span class="font-weight-medium text-end" style="min-width: 50%">{{ formatCurrency(pay.exchange_rate) }}</span>
-					</div>
-					<v-divider v-if="idx < selectedPaymentsDetail.length - 1" class="my-1"></v-divider>
-				</div>
-				<v-divider class="my-1"></v-divider>
-				<div class="d-flex align-center py-1 font-weight-bold">
-					<span class="text-body-2" style="min-width: 50%">{{ __("Total") }}</span>
-					<span class="text-body-2 text-end" style="min-width: 50%">
-						{{ currencySymbol(paymentTotalCurrency) }}&nbsp;{{ formatCurrency(totalSelectedPayments) }}
+	<div class="pay-sidebar" :dir="isRtl ? 'rtl' : 'ltr'">
+		<!-- 1. Summary Cards -->
+		<v-card variant="outlined" class="mb-2 section-card">
+			<v-card-text class="py-2">
+				<div class="d-flex justify-space-between align-center">
+					<span class="text-body-1 font-weight-medium text-medium-emphasis">
+						{{ __("Total Invoices") }}
 					</span>
-				</div>
-			</v-col>
-		</v-row>
-		<v-row v-else-if="totalSelectedPayments">
-			<v-col md="7" class="mt-1"
-				><span>{{ __("Total Payments:") }}</span></v-col
-			>
-			<v-col md="5">
-				<v-text-field
-					class="p-0 m-0 pos-themed-input"
-					density="compact"
-					color="primary"
-					hide-details
-					:model-value="formatCurrency(totalSelectedPayments)"
-					readonly
-					flat
-					:prefix="currencySymbol(paymentTotalCurrency)"
-				></v-text-field>
-			</v-col>
-		</v-row>
-
-		<v-row v-if="totalSelectedMpesa">
-			<v-col md="7" class="mt-1"
-				><span>{{ __("Total Mpesa:") }}</span></v-col
-			>
-			<v-col md="5">
-				<v-text-field
-					class="p-0 m-0 pos-themed-input"
-					density="compact"
-					color="primary"
-					hide-details
-					:model-value="formatCurrency(totalSelectedMpesa)"
-					readonly
-					flat
-					:prefix="currencySymbol(mpesaTotalCurrency)"
-				></v-text-field>
-			</v-col>
-		</v-row>
-
-		<v-divider v-if="paymentMethods.length"></v-divider>
-		<div v-if="posProfile.posa_allow_make_new_payments">
-			<h4 class="text-primary">{{ __("Make New Payment") }}</h4>
-			<template v-if="filteredPaymentMethods.length">
-				<v-select
-					v-model="selectedMopName"
-					:items="mopOptions"
-					:label="__('Mode of Payment')"
-					density="compact"
-					variant="outlined"
-					hide-details
-					class="mb-3"
-					clearable
-				></v-select>
-				<template v-if="selectedMop">
-					<div class="new-payment-card pa-3 mb-2">
-						<div class="d-flex align-center mb-2">
-							<span class="text-body-2 font-weight-medium">{{ __(selectedMop.mode_of_payment) }}</span>
-							<v-chip
-								v-if="getPaymentMethodAccount(selectedMop.mode_of_payment)?.account_type"
-								size="x-small"
-								color="primary"
-								variant="outlined"
-								class="ml-1"
-							>
-								{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_type }}
-							</v-chip>
+					<div class="text-end">
+						<div class="text-subtitle-1 font-weight-bold text-primary">
+							{{ currencySymbol(invoiceTotalCurrency) }}{{ formatCurrency(totalSelectedInvoices) }}
 						</div>
-						<div class="d-flex align-center mb-1">
-							<span class="text-caption text-medium-emphasis mr-1">{{ paymentType === "Pay" ? __("Paid:") : __("Recv:") }}</span>
-							<span class="text-h6 font-weight-bold mr-2">
-								{{ currencySymbol(getPaymentMethodCurrency(selectedMop.mode_of_payment)) }}
-							</span>
-							<v-text-field
-								class="paid-amount-input amount-field"
-								density="compact"
-								color="primary"
-								hide-details
-								v-model="selectedMop.amount"
-								type="number"
-								flat
-								variant="outlined"
-							></v-text-field>
-						</div>
-						<div v-if="flt(selectedMop.amount) > 0" class="text-caption text-medium-emphasis mt-1">
-							{{ __("Base:") }} {{ currencySymbol(companyCurrency) }}&nbsp;{{
-								formatCurrency(
-									flt(selectedMop.amount) * flt(selectedMopRate)
-								)
-							}}
-							<template v-if="flt(selectedMopRate) !== 1">
-								&nbsp;@ {{ formatCurrency(selectedMopRate) }}
-							</template>
+						<div v-if="selectedInvoicesCount" class="text-caption text-medium-emphasis">
+							{{ selectedInvoicesCount }} invoice(s)
 						</div>
 					</div>
-					<div v-if="partyAccount && getPaymentMethodAccount(selectedMop.mode_of_payment)" class="mb-2">
-						<div class="account-selector-row mb-2">
-							<div class="d-flex align-center">
-								<v-icon size="18" class="mr-2 text-medium-emphasis">mdi-account-arrow-right</v-icon>
-								<span class="text-body-2 text-medium-emphasis">{{ __("Party Account") }}</span>
+				</div>
+			</v-card-text>
+		</v-card>
+
+		<!-- 2. Selected Payments -->
+		<v-card
+			v-if="totalSelectedPayments && selectedPaymentsDetail.length"
+			variant="outlined"
+			class="mb-2 section-card"
+		>
+			<v-card-text class="py-2">
+				<h4 class="text-primary text-body-1 font-weight-bold mb-1">
+					{{ __("Selected Payments") }}
+				</h4>
+				<v-list density="compact" class="pa-0 bg-transparent">
+					<v-list-item
+						v-for="(pay, idx) in selectedPaymentsDetail"
+						:key="idx"
+						class="px-0 py-1"
+					>
+						<v-list-item-title class="d-flex justify-space-between align-center mb-1">
+							<span class="font-weight-medium">{{ __(pay.mode_of_payment) }}</span>
+							<span
+								v-if="pay.account"
+								class="text-caption text-medium-emphasis text-truncate"
+								style="max-width: 140px"
+							>
+								({{ pay.account }})
+							</span>
+						</v-list-item-title>
+
+						<v-list-item-subtitle>
+							<div class="payment-detail-row">
+								<span class="text-medium-emphasis">{{ __("Paid (orig):") }}</span>
+								<span class="font-weight-medium">
+									{{ currencySymbol(pay.currency) }}{{ formatCurrency(pay.paid_amount) }}
+								</span>
 							</div>
-							<div class="d-flex align-center ml-auto">
-								<span class="text-truncate text-body-2 font-weight-medium">{{ partyAccount.account }}</span>
-								<v-chip size="x-small" color="primary" variant="tonal" class="ml-2">{{ partyAccount.currency }}</v-chip>
+							<div class="payment-detail-row">
+								<span class="text-medium-emphasis">{{ __("Source Rate:") }}</span>
+								<span class="font-weight-medium">{{ formatCurrency(pay.exchange_rate) }}</span>
+							</div>
+							<div class="payment-detail-row">
+								<span class="text-medium-emphasis">{{ __("Unallocated:") }}</span>
+								<span class="font-weight-medium">
+									{{ currencySymbol(pay.currency) }}{{ formatCurrency(pay.unallocated_amount) }}
+								</span>
+							</div>
+							<div class="payment-detail-row">
+								<span class="text-medium-emphasis">{{ __("Received:") }}</span>
+								<span class="font-weight-medium">
+									{{ currencySymbol(companyCurrency) }}{{ formatCurrency(pay.received_amount) }}
+								</span>
+							</div>
+							<div class="payment-detail-row">
+								<span class="text-medium-emphasis">{{ __("Target Rate:") }}</span>
+								<span class="font-weight-medium">{{ formatCurrency(pay.exchange_rate) }}</span>
+							</div>
+						</v-list-item-subtitle>
+
+						<v-divider v-if="idx < selectedPaymentsDetail.length - 1" class="mt-1" />
+					</v-list-item>
+			</v-list>
+			
+			<v-divider class="my-1" />
+			<div class="d-flex justify-space-between align-center font-weight-bold text-body-2">
+				<span>{{ __("Total") }}</span>
+				<span>
+					{{ currencySymbol(paymentTotalCurrency) }}{{ formatCurrency(totalSelectedPayments) }}
+				</span>
+			</div>
+			</v-card-text>
+		</v-card>
+
+		<v-card
+			v-else-if="totalSelectedPayments"
+			variant="outlined"
+			class="mb-2 section-card"
+		>
+			<v-card-text class="py-2 d-flex justify-space-between align-center">
+				<span class="text-body-1 font-weight-medium text-medium-emphasis">
+					{{ __("Total Payments") }}
+				</span>
+				<span class="text-h6 font-weight-bold text-primary">
+					{{ currencySymbol(paymentTotalCurrency) }}{{ formatCurrency(totalSelectedPayments) }}
+				</span>
+			</v-card-text>
+		</v-card>
+
+		<!-- Total Mpesa -->
+		<v-card
+			v-if="totalSelectedMpesa"
+			variant="outlined"
+			class="mb-2 section-card"
+		>
+			<v-card-text class="py-2 d-flex justify-space-between align-center">
+				<span class="text-body-1 font-weight-medium text-medium-emphasis">
+					{{ __("Total Mpesa") }}
+				</span>
+				<span class="text-subtitle-1 font-weight-bold text-primary">
+					{{ currencySymbol(mpesaTotalCurrency) }}{{ formatCurrency(totalSelectedMpesa) }}
+				</span>
+			</v-card-text>
+		</v-card>
+
+		<!-- 3. Make New Payment -->
+		<v-card
+			v-if="posProfile.posa_allow_make_new_payments && paymentMethods.length"
+			variant="outlined"
+			class="mb-2 section-card"
+		>
+			<v-card-text class="py-2">
+				<h4 class="text-primary text-body-1 font-weight-bold mb-2">
+					{{ __("Make New Payment") }}
+				</h4>
+
+				<div v-if="filteredPaymentMethods.length">
+			<v-select
+				v-model="selectedMopName"
+				:items="mopOptions"
+				:label="__('Mode of Payment')"
+				density="compact"
+				variant="outlined"
+				hide-details
+				class="mb-2"
+				clearable
+			/>
+
+					<div v-if="selectedMop">
+						<div class="new-payment-card pa-2 mb-2">
+							<div class="d-flex align-center mb-2">
+								<span class="text-body-2 font-weight-medium">{{ __(selectedMop.mode_of_payment) }}</span>
+								<v-chip
+									v-if="getPaymentMethodAccount(selectedMop.mode_of_payment)?.account_type"
+									size="x-small"
+									color="primary"
+									variant="outlined"
+									class="ml-2"
+								>
+									{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_type }}
+								</v-chip>
+							</div>
+
+							<div class="d-flex align-center">
+								<span class="text-caption text-medium-emphasis mr-2">
+									{{ paymentType === "Pay" ? __("Paid:") : __("Recv:") }}
+								</span>
+								<v-text-field
+									v-model="selectedMop.amount"
+									type="number"
+									variant="outlined"
+									density="compact"
+									hide-details
+									class="payment-amount-input"
+									flat
+									:prefix="currencySymbol(getPaymentMethodCurrency(selectedMop.mode_of_payment))"
+									placeholder="0.00"
+									@wheel.prevent
+								/>
+							</div>
+
+							<div
+								v-if="flt(selectedMop.amount) > 0"
+								class="text-caption text-medium-emphasis mt-2"
+							>
+								{{ __("Base:") }} {{ currencySymbol(companyCurrency) }}{{ formatCurrency(flt(selectedMop.amount) * flt(selectedMopRate)) }}
+								<span v-if="flt(selectedMopRate) !== 1">
+									&nbsp;@ {{ formatCurrency(selectedMopRate) }}
+								</span>
 							</div>
 						</div>
-						<div class="account-selector-row">
-							<div class="d-flex align-center">
-								<v-icon size="18" class="mr-2 text-medium-emphasis">mdi-bank</v-icon>
-								<span class="text-body-2 text-medium-emphasis">{{ __("Payment Account") }}</span>
+
+						<!-- Accounts -->
+						<div
+							v-if="partyAccount && getPaymentMethodAccount(selectedMop.mode_of_payment)"
+							class="mb-2"
+						>
+							<div class="account-row mb-1">
+								<div class="d-flex align-center">
+									<v-icon size="18" class="mr-2 text-medium-emphasis">mdi-account-arrow-right</v-icon>
+									<span class="text-body-2 text-medium-emphasis">{{ __("Party Account") }}</span>
+								</div>
+								<div class="d-flex align-center ml-auto">
+									<span class="text-truncate text-body-2 font-weight-medium">{{ partyAccount.account }}</span>
+									<v-chip size="x-small" color="primary" variant="tonal" class="ml-2">{{ partyAccount.currency }}</v-chip>
+								</div>
 							</div>
-							<template v-if="paymentType === 'Pay' || paymentType === 'Receive'">
-								<template v-if="bankAccountOptions.length">
-									<div class="account-selector-card" @click="openAccountDialog">
+
+							<div class="account-row">
+								<div class="d-flex align-center">
+									<v-icon size="18" class="mr-2 text-medium-emphasis">mdi-bank</v-icon>
+									<span class="text-body-2 text-medium-emphasis">{{ __("Payment Account") }}</span>
+								</div>
+								<div
+									v-if="paymentType === 'Pay' || paymentType === 'Receive'"
+									class="d-flex align-center ml-auto"
+								>
+									<div
+										v-if="bankAccountOptions.length"
+										class="account-selector-card"
+										@click="openAccountDialog"
+									>
 										<div class="d-flex align-center">
 											<span class="text-truncate text-body-2 font-weight-medium">
 												{{ isCustomAccount ? selectedMop.bank_account : defaultBankAccount }}
 											</span>
-											<v-chip v-if="isCustomAccount" size="x-small" color="warning" variant="tonal" class="ml-2">
+											<v-chip
+												v-if="isCustomAccount"
+												size="x-small"
+												color="warning"
+												variant="tonal"
+												class="ml-2"
+											>
 												{{ __("Custom") }}
 											</v-chip>
 										</div>
 										<div class="d-flex align-center mt-1">
-											<v-chip size="x-small" :color="getAccountTypeColor(getCurrentSelectedAccountType())" variant="tonal">
+											<v-chip
+												size="x-small"
+												:color="getAccountTypeColor(getCurrentSelectedAccountType())"
+												variant="tonal"
+											>
 												<v-icon start size="12">{{ getAccountTypeIcon(getCurrentSelectedAccountType()) }}</v-icon>
 												{{ getCurrentSelectedAccountType() }}
 											</v-chip>
@@ -203,260 +247,180 @@
 											<v-icon size="18" class="ml-2 text-medium-emphasis">mdi-chevron-down</v-icon>
 										</div>
 									</div>
-								</template>
-								<template v-else>
-									<span class="text-truncate text-body-2 font-weight-medium">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account }}</span>
-									<v-chip size="x-small" color="primary" variant="tonal" class="ml-2">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_currency }}</v-chip>
-								</template>
-							</template>
-						</div>
-					</div>
-
-					<v-dialog v-model="accountDialogOpen" max-width="500" :scrim="true" class="account-dialog">
-						<v-card class="account-dialog-card">
-							<v-card-title class="d-flex align-center pa-4">
-								<v-icon class="mr-2">mdi-bank</v-icon>
-								<span>{{ __("Select Payment Account") }}</span>
-								<v-spacer></v-spacer>
-								<v-btn icon variant="text" size="small" @click="accountDialogOpen = false">
-									<v-icon>mdi-close</v-icon>
-								</v-btn>
-							</v-card-title>
-							<v-divider></v-divider>
-							<v-card-text class="pa-4">
-								<v-autocomplete
-									v-model="selectedAccountTemp"
-									:items="bankAccountOptions"
-									item-title="label"
-									item-value="value"
-									variant="outlined"
-									density="comfortable"
-									:label="__('Search Account')"
-									prepend-inner-icon="mdi-magnify"
-									hide-no-data
-									return-object
-									clearable
-								>
-									<template #item="{ props, item }">
-										<v-list-item v-bind="props" class="account-list-item">
-											<template #prepend>
-												<v-icon :color="getAccountTypeColor(item.raw.accountType)">
-													{{ getAccountTypeIcon(item.raw.accountType) }}
-												</v-icon>
-											</template>
-											<v-list-item-subtitle>
-												<div class="d-flex align-center">
-													<span class="font-weight-medium">{{ item.raw.label }}</span>
-												</div>
-											</v-list-item-subtitle>
-											<template #append>
-												<div class="d-flex align-center">
-													<v-chip size="small" :color="getAccountTypeColor(item.raw.accountType)" variant="tonal">
-														{{ item.raw.accountType }}
-													</v-chip>
-													<v-chip size="small" color="primary" variant="tonal" class="ml-1">
-														{{ item.raw.currency }}
-													</v-chip>
-												</div>
-											</template>
-										</v-list-item>
-									</template>
-									<template #selection="{ item }">
-										<div class="d-flex align-center">
-											<v-icon :color="getAccountTypeColor(item.raw.accountType)" class="mr-2">
-												{{ getAccountTypeIcon(item.raw.accountType) }}
-											</v-icon>
-											<span>{{ item.raw.label }}</span>
-											<v-chip size="small" :color="getAccountTypeColor(item.raw.accountType)" variant="tonal" class="ml-2">
-												{{ item.raw.accountType }}
-											</v-chip>
-											<v-chip size="small" color="primary" variant="tonal" class="ml-1">
-												{{ item.raw.currency }}
-											</v-chip>
-										</div>
-									</template>
-								</v-autocomplete>
-								<div class="d-flex align-center mt-3">
-									<v-btn
-										variant="tonal"
-										color="warning"
-										size="small"
-										prepend-icon="mdi-refresh"
-										@click="resetToDefault"
-									>
-										{{ __("Reset to Default") }}
-									</v-btn>
-									<v-spacer></v-spacer>
-									<span class="text-caption text-medium-emphasis">
-										{{ __("Default:") }} {{ defaultBankAccount }}
-									</span>
+									<div v-else class="d-flex align-center ml-auto">
+										<span class="text-truncate text-body-2 font-weight-medium">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account }}</span>
+										<v-chip size="x-small" color="primary" variant="tonal" class="ml-2">{{ getPaymentMethodAccount(selectedMop.mode_of_payment).account_currency }}</v-chip>
+									</div>
 								</div>
-							</v-card-text>
-							<v-divider></v-divider>
-							<v-card-actions class="pa-4">
-								<v-btn variant="text" @click="accountDialogOpen = false">
-									{{ __("Cancel") }}
-								</v-btn>
-								<v-spacer></v-spacer>
-								<v-btn color="primary" variant="flat" @click="confirmAccountSelection">
-									{{ __("Confirm") }}
-								</v-btn>
-							</v-card-actions>
-						</v-card>
-					</v-dialog>
-					<template v-if="flt(selectedMop.amount) > 0 && newPaymentFields[selectedMop.row_id]">
-						<v-divider class="my-1"></v-divider>
-						<div class="text-caption">
-							<div class="d-flex align-center mb-1">
-								<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Source Ex. Rate:") }}</span>
-								<span class="font-weight-medium text-end" style="min-width: 50%">{{ formatCurrency(newPaymentFields[selectedMop.row_id].sourceRate) }}</span>
-							</div>
-							<div class="d-flex align-center mb-1">
-								<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Base Paid Amt:") }}</span>
-								<span class="font-weight-medium text-end" style="min-width: 50%">
-									{{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(newPaymentFields[selectedMop.row_id].basePaidAmount) }}
-								</span>
-							</div>
-							<div class="d-flex align-center mb-1">
-								<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Target Ex. Rate:") }}</span>
-								<span class="font-weight-medium text-end" style="min-width: 50%">{{ formatCurrency(newPaymentFields[selectedMop.row_id].targetRate) }}</span>
-							</div>
-							<div class="d-flex align-center mb-1">
-								<span class="text-medium-emphasis" style="min-width: 50%">{{ __("Base Recv Amt:") }}</span>
-								<span class="font-weight-medium text-end" style="min-width: 50%">
-									{{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(newPaymentFields[selectedMop.row_id].baseReceivedAmount) }}
-								</span>
 							</div>
 						</div>
-					</template>
-				</template>
-				<div v-if="enteredPayments.length" class="mt-2">
-					<v-divider class="mb-1"></v-divider>
-					<div class="text-caption">
+
+						<!-- Payment Fields Summary -->
 						<div
-							v-for="entry in enteredPayments"
-							:key="entry.row_id"
-							class="d-flex align-center py-1"
+							v-if="flt(selectedMop.amount) > 0 && newPaymentFields[selectedMop.row_id]"
+							class="text-caption mt-1"
 						>
-							<span class="font-weight-medium" style="min-width: 40%">{{ __(entry.mode_of_payment) }}</span>
-							<span class="text-end" style="min-width: 30%">
-								{{ currencySymbol(getPaymentMethodCurrency(entry.mode_of_payment)) }}&nbsp;{{ formatCurrency(entry.amount) }}
-							</span>
-							<span class="text-medium-emphasis text-end" style="min-width: 30%">
-								({{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(entry.baseAmount) }})
-							</span>
+							<v-divider class="my-1" />
+							<v-row dense class="compact-grid">
+								<v-col cols="6" class="py-0">
+									<div class="d-flex justify-space-between pr-1">
+										<span class="text-medium-emphasis">{{ __("Source Ex. Rate:") }}</span>
+										<span class="font-weight-medium">{{ formatCurrency(newPaymentFields[selectedMop.row_id].sourceRate) }}</span>
+									</div>
+								</v-col>
+								<v-col cols="6" class="py-0">
+									<div class="d-flex justify-space-between pl-1">
+										<span class="text-medium-emphasis">{{ __("Target Ex. Rate:") }}</span>
+										<span class="font-weight-medium">{{ formatCurrency(newPaymentFields[selectedMop.row_id].targetRate) }}</span>
+									</div>
+								</v-col>
+								<v-col cols="6" class="py-0">
+									<div class="d-flex justify-space-between pr-1">
+										<span class="text-medium-emphasis">{{ __("Base Paid:") }}</span>
+										<span class="font-weight-medium">
+											{{ currencySymbol(companyCurrency) }}{{ formatCurrency(newPaymentFields[selectedMop.row_id].basePaidAmount) }}
+										</span>
+									</div>
+								</v-col>
+								<v-col cols="6" class="py-0">
+									<div class="d-flex justify-space-between pl-1">
+										<span class="text-medium-emphasis">{{ __("Base Recv:") }}</span>
+										<span class="font-weight-medium">
+											{{ currencySymbol(companyCurrency) }}{{ formatCurrency(newPaymentFields[selectedMop.row_id].baseReceivedAmount) }}
+										</span>
+									</div>
+								</v-col>
+							</v-row>
 						</div>
 					</div>
-					<v-divider class="my-1"></v-divider>
-					<div class="d-flex align-center font-weight-bold text-body-2">
-						<span style="min-width: 40%">{{ __("Total") }}</span>
+				</div>
+
+			<!-- Entered Payments List -->
+			<div v-if="enteredPayments.length" class="mt-1">
+				<v-divider class="mb-1" />
+				<div class="text-caption">
+					<div
+						v-for="entry in enteredPayments"
+						:key="entry.row_id"
+						class="d-flex justify-space-between align-center py-0"
+					>
+						<span class="font-weight-medium" style="min-width: 40%">{{ __(entry.mode_of_payment) }}</span>
 						<span class="text-end" style="min-width: 30%">
-							{{ currencySymbol(invoiceTotalCurrency) }}&nbsp;{{ formatCurrency(totalNewPayments) }}
+							{{ currencySymbol(getPaymentMethodCurrency(entry.mode_of_payment)) }}{{ formatCurrency(entry.amount) }}
 						</span>
-						<span class="text-end" style="min-width: 30%">
-							({{ currencySymbol(companyCurrency) }}&nbsp;{{ formatCurrency(totalNewPaymentsBase) }})
+						<span class="text-medium-emphasis text-end" style="min-width: 30%">
+							({{ currencySymbol(companyCurrency) }}{{ formatCurrency(entry.baseAmount) }})
 						</span>
 					</div>
 				</div>
-			</template>
-		</div>
+				<v-divider class="my-1" />
+				<div class="d-flex justify-space-between align-center font-weight-bold text-caption">
+					<span style="min-width: 40%">{{ __("Total") }}</span>
+					<span class="text-end" style="min-width: 30%">
+						{{ currencySymbol(invoiceTotalCurrency) }}{{ formatCurrency(totalNewPayments) }}
+					</span>
+					<span class="text-end" style="min-width: 30%">
+						({{ currencySymbol(companyCurrency) }}{{ formatCurrency(totalNewPaymentsBase) }})
+					</span>
+				</div>
+			</div>
+			</v-card-text>
+		</v-card>
 
-		<v-divider v-if="requiresExchangeRate"></v-divider>
-		<v-row v-if="requiresExchangeRate" class="mb-2">
-			<v-col md="7" class="mt-1">
-				<span class="text-primary">
-					{{ __("Exchange Rate") }} (1 {{ invoiceTotalCurrency }} = ? {{ companyCurrency }}):
-				</span>
-			</v-col>
-			<v-col md="5">
+		<!-- 4. Exchange Rate (Inline) -->
+		<v-card
+			v-if="requiresExchangeRate"
+			variant="outlined"
+			class="mb-2 section-card"
+		>
+			<v-card-text class="py-1">
 				<div class="d-flex align-center">
-					<div class="mr-1 text-primary">
-						{{ currencySymbol(companyCurrency) }}
-					</div>
+					<v-icon size="14" class="mr-1 text-primary">mdi-swap-horizontal</v-icon>
+					<span class="text-caption font-weight-medium text-medium-emphasis mr-1" style="white-space: nowrap;">{{ __("Exchange Rate") }}</span>
+					<span class="text-caption text-medium-emphasis mr-1" style="white-space: nowrap;">1 {{ invoiceTotalCurrency }} =</span>
 					<v-text-field
-						class="p-0 m-0 pos-themed-input"
-						density="compact"
-						color="primary"
-						hide-details
 						v-model="internalExchangeRate"
 						type="number"
 						step="0.01"
-						flat
-						@update:model-value="$emit('validate-exchange-rate')"
+						variant="plain"
+						density="compact"
+						hide-details
+						class="exchange-rate-input"
 						:loading="exchangeRateLoading"
 						:error="!!exchangeRateError"
 						:hint="exchangeRateError"
 						persistent-hint
-					></v-text-field>
+						@wheel.prevent
+						@update:model-value="$emit('validate-exchange-rate')"
+					/>
+					<span class="text-caption font-weight-medium mr-1">{{ companyCurrency }}</span>
 					<v-btn
 						icon
-						size="small"
+						size="x-small"
 						variant="text"
 						color="primary"
-						@click="$emit('fetch-exchange-rate')"
 						:loading="exchangeRateLoading"
 						:title="__('Refresh Exchange Rate')"
+						@click="$emit('fetch-exchange-rate')"
 					>
-						<v-icon>mdi-refresh</v-icon>
+						<v-icon size="14">mdi-refresh</v-icon>
 					</v-btn>
 				</div>
-				<small class="text-caption text-medium-emphasis">
-					1 {{ invoiceTotalCurrency }} = {{ formatCurrency(internalExchangeRate || 0) }}
-					{{ companyCurrency }}
-				</small>
-			</v-col>
-		</v-row>
+			</v-card-text>
+		</v-card>
 
-		<v-divider></v-divider>
-		<v-row>
-			<v-col md="7">
-				<h4 class="text-primary mt-1">{{ __("Difference:") }}</h4>
-			</v-col>
-			<v-col md="5">
-				<v-text-field
-					class="p-0 m-0 pos-themed-input"
-					density="compact"
-					color="primary"
-					hide-details
-					:model-value="formatCurrency(totalOfDiff)"
-					readonly
-					flat
-					:prefix="currencySymbol(invoiceTotalCurrency)"
-				></v-text-field>
-			</v-col>
-		</v-row>
+		<!-- 5. Difference (Prominent Status) -->
+		<v-card
+			:color="totalOfDiff === 0 ? 'success' : totalOfDiff > 0 ? 'warning' : 'error'"
+			variant="tonal"
+			class="mb-2 difference-card"
+		>
+			<v-card-text class="d-flex justify-space-between align-center py-2">
+				<span class="font-weight-bold">{{ __("Difference") }}</span>
+				<span class="text-subtitle-1 font-weight-bold">
+					{{ currencySymbol(invoiceTotalCurrency) }}{{ formatCurrency(totalOfDiff) }}
+				</span>
+			</v-card-text>
+		</v-card>
 
-		<v-divider></v-divider>
-		<h4 class="text-primary">{{ __("Transaction ID") }}</h4>
-		<v-row>
-			<v-col md="6" cols="12">
-				<v-text-field
-					density="compact"
-					variant="outlined"
-					hide-details
-					class="pos-themed-input"
-					v-model="internalReferenceNo"
-					:label="__('Cheque/Reference No')"
-				></v-text-field>
-			</v-col>
-			<v-col md="6" cols="12">
-				<VueDatePicker
-					:model-value="referenceDateDisplay"
-					model-type="format"
-					format="dd-MM-yyyy"
-					auto-apply
-					teleport
-					text-input
-					:enable-time-picker="false"
-					class="sleek-field pos-themed-input pay-reference-date"
-					:placeholder="__('Cheque/Reference Date')"
-					data-test="reference-date-input"
-					@update:model-value="updateReferenceDate"
-				/>
-			</v-col>
-		</v-row>
-		<v-row class="mt-2">
-			<v-col cols="12">
+		<!-- 6. Transaction ID -->
+		<v-card variant="outlined" class="mb-2 section-card">
+			<v-card-text class="py-2">
+				<h4 class="text-primary text-subtitle-1 font-weight-bold mb-2">
+					{{ __("Transaction ID") }}
+				</h4>
+				<v-row dense>
+					<v-col md="6" cols="12">
+						<v-text-field
+							v-model="internalReferenceNo"
+							density="compact"
+							variant="outlined"
+							hide-details
+							:label="__('Cheque/Reference No')"
+						/>
+					</v-col>
+					<v-col md="6" cols="12">
+						<VueDatePicker
+							:model-value="referenceDateDisplay"
+							model-type="format"
+							format="dd-MM-yyyy"
+							auto-apply
+							teleport
+							text-input
+							:enable-time-picker="false"
+							class="sleek-field pay-reference-date"
+							:placeholder="__('Cheque/Reference Date')"
+							data-test="reference-date-input"
+							@update:model-value="updateReferenceDate"
+						/>
+					</v-col>
+				</v-row>
+			</v-card-text>
+		</v-card>
+
+		<!-- 7. Auto Allocate -->
+		<v-card variant="outlined" class="section-card">
+			<v-card-text class="py-3">
 				<v-switch
 					:model-value="internalAutoAllocatePaymentAmount"
 					color="primary"
@@ -466,11 +430,105 @@
 					data-test="auto-allocate-payment-toggle"
 					@update:model-value="emit('update:autoAllocatePaymentAmount', Boolean($event))"
 				/>
-				<small class="text-caption text-medium-emphasis">
+				<div class="text-caption text-medium-emphasis mt-1">
 					{{ __("Unselected payments stay unallocated first, then auto reconcile after submit.") }}
-				</small>
-			</v-col>
-		</v-row>
+				</div>
+			</v-card-text>
+		</v-card>
+
+		<!-- Account Dialog -->
+		<v-dialog v-model="accountDialogOpen" max-width="500" :scrim="true" class="account-dialog">
+			<v-card class="account-dialog-card">
+				<v-card-title class="d-flex align-center pa-4">
+					<v-icon class="mr-2">mdi-bank</v-icon>
+					<span>{{ __("Select Payment Account") }}</span>
+					<v-spacer></v-spacer>
+					<v-btn icon variant="text" size="small" @click="accountDialogOpen = false">
+						<v-icon>mdi-close</v-icon>
+					</v-btn>
+				</v-card-title>
+				<v-divider />
+				<v-card-text class="pa-4">
+					<v-autocomplete
+						v-model="selectedAccountTemp"
+						:items="bankAccountOptions"
+						item-title="label"
+						item-value="value"
+						variant="outlined"
+						density="comfortable"
+						:label="__('Search Account')"
+						prepend-inner-icon="mdi-magnify"
+						hide-no-data
+						return-object
+						clearable
+					>
+						<template #item="{ props, item }">
+							<v-list-item v-bind="props" class="account-list-item">
+								<template #prepend>
+									<v-icon :color="getAccountTypeColor(item.raw.accountType)">
+										{{ getAccountTypeIcon(item.raw.accountType) }}
+									</v-icon>
+								</template>
+								<v-list-item-subtitle>
+									<div class="d-flex align-center">
+										<span class="font-weight-medium">{{ item.raw.label }}</span>
+									</div>
+								</v-list-item-subtitle>
+								<template #append>
+									<div class="d-flex align-center">
+										<v-chip size="small" :color="getAccountTypeColor(item.raw.accountType)" variant="tonal">
+											{{ item.raw.accountType }}
+										</v-chip>
+										<v-chip size="small" color="primary" variant="tonal" class="ml-1">
+											{{ item.raw.currency }}
+										</v-chip>
+									</div>
+								</template>
+							</v-list-item>
+						</template>
+						<template #selection="{ item }">
+							<div class="d-flex align-center">
+								<v-icon :color="getAccountTypeColor(item.raw.accountType)" class="mr-2">
+									{{ getAccountTypeIcon(item.raw.accountType) }}
+								</v-icon>
+								<span>{{ item.raw.label }}</span>
+								<v-chip size="small" :color="getAccountTypeColor(item.raw.accountType)" variant="tonal" class="ml-2">
+									{{ item.raw.accountType }}
+								</v-chip>
+								<v-chip size="small" color="primary" variant="tonal" class="ml-1">
+									{{ item.raw.currency }}
+								</v-chip>
+							</div>
+						</template>
+					</v-autocomplete>
+					<div class="d-flex align-center mt-3">
+						<v-btn
+							variant="tonal"
+							color="warning"
+							size="small"
+							prepend-icon="mdi-refresh"
+							@click="resetToDefault"
+						>
+							{{ __("Reset to Default") }}
+						</v-btn>
+						<v-spacer></v-spacer>
+						<span class="text-caption text-medium-emphasis">
+							{{ __("Default:") }} {{ defaultBankAccount }}
+						</span>
+					</div>
+				</v-card-text>
+				<v-divider />
+				<v-card-actions class="pa-4">
+					<v-btn variant="text" @click="accountDialogOpen = false">
+						{{ __("Cancel") }}
+					</v-btn>
+					<v-spacer></v-spacer>
+					<v-btn color="primary" variant="flat" @click="confirmAccountSelection">
+						{{ __("Confirm") }}
+					</v-btn>
+				</v-card-actions>
+			</v-card>
+		</v-dialog>
 	</div>
 </template>
 
@@ -478,6 +536,9 @@
 import { computed, ref, watch } from "vue";
 import VueDatePicker from "@vuepic/vue-datepicker";
 import { normalizeDateForBackend } from "../../format";
+import { useRtl } from "../../composables/core/useRtl";
+
+const { isRtl } = useRtl();
 
 const flt = (value, precision) => {
 	const num = parseFloat(String(value ?? 0).replace(/,/g, ""));
@@ -570,7 +631,6 @@ const rateFromCurrencyToCompany = (currency) => {
 		if (flt(props.exchangeRate) > 0) return flt(props.exchangeRate);
 		if (flt(props.invoiceConversionRate) > 0) return flt(props.invoiceConversionRate);
 	}
-	// Fallback for third currencies: use invoice→company rate as best estimate
 	if (flt(props.exchangeRate) > 0) return flt(props.exchangeRate);
 	if (flt(props.invoiceConversionRate) > 0) return flt(props.invoiceConversionRate);
 	return 1;
@@ -764,7 +824,6 @@ const internalReferenceDate = computed({
 const formatReferenceDateForDisplay = (value) => {
 	const normalized = normalizeDateForBackend(value);
 	if (!normalized) return "";
-
 	const [year, month, day] = normalized.split("-");
 	return `${day}-${month}-${year}`;
 };
@@ -784,6 +843,56 @@ defineExpose({
 </script>
 
 <style scoped>
+.pay-sidebar {
+	padding: 8px;
+	height: 100%;
+	overflow-y: auto;
+	overflow-x: hidden;
+}
+
+.section-card {
+	border-color: rgba(var(--v-border-color), 0.12);
+	background: rgb(var(--v-theme-surface));
+	border-radius: 12px;
+}
+
+.payment-detail-row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 2px;
+}
+
+.payment-detail-row:last-child {
+	margin-bottom: 0;
+}
+
+.compact-grid .v-col {
+	padding-top: 1px;
+	padding-bottom: 1px;
+}
+
+.exchange-rate-input {
+	max-width: 90px;
+	min-width: 70px;
+}
+.exchange-rate-input :deep(.v-field) {
+	background: transparent !important;
+	box-shadow: none !important;
+	border-bottom: 1px dashed rgba(var(--v-border-color), 0.3);
+	border-radius: 0;
+}
+.exchange-rate-input :deep(.v-field__input) {
+	font-size: 0.825rem;
+	font-weight: 600;
+	text-align: center;
+	padding: 2px 4px;
+	min-height: 28px;
+}
+.exchange-rate-input :deep(.v-field__overlay) {
+	display: none;
+}
+
 .pay-reference-date :deep(.dp__input_wrap) {
 	width: 100%;
 }
@@ -798,21 +907,52 @@ defineExpose({
 	padding: 0 12px;
 }
 
-.selected-payment-block + .selected-payment-block {
-	border-top: 1px solid rgba(var(--v-border-color), 0.3);
-	margin-top: 2px;
-	padding-top: 6px;
+/* RTL: datepicker component root — cascades to input + icon siblings */
+.pay-sidebar[dir="rtl"] :deep(.pay-reference-date) {
+	--dp-direction: rtl;
+}
+
+/* RTL: datepicker input text alignment */
+.pay-sidebar[dir="rtl"] .pay-reference-date :deep(.dp__input) {
+	direction: rtl;
+	text-align: right;
+}
+.pay-sidebar[dir="rtl"] .pay-reference-date :deep(.dp__input_icon) {
+	left: 8px;
+	right: auto;
+}
+.pay-sidebar[dir="rtl"] .pay-reference-date :deep(.dp__input_icon_pad) {
+	padding-left: 30px;
+	padding-right: 12px;
+}
+.pay-sidebar[dir="rtl"] .pay-reference-date :deep(.dp__clear_icon) {
+	left: 30px;
+	right: auto;
+}
+
+/* RTL: text field input alignment */
+.pay-sidebar[dir="rtl"] :deep(.v-field__input) {
+	text-align: right;
 }
 
 .new-payment-card {
 	border: 1px solid rgba(var(--v-border-color), 0.25);
-	border-radius: 8px;
+	border-radius: 10px;
 	background: rgba(var(--v-theme-surface), 0.6);
 }
 
-.new-payment-card .amount-field :deep(.v-field__input) {
-	font-size: 1rem;
+.payment-amount-input :deep(.v-field__input) {
+	font-size: 1.25rem;
+	font-weight: 700;
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
+.payment-amount-input :deep(.v-field__prefix) {
+	font-size: 1.1rem;
 	font-weight: 600;
+	color: rgb(var(--v-theme-primary));
+	padding-right: 4px;
 }
 
 .text-truncate {
@@ -821,7 +961,7 @@ defineExpose({
 	white-space: nowrap;
 }
 
-.account-selector-row {
+.account-row {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -835,9 +975,10 @@ defineExpose({
 	display: flex;
 	flex-direction: column;
 	padding: 10px 14px;
-	background: rgba(var(--v-theme-primary), 0.08);
+	background: rgba(var(--v-theme-primary), 0.06);
 	border: 1px solid rgba(var(--v-theme-primary), 0.2);
-	border-radius: 10px;
+	border-left: 3px solid rgb(var(--v-theme-primary));
+	border-radius: 8px;
 	cursor: pointer;
 	transition: all 0.2s ease;
 	min-width: 200px;
@@ -845,10 +986,12 @@ defineExpose({
 }
 
 .account-selector-card:hover {
-	background: rgba(var(--v-theme-primary), 0.12);
+	background: rgba(var(--v-theme-primary), 0.1);
 	border-color: rgba(var(--v-theme-primary), 0.35);
-	transform: translateY(-1px);
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.difference-card {
+	border-radius: 10px;
 }
 
 .account-dialog-card {
@@ -875,8 +1018,20 @@ defineExpose({
 	border-radius: 10px;
 }
 
+/* Custom scrollbar styling */
+.pay-sidebar::-webkit-scrollbar {
+	width: 6px;
+}
+.pay-sidebar::-webkit-scrollbar-track {
+	background: transparent;
+}
+.pay-sidebar::-webkit-scrollbar-thumb {
+	background: rgba(var(--v-border-color), 0.3);
+	border-radius: 3px;
+}
+
 @media (max-width: 600px) {
-	.account-selector-row {
+	.account-row {
 		flex-direction: column;
 		align-items: flex-start;
 		gap: 8px;
@@ -886,5 +1041,13 @@ defineExpose({
 		width: 100%;
 		max-width: none;
 	}
+}
+</style>
+
+<style>
+/* Unscoped: RTL support for teleported datepicker menu (appended to body) */
+.rtl-layout .dp__menu {
+	direction: rtl;
+	--dp-direction: rtl;
 }
 </style>

--- a/frontend/src/posapp/composables/pos/payments/usePosPaySelection.ts
+++ b/frontend/src/posapp/composables/pos/payments/usePosPaySelection.ts
@@ -1,6 +1,7 @@
 import { ref, computed, type Ref } from "vue";
 
 declare const flt: (_value: unknown, _precision?: number) => number;
+declare const __: (_text: string, _args?: any[]) => string;
 
 type PosPaySelectionArgs = {
 	posProfile: Ref<any>;
@@ -53,6 +54,19 @@ export function usePosPaySelection({
 			const amount = parseFloat(cur?.amount || 0);
 			return acc + (isNaN(amount) ? 0 : amount);
 		}, 0);
+	});
+
+	const selected_payments_detail = computed(() => {
+		if (!selected_payments.value.length) return [];
+		return selected_payments.value.map((payment: any) => ({
+			mode_of_payment: payment.mode_of_payment || __("Unknown"),
+			paid_amount: flt(payment.paid_amount || 0),
+			received_amount: flt(payment.received_amount || 0),
+			unallocated_amount: flt(payment.unallocated_amount || 0),
+			currency: payment.currency || posProfile.value?.currency,
+			exchange_rate: flt(payment.source_exchange_rate ?? payment.exchange_rate ?? 1),
+			account: payment.account || "",
+		}));
 	});
 
 	const total_of_diff = computed(() => {
@@ -112,6 +126,7 @@ export function usePosPaySelection({
 		total_selected_payments,
 		total_selected_mpesa_payments,
 		total_payment_methods,
+		selected_payments_detail,
 		total_of_diff,
 		toggleInvoiceSelection,
 		isInvoiceSelected,

--- a/frontend/src/posapp/composables/pos/payments/usePosPaySubmission.ts
+++ b/frontend/src/posapp/composables/pos/payments/usePosPaySubmission.ts
@@ -153,9 +153,14 @@ export function usePosPaySubmission({
 			pos_opening_shift_name: posOpeningShift.value.name,
 			pos_profile_name: posProfile.value.name,
 			pos_profile: posProfile.value,
-			payment_methods: payment_methods.value.filter(
-					(m: any) => flt(m.amount) > 0,
-				),
+			payment_methods: payment_methods.value
+				.filter((m: any) => flt(m.amount) > 0)
+				.map((m: any) => ({
+					mode_of_payment: m.mode_of_payment,
+					amount: m.amount,
+					row_id: m.row_id,
+					bank_account: m.bank_account || null,
+				})),
 				selected_invoices: selectedInvoicesForPayload,
 				selected_payments: selected_payments.value,
 				total_selected_invoices: flt(totalSelectedInvoicesAmount),
@@ -202,6 +207,20 @@ export function usePosPaySubmission({
 			}
 
 			frappe.utils.play_sound("submit");
+
+			// Show exchange gain/loss notification as toast (non-intrusive)
+			if (response.message?.net_gain_loss) {
+				const netAmount = response.message.net_gain_loss;
+				const currency = response.message.exchange_gain_loss_summary?.[0]?.currency || '';
+				const label = netAmount >= 0 ? __("Gain") : __("Loss");
+
+				// Use toast notification (auto-dismiss)
+				eventBus.emit("show_notification", {
+					message: __("{0}: {1} {2}", [label, Math.abs(netAmount).toFixed(2), currency]),
+					type: netAmount >= 0 ? "success" : "warning",
+					duration: 4000,
+				});
+			}
 
 			if (autoAllocatePaymentAmount.value) {
 				const autoReconcileResult = await autoReconcile(null, {

--- a/posawesome/posawesome/api/payment_processing/creation.py
+++ b/posawesome/posawesome/api/payment_processing/creation.py
@@ -28,6 +28,7 @@ def create_payment_entry(
     cost_center=None,
     submit=0,
     client_request_id=None,
+    bank_account=None,
 ):
     date = nowdate() if not posting_date else posting_date
     party = party or customer
@@ -46,7 +47,7 @@ def create_payment_entry(
     party_account_currency = get_account_currency(party_account)
 
     # Get bank details BEFORE validation
-    bank = get_bank_cash_account(company, mode_of_payment)
+    bank = get_bank_cash_account(company, mode_of_payment, bank_account=bank_account)
     if not bank:
         frappe.throw(_("Bank/Cash account not found for mode of payment {0}").format(mode_of_payment))
 

--- a/posawesome/posawesome/api/payment_processing/creation.py
+++ b/posawesome/posawesome/api/payment_processing/creation.py
@@ -50,19 +50,12 @@ def create_payment_entry(
     if not bank:
         frappe.throw(_("Bank/Cash account not found for mode of payment {0}").format(mode_of_payment))
 
-    # Validate currency: frontend always sends bank currency (physical cash)
-    expected_currency = bank.account_currency
-    if currency != expected_currency:
-        frappe.throw(_(
-            "Currency is not correct. Expected {expected}, got {currency}"
-        ).format(expected=expected_currency, currency=currency))
-
-    # Get exchange rate
+    # Get exchange rate using the MOP bank account currency
     if exchange_rate and flt(exchange_rate) > 0:
         conversion_rate = flt(exchange_rate)
     else:
         conversion_rate = get_exchange_rate(
-            currency, company_currency, date,
+            bank.account_currency, company_currency, date,
             "for_buying" if payment_type == "Pay" else "for_selling"
         )
 
@@ -126,11 +119,10 @@ def create_payment_entry(
         )
         pe.paid_amount = paid_amount
         pe.received_amount = received_amount
-        # Defensive: ensure base amounts are set for same-currency case
-        if not pe.base_paid_amount:
-            pe.base_paid_amount = flt(paid_amount)
-        if not pe.base_received_amount:
-            pe.base_received_amount = flt(received_amount)
+        pe.source_exchange_rate = conversion_rate
+        pe.target_exchange_rate = conversion_rate
+        pe.base_paid_amount = flt(paid_amount * conversion_rate, precision)
+        pe.base_received_amount = flt(received_amount * conversion_rate, precision)
 
     if submit:
         pe.insert(ignore_permissions=True)

--- a/posawesome/posawesome/api/payment_processing/data.py
+++ b/posawesome/posawesome/api/payment_processing/data.py
@@ -46,6 +46,7 @@ def _get_open_sales_invoices(
             "pos_profile",
             "customer_name",
             "conversion_rate",
+            "party_account_currency",
         ],
         order_by="posting_date desc, name desc",
     )
@@ -81,6 +82,7 @@ def _get_open_purchase_invoices(
             "currency",
             "supplier_name",
             "conversion_rate",
+            "party_account_currency",
         ],
         order_by="posting_date desc, name desc",
     )
@@ -200,7 +202,19 @@ def get_outstanding_invoices(
 
             row_currency = invoice.get("currency") or currency
 
-            outstanding_in_invoice_currency = flt(outstanding_amount / conversion_rate, 2) if conversion_rate > 0 else outstanding_amount
+            # Convert outstanding from party account currency to invoice currency
+            # Examples:
+            # - Party YER (company), Invoice USD: 60,003 YER ÷ 531 (YER/USD) = 113 USD
+            # - Party USD (invoice), Invoice USD: 100 USD → 100 USD (no conversion)
+            party_account_currency = invoice.get("party_account_currency") or currency
+            if party_account_currency == row_currency:
+                outstanding_in_invoice_currency = outstanding_amount
+            else:
+                precision = frappe.get_precision("Sales Invoice", "outstanding_amount") or 2
+                if conversion_rate > 0:
+                    outstanding_in_invoice_currency = flt(outstanding_amount / conversion_rate, precision)
+                else:
+                    outstanding_in_invoice_currency = outstanding_amount
             invoice_total = flt(
                 invoice.get("rounded_total")
                 or invoice.get("grand_total")
@@ -308,6 +322,7 @@ def get_unallocated_payments(
             "posting_date",
             "unallocated_amount",
             "mode_of_payment",
+            "source_exchange_rate",
             (
                 "paid_to_account_currency as currency"
                 if party_type == "Supplier"
@@ -337,6 +352,7 @@ def get_unallocated_payments(
                 "posting_date",
                 "unallocated_amount",
                 "mode_of_payment",
+                "source_exchange_rate",
                 (
                     "paid_to_account_currency as currency"
                     if party_type == "Supplier"

--- a/posawesome/posawesome/api/payment_processing/data.py
+++ b/posawesome/posawesome/api/payment_processing/data.py
@@ -3,6 +3,7 @@ from frappe import _
 from frappe.utils import nowdate, getdate, flt, cint
 from erpnext.accounts.party import get_party_account
 from erpnext.controllers.accounts_controller import get_advance_payment_entries_for_regional
+from erpnext.setup.utils import get_exchange_rate
 
 MAX_OUTSTANDING_PAGE_LENGTH = 500
 
@@ -207,14 +208,23 @@ def get_outstanding_invoices(
             # - Party YER (company), Invoice USD: 60,003 YER ÷ 531 (YER/USD) = 113 USD
             # - Party USD (invoice), Invoice USD: 100 USD → 100 USD (no conversion)
             party_account_currency = invoice.get("party_account_currency") or currency
+            company_currency = frappe.get_cached_value("Company", company, "default_currency")
             if party_account_currency == row_currency:
                 outstanding_in_invoice_currency = outstanding_amount
-            else:
+            elif party_account_currency == company_currency:
                 precision = frappe.get_precision("Sales Invoice", "outstanding_amount") or 2
                 if conversion_rate > 0:
                     outstanding_in_invoice_currency = flt(outstanding_amount / conversion_rate, precision)
                 else:
                     outstanding_in_invoice_currency = outstanding_amount
+            else:
+                # Third currency: convert from party account currency to invoice currency
+                precision = frappe.get_precision("Sales Invoice", "outstanding_amount") or 2
+                party_to_inv = get_exchange_rate(party_account_currency, row_currency, invoice.get("posting_date"))
+                if party_to_inv:
+                    outstanding_in_invoice_currency = flt(outstanding_amount / party_to_inv, precision)
+                else:
+                    outstanding_in_invoice_currency = flt(outstanding_amount / conversion_rate, precision) if conversion_rate > 0 else outstanding_amount
             invoice_total = flt(
                 invoice.get("rounded_total")
                 or invoice.get("grand_total")

--- a/posawesome/posawesome/api/payment_processing/processor.py
+++ b/posawesome/posawesome/api/payment_processing/processor.py
@@ -589,6 +589,7 @@ def process_pos_payment(payload):
                     cost_center=data.pos_profile.get("cost_center"),
                     submit=0,
                     client_request_id=client_request_id,
+                    bank_account=payment_method.get("bank_account"),
                 )
 
                 party_account = get_party_account(party_type, party, company)

--- a/posawesome/posawesome/api/payment_processing/processor.py
+++ b/posawesome/posawesome/api/payment_processing/processor.py
@@ -657,7 +657,7 @@ def process_pos_payment(payload):
                         inv_to_party = flt(get_exchange_rate(inv_currency, party_account_currency, posting_date))
                         total_amount = flt((inv_doc.rounded_total or inv_doc.grand_total) * inv_to_party, precision)
                         outstanding_amount = flt(inv_doc.outstanding_amount * inv_to_party, precision)
-                        exchange_rate = inv_to_party
+                        exchange_rate = flt(get_exchange_rate(party_account_currency, company_currency, posting_date))
                     inv_outstanding_party = outstanding_amount
 
                     inv_total_party = total_amount
@@ -728,14 +728,18 @@ def process_pos_payment(payload):
                     if inv_rate and pe_exchange_rate and inv_rate != pe_exchange_rate:
                         ref = ref_map.get(inv["name"])
                         if ref and ref.allocated_amount:
-                            # Convert from party account currency to invoice currency
-                            allocated_in_invoice_currency = flt(ref.allocated_amount) / inv_rate
+                            # Gain/loss in company currency using ERPNext pattern:
+                            # base at payment rate - base at reference/invoice rate
+                            # allocated_amount is in party account currency
+                            ref_rate = flt(ref.exchange_rate) or 1
+                            allocated_base = flt(ref.allocated_amount * pe_exchange_rate, precision)
+                            allocated_base_at_ref_rate = flt(ref.allocated_amount * ref_rate, precision)
+                            gl_value = allocated_base - allocated_base_at_ref_rate
                         else:
                             inv_doc = frappe.get_cached_doc(inv.get("voucher_type") or "Sales Invoice", inv["name"])
-                            # Fallback to full invoice amount (in invoice currency)
-                            allocated_in_invoice_currency = flt(inv_doc.rounded_total or inv_doc.grand_total, precision)
-
-                        gl_value = flt(allocated_in_invoice_currency * (pe_exchange_rate - inv_rate), precision)
+                            # Fallback to full invoice amount in company currency
+                            allocated_base = flt(inv_doc.base_rounded_total or inv_doc.base_grand_total, precision)
+                            gl_value = 0
                         if gl_value:
                             amount = abs(gl_value)
                             gl_type = "gain" if gl_value > 0 else "loss"

--- a/posawesome/posawesome/api/payment_processing/processor.py
+++ b/posawesome/posawesome/api/payment_processing/processor.py
@@ -5,9 +5,6 @@ from frappe.utils import nowdate, flt, fmt_money, cint
 from erpnext.accounts.party import get_party_account
 from erpnext.accounts.doctype.payment_reconciliation.payment_reconciliation import reconcile_dr_cr_note
 from erpnext.accounts.utils import get_account_currency, reconcile_against_document
-from posawesome.posawesome.api.payment_processing.journal_entry import (
-    create_pos_exchange_gain_loss_journal
-)
 from erpnext.setup.utils import get_exchange_rate
 from posawesome.posawesome.api.m_pesa import submit_mpesa_payment
 from posawesome.posawesome.api.payment_processing.creation import create_payment_entry
@@ -346,6 +343,7 @@ def process_pos_payment(payload):
                     "outstanding_amount": outstanding,
                     "voucher_type": voucher_type,
                     "conversion_rate": conversion_rate,
+                    "due_date": invoice.get("due_date") or invoice.get("posting_date"),
                 }
             )
 
@@ -355,6 +353,8 @@ def process_pos_payment(payload):
     all_payments_entry = list(cached_entries)
     reconciled_payments = list(completed_reconciliation_summaries)
     errors = []
+    exchange_gain_loss_summary = []
+    net_gain_loss = 0
 
     # first process mpesa payments
     if (
@@ -531,6 +531,7 @@ def process_pos_payment(payload):
                                 "grand_total": outstanding_before,
                                 "outstanding_amount": outstanding_before,
                                 "exchange_rate": 1,
+                                "due_date": inv.get("due_date"),
                                 "is_advance": 0,
                                 "difference_amount": 0,
                                 "cost_center": pe_doc.cost_center,
@@ -636,17 +637,30 @@ def process_pos_payment(payload):
                     inv_conv_rate = flt(inv_doc.conversion_rate)
 
                     # Get amounts in party account currency
+                    company_currency = payment_entry.company_currency
+                    party_account_currency = payment_entry.party_account_currency
+
+                    # Calculate reference details as per ERPNext's get_reference_details
+                    # All amounts must be in party account currency
                     if inv_currency == party_account_currency:
-                        inv_outstanding_party = flt(inv_doc.outstanding_amount)
-                        inv_total_party = flt(inv_doc.grand_total or inv_doc.rounded_total or inv_doc.outstanding_amount)
+                        # Invoice currency matches party account currency
+                        total_amount = flt(inv_doc.rounded_total or inv_doc.grand_total, precision)
+                        outstanding_amount = flt(inv_doc.outstanding_amount, precision)
+                        exchange_rate = inv_conv_rate
                     elif party_account_currency == company_currency:
-                        inv_outstanding_party = flt(inv_doc.outstanding_amount * inv_conv_rate, precision)
-                        inv_total_party = flt(inv_doc.base_rounded_total or inv_doc.base_grand_total or inv_outstanding_party)
+                        # Party account in company currency — use base amounts
+                        total_amount = flt(inv_doc.base_rounded_total or inv_doc.base_grand_total, precision)
+                        outstanding_amount = flt(getattr(inv_doc, 'base_outstanding_amount', 0) or inv_doc.outstanding_amount * inv_conv_rate, precision)
+                        exchange_rate = 1
                     else:
+                        # Party account in third currency (different from both invoice and company)
                         inv_to_party = flt(get_exchange_rate(inv_currency, party_account_currency, posting_date))
-                        comp_to_party = flt(get_exchange_rate(company_currency, party_account_currency, posting_date))
-                        inv_outstanding_party = flt(inv_doc.outstanding_amount * inv_to_party, precision)
-                        inv_total_party = flt((inv_doc.base_rounded_total or inv_doc.base_grand_total) * comp_to_party, precision)
+                        total_amount = flt((inv_doc.rounded_total or inv_doc.grand_total) * inv_to_party, precision)
+                        outstanding_amount = flt(inv_doc.outstanding_amount * inv_to_party, precision)
+                        exchange_rate = inv_to_party
+                    inv_outstanding_party = outstanding_amount
+
+                    inv_total_party = total_amount
 
                     if inv_outstanding_party <= 0:
                         continue
@@ -661,9 +675,10 @@ def process_pos_payment(payload):
                         {
                             "reference_doctype": voucher_type,
                             "reference_name": inv["name"],
-                            "total_amount": inv_total_party,
-                            "outstanding_amount": inv_outstanding_party,
+                            "total_amount": total_amount,
+                            "outstanding_amount": outstanding_amount,
                             "allocated_amount": allocation,
+                            "exchange_rate": exchange_rate,
                         },
                     )
 
@@ -672,6 +687,7 @@ def process_pos_payment(payload):
 
                 payment_entry.total_allocated_amount = total_allocated
 
+                # party_amount must be in party currency to match total_allocated (now in party currency)
                 party_amount = (
                     payment_entry.paid_amount if payment_type == "Receive" else payment_entry.received_amount
                 )
@@ -699,58 +715,54 @@ def process_pos_payment(payload):
 
                 pe_exchange_rate = payment_entry.target_exchange_rate if payment_type == "Receive" else payment_entry.source_exchange_rate
 
-                # Store gain/loss BEFORE save - ERPNext resets exchange_gain_loss during validation
-                # Map by reference_name instead of list index to avoid mismatch when invoices are skipped
-                gain_loss_refs = []
+                # Build a map of reference rows by invoice name
+                ref_map = {}
                 for ref in payment_entry.references:
-                    inv = next((inv for inv in remaining_invoices if inv["name"] == ref.reference_name), {})
+                    ref_map[ref.reference_name] = ref
+
+                # Calculate gain/loss for UI notification only (not set on reference)
+                exchange_gain_loss_summary = []
+                net_gain_loss = 0
+                for inv in remaining_invoices:
                     inv_rate = flt(inv.get("conversion_rate")) or 1
                     if inv_rate and pe_exchange_rate and inv_rate != pe_exchange_rate:
-                        allocated_yer = flt(ref.allocated_amount)
-                        allocated_at_inv_rate = flt((allocated_yer / pe_exchange_rate) * inv_rate, precision)
-                        gl_value = flt(allocated_yer - allocated_at_inv_rate, precision)
-                        ref.exchange_gain_loss = gl_value
-                        gain_loss_refs.append({
-                            "reference_name": ref.reference_name,
-                            "reference_doctype": ref.reference_doctype,
-                            "exchange_gain_loss": gl_value,
-                            "idx": ref.idx,
-                        })
+                        ref = ref_map.get(inv["name"])
+                        if ref and ref.allocated_amount:
+                            # Convert from party account currency to invoice currency
+                            allocated_in_invoice_currency = flt(ref.allocated_amount) / inv_rate
+                        else:
+                            inv_doc = frappe.get_cached_doc(inv.get("voucher_type") or "Sales Invoice", inv["name"])
+                            # Fallback to full invoice amount (in invoice currency)
+                            allocated_in_invoice_currency = flt(inv_doc.rounded_total or inv_doc.grand_total, precision)
+
+                        gl_value = flt(allocated_in_invoice_currency * (pe_exchange_rate - inv_rate), precision)
+                        if gl_value:
+                            amount = abs(gl_value)
+                            gl_type = "gain" if gl_value > 0 else "loss"
+                            exchange_gain_loss_summary.append({
+                                "payment": payment_entry.name,
+                                "invoice": inv["name"],
+                                "amount": amount,
+                                "currency": company_currency,
+                                "type": gl_type
+                            })
+                            net_gain_loss += gl_value
+
+                # Add gain/loss info to Payment Entry remarks (with deduplication)
+                if exchange_gain_loss_summary:
+                    gl_parts = []
+                    for item in exchange_gain_loss_summary:
+                        gl_parts.append(f"{item['type'].title()}: {item['amount']} {item['currency']}")
+                    gl_remark = f"Exchange Gain/Loss: {'; '.join(gl_parts)}"
+                    if gl_remark not in (payment_entry.remarks or ""):
+                        payment_entry.remarks += f"\n{gl_remark}"
 
                 payment_entry.save(ignore_permissions=True)
-                payment_entry.submit()
-
-                payment_entry.reload()
-
-                for gl_ref in gain_loss_refs:
-                    if not gl_ref["exchange_gain_loss"]:
-                        continue
-                    gain_loss_account = frappe.get_cached_value("Company", company, "exchange_gain_loss_account")
-                    if not gain_loss_account:
-                        frappe.log_error(f"No exchange_gain_loss_account set for company {company}", "POS Payment Error")
-                        continue
-                    party_acct = payment_entry.paid_from if payment_type == "Receive" else payment_entry.paid_to
-                    dr_or_cr = "debit" if gl_ref["exchange_gain_loss"] > 0 else "credit"
-                    reverse_dr_or_cr = "credit" if dr_or_cr == "debit" else "debit"
-                    create_pos_exchange_gain_loss_journal(
-                        company=company,
-                        posting_date=payment_entry.posting_date,
-                        party_type=party_type,
-                        party=party,
-                        party_account=party_acct,
-                        gain_loss_account=gain_loss_account,
-                        exc_gain_loss=abs(flt(gl_ref['exchange_gain_loss'])),
-                        dr_or_cr=dr_or_cr,
-                        reverse_dr_or_cr=reverse_dr_or_cr,
-                        ref1_dt=gl_ref['reference_doctype'],
-                        ref1_dn=gl_ref['reference_name'],
-                        ref1_detail_no=gl_ref['idx'],
-                        ref2_dt="Payment Entry",
-                        ref2_dn=payment_entry.name,
-                        ref2_detail_no=gl_ref['idx'],
-                        cost_center=payment_entry.cost_center,
-                        dimensions=None,
-                    )
+                frappe.flags.ignore_permissions = True
+                try:
+                    payment_entry.submit()
+                finally:
+                    frappe.flags.ignore_permissions = False
 
                 new_payments_entry.append(payment_entry)
                 all_payments_entry.append(payment_entry)
@@ -802,4 +814,7 @@ def process_pos_payment(payload):
         "all_payments_entry": _to_public_entries(all_payments_entry),
         "reconciled_payments": reconciled_payments,
         "errors": errors,
+        "exchange_gain_loss_summary": exchange_gain_loss_summary,
+        "net_gain_loss": net_gain_loss,
     }
+

--- a/posawesome/posawesome/api/payment_processing/utils.py
+++ b/posawesome/posawesome/api/payment_processing/utils.py
@@ -74,6 +74,31 @@ def set_paid_amount_and_received_amount(
 
 
 @frappe.whitelist()
+def get_available_accounts_for_mop(company, mode_of_payment):
+    """Get all bank/cash accounts available for a given mode of payment."""
+    default_account = get_bank_cash_account(company, mode_of_payment)
+    if not default_account:
+        return []
+
+    account_type = default_account.get("account_type")
+    if not account_type:
+        return []
+
+    accounts = frappe.get_list(
+        "Account",
+        filters={
+            "company": company,
+            "account_type": account_type,
+            "is_group": 0,
+            "disabled": 0,
+        },
+        fields=["name as account", "account_currency", "account_type", "account_name"],
+        order_by="name asc",
+    )
+    return accounts
+
+
+@frappe.whitelist()
 def get_mode_of_payment_accounts(company, mode_of_payments):
     import json
 

--- a/posawesome/posawesome/api/payment_processing/utils.py
+++ b/posawesome/posawesome/api/payment_processing/utils.py
@@ -80,9 +80,28 @@ def get_mode_of_payment_accounts(company, mode_of_payments):
     if isinstance(mode_of_payments, str):
         mode_of_payments = json.loads(mode_of_payments)
 
-    currency_map = {}
+    result = {}
     for mode in mode_of_payments:
         account = get_bank_cash_account(company, mode)
         if account:
-            currency_map[mode] = account.get("account_currency")
-    return currency_map
+            result[mode] = {
+                "account": account.get("account"),
+                "account_currency": account.get("account_currency"),
+                "account_type": account.get("account_type"),
+            }
+    return result
+
+
+@frappe.whitelist()
+def get_party_account_info(party_type, party, company):
+    account = get_party_account(party_type, party, company)
+    if not account:
+        return None
+
+    currency = frappe.get_cached_value("Account", account, "account_currency")
+    account_name = frappe.get_cached_value("Account", account, "account_name")
+    return {
+        "account": account,
+        "account_name": account_name,
+        "currency": currency,
+    }


### PR DESCRIPTION
- PayView.vue: remove currency filter to show all MOPs regardless of invoice currency

- PayTotalsSidebar.vue: replace all-MOPs list with single v-select dropdown; auto-select MOP matching invoice currency; hide From/To accounts until data loads; card-style UI

- creation.py: remove currency validation blocking cross-currency MOPs; use bank.account_currency for exchange rate lookup

- processor.py: fix UnboundLocalError by initializing exchange_gain_loss_summary at function level

- data.py, utils.py, usePosPaySelection.ts: related refinements for multi-currency payment precision