### PR TITLE
fix(idempotency): narrow ledger-insert except to DuplicateEntryError

### DIFF
--- a/posawesome/posawesome/api/invoice_processing/creation.py
+++ b/posawesome/posawesome/api/invoice_processing/creation.py
@@ -207,7 +207,10 @@ def _get_or_create_submission_ledger(client_request_id, invoice, data, document_
     try:
         ledger_doc = frappe.get_doc(payload)
         return _save_submission_ledger(ledger_doc)
-    except Exception:
+    except frappe.DuplicateEntryError:
+        # A concurrent request already created this ledger row — fall back to
+        # fetching it. Any other error (e.g. validation) must propagate so the
+        # invoice is never processed without idempotency protection.
         return _get_submission_ledger_by_key(ledger_key)
 
 

--- a/posawesome/posawesome/api/invoice_processing/creation.py
+++ b/posawesome/posawesome/api/invoice_processing/creation.py
@@ -211,7 +211,10 @@ def _get_or_create_submission_ledger(client_request_id, invoice, data, document_
         # A concurrent request already created this ledger row — fall back to
         # fetching it. Any other error (e.g. validation) must propagate so the
         # invoice is never processed without idempotency protection.
-        return _get_submission_ledger_by_key(ledger_key)
+        ledger = _get_submission_ledger_by_key(ledger_key)
+        if not ledger:
+            frappe.throw(_("A concurrent request is already processing this invoice. Please try again."))
+        return ledger
 
 
 def _ledger_response(ledger_doc, replayed=True):


### PR DESCRIPTION
The submission-ledger insert wrapped get_doc/save in a bare
'except Exception', so validation errors, programming errors and DB
failures were all silently swallowed and the code fell through to
_get_submission_ledger_by_key (often returning None) — leaving the
invoice to be processed with no idempotency protection.

Catch only frappe.DuplicateEntryError (the legitimate concurrent-create
race) and let every other exception propagate.

Refs: audit Q25 (critical) — confirmed present on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for invoice processing. Users now receive clear, actionable error messages with retry instructions when conflicts occur during concurrent operations, instead of silent fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->