### PR TITLE
chore(deps): bump vuetify 3.7.5 → 3.12.6

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
 		"vue-qrcode-reader": "^5.7.2",
 		"vue-router": "^4.6.4",
 		"vue-virtual-scroller": "^2.0.0-beta.8",
-		"vuetify": "^3.7.5"
+		"vuetify": "^3.12.6"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.16.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3469,10 +3469,10 @@ vue@^3.3.4:
     "@vue/server-renderer" "3.5.18"
     "@vue/shared" "3.5.18"
 
-vuetify@^3.7.5:
-  version "3.9.5"
-  resolved "https://registry.npmjs.org/vuetify/-/vuetify-3.9.5.tgz"
-  integrity sha512-rJBSo1FeKcJJaqTfVHbOdpFXCmgeEIGzrh6HBEMGjSflan6voPIMSiK2dTCUU4t9JeghwvJtoAE5eBuqYIkFVA==
+vuetify@^3.12.6:
+  version "3.12.6"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.12.6.tgz#ae972a63744cdbb8a3ebd8bcef29daf29410c91e"
+  integrity sha512-ARfflEJu+pKk+vya059qsUT/xUnYf0K6sIZdJwVh5w+kR6CJCXMQN1MONABb3Jm2kmhN/AXB4W5/MjYiKnVAFg==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Tracks Vuetify v3 latest. Drops a year of accumulated bug fixes into the SPA, including specifically the v-virtual-scroll deep-watch issue that matches a heap-snapshot signature seen in production under load.

Key v3.8 → v3.12 fixes likely affecting the cart/items OOM class:

  v3.8.0 — VVirtualScroll: don't fully deep watch items
            (#19941, #20608) — addresses the per-row deep-watch
            cost that compounds with reactive-trigger fan-out.
  v3.8.0 — theme: stylesheetId + scope options for theme CSS
            cleanup (#4065).
  v3.8.0 — VIcon: swap provideTheme with useTheme — kills a
            known per-icon theme-leak path.
  v3.10+  — multiple VDataTable / VAutocomplete render fixes.
  v3.11.0 — theme: layers option (cleaner CSS cascade).
  v3.12.0 — styles: opt-out from misc styles + skip VRow/VCol
            styles when only using VContainer/VSpacer.

Stayed on v3 (not v4). v4.0 is a major bump (CSS layers always on, default theme = system, removed `unimportant` option, removed several APIs) — too risky for a critical-path POS today.

Validated in production for several tenant-days on a fork of this repo prior to upstreaming. vitest 530/530 still green; SPA boots clean on lab; vendor chunk recomputed with new content hashes (expected).