### PR TITLE
fix(invoice): show negative subtotal/total for return invoices

### DIFF
--- a/frontend/src/posapp/components/pos/invoice/invoiceComputed.ts
+++ b/frontend/src/posapp/components/pos/invoice/invoiceComputed.ts
@@ -80,14 +80,11 @@ const invoiceComputed: Record<string, unknown> & ThisType<InvoiceComputedVm> = {
 		let sum;
 
 		if (typeof storeValue === "number" && !Number.isNaN(storeValue)) {
-			sum = this.isReturnInvoice ? Math.abs(storeValue) : storeValue;
+			sum = storeValue;
 		} else {
 			sum = 0;
 			this.items.forEach((item) => {
-				// For returns, use absolute value for correct calculation
-				const qty = this.isReturnInvoice
-					? Math.abs(flt(item.qty))
-					: flt(item.qty);
+				const qty = flt(item.qty);
 				const rate = flt(item.rate);
 				sum += qty * rate;
 			});
@@ -110,20 +107,19 @@ const invoiceComputed: Record<string, unknown> & ThisType<InvoiceComputedVm> = {
 
 		if (!(typeof storeValue === "number" && !Number.isNaN(storeValue))) {
 			this.items.forEach((item) => {
-				// For returns, use absolute value for correct calculation
-				const qty = this.isReturnInvoice
-					? Math.abs(flt(item.qty))
-					: flt(item.qty);
+				const qty = flt(item.qty);
 				const rate = flt(item.rate);
 				sum += qty * rate;
 			});
-		} else if (this.isReturnInvoice) {
-			sum = Math.abs(sum);
 		}
 
 		// Always reduce total by discount magnitude.
 		const additional_discount = Math.abs(flt(this.additional_discount));
-		sum -= additional_discount;
+		if (this.isReturnInvoice) {
+			sum += additional_discount;
+		} else {
+			sum -= additional_discount;
+		}
 
 		// Add delivery charges
 		const delivery_charges = flt(this.delivery_charges_rate);


### PR DESCRIPTION
## Problem

Return invoices store **negative** quantities, but the `subtotal` and `total`
computeds in `invoiceComputed.ts` wrapped the result in `Math.abs()` (and forced
each returned line's qty to its absolute value). As a result the POS displayed a
**positive** amount for a credit/return, contradicting:

- the signed line quantities shown in the items table, and
- the signed totals on the saved Sales Invoice (Return).

## Fix

- Drop the `Math.abs()` wrapping in both `subtotal` and `total` so returns render
  naturally negative.
- Flip the additional-discount handling for returns: a discount reduces the
  *magnitude* of a refund, so for return invoices add it back
  (`sum += discount`) instead of subtracting it, keeping the signed total correct.

No behavior change for normal (positive) invoices — those still subtract the
discount as before.

## Scope

Single file, `frontend/src/posapp/components/pos/invoice/invoiceComputed.ts`
(8 insertions, 12 deletions). This file is identical between the latest tag and
`develop`, and the bug is still present on `develop`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed total and subtotal calculations for return invoices to accurately reflect amounts using stored gross totals.
  * Improved discount application logic for return invoices to correctly adjust invoice totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->