### PR TITLE
fix(stock): invalidate item/bin/batch/serial caches on stock writes

### DIFF
--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -122,8 +122,26 @@ doc_events = {
         "after_insert": "posawesome.posawesome.api.customer.after_insert",
     },
     "Bin": {
-        "after_insert": "posawesome.posawesome.stock_realtime.publish_bin_stock_change",
-        "on_update": "posawesome.posawesome.stock_realtime.publish_bin_stock_change",
+        "after_insert": [
+            "posawesome.posawesome.stock_realtime.publish_bin_stock_change",
+            "posawesome.posawesome.api.item_fetchers.clear_stock_caches",
+        ],
+        "on_update": [
+            "posawesome.posawesome.stock_realtime.publish_bin_stock_change",
+            "posawesome.posawesome.api.item_fetchers.clear_stock_caches",
+        ],
+    },
+    "Stock Ledger Entry": {
+        "after_insert": "posawesome.posawesome.api.item_fetchers.clear_stock_caches",
+        "on_cancel": "posawesome.posawesome.api.item_fetchers.clear_stock_caches",
+    },
+    "Serial No": {
+        "after_insert": "posawesome.posawesome.api.item_fetchers.clear_stock_caches",
+        "on_update": "posawesome.posawesome.api.item_fetchers.clear_stock_caches",
+    },
+    "Batch": {
+        "after_insert": "posawesome.posawesome.api.item_fetchers.clear_stock_caches",
+        "on_update": "posawesome.posawesome.api.item_fetchers.clear_stock_caches",
     },
 }
 

--- a/posawesome/posawesome/api/item_fetchers.py
+++ b/posawesome/posawesome/api/item_fetchers.py
@@ -46,6 +46,27 @@ _serial_cache: Dict[int, Callable[..., Any]] = {}
 _bom_cache: Dict[int, Callable[..., Any]] = {}
 
 
+def clear_stock_caches(doc=None, method=None):
+    """Invalidate the stock / batch / serial redis caches.
+
+    These caches are wrapped with ``redis_cache(ttl=...)`` but were never
+    invalidated, so after any stock movement other POS terminals kept seeing
+    pre-movement quantities for up to the configured TTL. Wired (via hooks) to
+    Bin / Stock Ledger Entry / Serial No / Batch writes so quantities refresh
+    as soon as stock actually changes. Each cache holds one wrapper per TTL
+    variant, so clear them all.
+    """
+    for store in (_bin_cache, _batch_cache, _serial_cache):
+        for cached_fn in list(store.values()):
+            clearer = getattr(cached_fn, "clear_cache", None)
+            if callable(clearer):
+                try:
+                    clearer()
+                except Exception:
+                    # Cache invalidation must never break the triggering write
+                    frappe.log_error(frappe.get_traceback(), "POSAwesome stock cache clear failed")
+
+
 def _fetch_item_prices(
     price_list: str,
     currency: str,


### PR DESCRIPTION
The redis-cached _bin_cache/_batch_cache/_serial_cache helpers in
item_fetchers were never invalidated, so after any sale or stock
movement other POS terminals kept showing pre-movement quantities for
up to posa_server_cache_duration minutes — the root cause of 'wrong
stock numbers' on the floor.

Add clear_stock_caches() and wire it via doc_events on Bin, Stock
Ledger Entry, Serial No and Batch writes so quantities refresh as soon
as stock actually changes. Bin keeps its existing realtime broadcast
(now a handler list alongside the cache clear).

Refs: audit Q22 (critical) — confirmed present on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>