### PR TITLE
fix(cash-movement): create the Journal Entry inside on_submit (atomic)

### DIFF
--- a/posawesome/posawesome/api/cash_movement/service.py
+++ b/posawesome/posawesome/api/cash_movement/service.py
@@ -10,7 +10,6 @@ from .permissions import (
     ensure_owner_or_manager,
     is_manager,
 )
-from .posting import create_journal_entry
 from .queries import get_shift_movements, get_submitted_expenses as query_submitted_expenses
 from .validation import (
     extract_allowed_accounts,
@@ -85,18 +84,9 @@ def _create_cash_movement(payload, movement_type):
     )
     movement_doc.flags.ignore_permissions = True
     movement_doc.insert()
-
-    journal_entry = create_journal_entry(
-        company=movement_doc.company,
-        posting_date=movement_doc.posting_date,
-        movement_type=movement_doc.movement_type,
-        amount=movement_doc.amount,
-        source_account=movement_doc.source_account,
-        target_account=movement_doc.target_account,
-        remarks=movement_doc.remarks,
-        cost_center=profile_doc.get("cost_center"),
-    )
-    movement_doc.db_set("journal_entry", journal_entry, update_modified=False)
+    # The backing Journal Entry is created atomically inside the document's
+    # on_submit hook, so insert + JE + submit either all succeed or all roll
+    # back together (no orphan JE on a submit-time failure).
     movement_doc.submit()
     movement_doc.reload()
     return movement_doc.as_dict()

--- a/posawesome/posawesome/doctype/pos_cash_movement/pos_cash_movement.py
+++ b/posawesome/posawesome/doctype/pos_cash_movement/pos_cash_movement.py
@@ -3,7 +3,10 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt
 
-from posawesome.posawesome.api.cash_movement.posting import cancel_journal_entry
+from posawesome.posawesome.api.cash_movement.posting import (
+    cancel_journal_entry,
+    create_journal_entry,
+)
 
 
 class POSCashMovement(Document):
@@ -12,6 +15,27 @@ class POSCashMovement(Document):
         self._validate_company_links()
         self._validate_accounts()
         self._validate_movement_type_rules()
+
+    def on_submit(self):
+        # Create the backing Journal Entry inside the submit transaction so a
+        # failure rolls everything back together. Previously the JE was created
+        # and submitted before movement_doc.submit(), leaving an orphan JE on
+        # any submit-time failure.
+        if not self.journal_entry:
+            cost_center = frappe.db.get_value(
+                "POS Profile", self.pos_profile, "cost_center"
+            ) or frappe.db.get_value("Company", self.company, "cost_center")
+            journal_entry = create_journal_entry(
+                company=self.company,
+                posting_date=self.posting_date,
+                movement_type=self.movement_type,
+                amount=self.amount,
+                source_account=self.source_account,
+                target_account=self.target_account,
+                remarks=self.remarks,
+                cost_center=cost_center,
+            )
+            self.db_set("journal_entry", journal_entry, update_modified=False)
 
     def on_cancel(self):
         if self.journal_entry:

--- a/posawesome/posawesome/doctype/pos_cash_movement/pos_cash_movement.py
+++ b/posawesome/posawesome/doctype/pos_cash_movement/pos_cash_movement.py
@@ -22,9 +22,9 @@ class POSCashMovement(Document):
         # and submitted before movement_doc.submit(), leaving an orphan JE on
         # any submit-time failure.
         if not self.journal_entry:
-            cost_center = frappe.db.get_value(
+            cost_center = frappe.get_cached_value(
                 "POS Profile", self.pos_profile, "cost_center"
-            ) or frappe.db.get_value("Company", self.company, "cost_center")
+            ) or frappe.get_cached_value("Company", self.company, "cost_center")
             journal_entry = create_journal_entry(
                 company=self.company,
                 posting_date=self.posting_date,


### PR DESCRIPTION
The cash-movement service inserted the doc, then created AND submitted
the backing Journal Entry, then called movement_doc.submit(). If submit
threw (e.g. another app's hook), the JE was already submitted to the GL,
leaving an orphan entry.

Move JE creation into POSCashMovement.on_submit so insert -> JE -> submit
happen in one transaction and roll back together. service.py now just
insert()+submit(); the now-unused import is removed.

Refs: audit Q27 (critical) — confirmed present on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated cash movement submission workflow for improved consistency between the document and supporting Journal Entry creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->