### PR TITLE
fix(returns): apply credit-return default reliably + toggle mutual-exclusivity + clean guard message

### DIFF
--- a/frontend/src/posapp/components/pos/Payments.vue
+++ b/frontend/src/posapp/components/pos/Payments.vue
@@ -1198,11 +1198,12 @@ const ensurePaymentLinesInitialized = (doc = invoice_doc.value) => {
 	}
 
 	// For returns, always show all profile payment methods so user can split refund
+	// NOTE: the is_credit_return default is decided once when the return is loaded
+	// (send_invoice_doc_payment handler), NOT here — so reopening the dialog or a
+	// failed submit never overrides the cashier's manual toggle. Here we only
+	// honour the current toggle state.
 	if (doc.is_return) {
 		mergeProfilePaymentsIntoReturn(doc);
-		// Decide whether this return should default to a credit note (no cash)
-		// based on how much was actually paid on the original invoice.
-		applyReturnCreditDefault(doc);
 		if (is_credit_return.value) {
 			// Credit return: keep every payment row at 0 so it is recorded as a
 			// credit note that reduces the customer's balance (no cash refund).
@@ -1892,6 +1893,19 @@ watch(is_credit_return, (newVal) => {
 	}
 });
 
+// Keep "Cashback?" and "Store as Credit?" mutually exclusive for a return.
+// The is_credit_return watch already flips is_cashback; this mirrors the other
+// direction so toggling cashback also updates credit (you can't enable both).
+// The reciprocal set lands on a value that is already correct, so the watches
+// settle without looping.
+watch(is_cashback, (newVal) => {
+	if (!invoice_doc.value || !invoice_doc.value.is_return) return;
+	const shouldCredit = !newVal;
+	if (is_credit_return.value !== shouldCredit) {
+		is_credit_return.value = shouldCredit;
+	}
+});
+
 watch(
 	() => invoice_doc.value.customer,
 	(customer, previous) => {
@@ -1978,12 +1992,18 @@ onMounted(() => {
 			is_credit_sale.value = false;
 			is_write_off_change.value = false;
 
+			// Decide the credit-return default ONCE, when the return is first
+			// loaded, so reopening the dialog / a failed submit never overrides a
+			// manual toggle change by the cashier.
+			if (doc.is_return) {
+				applyReturnCreditDefault(doc);
+			}
+
 			const initializedPayment = ensurePaymentLinesInitialized(doc);
 
 			if (doc.is_return) {
 				is_return.value = true;
-				// is_credit_return is decided inside ensurePaymentLinesInitialized
-				// from the original invoice's paid amount; don't override it here.
+				// is_credit_return default was applied above on load; don't override.
 			} else if (initializedPayment) {
 				is_credit_return.value = false;
 			}

--- a/frontend/src/posapp/components/pos/invoice_utils/dialogs.ts
+++ b/frontend/src/posapp/components/pos/invoice_utils/dialogs.ts
@@ -45,6 +45,11 @@ export async function show_payment(context: any) {
 
 		if (context.ensure_auto_batch_selection) await context.ensure_auto_batch_selection();
 
+		// Capture the transient refundable cap before process_invoice()/backend
+		// reload, which return a doc stripped of non-DocType fields. It is
+		// re-attached below so the payment screen can default a credit return.
+		const carriedRefundableAmount = context.invoice_doc?.posa_refundable_amount;
+
 		let invoice_doc;
 		const paymentDoctype = resolvePosDocumentDoctype({
 			invoiceType: context.invoiceType,
@@ -144,6 +149,12 @@ export async function show_payment(context: any) {
 			await context.$nextTick();
 		}
 		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		// Re-attach the refundable cap stripped by the backend save/reload so the
+		// payment screen can default an unpaid-invoice return to a credit note.
+		if (carriedRefundableAmount != null && invoice_doc) {
+			invoice_doc.posa_refundable_amount = carriedRefundableAmount;
+		}
 
 		context.eventBus.emit("show_payment", "true");
 		context.eventBus.emit("send_invoice_doc_payment", invoice_doc);

--- a/frontend/src/posapp/composables/pos/payments/usePaymentSubmission.ts
+++ b/frontend/src/posapp/composables/pos/payments/usePaymentSubmission.ts
@@ -390,6 +390,26 @@ export function usePaymentSubmission(options: PaymentSubmissionOptions) {
 		// 1. Ensure return payments are negative
 		if (doc.is_return) {
 			ensureReturnPaymentsAreNegative();
+
+			// Never refund more cash than was actually paid on the original
+			// invoice. Mirrors the backend guard, but blocks here so the cashier
+			// gets one clean message instead of a failed submit round-trip
+			// (which the API layer would surface as a "connection problem").
+			if (doc.posa_refundable_amount != null) {
+				let refund = 0;
+				(doc.payments || []).forEach((p: any) => {
+					refund += Math.abs(formatFloat(p.amount, prec));
+				});
+				const refundable = formatFloat(doc.posa_refundable_amount, prec);
+				if (refund > refundable + 0.001) {
+					throw new Error(
+						__(
+							'Cannot refund {0} for this return: only {1} was paid on the original invoice. Turn on "Store as Credit?" to record it as a credit note that reduces the customer\'s balance.',
+							[refund, refundable],
+						),
+					);
+				}
+			}
 		}
 
 		let current_total_payments = 0;


### PR DESCRIPTION
## Follow-up to #3082 / #3086

Three issues surfaced while testing the unpaid-invoice return flow:

### 1. The credit-return default never actually applied (critical)
The PAY flow (`dialogs.ts`) reloads the invoice from the backend before opening
payment. That reload returns a doc **stripped of `posa_refundable_amount`** (a
transient field, not on the DocType), so the payment screen saw it `undefined`
and skipped defaulting to a credit note — the toggle stayed off and the full
refund was pre-filled.
**Fix:** capture the cap before the reload and re-attach it to the doc sent to
the payment screen.

### 2. `applyReturnCreditDefault` overrode the manual toggle (gemini on #3086)
It ran inside `ensurePaymentLinesInitialized`, which fires on every dialog open
and failed submit, re-asserting the default and discarding the cashier's manual
choice.
**Fix:** moved it to the `send_invoice_doc_payment` handler so the default is
applied **once on load**; `ensurePaymentLinesInitialized` now only honours the
current toggle state.

### 3. "Cashback?" and "Store as Credit?" weren't mutually exclusive
`is_credit_return`'s watch flipped `is_cashback`, but not the reverse — so both
could be enabled at once.
**Fix:** added the mirroring watch on `is_cashback` (returns only). The
reciprocal set lands on an already-correct value, so the watches settle without
looping.

### Bonus: clean message instead of "connection problem"
A return whose cash refund exceeds the original's paid amount now fails a
client-side guard in `validateSubmission` with a clear message **before**
submitting. Previously the backend `frappe.throw` was surfaced by the API layer
as a `TRANSPORT_ERROR` ("connection problem") and retried (2×). The backend
guard from #3082 stays as defense-in-depth.

## Notes
- `vue-tsc --noEmit && vite build` passes.
- Targeted at `fix-critical-performance-issues`.
