### PR TITLE
fix(import): pre-import pricing_rules to avoid Py3.14 ModuleLock

### DIFF
--- a/posawesome/posawesome/api/__init__.py
+++ b/posawesome/posawesome/api/__init__.py
@@ -44,6 +44,17 @@ from .offers import (
     get_offers,
     get_pos_coupon,
 )
+# Pre-import `pricing_rules` so its module load happens during the
+# package __init__ pass — same call stack as offers/items/etc.
+# Without this Python 3.14's stricter `_ModuleLock` raises a
+# deadlock when two concurrent SPA requests race on
+# `posawesome.posawesome.api.offers` (already loaded once via
+# this __init__) and `posawesome.posawesome.api.pricing_rules`
+# (loaded on first frappe.call to `get_active_pricing_rules`,
+# triggering a re-entry into this __init__ from a different
+# thread). Pre-importing means subsequent calls hit the cached
+# module without re-running this __init__ chain.
+from .pricing_rules import get_active_pricing_rules, reconcile_line_prices  # noqa: F401
 from .payments import (
     create_payment_request,
     get_available_credit,


### PR DESCRIPTION
Operator hit:
  Failed to get method for command
  posawesome.posawesome.api.pricing_rules.get_active_pricing_rules
  with deadlock detected by _ModuleLock(
    'posawesome.posawesome.api.offers') at 139843133460560

Python 3.14 added stricter detection of cross-thread module import lock cycles. The chain that triggers it on this Frappe v16 stack:

  Thread A (request 1): imports `posawesome.posawesome.api`
    package — runs __init__.py — currently mid `from .offers
    import ...` (offers module lock held).
  Thread B (request 2): wants `pricing_rules.get_active_pricing_rules`
    → Python imports `posawesome.posawesome.api.pricing_rules`,
    which first re-runs the package __init__.py, which tries
    again to acquire offers lock held by A. Both threads wait.

pricing_rules.py has no module-level dependency on offers; the deadlock is purely in Python's import lock graph + Frappe's on-demand `get_attr` import path.

Fix: pre-import `pricing_rules` from inside api/__init__.py right after offers, so a single-thread package init load brings both modules into sys.modules together. Subsequent frappe.call hits to `pricing_rules.*` find the cached module and skip the import lock entirely.

Restart workers required (`bench restart`) for new __init__ to take effect.

How to test
-----------
1. `bench restart` after pulling.
2. Open POS, change customer with a foreign price list (which fires `get_active_pricing_rules` + parallel `get_offers`).
3. No more "Failed to get method ... deadlock detected" errors in the worker log.