### PR TITLE
fix: tiered barcode index with race guard for 100K+ catalog scale

### DIFF
--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -570,6 +570,10 @@ const itemsSelectorSearch = useItemsSelectorSearch({
 	isLimitSearchEnabled: () => usesLimitSearch.value,
 	runLimitSearch: (term) => itemsIntegration.searchItems(term),
 	clearHighlightedItem: () => itemSelection.clearHighlightedItem(),
+	lookupItemByBarcode,
+	ensureBarcodeIndex,
+	replaceBarcodeIndex,
+	getItems: () => items.value,
 });
 const itemsSelectorSettings = useItemsSelectorSettings({ getVM: () => settingsContext, itemSync });
 const itemsSelectorFocus = useItemsSelectorFocus({
@@ -772,6 +776,7 @@ const scanProcessor = useScanProcessor({
 	ratePrecision: itemDisplay.ratePrecision,
 	customer: selectedCustomer,
 	onItemAdded: () => {
+		scannerInput.pendingScanCode.value = "";
 		clearSearch();
 		itemsSelectorFocus.focusItemSearch();
 	},
@@ -1058,6 +1063,11 @@ watch(isPosSupervisor, (isSupervisor) => {
 	scheduleLastBuyingRateRefresh();
 });
 
+// Auto-process barcodes when user stops typing (barcode fields only, excludes item_code/serial/batch)
+watch(search_input, (value) => {
+	autoAddByBarcode(value);
+});
+
 // 9. Template Bindings & Direct Exports
 const {
 	ratePrecision,
@@ -1168,6 +1178,28 @@ const click_item_row = (e: any, data: any) => {
 };
 const onVirtualRangeUpdate = (s, e, vs, ve) => itemsLoader.onVirtualRangeUpdate(s, e, vs, ve);
 const onListScroll = (e) => handleListScroll(e);
+
+// Strict barcode-only lookup for auto-process (excludes item_code/serial/batch)
+const findItemByBarcodeOnly = (code: string): any => {
+	const normalized = String(code).toLowerCase().trim();
+	if (!normalized || normalized.length < 3) return null;
+	return (items.value || []).find(item =>
+		(item.barcode && String(item.barcode).toLowerCase() === normalized) ||
+		(Array.isArray(item.item_barcode) && item.item_barcode.some(
+			(b: any) => b.barcode && String(b.barcode).toLowerCase() === normalized
+		)) ||
+		(Array.isArray(item.barcodes) && item.barcodes.some(
+			(bc: any) => String(bc).toLowerCase() === normalized
+		))
+	) || null;
+};
+
+const autoAddByBarcode = _.debounce((code: string) => {
+	if (!code || code.length < 3) return;
+	if (findItemByBarcodeOnly(code)) {
+		onBarcodeScanned(code);
+	}
+}, 300);
 
 defineExpose({
 	search_input,

--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -1183,6 +1183,22 @@ const onListScroll = (e) => handleListScroll(e);
 const findItemByBarcodeOnly = (code: string): any => {
 	const normalized = String(code).toLowerCase().trim();
 	if (!normalized || normalized.length < 3) return null;
+
+	if (typeof lookupItemByBarcode === "function") {
+		const indexedItem = lookupItemByBarcode(normalized);
+		if (indexedItem) {
+			const isBarcodeMatch =
+				(indexedItem.barcode && String(indexedItem.barcode).toLowerCase() === normalized) ||
+				(Array.isArray(indexedItem.item_barcode) && indexedItem.item_barcode.some(
+					(b: any) => b.barcode && String(b.barcode).toLowerCase() === normalized
+				)) ||
+				(Array.isArray(indexedItem.barcodes) && indexedItem.barcodes.some(
+					(bc: any) => String(bc).toLowerCase() === normalized
+				));
+			if (isBarcodeMatch) return indexedItem;
+		}
+	}
+
 	return (items.value || []).find(item =>
 		(item.barcode && String(item.barcode).toLowerCase() === normalized) ||
 		(Array.isArray(item.item_barcode) && item.item_barcode.some(

--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -147,19 +147,19 @@
 				</v-card>
 			</div>
 
-		<v-expand-transition>
-			<div v-if="multiSelect" class="multi-select-bar">
-				<v-btn
-					color="primary"
-					size="large"
-					:disabled="selectedItems.size === 0"
-					@click="emitAddSelected"
-					class="px-6"
-				>
+			<v-expand-transition>
+				<div v-if="multiSelect" class="multi-select-bar">
+					<v-btn
+						color="primary"
+						size="large"
+						:disabled="selectedItems.size === 0"
+						@click="emitAddSelected"
+						class="px-6"
+					>
 					{{ __('Add Selected') }} ({{ selectedItems.size }})
-				</v-btn>
-			</div>
-		</v-expand-transition>
+					</v-btn>
+				</div>
+			</v-expand-transition>
 		</v-card>
 		<ItemActionToolbar
 			v-model="item_group"
@@ -348,6 +348,7 @@ const {
 	indexItem,
 	replaceBarcodeIndex,
 	lookupItemByBarcode,
+	resolveItemByBarcode,
 	searchItemsByCode: searchItemsByCodeFn,
 } = useBarcodeIndexing();
 
@@ -570,10 +571,7 @@ const itemsSelectorSearch = useItemsSelectorSearch({
 	isLimitSearchEnabled: () => usesLimitSearch.value,
 	runLimitSearch: (term) => itemsIntegration.searchItems(term),
 	clearHighlightedItem: () => itemSelection.clearHighlightedItem(),
-	lookupItemByBarcode,
-	ensureBarcodeIndex,
-	replaceBarcodeIndex,
-	getItems: () => items.value,
+	resolveItemByBarcode: (code) => resolveItemByBarcode(items.value, code),
 });
 const itemsSelectorSettings = useItemsSelectorSettings({ getVM: () => settingsContext, itemSync });
 const itemsSelectorFocus = useItemsSelectorFocus({
@@ -1063,11 +1061,6 @@ watch(isPosSupervisor, (isSupervisor) => {
 	scheduleLastBuyingRateRefresh();
 });
 
-// Auto-process barcodes when user stops typing (barcode fields only, excludes item_code/serial/batch)
-watch(search_input, (value) => {
-	autoAddByBarcode(value);
-});
-
 // 9. Template Bindings & Direct Exports
 const {
 	ratePrecision,
@@ -1178,44 +1171,6 @@ const click_item_row = (e: any, data: any) => {
 };
 const onVirtualRangeUpdate = (s, e, vs, ve) => itemsLoader.onVirtualRangeUpdate(s, e, vs, ve);
 const onListScroll = (e) => handleListScroll(e);
-
-// Strict barcode-only lookup for auto-process (excludes item_code/serial/batch)
-const findItemByBarcodeOnly = (code: string): any => {
-	const normalized = String(code).toLowerCase().trim();
-	if (!normalized || normalized.length < 3) return null;
-
-	if (typeof lookupItemByBarcode === "function") {
-		const indexedItem = lookupItemByBarcode(normalized);
-		if (indexedItem) {
-			const isBarcodeMatch =
-				(indexedItem.barcode && String(indexedItem.barcode).toLowerCase() === normalized) ||
-				(Array.isArray(indexedItem.item_barcode) && indexedItem.item_barcode.some(
-					(b: any) => b.barcode && String(b.barcode).toLowerCase() === normalized
-				)) ||
-				(Array.isArray(indexedItem.barcodes) && indexedItem.barcodes.some(
-					(bc: any) => String(bc).toLowerCase() === normalized
-				));
-			if (isBarcodeMatch) return indexedItem;
-		}
-	}
-
-	return (items.value || []).find(item =>
-		(item.barcode && String(item.barcode).toLowerCase() === normalized) ||
-		(Array.isArray(item.item_barcode) && item.item_barcode.some(
-			(b: any) => b.barcode && String(b.barcode).toLowerCase() === normalized
-		)) ||
-		(Array.isArray(item.barcodes) && item.barcodes.some(
-			(bc: any) => String(bc).toLowerCase() === normalized
-		))
-	) || null;
-};
-
-const autoAddByBarcode = _.debounce((code: string) => {
-	if (!code || code.length < 3) return;
-	if (findItemByBarcodeOnly(code)) {
-		onBarcodeScanned(code);
-	}
-}, 300);
 
 defineExpose({
 	search_input,

--- a/frontend/src/posapp/composables/pos/items/useBarcodeIndexing.ts
+++ b/frontend/src/posapp/composables/pos/items/useBarcodeIndexing.ts
@@ -21,6 +21,8 @@ type ItemSource =
 	| Ref<BarcodeIndexedItem[]>
 	| (() => BarcodeIndexedItem[] | Ref<BarcodeIndexedItem[]>);
 
+export const MAX_BARCODE_INDEX_ITEMS = 100_000;
+
 // --- Stateless Helpers (formerly utils/barcodeIndex.js) ---
 
 export const ensureBarcodeIndex = (index: unknown): BarcodeIndex => {
@@ -93,9 +95,40 @@ export const replaceBarcodeIndex = (
 	items: BarcodeIndexedItem[] = [],
 ): BarcodeIndex => {
 	const map = resetBarcodeIndex(index);
+	if (items.length > MAX_BARCODE_INDEX_ITEMS) {
+		return map;
+	}
 	items.forEach((item) => indexItemInBarcodeIndex(map, item));
 	return map;
 };
+
+export const isExactBarcodeMatch = (
+	item: BarcodeIndexedItem | null | undefined,
+	code: unknown,
+): boolean => {
+	if (!item || code === undefined || code === null) return false;
+	const normalized = String(code).trim().toLowerCase();
+	if (!normalized) return false;
+	return Boolean(
+		(item.barcode &&
+			String(item.barcode).trim().toLowerCase() === normalized) ||
+			item.item_barcode?.some(
+				(row) =>
+					row?.barcode &&
+					String(row.barcode).trim().toLowerCase() === normalized,
+			) ||
+			item.barcodes?.some(
+				(barcode) =>
+					String(barcode).trim().toLowerCase() === normalized,
+			),
+	);
+};
+
+export const findItemByExactBarcode = (
+	items: BarcodeIndexedItem[] = [],
+	code: unknown,
+): BarcodeIndexedItem | null =>
+	items.find((item) => isExactBarcodeMatch(item, code)) || null;
 
 export const lookupItemInBarcodeIndex = (
 	index: unknown,
@@ -149,6 +182,28 @@ export function useBarcodeIndexing() {
 		return lookupItemInBarcodeIndex(ensureIndex(), code);
 	};
 
+	const resolveItemByBarcode = (items: ItemSource, code: unknown) => {
+		const itemsList = unwrapItemsSource(items);
+		if (itemsList.length > MAX_BARCODE_INDEX_ITEMS) {
+			reset();
+			return findItemByExactBarcode(itemsList, code);
+		}
+
+		let indexedItem = lookupItem(code);
+		if (isExactBarcodeMatch(indexedItem, code)) {
+			return indexedItem;
+		}
+
+		const index = ensureIndex();
+		if (index.size === 0 && itemsList.length <= MAX_BARCODE_INDEX_ITEMS) {
+			replaceIndex(itemsList);
+			indexedItem = lookupItem(code);
+			return isExactBarcodeMatch(indexedItem, code) ? indexedItem : null;
+		}
+
+		return null;
+	};
+
 	// Logic extracted from ItemsSelector.vue: searchItemsByCode
 	const searchItemsByCode = (items: ItemSource, code: string) => {
 		if (!items || !code) return [];
@@ -190,6 +245,7 @@ export function useBarcodeIndexing() {
 		indexItem,
 		replaceBarcodeIndex: replaceIndex,
 		lookupItemByBarcode: lookupItem,
+		resolveItemByBarcode,
 		searchItemsByCode,
 	};
 }

--- a/frontend/src/posapp/composables/pos/items/useItemsSelectorSearch.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemsSelectorSearch.ts
@@ -5,10 +5,6 @@ import { resolveBooleanSetting } from "./selectorSearch/resolveBooleanSetting";
 
 declare const flt: (_value: unknown) => number;
 
-// Safety threshold: above this catalog size, skip the O(1) barcode index Map
-// and fall back to O(n) linear scan to avoid OOM from the Map entries.
-const MAX_BARCODE_INDEX_SIZE = 100_000;
-
 type SearchDeps = {
 	getVM?: () => any;
 	scannerInput?: any;
@@ -18,10 +14,7 @@ type SearchDeps = {
 	isLimitSearchEnabled?: () => boolean;
 	runLimitSearch?: (_term: string) => Promise<unknown> | unknown;
 	clearHighlightedItem?: () => void;
-	lookupItemByBarcode?: (_code: string) => any;
-	ensureBarcodeIndex?: () => any;
-	replaceBarcodeIndex?: (_items: any[]) => void;
-	getItems?: () => any[];
+	resolveItemByBarcode?: (_code: string) => any;
 };
 
 export const useItemsSelectorSearch = ({
@@ -33,10 +26,7 @@ export const useItemsSelectorSearch = ({
 	isLimitSearchEnabled,
 	runLimitSearch,
 	clearHighlightedItem,
-	lookupItemByBarcode,
-	ensureBarcodeIndex,
-	replaceBarcodeIndex,
-	getItems,
+	resolveItemByBarcode,
 }: SearchDeps) => {
 	const getVm = (): any => (typeof getVM === "function" ? getVM() : null);
 
@@ -302,15 +292,9 @@ export const useItemsSelectorSearch = ({
 		vm.first_search = trimmedQuery;
 		syncSearchInput(vm, trimmedQuery);
 
-		// First try synchronous barcode index lookup (supports ALL barcode formats: EAN, UPC, CODE-39, GS1, ISBN, etc.)
-		if (typeof ensureBarcodeIndex === "function" && typeof lookupItemByBarcode === "function") {
-			const index = ensureBarcodeIndex();
-			const allItems = typeof getItems === "function" ? getItems() : [];
-			// Only populate index when empty and within the 100K safety threshold to avoid OOM
-			if ((!index || index.size === 0) && allItems && allItems.length <= MAX_BARCODE_INDEX_SIZE && typeof replaceBarcodeIndex === "function") {
-				replaceBarcodeIndex(allItems);
-			}
-			if (lookupItemByBarcode(trimmedQuery)) {
+		// The barcode index owns its memory threshold and large-catalog fallback.
+		if (typeof resolveItemByBarcode === "function") {
+			if (resolveItemByBarcode(trimmedQuery)) {
 				// Guard: auto-add watcher already triggered scan pipeline for this code
 				if (scannerInput?.pendingScanCode?.value === trimmedQuery) {
 					return;

--- a/frontend/src/posapp/composables/pos/items/useItemsSelectorSearch.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemsSelectorSearch.ts
@@ -14,6 +14,10 @@ type SearchDeps = {
 	isLimitSearchEnabled?: () => boolean;
 	runLimitSearch?: (_term: string) => Promise<unknown> | unknown;
 	clearHighlightedItem?: () => void;
+	lookupItemByBarcode?: (_code: string) => any;
+	ensureBarcodeIndex?: () => any;
+	replaceBarcodeIndex?: (_items: any[]) => void;
+	getItems?: () => any[];
 };
 
 export const useItemsSelectorSearch = ({
@@ -25,6 +29,10 @@ export const useItemsSelectorSearch = ({
 	isLimitSearchEnabled,
 	runLimitSearch,
 	clearHighlightedItem,
+	lookupItemByBarcode,
+	ensureBarcodeIndex,
+	replaceBarcodeIndex,
+	getItems,
 }: SearchDeps) => {
 	const getVm = (): any => (typeof getVM === "function" ? getVM() : null);
 
@@ -289,6 +297,27 @@ export const useItemsSelectorSearch = ({
 		// Keep both search refs aligned with the value we are about to process.
 		vm.first_search = trimmedQuery;
 		syncSearchInput(vm, trimmedQuery);
+
+		// First try synchronous barcode index lookup (supports ALL barcode formats: EAN, UPC, CODE-39, GS1, ISBN, etc.)
+		if (typeof ensureBarcodeIndex === "function" && typeof lookupItemByBarcode === "function") {
+			const index = ensureBarcodeIndex();
+			// Only populate index when empty to avoid O(n) rebuild on every Enter
+			if ((!index || index.size === 0) && typeof replaceBarcodeIndex === "function" && typeof getItems === "function") {
+				replaceBarcodeIndex(getItems());
+			}
+			if (lookupItemByBarcode(trimmedQuery)) {
+				// Guard: auto-add watcher already triggered scan pipeline for this code
+				if (scannerInput?.pendingScanCode?.value === trimmedQuery) {
+					return;
+				}
+				if (typeof vm.onBarcodeScanned === "function") {
+					vm.onBarcodeScanned(trimmedQuery);
+				} else if (scannerInput.onBarcodeScanned) {
+					scannerInput.onBarcodeScanned(trimmedQuery);
+				}
+				return;
+			}
+		}
 
 		// If the input is a numeric string 12 characters or longer, treat it as a barcode
 		if (/^\d{12,}$/.test(trimmedQuery)) {

--- a/frontend/src/posapp/composables/pos/items/useItemsSelectorSearch.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemsSelectorSearch.ts
@@ -5,6 +5,10 @@ import { resolveBooleanSetting } from "./selectorSearch/resolveBooleanSetting";
 
 declare const flt: (_value: unknown) => number;
 
+// Safety threshold: above this catalog size, skip the O(1) barcode index Map
+// and fall back to O(n) linear scan to avoid OOM from the Map entries.
+const MAX_BARCODE_INDEX_SIZE = 100_000;
+
 type SearchDeps = {
 	getVM?: () => any;
 	scannerInput?: any;
@@ -301,9 +305,10 @@ export const useItemsSelectorSearch = ({
 		// First try synchronous barcode index lookup (supports ALL barcode formats: EAN, UPC, CODE-39, GS1, ISBN, etc.)
 		if (typeof ensureBarcodeIndex === "function" && typeof lookupItemByBarcode === "function") {
 			const index = ensureBarcodeIndex();
-			// Only populate index when empty to avoid O(n) rebuild on every Enter
-			if ((!index || index.size === 0) && typeof replaceBarcodeIndex === "function" && typeof getItems === "function") {
-				replaceBarcodeIndex(getItems());
+			const allItems = typeof getItems === "function" ? getItems() : [];
+			// Only populate index when empty and within the 100K safety threshold to avoid OOM
+			if ((!index || index.size === 0) && allItems && allItems.length <= MAX_BARCODE_INDEX_SIZE && typeof replaceBarcodeIndex === "function") {
+				replaceBarcodeIndex(allItems);
 			}
 			if (lookupItemByBarcode(trimmedQuery)) {
 				// Guard: auto-add watcher already triggered scan pipeline for this code
@@ -312,8 +317,8 @@ export const useItemsSelectorSearch = ({
 				}
 				if (typeof vm.onBarcodeScanned === "function") {
 					vm.onBarcodeScanned(trimmedQuery);
-				} else if (scannerInput.onBarcodeScanned) {
-					scannerInput.onBarcodeScanned(trimmedQuery);
+				} else if (scannerInput?.onBarcodeScanned) {
+					scannerInput?.onBarcodeScanned(trimmedQuery);
 				}
 				return;
 			}
@@ -323,8 +328,8 @@ export const useItemsSelectorSearch = ({
 		if (/^\d{12,}$/.test(trimmedQuery)) {
 			if (typeof vm.onBarcodeScanned === "function") {
 				vm.onBarcodeScanned(trimmedQuery);
-			} else if (scannerInput.onBarcodeScanned) {
-				scannerInput.onBarcodeScanned(trimmedQuery);
+			} else if (scannerInput?.onBarcodeScanned) {
+				scannerInput?.onBarcodeScanned(trimmedQuery);
 			}
 			return;
 		}

--- a/frontend/src/posapp/composables/pos/items/useScannerInput.ts
+++ b/frontend/src/posapp/composables/pos/items/useScannerInput.ts
@@ -71,6 +71,7 @@ export function useScannerInput(options: ScannerInputOptions = {}) {
 	const scanAudioContext = ref<AudioContext | null>(null);
 	const scanDebounceId = ref<any>(null);
 	const scanQueuedCode = ref("");
+	const activeScanCodes = new Set<string>();
 
 	// Keyboard Scan Detection State
 	const keyboardScanBuffer = ref("");
@@ -270,6 +271,14 @@ export function useScannerInput(options: ScannerInputOptions = {}) {
 	// --- Main Scan Handler ---
 	const onBarcodeScanned = (scannedCode: string) => {
 		resetKeyboardScanDetection();
+		const normalizedCode = String(scannedCode || "").trim();
+		if (!normalizedCode) return;
+		if (
+			scanQueuedCode.value === normalizedCode ||
+			activeScanCodes.has(normalizedCode)
+		) {
+			return;
+		}
 
 		if (scannerLocked.value) {
 			playScanTone("error");
@@ -312,17 +321,19 @@ export function useScannerInput(options: ScannerInputOptions = {}) {
 			} catch (error) {
 				handleScanPipelineError(error, code);
 			} finally {
+				activeScanCodes.delete(code);
 				perfMarkEnd("pos:scan-handler", mark);
 			}
 		};
 
 		if (scanDebounceId.value) clearTimeout(scanDebounceId.value);
-		scanQueuedCode.value = scannedCode;
+		scanQueuedCode.value = normalizedCode;
 
 		scanDebounceId.value = setTimeout(() => {
 			scanDebounceId.value = null;
-			const code = scanQueuedCode.value || scannedCode;
+			const code = scanQueuedCode.value || normalizedCode;
 			scanQueuedCode.value = "";
+			activeScanCodes.add(code);
 
 			scheduleFrame(() => {
 				const maybePromise = runScanPipeline(code);

--- a/frontend/tests/itemsSelectorStockWiring.spec.ts
+++ b/frontend/tests/itemsSelectorStockWiring.spec.ts
@@ -303,6 +303,7 @@ vi.mock("../src/posapp/composables/pos/items/useBarcodeIndexing", () => ({
 		indexItem: vi.fn(),
 		replaceBarcodeIndex: vi.fn(),
 		lookupItemByBarcode: vi.fn(() => null),
+		resolveItemByBarcode: vi.fn(() => null),
 		searchItemsByCode: vi.fn(() => []),
 	}),
 }));

--- a/frontend/tests/useBarcodeIndexing.spec.ts
+++ b/frontend/tests/useBarcodeIndexing.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	MAX_BARCODE_INDEX_ITEMS,
+	replaceBarcodeIndex,
+	useBarcodeIndexing,
+} from "../src/posapp/composables/pos/items/useBarcodeIndexing";
+
+describe("useBarcodeIndexing", () => {
+	it("does not populate the Map above the catalog safety threshold", () => {
+		const items = new Array(MAX_BARCODE_INDEX_ITEMS + 1);
+		items[MAX_BARCODE_INDEX_ITEMS] = {
+			item_code: "ITEM-LAST",
+			barcode: "LARGE-CATALOG-BARCODE",
+		};
+
+		const index = replaceBarcodeIndex(new Map(), items);
+
+		expect(index.size).toBe(0);
+	});
+
+	it("uses an exact linear barcode lookup when the catalog is too large to index", () => {
+		const items = new Array(MAX_BARCODE_INDEX_ITEMS + 1);
+		const expected = {
+			item_code: "ITEM-LAST",
+			item_barcode: [{ barcode: "BOX-LAST" }],
+		};
+		items[MAX_BARCODE_INDEX_ITEMS] = expected;
+		const barcodeIndex = useBarcodeIndexing();
+		barcodeIndex.replaceBarcodeIndex([
+			{ item_code: "SMALL", barcode: "SMALL-BARCODE" },
+		]);
+		expect(barcodeIndex.ensureBarcodeIndex().size).toBeGreaterThan(0);
+
+		const resolved = barcodeIndex.resolveItemByBarcode(items, "box-last");
+
+		expect(resolved).toBe(expected);
+		expect(barcodeIndex.ensureBarcodeIndex().size).toBe(0);
+	});
+});

--- a/frontend/tests/useItemsSelectorSearch.spec.ts
+++ b/frontend/tests/useItemsSelectorSearch.spec.ts
@@ -86,6 +86,30 @@ describe("useItemsSelectorSearch", () => {
 		expect(selectHighlightedItem).not.toHaveBeenCalled();
 	});
 
+	it("routes an exact barcode resolved by the shared index through the scan pipeline", async () => {
+		const scannerInput = createScannerInput();
+		const resolveItemByBarcode = vi.fn(() => ({ item_code: "ITEM-001" }));
+		const vm = {
+			first_search: "BOX-001",
+			search_input: "BOX-001",
+			search: "",
+			search_from_scanner: false,
+			isBackgroundLoading: false,
+		};
+
+		const api = useItemsSelectorSearch({
+			getVM: () => vm,
+			scannerInput,
+			resolveItemByBarcode,
+		});
+
+		await api._performSearch();
+
+		expect(resolveItemByBarcode).toHaveBeenCalledWith("BOX-001");
+		expect(scannerInput.onBarcodeScanned).toHaveBeenCalledWith("BOX-001");
+		expect(vm.search).toBe("");
+	});
+
 	it("prioritizes search over highlighted selection when enter is pressed in limit search mode", async () => {
 		const searchItems = vi.fn().mockResolvedValue([]);
 		const selectHighlightedItem = vi.fn();

--- a/frontend/tests/useScannerInput.spec.ts
+++ b/frontend/tests/useScannerInput.spec.ts
@@ -60,4 +60,30 @@ describe("useScannerInput", () => {
 
 		expect(onScan).not.toHaveBeenCalled();
 	});
+
+	it("coalesces the same barcode while its scan pipeline is active", async () => {
+		let finishScan: (() => void) | undefined;
+		const onScan = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishScan = resolve;
+				}),
+		);
+		const scanner = useScannerInput({ onScan });
+
+		scanner.onBarcodeScanned("123456789012");
+		scanner.onBarcodeScanned("123456789012");
+		await vi.advanceTimersByTimeAsync(32);
+		expect(onScan).toHaveBeenCalledTimes(1);
+
+		scanner.onBarcodeScanned("123456789012");
+		await vi.advanceTimersByTimeAsync(32);
+		expect(onScan).toHaveBeenCalledTimes(1);
+
+		finishScan?.();
+		await vi.advanceTimersByTimeAsync(1);
+		scanner.onBarcodeScanned("123456789012");
+		await vi.advanceTimersByTimeAsync(32);
+		expect(onScan).toHaveBeenCalledTimes(2);
+	});
 });


### PR DESCRIPTION
## Problem
- Barcode auto-detection and Enter could start overlapping scan pipelines for the same code
- Barcode indexes could be rebuilt for catalogs large enough to cause excessive memory use
- Large catalogs still need exact barcode resolution without allocating a full Map
- `pendingScanCode` needed to be reset after a successful add

## Changes

### Shared barcode index
- Centralized the 100,000-item safety threshold in `useBarcodeIndexing.ts`
- Index replacement now clears/skips the Map above the threshold across all callers
- Added a shared exact-barcode resolver:
  - indexed O(1) lookup for catalogs at or below the threshold
  - exact O(n) lookup with an empty Map for larger catalogs
- Kept barcode matching separate from item-code, serial, and batch matching

### Scan lifecycle
- Coalesces duplicate requests for the same barcode while its scan pipeline is queued or active
- Allows the same barcode to be scanned again after the active pipeline completes
- Clears `scannerInput.pendingScanCode` after a successful item add
- Removed the extra 300 ms item-search watcher that duplicated existing scanner-input detection

### Enter handling
- Routes exact barcode Enter actions through the shared barcode resolver
- Preserves existing search behavior when the input is not an exact barcode
- Keeps optional scanner handling safe

## Linked features checked
- Item search and Enter handling
- Keyboard/virtual scanner input
- Barcode UOM scan path
- Serial and batch scan behavior
- Cart item addition and stock-validation wiring
- Large-catalog memory fallback
- Current `fix-critical-performance-issues` target branch integration

## Verification
- `vue-tsc --noEmit`
- ESLint on changed files
- 22 targeted Vitest tests passed:
  - barcode indexing and >100K fallback
  - duplicate scan coalescing and re-scan
  - item selector search
  - scan processor/UOM/serial/batch paths
  - item selector stock wiring
