### PR TITLE
feat: add performance benchmark suite for catalog load and concurrent stations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
 		"test:unit": "vitest run",
 		"test:smoke": "playwright test --config=playwright.config.ts",
 		"test:smoke:headed": "playwright test --config=playwright.config.ts --headed",
+		"test:perf": "vitest run tests/performance",
+		"test:perf:smoke": "playwright test --config=playwright.perf.config.ts",
 		"docs:generate": "typedoc --options typedoc.json",
 		"docs:check": "typedoc --options typedoc.json --emit none"
 	},

--- a/frontend/playwright.perf.config.ts
+++ b/frontend/playwright.perf.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "@playwright/test";
+import baseConfig from "./playwright.config";
+
+export default defineConfig({
+	...baseConfig,
+	testMatch: ["performance/**/*.spec.ts"],
+	timeout: 300000,
+	use: {
+		...baseConfig.use,
+	},
+});

--- a/frontend/tests/performance/TTI.spec.ts
+++ b/frontend/tests/performance/TTI.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const POS_PATH = process.env.POSA_SMOKE_PATH || "/app/posapp";
+const SKIP_TESTS = Boolean(process.env.CI) && !Boolean(process.env.POSA_SMOKE_BASE_URL);
+
+async function loginIfCredentialsProvided(page: Page) {
+	const username = process.env.POSA_SMOKE_USER;
+	const password = process.env.POSA_SMOKE_PASSWORD;
+	if (!username || !password) return;
+	await page.goto("/login", { waitUntil: "networkidle" });
+	const userInput = page.locator('input[name="login_email"], input#login_email');
+	const passInput = page.locator('input[name="login_password"], input#login_password');
+	const loginButton = page.locator("button.btn-login").or(
+		page.locator('button:has-text("Login"), button:has-text("Log In")'),
+	);
+	if ((await userInput.count()) === 0 || (await passInput.count()) === 0) return;
+	await userInput.first().fill(username);
+	await passInput.first().fill(password);
+	await Promise.all([
+		page.waitForURL(/\/app(\/|$)/, { timeout: 60000 }),
+		loginButton.first().click(),
+	]);
+}
+
+const describeFn = SKIP_TESTS ? test.describe.skip : test.describe;
+
+describeFn("POS app time-to-interactive benchmarks", () => {
+	test("measures TTFB, first paint, and time-to-interactive on cold load", async ({ page }) => {
+		await loginIfCredentialsProvided(page);
+
+		const timings: Record<string, number> = {};
+		const errors: string[] = [];
+		let heapUsedAtInteractive = 0;
+
+		page.on("pageerror", (error) => errors.push(String(error?.message || error)));
+
+		await page.goto(POS_PATH, { waitUntil: "commit" });
+		timings["ttfb"] = performance.now();
+
+		await page.waitForSelector("body", { timeout: 30000 });
+		timings["firstPaint"] = performance.now();
+
+		await page.locator(".main-section").first().waitFor({ state: "visible", timeout: 60000 });
+		timings["interactive"] = performance.now();
+
+		await page.waitForTimeout(2000);
+		timings["settled"] = performance.now();
+
+		heapUsedAtInteractive = await page.evaluate(() =>
+			(performance as any).memory?.usedJSHeapSize || 0,
+		);
+
+		const ttfb = timings["ttfb"];
+		const firstPaint = timings["firstPaint"] - timings["ttfb"];
+		const tti = timings["interactive"] - timings["ttfb"];
+		const settleTime = timings["settled"] - timings["ttfb"];
+
+		console.log(`\n[TTI metrics]`);
+		console.log(`  TTFB (wall):          ${ttfb.toFixed(0)}ms`);
+		console.log(`  First paint:          ${firstPaint.toFixed(0)}ms`);
+		console.log(`  Time-to-interactive:  ${tti.toFixed(0)}ms`);
+		console.log(`  Settle (2s after TTI):${settleTime.toFixed(0)}ms`);
+		console.log(`  JS heap (interactive):${(heapUsedAtInteractive / 1_048_576).toFixed(1)}MB`);
+		console.log(`  Global errors:        ${errors.length}`);
+
+		expect(errors, `Page errors: ${errors.join("; ")}`).toHaveLength(0);
+		expect(tti, "TTI exceeds 15s threshold").toBeLessThan(15000);
+	});
+
+	test("measures search interaction latency after app is settled", async ({ page }) => {
+		await loginIfCredentialsProvided(page);
+		await page.goto(POS_PATH, { waitUntil: "networkidle" });
+		await page.locator(".main-section").first().waitFor({ state: "visible", timeout: 60000 });
+
+		const searchInput = page.locator(
+			'input[type="text"][placeholder*="Search"], input[type="search"], ' +
+			'.v-field input, .v-text-field input',
+		).first();
+
+		await searchInput.waitFor({ state: "visible", timeout: 30000 });
+
+		const searchTimings: number[] = [];
+		for (let i = 0; i < 10; i++) {
+			const before = performance.now();
+			await searchInput.fill(`ITEM-${String(i).padStart(5, "0")}`);
+			await page.waitForTimeout(300);
+			if (i > 0) {
+				searchTimings.push((performance.now() - before) - 300);
+			}
+		}
+
+		const avgSearch = searchTimings.reduce((a, b) => a + b, 0) / searchTimings.length;
+		const maxSearch = Math.max(...searchTimings);
+
+		console.log(`\n[search latency (10 iterations, excluding 300ms settle)]`);
+		console.log(`  Average: ${avgSearch.toFixed(1)}ms`);
+		console.log(`  Maximum: ${maxSearch.toFixed(1)}ms`);
+
+		expect(avgSearch, `Average search latency ${avgSearch.toFixed(1)}ms > 500ms threshold`)
+			.toBeLessThan(500);
+	});
+
+	test("records JS heap snapshot during normal operation", async ({ page }) => {
+		await loginIfCredentialsProvided(page);
+		await page.goto(POS_PATH, { waitUntil: "networkidle" });
+		await page.locator(".main-section").first().waitFor({ state: "visible", timeout: 60000 });
+		await page.waitForTimeout(3000);
+
+		const heapInfo = await page.evaluate(() => {
+			const mem = (performance as any).memory;
+			if (!mem) return null;
+			return {
+				usedJSHeapSize: mem.usedJSHeapSize,
+				totalJSHeapSize: mem.totalJSHeapSize,
+				jsHeapSizeLimit: mem.jsHeapSizeLimit,
+			};
+		});
+
+		if (heapInfo) {
+			const usedMB = (heapInfo.usedJSHeapSize / 1_048_576).toFixed(1);
+			const totalMB = (heapInfo.totalJSHeapSize / 1_048_576).toFixed(1);
+			const limitMB = (heapInfo.jsHeapSizeLimit / 1_048_576).toFixed(1);
+			console.log(`\n[JS heap]`);
+			console.log(`  Used:  ${usedMB}MB`);
+			console.log(`  Total: ${totalMB}MB`);
+			console.log(`  Limit: ${limitMB}MB`);
+
+			expect(heapInfo.usedJSHeapSize,
+				`JS heap ${usedMB}MB exceeds 500MB threshold`)
+				.toBeLessThan(500 * 1_048_576);
+		} else {
+			console.log(`\n[JS heap] --no-js-flags=--max-old-space-size, skipping memory assertion`);
+		}
+	});
+});

--- a/frontend/tests/performance/catalogLoad.spec.ts
+++ b/frontend/tests/performance/catalogLoad.spec.ts
@@ -3,14 +3,9 @@ import { createPinia, setActivePinia } from "pinia";
 import { generateItems, type CatalogSize, CATALOG_SIZES } from "./helpers/mockDataGenerators";
 import { createMockFrappeCall } from "./helpers/mockApiFactory";
 import { measureAsync, assertUnderThreshold, BenchmarkCollector } from "./helpers/perfMeasure";
+import { catalogThreshold } from "./helpers/benchmark.config";
 
 const collector = new BenchmarkCollector();
-
-const THRESHOLDS: Record<CatalogSize, { load: number; search: number; barcode: number }> = {
-	10_000: { load: 3000, search: 100, barcode: 50 },
-	50_000: { load: 8000, search: 200, barcode: 50 },
-	100_000: { load: 15000, search: 300, barcode: 50 },
-};
 
 const TEST_TIMEOUTS: Record<CatalogSize, number> = {
 	10_000: 10000,
@@ -35,6 +30,7 @@ describe("catalog load performance", () => {
 			});
 
 			it(`loads ${(size / 1000).toFixed(0)}K items from paginated API within time budget`, async () => {
+				const thresholds = catalogThreshold(size);
 				const pageSize = 200;
 				const frappeCall = createMockFrappeCall(items, { latencyMs: 20, jitterMs: 5, pageSize });
 				(globalThis as any).frappe = { call: frappeCall };
@@ -55,7 +51,7 @@ describe("catalog load performance", () => {
 
 				collector.add(result);
 				expect(loaded.length).toBe(items.length);
-				assertUnderThreshold(`load ${size} items`, result.durationMs, THRESHOLDS[size].load);
+				assertUnderThreshold(`load ${size} items`, result.durationMs, thresholds.load);
 				if (result.memoryMB !== undefined) {
 					expect(
 						result.memoryMB,
@@ -65,6 +61,7 @@ describe("catalog load performance", () => {
 			}, TEST_TIMEOUTS[size]);
 
 			it(`searches item_code from ${(size / 1000).toFixed(0)}K catalog within time budget`, async () => {
+				const thresholds = catalogThreshold(size);
 				const midIndex = Math.floor(items.length / 2);
 				const targetCode = items[midIndex].item_code;
 
@@ -74,10 +71,11 @@ describe("catalog load performance", () => {
 				}, { iterations: 50 });
 
 				collector.add(result);
-				assertUnderThreshold(`search in ${size} items`, result.durationMs, THRESHOLDS[size].search);
+				assertUnderThreshold(`search in ${size} items`, result.durationMs, thresholds.search);
 			}, TEST_TIMEOUTS[size]);
 
 			it(`looks up barcode from ${(size / 1000).toFixed(0)}K catalog within time budget`, async () => {
+				const thresholds = catalogThreshold(size);
 				const midIndex = Math.floor(items.length / 2);
 				const targetBarcode = items[midIndex].barcode!;
 
@@ -87,12 +85,13 @@ describe("catalog load performance", () => {
 				}, { iterations: 50 });
 
 				collector.add(result);
-				assertUnderThreshold(`barcode lookup in ${size} items`, result.durationMs, THRESHOLDS[size].barcode);
+				assertUnderThreshold(`barcode lookup in ${size} items`, result.durationMs, thresholds.barcode);
 			}, TEST_TIMEOUTS[size]);
 		});
 	}
 
 	afterAll(() => {
+		delete (globalThis as any).frappe;
 		if (collector.results.length > 0) {
 			console.log("\n[catalog benchmark results]\n" + collector.summary);
 		}

--- a/frontend/tests/performance/catalogLoad.spec.ts
+++ b/frontend/tests/performance/catalogLoad.spec.ts
@@ -56,6 +56,12 @@ describe("catalog load performance", () => {
 				collector.add(result);
 				expect(loaded.length).toBe(items.length);
 				assertUnderThreshold(`load ${size} items`, result.durationMs, THRESHOLDS[size].load);
+				if (result.memoryMB !== undefined) {
+					expect(
+						result.memoryMB,
+						`load ${size} items delta memory ${result.memoryMB.toFixed(1)}MB > 200MB`,
+					).toBeLessThan(200);
+				}
 			}, TEST_TIMEOUTS[size]);
 
 			it(`searches item_code from ${(size / 1000).toFixed(0)}K catalog within time budget`, async () => {

--- a/frontend/tests/performance/catalogLoad.spec.ts
+++ b/frontend/tests/performance/catalogLoad.spec.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { generateItems, type CatalogSize, CATALOG_SIZES } from "./helpers/mockDataGenerators";
+import { createMockFrappeCall } from "./helpers/mockApiFactory";
+import { measureAsync, assertUnderThreshold, BenchmarkCollector } from "./helpers/perfMeasure";
+
+const collector = new BenchmarkCollector();
+
+const THRESHOLDS: Record<CatalogSize, { load: number; search: number; barcode: number }> = {
+	10_000: { load: 3000, search: 100, barcode: 50 },
+	50_000: { load: 8000, search: 200, barcode: 50 },
+	100_000: { load: 15000, search: 300, barcode: 50 },
+};
+
+const TEST_TIMEOUTS: Record<CatalogSize, number> = {
+	10_000: 10000,
+	50_000: 20000,
+	100_000: 30000,
+};
+
+describe("catalog load performance", () => {
+	for (const size of CATALOG_SIZES) {
+		describe(`${(size / 1000).toFixed(0)}K items`, () => {
+			let items: ReturnType<typeof generateItems>;
+			let itemsMap: Map<string, (typeof items)[number]>;
+			let barcodeIndex: Map<string, string>;
+
+			beforeAll(() => {
+				setActivePinia(createPinia());
+				items = generateItems(size);
+				itemsMap = new Map(items.map((i) => [i.item_code, i]));
+				barcodeIndex = new Map(
+					items.filter((i) => i.barcode).map((i) => [i.barcode!, i.item_code]),
+				);
+			});
+
+			it(`loads ${(size / 1000).toFixed(0)}K items from paginated API within time budget`, async () => {
+				const pageSize = 200;
+				const frappeCall = createMockFrappeCall(items, { latencyMs: 20, jitterMs: 5, pageSize });
+				(globalThis as any).frappe = { call: frappeCall };
+
+				const totalPages = Math.ceil(items.length / pageSize);
+				const loaded: Array<Record<string, any>> = [];
+
+				const result = await measureAsync(`load ${size} items`, async () => {
+					loaded.length = 0;
+					for (let page = 0; page < totalPages; page++) {
+						const resp = await frappeCall({
+							method: "get_items",
+							args: { offset: page * pageSize, limit: pageSize },
+						});
+						loaded.push(...resp.message);
+					}
+				}, { warmup: false });
+
+				collector.add(result);
+				expect(loaded.length).toBe(items.length);
+				assertUnderThreshold(`load ${size} items`, result.durationMs, THRESHOLDS[size].load);
+			}, TEST_TIMEOUTS[size]);
+
+			it(`searches item_code from ${(size / 1000).toFixed(0)}K catalog within time budget`, async () => {
+				const midIndex = Math.floor(items.length / 2);
+				const targetCode = items[midIndex].item_code;
+
+				const result = await measureAsync(`search in ${size} items`, async () => {
+					const found = itemsMap.get(targetCode);
+					if (!found) throw new Error("not found");
+				}, { iterations: 50 });
+
+				collector.add(result);
+				assertUnderThreshold(`search in ${size} items`, result.durationMs, THRESHOLDS[size].search);
+			}, TEST_TIMEOUTS[size]);
+
+			it(`looks up barcode from ${(size / 1000).toFixed(0)}K catalog within time budget`, async () => {
+				const midIndex = Math.floor(items.length / 2);
+				const targetBarcode = items[midIndex].barcode!;
+
+				const result = await measureAsync(`barcode lookup in ${size} items`, async () => {
+					const code = barcodeIndex.get(targetBarcode);
+					if (!code) throw new Error("not found");
+				}, { iterations: 50 });
+
+				collector.add(result);
+				assertUnderThreshold(`barcode lookup in ${size} items`, result.durationMs, THRESHOLDS[size].barcode);
+			}, TEST_TIMEOUTS[size]);
+		});
+	}
+
+	afterAll(() => {
+		if (collector.results.length > 0) {
+			console.log("\n[catalog benchmark results]\n" + collector.summary);
+		}
+	});
+});

--- a/frontend/tests/performance/concurrentStations.spec.ts
+++ b/frontend/tests/performance/concurrentStations.spec.ts
@@ -4,6 +4,7 @@ import type { SyncResourceDefinition, SyncTrigger } from "../../src/offline/sync
 import { measureAsync, assertUnderThreshold, BenchmarkCollector } from "./helpers/perfMeasure";
 import { generateItems, generateItemCodes } from "./helpers/mockDataGenerators";
 import { sleep } from "./helpers/mockApiFactory";
+import { concurrentThreshold } from "./helpers/benchmark.config";
 
 const collector = new BenchmarkCollector();
 
@@ -32,6 +33,7 @@ describe("concurrent stations", () => {
 	describe("SyncCoordinator throughput", () => {
 		for (const stationCount of STATION_COUNTS) {
 			it(`processes ${stationCount} station-wide resources without exceeding concurrency limit`, async () => {
+				const thresholds = concurrentThreshold(stationCount);
 				const resources = Array.from({ length: stationCount }, (_, i) =>
 					makeResource(`station_${i}`, "warm", ["boot"]),
 				);
@@ -59,7 +61,7 @@ describe("concurrent stations", () => {
 				assertUnderThreshold(
 					`sync ${stationCount} resources`,
 					result.durationMs,
-					stationCount * 5,
+					thresholds.syncCoordinator,
 				);
 			});
 		}
@@ -70,6 +72,7 @@ describe("concurrent stations", () => {
 
 		for (const stationCount of STATION_COUNTS) {
 			it(`handles ${Math.min(stationCount, PAYLOAD_COUNT)} parallel submissions with dedup`, async () => {
+				const thresholds = concurrentThreshold(stationCount);
 				const seen = new Set<string>();
 				const actualExecutions: string[] = [];
 
@@ -84,7 +87,8 @@ describe("concurrent stations", () => {
 				};
 
 				const stationCountCapped = Math.min(stationCount, PAYLOAD_COUNT);
-				const keys = generateItemCodes(stationCountCapped, 1);
+				const uniqueKeys = generateItemCodes(stationCountCapped, 1);
+				const keys = [...uniqueKeys, ...uniqueKeys.slice(0, Math.min(5, stationCountCapped))];
 
 				const result = await measureAsync(
 					`${stationCountCapped} parallel submissions with idempotency check`,
@@ -101,11 +105,11 @@ describe("concurrent stations", () => {
 
 				collector.add(result);
 				expect(actualExecutions.length).toBe(stationCountCapped);
-				expect(actualExecutions).toEqual(keys);
+				expect(actualExecutions).toEqual(uniqueKeys);
 				assertUnderThreshold(
 					`${stationCountCapped} parallel submissions`,
 					result.durationMs,
-					stationCount * 10 + 200,
+					thresholds.parallelSubmissions,
 				);
 			});
 		}
@@ -123,6 +127,7 @@ describe("concurrent stations", () => {
 
 		for (const stationCount of STATION_COUNTS) {
 			it(`executes ${stationCount} parallel searches on ${(ITEM_COUNT / 1000).toFixed(0)}K catalog`, async () => {
+				const thresholds = concurrentThreshold(stationCount);
 				const targetCodes = items.slice(0, Math.min(stationCount, ITEM_COUNT)).map((i) => i.item_code);
 
 				const result = await measureAsync(
@@ -141,7 +146,7 @@ describe("concurrent stations", () => {
 				assertUnderThreshold(
 					`${stationCount} concurrent lookups`,
 					result.durationMs,
-					200,
+					thresholds.concurrentSearch,
 				);
 			});
 		}

--- a/frontend/tests/performance/concurrentStations.spec.ts
+++ b/frontend/tests/performance/concurrentStations.spec.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
+import { SyncCoordinator } from "../../src/offline/sync/SyncCoordinator";
+import type { SyncResourceDefinition, SyncTrigger } from "../../src/offline/sync/types";
+import { measureAsync, assertUnderThreshold, BenchmarkCollector } from "./helpers/perfMeasure";
+import { generateItems, generateItemCodes } from "./helpers/mockDataGenerators";
+import { sleep } from "./helpers/mockApiFactory";
+
+const collector = new BenchmarkCollector();
+
+vi.mock("../../src/offline/sync/syncState", () => ({
+	setSyncResourceState: vi.fn(async () => undefined),
+}));
+
+const makeResource = (
+	id: SyncResourceDefinition["id"],
+	priority: SyncResourceDefinition["priority"],
+	triggers: SyncTrigger[],
+): SyncResourceDefinition => ({
+	id,
+	scope: "profile" as const,
+	mode: "delta" as const,
+	priority,
+	triggers,
+	storageKey: `${id}_cache`,
+	watermarkType: "timestamp" as const,
+	fullResyncSupported: true,
+});
+
+const STATION_COUNTS = [10, 50, 100] as const;
+
+describe("concurrent stations", () => {
+	describe("SyncCoordinator throughput", () => {
+		for (const stationCount of STATION_COUNTS) {
+			it(`processes ${stationCount} station-wide resources without exceeding concurrency limit`, async () => {
+				const resources = Array.from({ length: stationCount }, (_, i) =>
+					makeResource(`station_${i}`, "warm", ["boot"]),
+				);
+				let activeRuns = 0;
+				let maxActiveRuns = 0;
+
+				const coordinator = new SyncCoordinator({
+					concurrency: 5,
+					resources,
+					runResource: async () => {
+						activeRuns += 1;
+						maxActiveRuns = Math.max(maxActiveRuns, activeRuns);
+						await sleep(2);
+						activeRuns -= 1;
+					},
+				});
+
+				const result = await measureAsync(
+					`SyncCoordinator ${stationCount} resources (concurrency=5)`,
+					() => coordinator.runTrigger("boot"),
+				);
+
+				collector.add(result);
+				expect(maxActiveRuns).toBeLessThanOrEqual(5);
+				assertUnderThreshold(
+					`sync ${stationCount} resources`,
+					result.durationMs,
+					stationCount * 5,
+				);
+			});
+		}
+	});
+
+	describe("parallel idempotent API calls", () => {
+		const PAYLOAD_COUNT = 50;
+
+		for (const stationCount of STATION_COUNTS) {
+			it(`handles ${Math.min(stationCount, PAYLOAD_COUNT)} parallel submissions with dedup`, async () => {
+				const seen = new Set<string>();
+				const actualExecutions: string[] = [];
+
+				const handler = async (key: string) => {
+					await sleep(1);
+					if (seen.has(key)) {
+						throw new Error(`Duplicate submission detected for ${key}`);
+					}
+					seen.add(key);
+					actualExecutions.push(key);
+					return { success: true };
+				};
+
+				const stationCountCapped = Math.min(stationCount, PAYLOAD_COUNT);
+				const keys = generateItemCodes(stationCountCapped, 1);
+
+				const result = await measureAsync(
+					`${stationCountCapped} parallel submissions with idempotency check`,
+					async () => {
+						seen.clear();
+						actualExecutions.length = 0;
+						await Promise.all(
+							keys.map((key) =>
+								handler(key).catch((e) => ({ error: e.message, key })),
+							),
+						);
+					},
+				);
+
+				collector.add(result);
+				expect(actualExecutions.length).toBe(stationCountCapped);
+				expect(actualExecutions).toEqual(keys);
+				assertUnderThreshold(
+					`${stationCountCapped} parallel submissions`,
+					result.durationMs,
+					stationCount * 10 + 200,
+				);
+			});
+		}
+	});
+
+	describe("concurrent search throughput", () => {
+		const ITEM_COUNT = 10_000;
+		let items: ReturnType<typeof generateItems>;
+		let itemsMap: Map<string, (typeof items)[number]>;
+
+		beforeAll(() => {
+			items = generateItems(ITEM_COUNT);
+			itemsMap = new Map(items.map((i) => [i.item_code, i]));
+		});
+
+		for (const stationCount of STATION_COUNTS) {
+			it(`executes ${stationCount} parallel searches on ${(ITEM_COUNT / 1000).toFixed(0)}K catalog`, async () => {
+				const targetCodes = items.slice(0, Math.min(stationCount, ITEM_COUNT)).map((i) => i.item_code);
+
+				const result = await measureAsync(
+					`${stationCount} concurrent map lookups`,
+					async () => {
+						await Promise.all(
+							targetCodes.map((code) => {
+								const found = itemsMap.get(code);
+								if (!found) throw new Error(`not found: ${code}`);
+							}),
+						);
+					},
+				);
+
+				collector.add(result);
+				assertUnderThreshold(
+					`${stationCount} concurrent lookups`,
+					result.durationMs,
+					200,
+				);
+			});
+		}
+	});
+
+	afterAll(() => {
+		if (collector.results.length > 0) {
+			console.log("\n[concurrent benchmark results]\n" + collector.summary);
+		}
+	});
+});

--- a/frontend/tests/performance/helpers/benchmark.config.ts
+++ b/frontend/tests/performance/helpers/benchmark.config.ts
@@ -58,7 +58,9 @@ export const config: BenchmarkConfig = scale(defaultConfig) as BenchmarkConfig;
 export function catalogThreshold(size: CatalogSize): CatalogThresholds {
 	const t = config.catalog[size];
 	if (!t) throw new Error(`No thresholds for catalog size ${size}`);
-	const envOverride = process?.env?.[`PERF_THRESHOLD_CATALOG_${size}`];
+	const envOverride = typeof process !== "undefined"
+		? process.env?.[`PERF_THRESHOLD_CATALOG_${size}`]
+		: undefined;
 	if (envOverride) {
 		try {
 			return JSON.parse(envOverride);

--- a/frontend/tests/performance/helpers/benchmark.config.ts
+++ b/frontend/tests/performance/helpers/benchmark.config.ts
@@ -1,0 +1,74 @@
+import type { CatalogSize } from "./mockDataGenerators";
+
+export interface CatalogThresholds {
+	load: number;
+	search: number;
+	barcode: number;
+}
+
+export interface ConcurrentThresholds {
+	syncCoordinator: number;
+	parallelSubmissions: number;
+	concurrentSearch: number;
+}
+
+export interface BenchmarkConfig {
+	catalog: Record<CatalogSize, CatalogThresholds>;
+	concurrent: Record<number, ConcurrentThresholds>;
+}
+
+const defaultConfig: BenchmarkConfig = {
+	catalog: {
+		10_000: { load: 3000, search: 100, barcode: 50 },
+		50_000: { load: 8000, search: 200, barcode: 50 },
+		100_000: { load: 15000, search: 300, barcode: 50 },
+	},
+	concurrent: {
+		10: { syncCoordinator: 50, parallelSubmissions: 120, concurrentSearch: 50 },
+		50: { syncCoordinator: 200, parallelSubmissions: 300, concurrentSearch: 100 },
+		100: { syncCoordinator: 400, parallelSubmissions: 700, concurrentSearch: 200 },
+	},
+};
+
+const multiplier = (() => {
+	if (typeof process !== "undefined" && process.env) {
+		const m = Number(process.env.PERF_THRESHOLD_MULTIPLIER);
+		return Number.isFinite(m) && m > 0 ? m : 1;
+	}
+	return 1;
+})();
+
+function scale(thresholds: Record<string, number | Record<string, number>>): any {
+	if (multiplier === 1) return thresholds;
+	const scaled: Record<string, any> = {};
+	for (const [key, value] of Object.entries(thresholds)) {
+		if (typeof value === "number") {
+			scaled[key] = Math.round(value * multiplier);
+		} else if (typeof value === "object") {
+			scaled[key] = scale(value as any);
+		} else {
+			scaled[key] = value;
+		}
+	}
+	return scaled;
+}
+
+export const config: BenchmarkConfig = scale(defaultConfig) as BenchmarkConfig;
+
+export function catalogThreshold(size: CatalogSize): CatalogThresholds {
+	const t = config.catalog[size];
+	if (!t) throw new Error(`No thresholds for catalog size ${size}`);
+	const envOverride = process?.env?.[`PERF_THRESHOLD_CATALOG_${size}`];
+	if (envOverride) {
+		try {
+			return JSON.parse(envOverride);
+		} catch {}
+	}
+	return t;
+}
+
+export function concurrentThreshold(stationCount: number): ConcurrentThresholds {
+	const t = config.concurrent[stationCount];
+	if (!t) throw new Error(`No thresholds for ${stationCount} stations`);
+	return t;
+}

--- a/frontend/tests/performance/helpers/mockApiFactory.ts
+++ b/frontend/tests/performance/helpers/mockApiFactory.ts
@@ -1,0 +1,86 @@
+import type { Item } from "../../../src/posapp/types/models";
+
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export interface MockApiOptions {
+	/** Per-API-call artificial latency */
+	latencyMs: number;
+	/** Random jitter added to latency (±jitterMs) */
+	jitterMs: number;
+	/** Items returned per paginated page */
+	pageSize: number;
+}
+
+export const DEFAULT_MOCK_API_OPTIONS: MockApiOptions = {
+	latencyMs: 50,
+	jitterMs: 10,
+	pageSize: 200,
+};
+
+interface FrappeCallFn {
+	(request: any): Promise<{ message: any }>;
+}
+
+export function createMockFrappeCall(
+	items: Item[],
+	options: Partial<MockApiOptions> = {},
+): FrappeCallFn {
+	const opts = { ...DEFAULT_MOCK_API_OPTIONS, ...options };
+
+	return async (request: any) => {
+		const jitter = Math.random() * opts.jitterMs * 2 - opts.jitterMs;
+		const delay = Math.max(0, opts.latencyMs + jitter);
+		await sleep(delay);
+
+		const method: string =
+			typeof request === "string" ? request : request.method;
+		const args: Record<string, any> =
+			typeof request === "string" ? {} : request.args || {};
+
+		if (
+			method.endsWith("get_items_count") ||
+			method.endsWith("get_items_count_data")
+		) {
+			return { message: items.length };
+		}
+
+		if (method.endsWith("get_items") || method.endsWith("get_items_data")) {
+			const offset = args.offset ?? 0;
+			const limit = args.limit ?? opts.pageSize;
+			const page = items.slice(offset, offset + limit);
+			return { message: page };
+		}
+
+		if (method.endsWith("get_items_from_barcode")) {
+			const barcode: string = args.barcode || "";
+			const found = items.find(
+				(item: any) => item.barcode === barcode,
+			);
+			return { message: found ?? null };
+		}
+
+		return { message: [] };
+	};
+}
+
+export function createPaginationObserver() {
+	const calls: Array<{ offset: number; timestamp: number }> = [];
+	return {
+		record(offset: number) {
+			calls.push({ offset, timestamp: performance.now() });
+		},
+		get pageCount(): number {
+			return calls.length;
+		},
+		get lastOffset(): number {
+			return calls.length > 0 ? calls[calls.length - 1].offset : 0;
+		},
+		get totalDurationMs(): number {
+			if (calls.length < 2) return 0;
+			return calls[calls.length - 1].timestamp - calls[0].timestamp;
+		},
+		reset() {
+			calls.length = 0;
+		},
+	};
+}

--- a/frontend/tests/performance/helpers/mockDataGenerators.ts
+++ b/frontend/tests/performance/helpers/mockDataGenerators.ts
@@ -1,0 +1,55 @@
+import type { Item } from "../../../src/posapp/types/models";
+
+const ITEM_GROUPS = [
+	"Products", "Raw Materials", "Consumables", "Sub Assemblies",
+	"Services", "All Item Groups",
+];
+
+const UOMS = ["Nos", "Kgs", "Ltrs", "Box", "Pcs", "Mtrs"];
+
+const BRANDS = [
+	"AlphaBrand", "BetaMfg", "GammaCorp", "DeltaInc",
+	"", "", "",
+];
+
+function padIndex(i: number, total: number): string {
+	const width = String(total).length;
+	return String(i).padStart(width, "0");
+}
+
+export function generateItems(count: number, startIndex = 1): Item[] {
+	return Array.from({ length: count }, (_, idx) => {
+		const i = startIndex + idx;
+		const id = padIndex(i, count + startIndex);
+		const group = ITEM_GROUPS[idx % ITEM_GROUPS.length];
+		const uom = UOMS[idx % UOMS.length];
+		const brand = BRANDS[idx % BRANDS.length];
+		return {
+			item_code: `ITEM-${id}`,
+			item_name: `Benchmark Item ${id}`,
+			description: `Performance test item ${id} in group ${group}`,
+			stock_qty: (idx % 100) + 10,
+			standard_rate: 10 + (idx % 991),
+			uom,
+			item_group: group,
+			brand,
+			actual_qty: (idx % 50) + 5,
+			is_stock_item: 1,
+			has_serial_no: idx % 20 === 0 ? 1 : 0,
+			has_batch_no: idx % 30 === 0 ? 1 : 0,
+			conversion_factor: 1,
+			barcode: `BARCODE-${id}`,
+			image: idx % 10 === 0 ? `/files/item_${id}.png` : undefined,
+		};
+	});
+}
+
+export function generateItemCodes(count: number, startIndex = 1): string[] {
+	return Array.from(
+		{ length: count },
+		(_, idx) => `ITEM-${padIndex(startIndex + idx, count + startIndex)}`,
+	);
+}
+
+export const CATALOG_SIZES = [10_000, 50_000, 100_000] as const;
+export type CatalogSize = (typeof CATALOG_SIZES)[number];

--- a/frontend/tests/performance/helpers/perfMeasure.ts
+++ b/frontend/tests/performance/helpers/perfMeasure.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest";
+
 export interface MeasureResult {
 	label: string;
 	durationMs: number;
@@ -73,10 +75,7 @@ export function assertUnderThreshold(
 	measuredMs: number,
 	thresholdMs: number,
 ): void {
-	const { expect } = globalThis as any;
-	if (typeof expect === "function") {
-		expect(measuredMs, `${label} exceeded threshold of ${thresholdMs}ms`).toBeLessThan(thresholdMs);
-	}
+	expect(measuredMs, `${label} exceeded threshold of ${thresholdMs}ms`).toBeLessThan(thresholdMs);
 }
 
 export function assertBetween(
@@ -85,17 +84,14 @@ export function assertBetween(
 	lowerMs: number,
 	upperMs: number,
 ): void {
-	const { expect } = globalThis as any;
-	if (typeof expect === "function") {
-		expect(
-			measuredMs,
-			`${label} expected between ${lowerMs}ms and ${upperMs}ms`,
-		).toBeGreaterThanOrEqual(lowerMs);
-		expect(
-			measuredMs,
-			`${label} exceeded upper bound of ${upperMs}ms`,
-		).toBeLessThan(upperMs);
-	}
+	expect(
+		measuredMs,
+		`${label} expected between ${lowerMs}ms and ${upperMs}ms`,
+	).toBeGreaterThanOrEqual(lowerMs);
+	expect(
+		measuredMs,
+		`${label} exceeded upper bound of ${upperMs}ms`,
+	).toBeLessThan(upperMs);
 }
 
 export class BenchmarkCollector {

--- a/frontend/tests/performance/helpers/perfMeasure.ts
+++ b/frontend/tests/performance/helpers/perfMeasure.ts
@@ -1,0 +1,96 @@
+export interface MeasureResult {
+	label: string;
+	durationMs: number;
+	success: boolean;
+	iterations: number;
+}
+
+export interface MeasureOptions {
+	iterations?: number;
+	warmup?: boolean;
+}
+
+export function measure(
+	label: string,
+	fn: () => void,
+	options?: MeasureOptions,
+): MeasureResult {
+	const iterations = options?.iterations ?? 1;
+	if (options?.warmup !== false) {
+		fn();
+	}
+	const start = performance.now();
+	for (let i = 0; i < iterations; i++) {
+		fn();
+	}
+	const durationMs = (performance.now() - start) / iterations;
+	return { label, durationMs, success: true, iterations };
+}
+
+export async function measureAsync(
+	label: string,
+	fn: () => Promise<void>,
+	options?: MeasureOptions,
+): Promise<MeasureResult> {
+	const iterations = options?.iterations ?? 1;
+	if (options?.warmup !== false) {
+		await fn();
+	}
+	const start = performance.now();
+	for (let i = 0; i < iterations; i++) {
+		await fn();
+	}
+	const durationMs = (performance.now() - start) / iterations;
+	return { label, durationMs, success: true, iterations };
+}
+
+export function assertUnderThreshold(
+	label: string,
+	measuredMs: number,
+	thresholdMs: number,
+): void {
+	const { expect } = globalThis as any;
+	if (typeof expect === "function") {
+		expect(measuredMs, `${label} exceeded threshold of ${thresholdMs}ms`).toBeLessThan(thresholdMs);
+	}
+}
+
+export function assertBetween(
+	label: string,
+	measuredMs: number,
+	lowerMs: number,
+	upperMs: number,
+): void {
+	const { expect } = globalThis as any;
+	if (typeof expect === "function") {
+		expect(
+			measuredMs,
+			`${label} expected between ${lowerMs}ms and ${upperMs}ms`,
+		).toBeGreaterThanOrEqual(lowerMs);
+		expect(
+			measuredMs,
+			`${label} exceeded upper bound of ${upperMs}ms`,
+		).toBeLessThan(upperMs);
+	}
+}
+
+export class BenchmarkCollector {
+	private results: MeasureResult[] = [];
+
+	add(result: MeasureResult): void {
+		this.results.push(result);
+	}
+
+	get summary(): string {
+		if (this.results.length === 0) return "No benchmarks collected.";
+		const lines = this.results.map(
+			(r) =>
+				`  ${r.label}: ${r.durationMs.toFixed(2)}ms (${r.iterations} iteration(s))`,
+		);
+		return lines.join("\n");
+	}
+
+	get totalDurationMs(): number {
+		return this.results.reduce((sum, r) => sum + r.durationMs, 0);
+	}
+}

--- a/frontend/tests/performance/helpers/perfMeasure.ts
+++ b/frontend/tests/performance/helpers/perfMeasure.ts
@@ -3,11 +3,25 @@ export interface MeasureResult {
 	durationMs: number;
 	success: boolean;
 	iterations: number;
+	memoryMB?: number;
 }
 
 export interface MeasureOptions {
 	iterations?: number;
 	warmup?: boolean;
+}
+
+function getMemoryMB(): number | undefined {
+	try {
+		const mem = (performance as any).memory;
+		if (mem?.usedJSHeapSize) {
+			return mem.usedJSHeapSize / 1_048_576;
+		}
+		if (typeof process !== "undefined" && process.memoryUsage) {
+			return process.memoryUsage().heapUsed / 1_048_576;
+		}
+	} catch {}
+	return undefined;
 }
 
 export function measure(
@@ -19,12 +33,17 @@ export function measure(
 	if (options?.warmup !== false) {
 		fn();
 	}
+	const beforeMem = getMemoryMB();
 	const start = performance.now();
 	for (let i = 0; i < iterations; i++) {
 		fn();
 	}
 	const durationMs = (performance.now() - start) / iterations;
-	return { label, durationMs, success: true, iterations };
+	const afterMem = getMemoryMB();
+	const memoryMB = beforeMem !== undefined && afterMem !== undefined
+		? Math.round((afterMem - beforeMem) * 10) / 10
+		: undefined;
+	return { label, durationMs, success: true, iterations, memoryMB };
 }
 
 export async function measureAsync(
@@ -36,12 +55,17 @@ export async function measureAsync(
 	if (options?.warmup !== false) {
 		await fn();
 	}
+	const beforeMem = getMemoryMB();
 	const start = performance.now();
 	for (let i = 0; i < iterations; i++) {
 		await fn();
 	}
 	const durationMs = (performance.now() - start) / iterations;
-	return { label, durationMs, success: true, iterations };
+	const afterMem = getMemoryMB();
+	const memoryMB = beforeMem !== undefined && afterMem !== undefined
+		? Math.round((afterMem - beforeMem) * 10) / 10
+		: undefined;
+	return { label, durationMs, success: true, iterations, memoryMB };
 }
 
 export function assertUnderThreshold(
@@ -83,10 +107,10 @@ export class BenchmarkCollector {
 
 	get summary(): string {
 		if (this.results.length === 0) return "No benchmarks collected.";
-		const lines = this.results.map(
-			(r) =>
-				`  ${r.label}: ${r.durationMs.toFixed(2)}ms (${r.iterations} iteration(s))`,
-		);
+		const lines = this.results.map((r) => {
+			const mem = r.memoryMB !== undefined ? ` | Δmem ${r.memoryMB.toFixed(1)}MB` : "";
+			return `  ${r.label}: ${r.durationMs.toFixed(2)}ms (${r.iterations} iteration(s))${mem}`;
+		});
 		return lines.join("\n");
 	}
 

--- a/frontend/tests/performance/k6-load-test.js
+++ b/frontend/tests/performance/k6-load-test.js
@@ -1,0 +1,78 @@
+// Run: k6 run --vus 10 --duration 30s tests/performance/k6-load-test.js
+// Requires: k6 v0.49+, POSA_SMOKE_BASE_URL, POSA_API_KEY, POSA_API_SECRET (or cookie)
+
+import { check, group, sleep } from "k6";
+import http from "k6/http";
+
+// Environments
+const BASE = __ENV.POSA_SMOKE_BASE_URL || "http://localhost:8000";
+const COOKIE = __ENV.POSA_COOKIE || "";
+
+const METHODS = [
+	"posawesome.api.invoice_processing.get_items",
+	"posawesome.api.invoice_processing.get_customers",
+	"posawesome.api.invoice_processing.get_pricing_rules",
+];
+
+function frappePost(method: string, args: Record<string, any> = {}) {
+	const url = `${BASE}/api/method/${method}`;
+	const payload = JSON.stringify({ args, method });
+	const params: Record<string, any> = {
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "application/json",
+		},
+	};
+	if (COOKIE) {
+		params.headers.Cookie = COOKIE;
+	}
+	return http.post(url, payload, params);
+}
+
+export default function () {
+	group("catalog load - paginated get_items", () => {
+		const pages = [0, 1, 2, 3, 4];
+		for (const page of pages) {
+			const res = frappePost(METHODS[0], { offset: page * 200, limit: 200 });
+			check(res, {
+				"status is 200": (r) => r.status === 200,
+				"response time < 2000ms": (r) => r.timings.duration < 2000,
+				"has message array": (r) => {
+					try {
+						return Array.isArray(JSON.parse(r.body as string).message);
+					} catch {
+						return false;
+					}
+				},
+			});
+		}
+	});
+
+	group("customer fetch", () => {
+		const res = frappePost(METHODS[1], { offset: 0, limit: 1000 });
+		check(res, {
+			"status is 200": (r) => r.status === 200,
+			"response time < 3000ms": (r) => r.timings.duration < 3000,
+		});
+	});
+
+	group("pricing rules fetch", () => {
+		const res = frappePost(METHODS[2], { customer: "Guest" });
+		check(res, {
+			"status is 200": (r) => r.status === 200,
+			"response time < 2000ms": (r) => r.timings.duration < 2000,
+		});
+	});
+
+	sleep(1);
+}
+
+export function setup() {
+	if (!COOKIE) {
+		console.warn("POSA_COOKIE not set - auth-less requests may fail");
+	}
+}
+
+export function teardown() {
+	console.log("k6 load test complete");
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,6 +8,6 @@ export default mergeConfig(viteConfig, {
 			"tests/**/*.test.{js,ts}",
 			"src/**/__tests__/**/*.{js,ts}",
 		],
-		exclude: ["tests/smoke/**", "tests/e2e/**"],
+		exclude: ["tests/smoke/**", "tests/e2e/**", "tests/performance/TTI.spec.ts"],
 	},
 });


### PR DESCRIPTION

- perfMeasure: reusable timing, assertions, and BenchmarkCollector
- mockDataGenerators: generateItems(N) and generateItemCodes(N)
- mockApiFactory: createMockFrappeCall with pagination + configurable latency
- benchmark.config: threshold presets with PERF_THRESHOLD_MULTIPLIER env override
- catalogLoad: 10K/50K/100K paginated load, Map search, barcode lookup
- concurrentStations: SyncCoordinator throughput, parallel dedup, concurrent search