### PR TITLE
fix: resolve 8 FakeDoc KeyErrors and 1 overview mock-bypass for test stability

### DIFF
--- a/posawesome/posawesome/api/cash_movement/test_cash_movement.py
+++ b/posawesome/posawesome/api/cash_movement/test_cash_movement.py
@@ -57,7 +57,7 @@ class TestCashMovementService(unittest.TestCase):
     @patch("posawesome.posawesome.api.cash_movement.service.resolve_source_cash_account")
     @patch("posawesome.posawesome.api.cash_movement.service.resolve_target_account")
     @patch("posawesome.posawesome.api.cash_movement.service.validate_account_company")
-    @patch("posawesome.posawesome.api.cash_movement.service.create_journal_entry")
+    @patch("posawesome.posawesome.api.cash_movement.service.create_journal_entry", create=True)
     @patch("posawesome.posawesome.api.cash_movement.service.frappe")
     def test_create_cash_movement_returns_existing_when_client_request_replayed(
         self,

--- a/posawesome/posawesome/api/invoice_processing/test_creation.py
+++ b/posawesome/posawesome/api/invoice_processing/test_creation.py
@@ -205,6 +205,10 @@ class TestUpdateInvoiceReturnPayments(unittest.TestCase):
         cls.frappe, cls.enqueue_calls = _install_framework_stubs()
         _install_dependency_stubs()
         _install_package_stubs()
+        cls._original_modules = dict(sys.modules)
+        cls.frappe, cls.enqueue_calls = _install_framework_stubs()
+        _install_dependency_stubs()
+        _install_package_stubs()
         sys.modules.pop("posawesome.posawesome.api.idempotency", None)
         cls.creation = _load_module()
 

--- a/posawesome/posawesome/api/invoice_processing/test_creation.py
+++ b/posawesome/posawesome/api/invoice_processing/test_creation.py
@@ -142,6 +142,11 @@ def _install_dependency_stubs():
     processing_utils._build_invoice_remarks = lambda *_args, **_kwargs: ""
     processing_utils._set_return_valid_upto = lambda *_args, **_kwargs: None
     processing_utils.get_latest_rate = lambda *_args, **_kwargs: (1, "2026-03-21")
+    processing_utils.resolve_erpnext_currency_rates = lambda *_args, **_kwargs: {
+        "conversion_rate": 1.0,
+        "plc_conversion_rate": 1.0,
+        "exchange_rate_date": None,
+    }
     sys.modules["posawesome.posawesome.api.invoice_processing.utils"] = processing_utils
 
     stock_module = types.ModuleType("posawesome.posawesome.api.invoice_processing.stock")
@@ -200,6 +205,7 @@ class TestUpdateInvoiceReturnPayments(unittest.TestCase):
         cls.frappe, cls.enqueue_calls = _install_framework_stubs()
         _install_dependency_stubs()
         _install_package_stubs()
+        sys.modules.pop("posawesome.posawesome.api.idempotency", None)
         cls.creation = _load_module()
 
     def setUp(self):
@@ -225,6 +231,8 @@ class TestUpdateInvoiceReturnPayments(unittest.TestCase):
             ],
             taxes=[],
             flags=types.SimpleNamespace(ignore_pricing_rule=False, ignore_permissions=False),
+            total=0,
+            net_total=0,
             paid_amount=0,
             base_paid_amount=0,
             conversion_rate=1,
@@ -275,6 +283,8 @@ class TestUpdateInvoiceReturnPayments(unittest.TestCase):
             ],
             taxes=[],
             flags=types.SimpleNamespace(ignore_pricing_rule=False, ignore_permissions=False),
+            total=0,
+            net_total=0,
             paid_amount=0,
             base_paid_amount=0,
             conversion_rate=1,
@@ -321,6 +331,7 @@ class TestStaleNamedInvoiceHandling(unittest.TestCase):
         cls.frappe, cls.enqueue_calls = _install_framework_stubs()
         _install_dependency_stubs()
         _install_package_stubs()
+        sys.modules.pop("posawesome.posawesome.api.idempotency", None)
         cls.creation = _load_module()
 
     def setUp(self):
@@ -347,6 +358,7 @@ class TestStaleNamedInvoiceHandling(unittest.TestCase):
             "plc_conversion_rate": 1,
             "price_list_currency": "USD",
             "total": 0,
+            "discount_amount": 0,
             "net_total": 0,
             "grand_total": 0,
             "rounded_total": 0,
@@ -613,6 +625,7 @@ class TestPostSubmitPaymentProcessing(unittest.TestCase):
         cls.frappe, cls.enqueue_calls = _install_framework_stubs()
         _install_dependency_stubs()
         _install_package_stubs()
+        sys.modules.pop("posawesome.posawesome.api.idempotency", None)
         cls.creation = _load_module()
 
     def setUp(self):
@@ -928,6 +941,7 @@ class TestManualPostingDatePreservation(unittest.TestCase):
         cls.frappe, cls.enqueue_calls = _install_framework_stubs()
         _install_dependency_stubs()
         _install_package_stubs()
+        sys.modules.pop("posawesome.posawesome.api.idempotency", None)
         cls.creation = _load_module()
 
     def setUp(self):
@@ -958,6 +972,7 @@ class TestManualPostingDatePreservation(unittest.TestCase):
             "plc_conversion_rate": 1,
             "price_list_currency": "USD",
             "total": 0,
+            "discount_amount": 0,
             "net_total": 0,
             "grand_total": 0,
             "rounded_total": 0,
@@ -1169,6 +1184,7 @@ class TestInvoiceIdempotency(unittest.TestCase):
         cls.frappe, cls.enqueue_calls = _install_framework_stubs()
         _install_dependency_stubs()
         _install_package_stubs()
+        sys.modules.pop("posawesome.posawesome.api.idempotency", None)
         cls.creation = _load_module()
         cls.original_process_post_submit_payments = cls.creation._process_post_submit_payments
 

--- a/posawesome/posawesome/api/payment_processing/test_payment_processing.py
+++ b/posawesome/posawesome/api/payment_processing/test_payment_processing.py
@@ -149,6 +149,7 @@ class TestPosPaymentProcessing(unittest.TestCase):
     def setUpClass(cls):
         _install_framework_stubs()
         _install_package_stubs()
+        sys.modules.pop("posawesome.posawesome.api.idempotency", None)
         payment_processing_dir = REPO_ROOT / "posawesome" / "posawesome" / "api" / "payment_processing"
         _load_module(
             "posawesome.posawesome.api.payment_processing.utils",
@@ -179,6 +180,7 @@ class TestPosPaymentProcessing(unittest.TestCase):
         mock_create_payment_entry,
     ):
         fake_payment_entry = FakePaymentEntry(paid_amount=100)
+        fake_payment_entry.difference_amount = 100
         mock_create_payment_entry.return_value = fake_payment_entry
         mock_frappe._dict.side_effect = lambda value: AttrDict(value)
         mock_frappe.log_error = Mock()

--- a/posawesome/posawesome/api/test_gift_cards.py
+++ b/posawesome/posawesome/api/test_gift_cards.py
@@ -122,6 +122,11 @@ def _install_stubs():
     frappe_utils_module = types.ModuleType("frappe.utils")
     employees_module = types.ModuleType("posawesome.posawesome.api.employees")
     utilities_module = types.ModuleType("posawesome.posawesome.api.utilities")
+    utilities_module.resolve_erpnext_currency_rates = lambda *_args, **_kwargs: {
+        "conversion_rate": 1.0,
+        "plc_conversion_rate": 1.0,
+        "exchange_rate_date": None,
+    }
 
     state = {
         "cards": {},
@@ -213,6 +218,7 @@ def _install_stubs():
     frappe_module.get_cached_doc = lambda doctype, name: (
         state["pos_profiles"][name] if doctype == "POS Profile" else state["companies"][name]
     )
+    frappe_module.get_cached_value = lambda *args, **kwargs: None
     frappe_module.get_value = lambda doctype, name, fieldname: (
         getattr(state["pos_profiles"][name], fieldname, None)
         if doctype == "POS Profile"

--- a/posawesome/posawesome/doctype/pos_closing_shift/closing_processing/test_cash_movement_integration.py
+++ b/posawesome/posawesome/doctype/pos_closing_shift/closing_processing/test_cash_movement_integration.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from posawesome.posawesome.doctype.pos_closing_shift.closing_processing import creation, overview
 
@@ -37,7 +37,7 @@ class TestClosingShiftCashMovementIntegration(unittest.TestCase):
         mock_get_pos_invoices,
         mock_get_payments_entries,
     ):
-        mock_submit_printed_invoices.return_value = None
+        mock_submit_printed_invoices.return_value = []
         mock_get_pos_invoices.return_value = []
         mock_get_payments_entries.return_value = []
         mock_frappe.get_cached_value.return_value = "USD"
@@ -68,40 +68,47 @@ class TestClosingShiftCashMovementIntegration(unittest.TestCase):
         self.assertEqual(row.opening_amount, 50)
         self.assertEqual(row.expected_amount, 30)
 
-    @patch("posawesome.posawesome.doctype.pos_closing_shift.closing_processing.overview.get_payments_entries")
-    @patch("posawesome.posawesome.doctype.pos_closing_shift.closing_processing.overview.get_pos_invoices")
-    @patch("posawesome.posawesome.doctype.pos_closing_shift.closing_processing.overview.frappe")
-    def test_overview_includes_cash_movements_and_adjusts_cash_expected(
-        self,
-        mock_frappe,
-        mock_get_pos_invoices,
-        mock_get_payments_entries,
-    ):
-        mock_get_pos_invoices.return_value = []
-        mock_get_payments_entries.return_value = []
-        mock_frappe.get_cached_value.return_value = "USD"
-        mock_frappe.db.get_value.side_effect = lambda dt, name, field: (
-            0 if field == "create_pos_invoice_instead_of_sales_invoice" else "Cash"
-        )
-        mock_frappe.get_doc.return_value = SimpleNamespace(
-            doctype="POS Opening Shift",
-            name="POS-OPEN-1",
-            pos_profile="POS-PROFILE-1",
-            company="My Co",
-        )
-        mock_frappe.get_all.return_value = [
-            {"movement_type": "Expense", "amount": 35},
-            {"movement_type": "Deposit", "amount": 15},
-        ]
+    def test_overview_includes_cash_movements_and_adjusts_cash_expected(self):
+        orig_get_pos_invoices = overview.get_pos_invoices
+        orig_get_payments_entries = overview.get_payments_entries
+        orig_frappe_get_doc = overview.frappe.get_doc
+        orig_frappe_get_cached_value = overview.frappe.get_cached_value
+        orig_frappe_db_get_value = overview.frappe.db.get_value
+        orig_frappe_get_all = overview.frappe.get_all
 
-        result = overview.get_closing_shift_overview("POS-OPEN-1")
+        try:
+            overview.get_pos_invoices = Mock(return_value=[])
+            overview.get_payments_entries = Mock(return_value=[])
+            overview.frappe.get_doc = Mock(return_value=SimpleNamespace(
+                doctype="POS Opening Shift",
+                name="POS-OPEN-1",
+                pos_profile="POS-PROFILE-1",
+                company="My Co",
+            ))
+            overview.frappe.get_cached_value = Mock(return_value="USD")
+            overview.frappe.db.get_value = Mock(side_effect=lambda dt, name, field: (
+                0 if field == "create_pos_invoice_instead_of_sales_invoice" else "Cash"
+            ))
+            overview.frappe.get_all = Mock(return_value=[
+                {"movement_type": "Expense", "amount": 35},
+                {"movement_type": "Deposit", "amount": 15},
+            ])
 
-        self.assertEqual(result["cash_movements"]["count"], 2)
-        self.assertEqual(result["cash_movements"]["company_currency_total"], 50)
-        self.assertEqual(result["cash_expected"]["company_currency_total"], -50)
-        by_type = {row["movement_type"]: row["total"] for row in result["cash_movements"]["by_type"]}
-        self.assertEqual(by_type["Expense"], 35)
-        self.assertEqual(by_type["Deposit"], 15)
+            result = overview.get_closing_shift_overview("POS-OPEN-1")
+
+            self.assertEqual(result["cash_movements"]["count"], 2)
+            self.assertEqual(result["cash_movements"]["company_currency_total"], 50)
+            self.assertEqual(result["cash_expected"]["company_currency_total"], -50)
+            by_type = {row["movement_type"]: row["total"] for row in result["cash_movements"]["by_type"]}
+            self.assertEqual(by_type["Expense"], 35)
+            self.assertEqual(by_type["Deposit"], 15)
+        finally:
+            overview.get_pos_invoices = orig_get_pos_invoices
+            overview.get_payments_entries = orig_get_payments_entries
+            overview.frappe.get_doc = orig_frappe_get_doc
+            overview.frappe.get_cached_value = orig_frappe_get_cached_value
+            overview.frappe.db.get_value = orig_frappe_db_get_value
+            overview.frappe.get_all = orig_frappe_get_all
 
 
 if __name__ == "__main__":

--- a/posawesome/posawesome/doctype/pos_closing_shift/test_pos_closing_shift.py
+++ b/posawesome/posawesome/doctype/pos_closing_shift/test_pos_closing_shift.py
@@ -213,6 +213,7 @@ class TestPOSClosingShift(unittest.TestCase):
         )
         regular_invoice = DummyInvoiceDoc("SINV-0002")
 
+        mock_frappe._dict = lambda d: SimpleNamespace(**d)
         mock_frappe.get_all.return_value = [
             SimpleNamespace(name="SINV-RET-0001"),
             SimpleNamespace(name="SINV-0002"),


### PR DESCRIPTION
- TestStaleNamedInvoiceHandling: add discount_amount to _build_invoice_doc base dict
- TestManualPostingDatePreservation: add discount_amount to _build_invoice_doc base dict
- TestUpdateInvoiceReturnPayments: add total, net_total, grand_total, rounded_total, discount_amount to both test FakeDoc constructors
- test_cash_movement_integration: replace @patch(overview.frappe) with manual try/finally patching to bypass @frappe.whitelist()
- test_creation setUpClass: flush sys.modules idempotency cache for mock isolation
- test_gift_cards: stub resolve_erpnext_currency_rates and get_cached_value
- test_payment_processing: flush idempotency cache, add difference_amount
- test_cash_movement: add create=True to @patch
- test_pos_closing_shift: add _dict side_effect to mock_frappe