### PR TITLE
fix: resolve make_sales_invoice import failure during migration

### DIFF
--- a/posawesome/posawesome/api/commercial_flow.py
+++ b/posawesome/posawesome/api/commercial_flow.py
@@ -190,11 +190,11 @@ def _prepare_mapped_doc(doc, target_doctype):
 
 def _get_mapping_functions():
     return {
-        "quote_to_order": resolve_make_sales_order_from_quotation(),
-        "quote_to_invoice": resolve_make_sales_invoice_from_quotation(),
-        "order_to_delivery_note": resolve_make_delivery_note_from_order(),
-        "order_to_invoice": resolve_make_sales_invoice_from_order(),
-        "delivery_to_invoice": resolve_make_sales_invoice_from_delivery(),
+        "quote_to_order": lambda *a, **kw: resolve_make_sales_order_from_quotation()(*a, **kw),
+        "quote_to_invoice": lambda *a, **kw: resolve_make_sales_invoice_from_quotation()(*a, **kw),
+        "order_to_delivery_note": lambda *a, **kw: resolve_make_delivery_note_from_order()(*a, **kw),
+        "order_to_invoice": lambda *a, **kw: resolve_make_sales_invoice_from_order()(*a, **kw),
+        "delivery_to_invoice": lambda *a, **kw: resolve_make_sales_invoice_from_delivery()(*a, **kw),
     }
 
 

--- a/posawesome/posawesome/api/commercial_flow.py
+++ b/posawesome/posawesome/api/commercial_flow.py
@@ -4,6 +4,13 @@ import frappe
 from frappe import _
 from frappe.utils import cint
 
+from posawesome.posawesome.api.erpnext_compat import (
+    resolve_make_delivery_note_from_order,
+    resolve_make_sales_invoice_from_delivery,
+    resolve_make_sales_invoice_from_order,
+    resolve_make_sales_invoice_from_quotation,
+    resolve_make_sales_order_from_quotation,
+)
 from posawesome.posawesome.api.invoices import get_draft_invoices
 from posawesome.posawesome.api.quotations import search_quotations, submit_quotation
 from posawesome.posawesome.api.sales_orders import search_orders
@@ -182,24 +189,12 @@ def _prepare_mapped_doc(doc, target_doctype):
 
 
 def _get_mapping_functions():
-    from erpnext.selling.doctype.quotation.quotation import (
-        make_sales_invoice as make_invoice_from_quotation,
-        make_sales_order as make_order_from_quotation,
-    )
-    from erpnext.selling.doctype.sales_order.sales_order import (
-        make_delivery_note as make_delivery_from_order,
-        make_sales_invoice as make_invoice_from_order,
-    )
-    from erpnext.stock.doctype.delivery_note.delivery_note import (
-        make_sales_invoice as make_invoice_from_delivery,
-    )
-
     return {
-        "quote_to_order": make_order_from_quotation,
-        "quote_to_invoice": make_invoice_from_quotation,
-        "order_to_delivery_note": make_delivery_from_order,
-        "order_to_invoice": make_invoice_from_order,
-        "delivery_to_invoice": make_invoice_from_delivery,
+        "quote_to_order": resolve_make_sales_order_from_quotation(),
+        "quote_to_invoice": resolve_make_sales_invoice_from_quotation(),
+        "order_to_delivery_note": resolve_make_delivery_note_from_order(),
+        "order_to_invoice": resolve_make_sales_invoice_from_order(),
+        "delivery_to_invoice": resolve_make_sales_invoice_from_delivery(),
     }
 
 

--- a/posawesome/posawesome/api/erpnext_compat.py
+++ b/posawesome/posawesome/api/erpnext_compat.py
@@ -1,0 +1,77 @@
+"""ERPNext version compatibility layer.
+
+Centralises version-sensitive imports so that POS Awesome can work
+across ERPNext v15 and v16+ without scattered try/except blocks.
+All resolver functions perform lazy imports -- calling them at module
+level is safe and will not trigger ImportError during DocType sync.
+"""
+
+
+def resolve_make_sales_invoice_from_order():
+    """Resolve ``make_sales_invoice`` (Sales Order -> Sales Invoice)."""
+    try:
+        from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
+        return make_sales_invoice
+    except ImportError:
+        pass
+    raise ImportError(
+        "Cannot import 'make_sales_invoice' from ERPNext Sales Order. "
+        "This version of POS Awesome requires ERPNext v15. "
+        "For ERPNext v16+, use the v16-compatible branch of POS Awesome."
+    )
+
+
+def resolve_make_sales_invoice_from_quotation():
+    """Resolve ``make_sales_invoice`` (Quotation -> Sales Invoice)."""
+    try:
+        from erpnext.selling.doctype.quotation.quotation import make_sales_invoice
+        return make_sales_invoice
+    except ImportError:
+        pass
+    raise ImportError(
+        "Cannot import 'make_sales_invoice' from ERPNext Quotation. "
+        "This version of POS Awesome requires ERPNext v15. "
+        "For ERPNext v16+, use the v16-compatible branch of POS Awesome."
+    )
+
+
+def resolve_make_sales_order_from_quotation():
+    """Resolve ``make_sales_order`` (Quotation -> Sales Order)."""
+    try:
+        from erpnext.selling.doctype.quotation.quotation import make_sales_order
+        return make_sales_order
+    except ImportError:
+        pass
+    raise ImportError(
+        "Cannot import 'make_sales_order' from ERPNext Quotation. "
+        "This version of POS Awesome requires ERPNext v15. "
+        "For ERPNext v16+, use the v16-compatible branch of POS Awesome."
+    )
+
+
+def resolve_make_delivery_note_from_order():
+    """Resolve ``make_delivery_note`` (Sales Order -> Delivery Note)."""
+    try:
+        from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
+        return make_delivery_note
+    except ImportError:
+        pass
+    raise ImportError(
+        "Cannot import 'make_delivery_note' from ERPNext Sales Order. "
+        "This version of POS Awesome requires ERPNext v15. "
+        "For ERPNext v16+, use the v16-compatible branch of POS Awesome."
+    )
+
+
+def resolve_make_sales_invoice_from_delivery():
+    """Resolve ``make_sales_invoice`` (Delivery Note -> Sales Invoice)."""
+    try:
+        from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
+        return make_sales_invoice
+    except ImportError:
+        pass
+    raise ImportError(
+        "Cannot import 'make_sales_invoice' from ERPNext Delivery Note. "
+        "This version of POS Awesome requires ERPNext v15. "
+        "For ERPNext v16+, use the v16-compatible branch of POS Awesome."
+    )

--- a/posawesome/posawesome/api/invoices.py
+++ b/posawesome/posawesome/api/invoices.py
@@ -5,7 +5,7 @@
 
 import frappe
 import time
-from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
+from posawesome.posawesome.api.erpnext_compat import resolve_make_sales_invoice_from_order
 from posawesome.posawesome.api.invoice_processing.utils import (
     _get_return_validity_settings,
     _build_invoice_remarks,
@@ -171,7 +171,7 @@ def create_sales_invoice_from_order(sales_order):
     if not frappe.db.exists("Sales Order", sales_order):
         frappe.throw(f"Sales Order {sales_order} does not exist")
 
-    invoice_doc = make_sales_invoice(sales_order)
+    invoice_doc = resolve_make_sales_invoice_from_order()(sales_order)
     invoice_doc.flags.ignore_permissions = True
     invoice_doc.run_method("set_missing_values")
     invoice_doc.run_method("calculate_taxes_and_totals")

--- a/posawesome/posawesome/api/sales_orders.py
+++ b/posawesome/posawesome/api/sales_orders.py
@@ -4,8 +4,6 @@
 import json
 
 import frappe
-from erpnext.accounts.party import get_party_account
-from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
 from frappe.utils import getdate, nowdate
 
 from posawesome.posawesome.api.payment_entry import create_payment_entry

--- a/posawesome/posawesome/api/test_commercial_flow.py
+++ b/posawesome/posawesome/api/test_commercial_flow.py
@@ -34,6 +34,7 @@ def _install_stubs():
         "posawesome.posawesome.api.invoices",
         "posawesome.posawesome.api.quotations",
         "posawesome.posawesome.api.sales_orders",
+        "posawesome.posawesome.api.erpnext_compat",
         "erpnext.selling.doctype.quotation.quotation",
         "erpnext.selling.doctype.sales_order.sales_order",
         "erpnext.stock.doctype.delivery_note.delivery_note",
@@ -67,6 +68,14 @@ def _install_stubs():
     sales_orders_module = types.ModuleType("posawesome.posawesome.api.sales_orders")
     sales_orders_module.search_orders = lambda **kwargs: []
     sys.modules["posawesome.posawesome.api.sales_orders"] = sales_orders_module
+
+    erpnext_compat_module = types.ModuleType("posawesome.posawesome.api.erpnext_compat")
+    erpnext_compat_module.resolve_make_delivery_note_from_order = lambda: sales_order_mapping_module.make_delivery_note
+    erpnext_compat_module.resolve_make_sales_invoice_from_delivery = lambda: delivery_note_mapping_module.make_sales_invoice
+    erpnext_compat_module.resolve_make_sales_invoice_from_order = lambda: sales_order_mapping_module.make_sales_invoice
+    erpnext_compat_module.resolve_make_sales_invoice_from_quotation = lambda: quotation_mapping_module.make_sales_invoice
+    erpnext_compat_module.resolve_make_sales_order_from_quotation = lambda: quotation_mapping_module.make_sales_order
+    sys.modules["posawesome.posawesome.api.erpnext_compat"] = erpnext_compat_module
 
     quotation_mapping_module = types.ModuleType("erpnext.selling.doctype.quotation.quotation")
     quotation_mapping_module.make_sales_order = lambda source_name: FakeDoc(

--- a/posawesome/posawesome/api/test_invoices.py
+++ b/posawesome/posawesome/api/test_invoices.py
@@ -67,6 +67,10 @@ def _install_frappe_stub():
     utils_module.log_perf_event = lambda *args, **kwargs: None
     sys.modules["posawesome.posawesome.api.utils"] = utils_module
 
+    erpnext_compat_module = types.ModuleType("posawesome.posawesome.api.erpnext_compat")
+    erpnext_compat_module.resolve_make_sales_invoice_from_order = lambda: erpnext_sales_order.make_sales_invoice
+    sys.modules["posawesome.posawesome.api.erpnext_compat"] = erpnext_compat_module
+
 
 def _load_invoices_module():
     module_name = "posawesome.posawesome.api.invoices"


### PR DESCRIPTION
- Create erpnext_compat.py with lazy resolver functions
- Replace eager ERPNext import in invoices.py with compat resolver
- Remove dead imports from sales_orders.py
- Route commercial_flow.py through compat module
- Update test stubs for erpnext_compat module