### PR TITLE
fix: triggerUpdateTotals() now touches metadata after recomputing tot…

### DIFF
--- a/frontend/src/posapp/components/pos/invoice/CartItemRow.vue
+++ b/frontend/src/posapp/components/pos/invoice/CartItemRow.vue
@@ -567,12 +567,6 @@ function changeUom(direction) {
 	}
 
 	const newUom = uoms[newIndex];
-	console.log("[CartItemRow] changeUom", {
-		item: props.item.item_code,
-		direction,
-		old_uom: props.item.uom,
-		new_uom: newUom,
-	});
 	if (newUom !== props.item.uom) {
 		emit("calc-uom", props.item, newUom);
 	}
@@ -580,11 +574,6 @@ function changeUom(direction) {
 
 function handleUomSelect(newUom) {
 	if (disableUomEdit.value) return;
-	console.log("[CartItemRow] handleUomSelect", {
-		item: props.item.item_code,
-		old_uom: props.item.uom,
-		new_uom: newUom,
-	});
 	if (newUom && newUom !== props.item.uom) {
 		emit("calc-uom", props.item, newUom);
 	}

--- a/frontend/src/posapp/composables/pos/shared/useDiscounts.ts
+++ b/frontend/src/posapp/composables/pos/shared/useDiscounts.ts
@@ -21,6 +21,14 @@ declare const __: (_text: string, _args?: any[]) => string;
 export function useDiscounts() {
 	const toastStore = useToastStore();
 
+	const refreshInvoiceTotals = (context: any) => {
+		if (context.invoiceStore?.triggerUpdateTotals) {
+			context.invoiceStore.triggerUpdateTotals();
+			return;
+		}
+		context.invoiceStore?.recalculateTotals?.();
+	};
+
 	/**
 	 * Captures a shallow snapshot of all price-related fields from `item`.
 	 * Used immediately before a price mutation so that `enforceOfferPriceLimits` can
@@ -545,9 +553,7 @@ export function useDiscounts() {
 
 			// Update stock calculations and force UI update
 			if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);
-			if (context.invoiceStore?.triggerUpdateTotals) {
-				context.invoiceStore.triggerUpdateTotals();
-			}
+			refreshInvoiceTotals(context);
 			if (context.forceUpdate) context.forceUpdate();
 		} catch (error: unknown) {
 			console.error("Error calculating prices:", error);
@@ -614,6 +620,7 @@ export function useDiscounts() {
 				context.currency_precision,
 			);
 			item.base_amount = toBaseCurrency(context, item.amount);
+			refreshInvoiceTotals(context);
 			if (context.forceUpdate) context.forceUpdate();
 			return;
 		}
@@ -624,6 +631,7 @@ export function useDiscounts() {
 				context.currency_precision,
 			);
 			item.base_amount = toBaseCurrency(context, item.amount);
+			refreshInvoiceTotals(context);
 			if (context.forceUpdate) context.forceUpdate();
 			return;
 		}
@@ -675,9 +683,7 @@ export function useDiscounts() {
 		);
 		item.base_amount = toBaseCurrency(context, item.amount);
 
-		if (context.invoiceStore?.triggerUpdateTotals) {
-			context.invoiceStore.triggerUpdateTotals();
-		}
+		refreshInvoiceTotals(context);
 		if (context.forceUpdate) context.forceUpdate();
 	};
 

--- a/frontend/src/posapp/stores/invoiceStore.ts
+++ b/frontend/src/posapp/stores/invoiceStore.ts
@@ -178,6 +178,7 @@ export const useInvoiceStore = defineStore("invoice", () => {
 		if (updateTimer) return;
 		updateTimer = setTimeout(() => {
 			recalculateTotals();
+			touch();
 			updateTimer = null;
 		}, 50);
 	};

--- a/frontend/tests/cartLargeInvoicePerformance.spec.ts
+++ b/frontend/tests/cartLargeInvoicePerformance.spec.ts
@@ -12,7 +12,7 @@ describe("large cart performance guards", () => {
 			"utf8",
 		);
 
-		expect(source).not.toMatch(/console\.log\(\`\[CartItemRow\]/);
+		expect(source).not.toMatch(/console\.log\(\s*[`'"]\[CartItemRow\]/);
 	});
 
 	it("does not deep-watch every cart item for offer refreshes", () => {

--- a/frontend/tests/useItemAddition.spec.ts
+++ b/frontend/tests/useItemAddition.spec.ts
@@ -51,6 +51,7 @@ describe("useItemAddition new line behavior", () => {
 	beforeEach(() => {
 		(globalThis as any).__ = (text: string) => text;
 		(globalThis as any).frappe = {
+			call: vi.fn(async () => ({ message: [] })),
 			datetime: {
 				nowdate: () => "2026-03-05",
 			},

--- a/frontend/tests/useItemsSelectorPriceListSync.spec.ts
+++ b/frontend/tests/useItemsSelectorPriceListSync.spec.ts
@@ -33,6 +33,23 @@ describe("useItemsSelectorPriceListSync", () => {
 
 		await sync.syncSelectorPriceList("  ");
 
+		expect(sync.resolveIncomingPriceList("  ")).toBe("Retail");
+		expect(updatePriceList).not.toHaveBeenCalled();
+	});
+
+	it("skips redundant updates after trimming the incoming price list", async () => {
+		const activePriceList = ref("Wholesale");
+		const updatePriceList = vi.fn();
+
+		const sync = useItemsSelectorPriceListSync({
+			activePriceList,
+			getDefaultPriceList: () => "Retail",
+			updatePriceList,
+		});
+
+		await sync.syncSelectorPriceList(" Wholesale ");
+
+		expect(sync.resolveIncomingPriceList(" Wholesale ")).toBe("Wholesale");
 		expect(updatePriceList).not.toHaveBeenCalled();
 	});
 

--- a/posawesome/posawesome/api/payment_processing/creation.py
+++ b/posawesome/posawesome/api/payment_processing/creation.py
@@ -84,9 +84,9 @@ def create_payment_entry(
 
     # Set bank account if available
     if pe.party_type in ["Customer", "Supplier"]:
-        bank_account = get_party_bank_account(pe.party_type, pe.party)
-        if bank_account:
-            pe.bank_account = bank_account
+        party_bank_account = get_party_bank_account(pe.party_type, pe.party)
+        if party_bank_account:
+            pe.bank_account = party_bank_account
             pe.set_bank_account_data()
 
     # Let ERPNext fill missing metadata (party name, contact, defaults)

--- a/posawesome/posawesome/api/payment_processing/utils.py
+++ b/posawesome/posawesome/api/payment_processing/utils.py
@@ -123,8 +123,16 @@ def get_party_account_info(party_type, party, company):
     if not account:
         return None
 
-    currency = frappe.get_cached_value("Account", account, "account_currency")
-    account_name = frappe.get_cached_value("Account", account, "account_name")
+    account_values = frappe.get_cached_value(
+        "Account",
+        account,
+        ["account_currency", "account_name"],
+    )
+    if isinstance(account_values, dict):
+        currency = account_values.get("account_currency")
+        account_name = account_values.get("account_name")
+    else:
+        currency, account_name = account_values or (None, None)
     return {
         "account": account,
         "account_name": account_name,


### PR DESCRIPTION
…als, widened the CartItemRow console-log guard regex, removed the quoted console.log("[CartItemRow]..."), dded a safe totals refresh helper.