### PR TITLE
fix: resolve get_party_bank_account import for ERPNext v15/v16 compat

### DIFF
--- a/posawesome/posawesome/api/erpnext_compat.py
+++ b/posawesome/posawesome/api/erpnext_compat.py
@@ -75,3 +75,21 @@ def resolve_make_sales_invoice_from_delivery():
         "This version of POS Awesome requires ERPNext v15. "
         "For ERPNext v16+, use the v16-compatible branch of POS Awesome."
     )
+
+
+def resolve_get_party_bank_account():
+    """Resolve ``get_party_bank_account`` (v15: erpnext.accounts.party, v16+: erpnext.accounts.doctype.bank_account.bank_account)."""
+    try:
+        from erpnext.accounts.doctype.bank_account.bank_account import get_party_bank_account
+        return get_party_bank_account
+    except ImportError:
+        pass
+    try:
+        from erpnext.accounts.party import get_party_bank_account
+        return get_party_bank_account
+    except ImportError:
+        pass
+    raise ImportError(
+        "Cannot import 'get_party_bank_account' from ERPNext. "
+        "This version of POS Awesome requires ERPNext v15 or v16."
+    )

--- a/posawesome/posawesome/api/payments.py
+++ b/posawesome/posawesome/api/payments.py
@@ -15,7 +15,8 @@ from erpnext.accounts.doctype.payment_request.payment_request import (
 )
 from posawesome.posawesome.api.utilities import ensure_child_doctype
 
-get_party_bank_account = resolve_get_party_bank_account()
+def get_party_bank_account(*args, **kwargs):
+    return resolve_get_party_bank_account()(*args, **kwargs)
 
 
 def get_posawesome_credit_redeem_remark(invoice_name):

--- a/posawesome/posawesome/api/payments.py
+++ b/posawesome/posawesome/api/payments.py
@@ -7,13 +7,15 @@ import json
 import frappe
 from frappe.utils import nowdate, flt
 from frappe import _
-from erpnext.accounts.party import get_party_bank_account
 from erpnext.accounts.utils import reconcile_against_document
+from posawesome.posawesome.api.erpnext_compat import resolve_get_party_bank_account
 from erpnext.accounts.doctype.payment_request.payment_request import (
     get_dummy_message,
     get_existing_payment_request_amount,
 )
 from posawesome.posawesome.api.utilities import ensure_child_doctype
+
+get_party_bank_account = resolve_get_party_bank_account()
 
 
 def get_posawesome_credit_redeem_remark(invoice_name):

--- a/posawesome/posawesome/api/test_payments.py
+++ b/posawesome/posawesome/api/test_payments.py
@@ -65,8 +65,8 @@ class FakePaymentEntry:
 def _install_stubs():
     frappe_module = types.ModuleType("frappe")
     frappe_utils = types.ModuleType("frappe.utils")
-    accounts_party = types.ModuleType("erpnext.accounts.party")
     accounts_utils = types.ModuleType("erpnext.accounts.utils")
+    erpnext_compat = types.ModuleType("posawesome.posawesome.api.erpnext_compat")
     payment_request_module = types.ModuleType("erpnext.accounts.doctype.payment_request.payment_request")
     utilities_module = types.ModuleType("posawesome.posawesome.api.utilities")
 
@@ -146,17 +146,17 @@ def _install_stubs():
 
     accounts_utils.reconcile_against_document = _reconcile_against_document
 
-    accounts_party.get_party_bank_account = lambda *args, **kwargs: None
+    erpnext_compat.resolve_get_party_bank_account = lambda: lambda *args, **kwargs: None
     payment_request_module.get_dummy_message = lambda *_args, **_kwargs: ""
     payment_request_module.get_existing_payment_request_amount = lambda *_args, **_kwargs: 0
     utilities_module.ensure_child_doctype = lambda *_args, **_kwargs: None
 
     sys.modules["frappe"] = frappe_module
     sys.modules["frappe.utils"] = frappe_utils
-    sys.modules["erpnext.accounts.party"] = accounts_party
     sys.modules["erpnext.accounts.utils"] = accounts_utils
     sys.modules["erpnext.accounts.doctype.payment_request.payment_request"] = payment_request_module
     sys.modules["posawesome.posawesome.api.utilities"] = utilities_module
+    sys.modules["posawesome.posawesome.api.erpnext_compat"] = erpnext_compat
 
     return created_docs, get_all_responses, sql_responses, get_doc_responses, reconcile_calls
 


### PR DESCRIPTION
- Use centralized erpnext_compat resolver with v15->v16 fallback
- Unblocks bench migrate crash on POS Cash Movement DocType sync