### PR TITLE
fix(invoice): restore tax-inclusive logic killed by misplaced continue

### DIFF
--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -335,10 +335,11 @@ def apply_tax_inclusive(doc):
     has_changes = False
     for tax in doc.get("taxes", []):
         if tax.charge_type == "Actual":
+            # Actual (flat-amount) taxes cannot be inclusive in the print rate
             if tax.included_in_print_rate:
                 tax.included_in_print_rate = 0
                 has_changes = True
-        continue
+            continue
         if tax_inclusive and not tax.included_in_print_rate:
             tax.included_in_print_rate = 1
             has_changes = True


### PR DESCRIPTION
The bare `continue` in apply_tax_inclusive() sat at loop-body
indentation, so every iteration short-circuited and the entire
posa_tax_inclusive toggle (lines below it) was dead code. POS Profiles
that enabled "Tax Inclusive" had a setting that did nothing.

Move the `continue` inside the `charge_type == "Actual"` branch so
Actual (flat-amount) taxes remain print-exclusive while non-Actual
taxes flow through the inclusive/exclusive toggle as intended.

Refs: audit Q1 (critical) — confirmed present on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved clarity in internal tax handling logic with additional explanatory documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->