### PR TITLE
fix(loyalty): use real doctype + program expiry for Loyalty Point Entry

### DIFF
--- a/posawesome/posawesome/api/invoice.py
+++ b/posawesome/posawesome/api/invoice.py
@@ -130,16 +130,26 @@ def add_loyalty_point(invoice_doc):
                 loyalty_program = frappe.get_value("Customer", invoice_doc.customer, "loyalty_program")
                 if not loyalty_program:
                     loyalty_program = original_offer.loyalty_program
+                # Honour the loyalty program's configured expiry instead of a
+                # hardcoded ~27-year window; leave empty when no expiry is set.
+                expiry_duration = frappe.db.get_value(
+                    "Loyalty Program", loyalty_program, "expiry_duration"
+                )
+                expiry_date = (
+                    add_days(invoice_doc.posting_date, expiry_duration)
+                    if expiry_duration
+                    else None
+                )
                 doc = frappe.get_doc(
                     {
                         "doctype": "Loyalty Point Entry",
                         "loyalty_program": loyalty_program,
                         "loyalty_program_tier": original_offer.name,
                         "customer": invoice_doc.customer,
-                        "invoice_type": "Sales Invoice",
+                        "invoice_type": invoice_doc.doctype,
                         "invoice": invoice_doc.name,
                         "loyalty_points": original_offer.loyalty_points,
-                        "expiry_date": add_days(invoice_doc.posting_date, 10000),
+                        "expiry_date": expiry_date,
                         "posting_date": invoice_doc.posting_date,
                         "company": invoice_doc.company,
                     }


### PR DESCRIPTION
add_loyalty_point() hardcoded invoice_type='Sales Invoice' (breaking
sites that issue POS Invoices) and set expiry_date to posting_date +
10000 days (~27 years), overriding the loyalty program's configured
expiry_duration so points effectively never expired.

Use invoice_doc.doctype for invoice_type and derive expiry_date from
the Loyalty Program's expiry_duration (None when unset), mirroring
ERPNext's own make_loyalty_point_entry().

Refs: audit Q18 (critical) — confirmed present on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>