### PR TITLE
chore(deps): declare required_apps=erpnext and pin ERPNext to v15.x

### DIFF
--- a/posawesome/hooks.py
+++ b/posawesome/hooks.py
@@ -10,6 +10,11 @@ app_url = "https://github.com/defendicon/POS-Awesome-V15"
 app_source_link = "https://github.com/defendicon/POS-Awesome-V15"
 source_link = "https://github.com/defendicon/POS-Awesome-V15"
 
+# POS Awesome extends ERPNext heavily (custom fields, controller overrides,
+# and many `from erpnext...` imports). Declare the hard dependency so bench
+# installs/loads ERPNext first and refuses to install without it.
+required_apps = ["erpnext"]
+
 # Includes in <head>
 # ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ build-backend = "flit_core.buildapi"
 
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.0.0,<16.0.0"
-erpnext = ">=15.0.0,<16.0.0"
+frappe = ">=15.0.0"
+erpnext = ">=15.0.0"
 
 [tool.ruff]
 line-length = 110

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ build-backend = "flit_core.buildapi"
 
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.0.0"
-erpnext = ">=15.0.0"
+frappe = ">=15.0.0,<16.0.0"
+erpnext = ">=15.0.0,<16.0.0"
 
 [tool.ruff]
 line-length = 110


### PR DESCRIPTION
The app had no required_apps declaration, so bench would install it
against any ERPNext (or none) without warning, despite 40+ internal
'from erpnext...' imports and controller overrides that break across
major versions. Add required_apps=['erpnext'] and cap the
frappe/erpnext bench dependency at <16.0.0 to fail fast on
incompatible majors.

Refs: audit Q31 (critical) — confirmed missing on develop (15.30.0)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ERPNext as a mandatory system requirement. The application now requires ERPNext to be installed before it can be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->