### PR TITLE
Fix/rate discount total reactivity

### DIFF
--- a/frontend/src/posapp/components/pos/invoice/CartItemRow.vue
+++ b/frontend/src/posapp/components/pos/invoice/CartItemRow.vue
@@ -1,5 +1,5 @@
 <template>
-	<tr class="posa-cart-item-row" v-memo="memoDepsValue">
+	<tr class="posa-cart-item-row" v-memo="memoDeps">
 		<template v-for="column in visibleColumns" :key="column.key">
 			<!-- Item Name Column -->
 			<td v-if="column.key === 'item_name'" class="text-start" :data-column-key="'item_name'">
@@ -438,7 +438,6 @@ const emit = defineEmits([
 ]);
 
 const __ = window.__ || ((text) => text);
-const memoDepsValue = computed(() => memoDeps.value);
 
 const isEditingQty = ref(false);
 const editingQtyValue = ref("");

--- a/frontend/src/posapp/components/pos/invoice/CartItemRow.vue
+++ b/frontend/src/posapp/components/pos/invoice/CartItemRow.vue
@@ -1,5 +1,5 @@
 <template>
-	<tr class="posa-cart-item-row" v-memo="memoDeps">
+	<tr class="posa-cart-item-row" v-memo="memoDepsValue">
 		<template v-for="column in visibleColumns" :key="column.key">
 			<!-- Item Name Column -->
 			<td v-if="column.key === 'item_name'" class="text-start" :data-column-key="'item_name'">
@@ -438,6 +438,7 @@ const emit = defineEmits([
 ]);
 
 const __ = window.__ || ((text) => text);
+const memoDepsValue = computed(() => memoDeps.value);
 
 const isEditingQty = ref(false);
 const editingQtyValue = ref("");

--- a/frontend/src/posapp/composables/pos/shared/useDiscounts.ts
+++ b/frontend/src/posapp/composables/pos/shared/useDiscounts.ts
@@ -22,11 +22,12 @@ export function useDiscounts() {
 	const toastStore = useToastStore();
 
 	const refreshInvoiceTotals = (context: any) => {
-		if (context.invoiceStore?.triggerUpdateTotals) {
-			context.invoiceStore.triggerUpdateTotals();
-			return;
+		if (context.invoiceStore?.recalculateTotals) {
+			context.invoiceStore.recalculateTotals();
 		}
-		context.invoiceStore?.recalculateTotals?.();
+		if (context.invoiceStore?.touch) {
+			context.invoiceStore.touch();
+		}
 	};
 
 	/**
@@ -457,7 +458,7 @@ export function useDiscounts() {
 					item.base_rate = toBaseCurrency(context, newValue);
 
 					item.base_discount_amount = context.flt(
-						item.base_price_list_rate - item.base_rate,
+						Math.max(item.base_price_list_rate - item.base_rate, 0),
 						context.currency_precision,
 					);
 					item.discount_amount = toSelectedCurrency(
@@ -550,6 +551,13 @@ export function useDiscounts() {
 					return;
 				}
 			}
+
+			// Recalculate amount based on updated rate/discount
+			item.amount = context.flt(
+				item.qty * item.rate,
+				context.currency_precision,
+			);
+			item.base_amount = toBaseCurrency(context, item.amount);
 
 			// Update stock calculations and force UI update
 			if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);

--- a/frontend/src/posapp/composables/pos/shared/useDiscounts.ts
+++ b/frontend/src/posapp/composables/pos/shared/useDiscounts.ts
@@ -24,9 +24,10 @@ export function useDiscounts() {
 	const refreshInvoiceTotals = (context: any) => {
 		if (context.invoiceStore?.triggerUpdateTotals) {
 			context.invoiceStore.triggerUpdateTotals();
-			return;
+		} else {
+			context.invoiceStore?.recalculateTotals?.();
+			context.invoiceStore?.touch?.();
 		}
-		context.invoiceStore?.recalculateTotals?.();
 	};
 
 	/**

--- a/frontend/src/posapp/composables/pos/shared/useDiscounts.ts
+++ b/frontend/src/posapp/composables/pos/shared/useDiscounts.ts
@@ -22,12 +22,11 @@ export function useDiscounts() {
 	const toastStore = useToastStore();
 
 	const refreshInvoiceTotals = (context: any) => {
-		if (context.invoiceStore?.recalculateTotals) {
-			context.invoiceStore.recalculateTotals();
+		if (context.invoiceStore?.triggerUpdateTotals) {
+			context.invoiceStore.triggerUpdateTotals();
+			return;
 		}
-		if (context.invoiceStore?.touch) {
-			context.invoiceStore.touch();
-		}
+		context.invoiceStore?.recalculateTotals?.();
 	};
 
 	/**
@@ -458,7 +457,7 @@ export function useDiscounts() {
 					item.base_rate = toBaseCurrency(context, newValue);
 
 					item.base_discount_amount = context.flt(
-						Math.max(item.base_price_list_rate - item.base_rate, 0),
+						Math.max((item.base_price_list_rate || 0) - item.base_rate, 0),
 						context.currency_precision,
 					);
 					item.discount_amount = toSelectedCurrency(
@@ -558,6 +557,14 @@ export function useDiscounts() {
 				context.currency_precision,
 			);
 			item.base_amount = toBaseCurrency(context, item.amount);
+
+			// Sync totals for immediate UI update on single-item edits
+			if (context.invoiceStore?.recalculateTotals) {
+				context.invoiceStore.recalculateTotals();
+			}
+			if (context.invoiceStore?.touch) {
+				context.invoiceStore.touch();
+			}
 
 			// Update stock calculations and force UI update
 			if (context.calc_stock_qty) context.calc_stock_qty(item, item.qty);

--- a/frontend/src/posapp/stores/invoiceStore.ts
+++ b/frontend/src/posapp/stores/invoiceStore.ts
@@ -632,7 +632,18 @@ export const useInvoiceStore = defineStore("invoice", () => {
 	// Computed property that reconstructs the array from map + order
 	const items = computed(() => {
 		return itemOrder.value
-			.map((id) => itemsData.get(id))
+			.map((id) => {
+				const item = itemsData.get(id);
+				if (item) {
+					// Track reactive item properties so computed re-runs
+					// synchronously when calcPrices modifies them
+					item.rate;
+					item.discount_amount;
+					item.discount_percentage;
+					item.qty;
+				}
+				return item;
+			})
 			.filter(
 				(item): item is CartItem => item !== undefined && item !== null,
 			);
@@ -651,6 +662,12 @@ export const useInvoiceStore = defineStore("invoice", () => {
 		itemOrder.value.forEach((id, index) => {
 			const item = itemsData.get(id);
 			if (item) {
+				// Track reactive item properties so computed re-runs
+				// synchronously when calcPrices modifies them
+				item.rate;
+				item.discount_amount;
+				item.discount_percentage;
+				item.qty;
 				map.set(id, { index, item });
 			}
 		});


### PR DESCRIPTION
- Clamp discount_amount to zero when rate > price_list_rate (Math.max)
- Recalculate item.amount and item.base_amount after rate/discount edits
- Call recalculateTotals() + touch() synchronously (skip debounce)
- Track item reactive properties in items/itemsMap computeds
- Restore v-memo memoization in CartItemRow