### PR TITLE
feat(invoice): share invoice PDF via the native share sheet (WhatsApp, etc.)

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -258,6 +258,7 @@
 			@open-invoice-management="open_invoice_management"
 			@open-returns="open_returns"
 			@print-draft="print_draft_invoice"
+			@share-last="share_last_invoice"
 			@show-payment="handleShowPaymentRequest"
 			@open-customer-display="handleOpenCustomerDisplayRequest"
 			@resume-parked-order="resume_parked_order"
@@ -377,6 +378,7 @@ export default {
 	},
 	data() {
 		return {
+			is_sharing: false,
 			pos_profile: "",
 			pos_opening_shift: "",
 			stock_settings: "",
@@ -571,6 +573,86 @@ export default {
 
 		handleExpandedUpdate(ids) {
 			this.expanded = Array.isArray(ids) ? ids.slice(-1) : [];
+		},
+
+		async share_last_invoice() {
+			if (this.is_sharing) {
+				return;
+			}
+			this.is_sharing = true;
+			this.eventBus.emit("show_message", {
+				title: __("Preparing invoice for sharing..."),
+				color: "info",
+			});
+			try {
+				const profile_name = this.pos_profile?.name;
+				if (!profile_name) {
+					throw new Error(__("POS Profile is not available."));
+				}
+				const result = await frappe.call({
+					method: "frappe.client.get_list",
+					args: {
+						doctype: "Sales Invoice",
+						filters: { pos_profile: profile_name, docstatus: 1 },
+						fields: ["name"],
+						order_by: "creation desc",
+						limit_page_length: 1,
+					},
+				});
+				if (!result.message || result.message.length === 0) {
+					throw new Error(__("No submitted invoices found for this profile."));
+				}
+				const invoice_name = result.message[0].name;
+				const format =
+					this.pos_profile.print_format_for_online || this.pos_profile.print_format || "Standard";
+				const pdf_url = `/api/method/frappe.utils.print_format.download_pdf?doctype=Sales%20Invoice&name=${encodeURIComponent(invoice_name)}&format=${encodeURIComponent(format)}&no_letterhead=0`;
+				const response = await fetch(pdf_url, {
+					method: "GET",
+					headers: { "X-Frappe-CSRF-Token": frappe.csrf_token },
+				});
+				if (!response.ok) {
+					throw new Error(__("Failed to download invoice. Status: {0}", [response.status]));
+				}
+				const blob = await response.blob();
+				const file = new File([blob], `${invoice_name}.pdf`, { type: "application/pdf" });
+				const canShare =
+					navigator.share && navigator.canShare && navigator.canShare({ files: [file] });
+				if (canShare) {
+					try {
+						await navigator.share({
+							title: __("Sales Invoice"),
+							text: __("Invoice No: {0}", [invoice_name]),
+							files: [file],
+						});
+					} catch (shareError) {
+						// User dismissed the native share sheet: fall back to download.
+						if (shareError.name !== "AbortError") {
+							this.download_pdf_blob(blob, invoice_name);
+						}
+					}
+				} else {
+					// Web Share API (with files) unavailable: download instead.
+					this.download_pdf_blob(blob, invoice_name);
+				}
+			} catch (error) {
+				this.eventBus.emit("show_message", {
+					title: error.message || __("Failed to share invoice"),
+					color: "error",
+				});
+			} finally {
+				this.is_sharing = false;
+			}
+		},
+
+		download_pdf_blob(blob, invoice_name) {
+			const url = window.URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${invoice_name}.pdf`;
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			window.URL.revokeObjectURL(url);
 		},
 
 		applyReturnDiscountProration(options = {}) {

--- a/frontend/src/posapp/components/pos/flows/InvoiceManagement.vue
+++ b/frontend/src/posapp/components/pos/flows/InvoiceManagement.vue
@@ -309,6 +309,15 @@
 											@click="printInvoice(item)"
 										/>
 										<v-btn
+											icon="mdi-share-variant-outline"
+											variant="text"
+											size="small"
+											color="info"
+											:title="__('Share')"
+											:aria-label="__('Share invoice')"
+											@click="shareInvoice(item)"
+										/>
+										<v-btn
 											v-if="posProfile?.posa_allow_return == 1"
 											icon="mdi-backup-restore"
 											variant="text"
@@ -442,6 +451,15 @@
 											:title="__('Print')"
 											:aria-label="__('Print invoice')"
 											@click="printInvoice(invoice)"
+										/>
+										<v-btn
+											icon="mdi-share-variant-outline"
+											variant="text"
+											size="small"
+											color="info"
+											:title="__('Share')"
+											:aria-label="__('Share invoice')"
+											@click="shareInvoice(invoice)"
 										/>
 										<v-btn
 											v-if="posProfile?.posa_allow_return == 1"
@@ -671,6 +689,15 @@
 											:aria-label="__('Print invoice')"
 											@click="printInvoice(item)"
 										/>
+										<v-btn
+											icon="mdi-share-variant-outline"
+											variant="text"
+											size="small"
+											color="info"
+											:title="__('Share')"
+											:aria-label="__('Share invoice')"
+											@click="shareInvoice(item)"
+										/>
 									</div>
 								</template>
 							</v-data-table>
@@ -800,6 +827,15 @@
 											:title="__('Print')"
 											:aria-label="__('Print invoice')"
 											@click="printInvoice(invoice)"
+										/>
+										<v-btn
+											icon="mdi-share-variant-outline"
+											variant="text"
+											size="small"
+											color="info"
+											:title="__('Share')"
+											:aria-label="__('Share invoice')"
+											@click="shareInvoice(invoice)"
 										/>
 									</div>
 								</v-card>
@@ -1114,6 +1150,15 @@
 											:aria-label="__('Print invoice')"
 											@click="printInvoice(item)"
 										/>
+										<v-btn
+											icon="mdi-share-variant-outline"
+											variant="text"
+											size="small"
+											color="info"
+											:title="__('Share')"
+											:aria-label="__('Share invoice')"
+											@click="shareInvoice(item)"
+										/>
 									</div>
 								</template>
 							</v-data-table>
@@ -1192,6 +1237,15 @@
 											:title="__('Print')"
 											:aria-label="__('Print invoice')"
 											@click="printInvoice(invoice)"
+										/>
+										<v-btn
+											icon="mdi-share-variant-outline"
+											variant="text"
+											size="small"
+											color="info"
+											:title="__('Share')"
+											:aria-label="__('Share invoice')"
+											@click="shareInvoice(invoice)"
 										/>
 									</div>
 								</v-card>
@@ -2644,6 +2698,51 @@ export default {
 			}
 			const printWindow = window.open(url, "Print");
 			if (printWindow) watchPrintWindow(printWindow, printOptions);
+		},
+		async shareInvoice(invoice) {
+			try {
+				const profile = this.posProfile;
+				if (!invoice?.name || !profile) return;
+				const doctype = invoice.doctype || this.currentInvoiceDoctype;
+				const printFormat = profile.print_format_for_online || profile.print_format || "Standard";
+				const pdf_url = `/api/method/frappe.utils.print_format.download_pdf?doctype=${encodeURIComponent(doctype)}&name=${encodeURIComponent(invoice.name)}&format=${encodeURIComponent(printFormat)}&no_letterhead=0`;
+				const response = await fetch(pdf_url, {
+					headers: { "X-Frappe-CSRF-Token": frappe.csrf_token },
+				});
+				if (!response.ok) throw new Error(__("Failed to download invoice. Status: {0}", [response.status]));
+				const blob = await response.blob();
+				const file = new File([blob], `${invoice.name}.pdf`, { type: "application/pdf" });
+				if (navigator.share && navigator.canShare && navigator.canShare({ files: [file] })) {
+					try {
+						await navigator.share({
+							title: __("Sales Invoice"),
+							text: __("Invoice No: {0}", [invoice.name]),
+							files: [file],
+						});
+					} catch (shareError) {
+						if (shareError.name !== "AbortError") {
+							this.downloadInvoicePdf(blob, invoice.name);
+						}
+					}
+				} else {
+					this.downloadInvoicePdf(blob, invoice.name);
+				}
+			} catch (error) {
+				this.eventBus?.emit?.("show_message", {
+					title: error.message || __("Failed to share invoice"),
+					color: "error",
+				});
+			}
+		},
+		downloadInvoicePdf(blob, name) {
+			const url = window.URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${name}.pdf`;
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			window.URL.revokeObjectURL(url);
 		},
 	},
 };

--- a/frontend/src/posapp/components/pos/invoice/InvoiceActionButtons.vue
+++ b/frontend/src/posapp/components/pos/invoice/InvoiceActionButtons.vue
@@ -92,6 +92,18 @@
 				{{ __("Print Draft") }}
 			</v-btn>
 		</v-col>
+		<v-col cols="12" sm="6">
+			<v-btn
+				block
+				color="primary"
+				theme="dark"
+				prepend-icon="mdi-share-variant"
+				@click="$emit('share-last')"
+				class="summary-btn"
+			>
+				{{ __("Share Last Invoice") }}
+			</v-btn>
+		</v-col>
 		<v-col cols="12" sm="6" v-if="showCustomerDisplayButton">
 			<v-btn
 				block
@@ -151,6 +163,7 @@ defineEmits([
 	"open-invoice-management",
 	"open-returns",
 	"print-draft",
+	"share-last",
 	"show-payment",
 	"open-customer-display",
 ]);

--- a/frontend/src/posapp/components/pos/invoice/InvoiceSummary.vue
+++ b/frontend/src/posapp/components/pos/invoice/InvoiceSummary.vue
@@ -107,6 +107,7 @@
 					@open-invoice-management="handleOpenInvoiceManagement"
 					@open-returns="handleOpenReturns"
 					@print-draft="handlePrintDraft"
+					@share-last="emit('share-last')"
 					@show-payment="handleShowPayment"
 					@open-customer-display="handleOpenCustomerDisplay"
 				/>
@@ -229,6 +230,7 @@ const emit = defineEmits([
 	"open-invoice-management",
 	"open-returns",
 	"print-draft",
+	"share-last",
 	"show-payment",
 	"open-customer-display",
 	"resume-parked-order",


### PR DESCRIPTION
## What

Adds the ability to **share an invoice as a PDF** straight from the POS,
using the browser's **Web Share API** (`navigator.share`). On supported
devices this opens the operating system's native share sheet, so the
cashier can send the invoice directly to **WhatsApp** and other installed
apps (email, Telegram, AirDrop, etc.) to complete the process. When sharing
with files is not available — or the user dismisses the share sheet — it
gracefully falls back to downloading the PDF.

Two entry points:

- **POS screen** — a *"Share Last Invoice"* action fetches the most recent
  **submitted** Sales Invoice for the active POS Profile, renders it to PDF
  and shares it.
- **Invoice Management** — a share icon next to each listed invoice shares
  that specific invoice.

## How

The PDF is generated with `frappe.utils.print_format.download_pdf` using the
POS Profile's print format (`print_format_for_online` → `print_format`) with
a `"Standard"` fallback, so whatever print format is configured works without
extra setup.

## Notes

- Purely additive and behind a user action; no change to existing flows.
- All user-facing strings go through `__()` for translation.
- `vue-tsc --noEmit && vite build` passes.

## Files

- `Invoice.vue` — `share_last_invoice` + download fallback, wired through
  `InvoiceSummary` → `InvoiceActionButtons` via a `share-last` event.
- `flows/InvoiceManagement.vue` — per-row `shareInvoice` + share icons.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added invoice sharing functionality for the last submitted invoice in the POS interface
  * Added share buttons across invoice management views (History, Unpaid, Partial, Returns) in both list and card layouts with automatic PDF download fallback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->