### PR TITLE
fix(shift): reject a second open POS shift for same user + profile

### DIFF
--- a/posawesome/posawesome/doctype/pos_opening_shift/pos_opening_shift.py
+++ b/posawesome/posawesome/doctype/pos_opening_shift/pos_opening_shift.py
@@ -13,7 +13,35 @@ from posawesome.posawesome.api.status_updater import StatusUpdater
 class POSOpeningShift(StatusUpdater):
     def validate(self):
         self.validate_pos_profile_and_cashier()
+        self.validate_unique_open_shift()
         self.set_status()
+
+    def validate_unique_open_shift(self):
+        """Reject creating a second open shift for the same user + POS Profile.
+
+        Note: this is a best-effort guard at validate time. A truly
+        race-proof solution would also need a DB-level partial unique
+        constraint on (user, pos_profile, status='Open'); recommended as a
+        follow-up.
+        """
+        existing = frappe.db.get_value(
+            "POS Opening Shift",
+            {
+                "user": self.user,
+                "pos_profile": self.pos_profile,
+                "status": "Open",
+                "docstatus": 1,
+                "name": ["!=", self.name],
+            },
+            "name",
+        )
+        if existing:
+            frappe.throw(
+                _(
+                    "User {0} already has an open POS shift {1} for POS Profile {2}. "
+                    "Close it before opening a new one."
+                ).format(self.user, existing, self.pos_profile)
+            )
 
     def validate_pos_profile_and_cashier(self):
         if self.company != frappe.db.get_value("POS Profile", self.pos_profile, "company"):


### PR DESCRIPTION
create_opening_voucher inserted+submitted opening shifts with no check
that the user already had an open one, so concurrent or repeated calls
left a user with multiple 'Open' shifts. Add validate_unique_open_shift()
to POSOpeningShift.validate() rejecting another submitted Open shift for
the same (user, pos_profile). A DB-level partial unique constraint is
recommended as a follow-up for full race safety.

Refs: audit Q28 (critical) — confirmed present on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>