### PR TITLE
fix(gift-card): resolve currency from profile/company, not hardcoded PKR

### DIFF
--- a/posawesome/posawesome/api/gift_cards.py
+++ b/posawesome/posawesome/api/gift_cards.py
@@ -462,7 +462,7 @@ def issue_gift_card(
     # company default — never a hardcoded "PKR".
     gift_card_doc.currency = (
         currency
-        or getattr(profile_doc, "currency", None)
+        or _doc_value(profile_doc, "currency")
         or frappe.get_cached_value("Company", company, "default_currency")
     )
     gift_card_doc.current_balance = amount

--- a/posawesome/posawesome/api/gift_cards.py
+++ b/posawesome/posawesome/api/gift_cards.py
@@ -440,7 +440,7 @@ def issue_gift_card(
     initial_amount=0,
     gift_card_code=None,
     expiry_date=None,
-    currency="PKR",
+    currency=None,
 ):
     profile_name, cashier, _user_doc = _require_supervisor(pos_profile, cashier)
     profile_doc = _get_profile_doc(profile_name)
@@ -458,7 +458,13 @@ def issue_gift_card(
     gift_card_doc = frappe.new_doc("POS Gift Card")
     gift_card_doc.gift_card_code = code
     gift_card_doc.company = company
-    gift_card_doc.currency = currency or "PKR"
+    # Resolve currency from the caller, then the POS Profile, then the
+    # company default — never a hardcoded "PKR".
+    gift_card_doc.currency = (
+        currency
+        or getattr(profile_doc, "currency", None)
+        or frappe.get_cached_value("Company", company, "default_currency")
+    )
     gift_card_doc.current_balance = amount
     gift_card_doc.status = "Active"
     gift_card_doc.expiry_date = expiry_date


### PR DESCRIPTION
issue_gift_card() defaulted currency to 'PKR' both in the signature and
the fallback, so any non-PKR site that didn't pass currency explicitly
minted gift cards in PKR — mislabelling the liability and breaking
redemption against the real company currency.

Default to None and resolve currency as: caller value -> POS Profile
currency -> Company default_currency.

Refs: audit Q17 (critical) — confirmed present on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gift card issuance now supports optional currency configuration with automatic resolution from provided currency, POS Profile settings, or Company defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->