### PR TITLE
feat(payment): share last payment PDF via the native share sheet (WhatsApp, etc.)

### DIFF
--- a/frontend/src/posapp/components/pos/shell/PayView.vue
+++ b/frontend/src/posapp/components/pos/shell/PayView.vue
@@ -194,6 +194,7 @@
 						:disabled="false"
 						@submit="submit"
 						@submit-and-print="submit_and_print"
+						@share-last-payment="share_last_payment"
 					/>
 				</v-card>
 			</v-col>
@@ -1032,6 +1033,83 @@ export default {
 		const submit = () => processPayment({ printAfter: false });
 		const submit_and_print = () => processPayment({ printAfter: true });
 
+		const share_last_payment = async () => {
+			try {
+				const party = customer_name.value;
+				if (!party) {
+					proxy?.eventBus?.emit("show_message", {
+						title: __("Please select a party first."),
+						color: "warning",
+					});
+					return;
+				}
+				const { message: payments } = await frappe.call({
+					method: "frappe.client.get_list",
+					args: {
+						doctype: "Payment Entry",
+						fields: ["name"],
+						filters: { party, docstatus: 1 },
+						order_by: "creation desc",
+						limit_page_length: 1,
+					},
+				});
+				if (!payments || payments.length === 0) {
+					proxy?.eventBus?.emit("show_message", {
+						title: __("No previous payments found for this party."),
+						color: "warning",
+					});
+					return;
+				}
+				const payment_name = payments[0].name;
+				const print_format =
+					pos_profile.value?.print_format_for_online ||
+					pos_profile.value?.print_format ||
+					"Standard";
+				const pdf_url = `/api/method/frappe.utils.print_format.download_pdf?doctype=Payment%20Entry&name=${encodeURIComponent(payment_name)}&format=${encodeURIComponent(print_format)}&no_letterhead=0`;
+				const response = await fetch(pdf_url, {
+					headers: { "X-Frappe-CSRF-Token": frappe.csrf_token },
+				});
+				if (!response.ok) {
+					throw new Error(__("Failed to download payment. Status: {0}", [response.status]));
+				}
+				const blob = await response.blob();
+				const file = new File([blob], `${payment_name}.pdf`, { type: "application/pdf" });
+				if (navigator.share && navigator.canShare && navigator.canShare({ files: [file] })) {
+					try {
+						await navigator.share({
+							title: __("Payment Entry"),
+							text: __("Payment No: {0}", [payment_name]),
+							files: [file],
+						});
+					} catch (shareError) {
+						// User dismissed the native share sheet: fall back to download.
+						if (shareError.name !== "AbortError") {
+							download_pdf_blob(blob, payment_name);
+						}
+					}
+				} else {
+					// Web Share API (with files) unavailable: download instead.
+					download_pdf_blob(blob, payment_name);
+				}
+			} catch (error) {
+				proxy?.eventBus?.emit("show_message", {
+					title: error.message || __("Failed to share payment"),
+					color: "error",
+				});
+			}
+		};
+
+		const download_pdf_blob = (blob, name) => {
+			const url = window.URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = `${name}.pdf`;
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			window.URL.revokeObjectURL(url);
+		};
+
 		// Lifecycle & Watchers
 		const payTotalsSidebarRef = ref(null);
 
@@ -1253,6 +1331,7 @@ export default {
 			handleInvoiceSelection,
 			submit,
 			submit_and_print,
+			share_last_payment,
 			rtlStyles,
 			rtlClasses,
 			customersStore,

--- a/frontend/src/posapp/components/pos_pay/PayActionButtons.vue
+++ b/frontend/src/posapp/components/pos_pay/PayActionButtons.vue
@@ -28,6 +28,19 @@
 					{{ __("Submit & Print") }}
 				</v-btn>
 			</v-col>
+			<v-col cols="12" class="pt-2">
+				<v-btn
+					block
+					size="large"
+					color="info"
+					theme="dark"
+					prepend-icon="mdi-share-variant"
+					@click="$emit('share-last-payment')"
+					:disabled="disabled || loading"
+				>
+					{{ __("Share Last Payment") }}
+				</v-btn>
+			</v-col>
 		</v-row>
 	</div>
 </template>
@@ -38,5 +51,5 @@ defineProps({
 	disabled: Boolean,
 });
 
-defineEmits(["submit", "submit-and-print"]);
+defineEmits(["submit", "submit-and-print", "share-last-payment"]);
 </script>


### PR DESCRIPTION
## What

Adds a **"Share Last Payment"** action to the payments view. It fetches the
most recent **submitted** Payment Entry for the selected party, renders it to
PDF and opens the operating system's native share sheet via the **Web Share
API** (`navigator.share`) — so the receipt can be sent directly to
**WhatsApp** and other installed apps to finish the process. If sharing with
files is unavailable, or the user dismisses the share sheet, it falls back to
downloading the PDF.

## How

The PDF is produced with `frappe.utils.print_format.download_pdf` using the
POS Profile print format (`print_format_for_online` → `print_format`) with a
`"Standard"` fallback, so any configured print format works.

User feedback (no party selected / no previous payment / download failure) is
surfaced through the existing `show_message` event bus.

## Notes

- Additive, behind an explicit user action.
- All strings go through `__()`.
- `vue-tsc --noEmit && vite build` passes.

## Files

- `shell/PayView.vue` — `share_last_payment` + download fallback, exposed to
  the template and wired to `PayActionButtons`.
- `pos_pay/PayActionButtons.vue` — the "Share Last Payment" button + event.
