### PR TITLE
fix(mpesa): pass create_payment_entry args by keyword (were positionally scrambled)

### DIFF
--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
@@ -46,15 +46,15 @@ class MpesaPaymentRegister(Document):
 
     def create_payment_entry(self):
         payment_entry = create_payment_entry(
-            self.company,
-            self.customer,
-            self.transamount,
-            self.currency,
-            self.mode_of_payment,
-            self.posting_date,
-            self.transid,
-            self.posting_date,
-            None,
-            self.submit_payment,
+            company=self.company,
+            amount=self.transamount,
+            currency=self.currency,
+            mode_of_payment=self.mode_of_payment,
+            customer=self.customer,
+            posting_date=self.posting_date,
+            reference_no=self.transid,
+            reference_date=self.posting_date,
+            exchange_rate=None,
+            submit=self.submit_payment,
         )
         return payment_entry.name


### PR DESCRIPTION
MpesaPaymentRegister.create_payment_entry() called the helper with
positional arguments in the wrong order against the current signature
create_payment_entry(company, amount, currency, mode_of_payment,
customer=..., ...). It passed customer as amount, transamount as
currency, currency as mode_of_payment, etc. — so submitting any Mpesa
Payment Register either crashed downstream or created a wildly wrong
Payment Entry.

Map each value to its intended keyword: amount=transamount,
currency=currency, mode_of_payment=mode_of_payment, customer=customer,
reference_no=transid (the M-Pesa transaction id), reference_date and
posting_date from posting_date, submit=submit_payment.

Refs: audit Q2 (critical) — confirmed present on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization to enhance code quality and maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->