### PR TITLE
fix(returns): correct partial return of multi-batch items (false "qty > original" error)

### DIFF
--- a/frontend/src/posapp/components/pos/invoice_utils/loader.ts
+++ b/frontend/src/posapp/components/pos/invoice_utils/loader.ts
@@ -238,6 +238,34 @@ export async function load_invoice(
 			if (!item.original_item_name) {
 				item.original_item_name = item.item_name;
 			}
+
+			// Return rows come back from the backend with a `batch_no` string but
+			// no `batch_no_data`, so the batch column renders blank until the qty
+			// is touched. Seed a single display option (with a positive qty, since
+			// getDisplayableBatchOptions filters out non-positive batches) so the
+			// selected batch shows immediately. Display-only: we deliberately do
+			// NOT call set_batch_qty here — it would refetch item details and could
+			// reset the locked return price.
+			if (
+				data.is_return &&
+				data.return_against &&
+				item.batch_no &&
+				(!Array.isArray(item.batch_no_data) ||
+					item.batch_no_data.length === 0)
+			) {
+				// The cart row's blue "Batch: …" chip is gated on has_batch_no,
+				// which the return payload omits; the item clearly has a batch.
+				if (!item.has_batch_no) item.has_batch_no = 1;
+				const displayQty = Math.abs(flt(item.qty)) || 0;
+				item.batch_no_data = [
+					{
+						batch_no: item.batch_no,
+						batch_qty: displayQty,
+						available_qty: displayQty,
+						expiry_date: item.batch_no_expiry_date || null,
+					},
+				];
+			}
 		});
 
 		const manualSnapshots = context._snapshotManualValuesFromDocItems

--- a/frontend/src/posapp/components/pos/invoice_utils/validation.ts
+++ b/frontend/src/posapp/components/pos/invoice_utils/validation.ts
@@ -77,10 +77,23 @@ export async function validate(context: any) {
 				// Normalize item codes
 				const normalized_return_item_code = item.item_code.trim().toUpperCase();
 
-				// Find matching item in original invoice
-				const original_item = original_items.find(
-					(orig) => orig.item_code.trim().toUpperCase() === normalized_return_item_code,
-				);
+				// Match the original invoice row via its exact reference (set in
+				// Returns.vue), not by item_code alone. A batch-tracked item can span
+				// multiple original rows (one per batch); matching the first row by code
+				// compares the return against the wrong batch's quantity → false
+				// "greater than original quantity" error.
+				//
+				// Fall back to item_code ONLY for legacy rows that carry no reference.
+				// When a reference IS present but doesn't resolve, fail closed (leave
+				// original_item undefined → "not found" below) instead of falling back
+				// to a fuzzy item_code match that could pick the wrong batch row and
+				// reintroduce the very bug this guards against.
+				const ref_name = item.sales_invoice_item || item.pos_invoice_item;
+				const original_item = ref_name
+					? original_items.find((orig) => orig.name === ref_name)
+					: original_items.find(
+							(orig) => orig.item_code.trim().toUpperCase() === normalized_return_item_code,
+						);
 
 				if (!original_item) {
 					context.toastStore.show({


### PR DESCRIPTION
## Problem

A **partial** return of a batch-tracked item fails with a false error:
*"Return quantity cannot be greater than original quantity for item X"*.
It only happens with batch items, and editing the qty doesn't help.

## Root cause

In ERPNext a batch-tracked item can be sold across **multiple invoice rows
(one row per batch)**. The return validation (`invoice_utils/validation.ts`)
matched the original row by `item_code` using `Array.find()`, which returns
the **first** matching row. When the customer returns a batch other than the
first, the return qty is compared against the wrong batch row's quantity and
wrongly rejected.

## Fix

- **`validation.ts`** — match the original row by its exact reference
  (`sales_invoice_item` / `pos_invoice_item`, already set per row in
  `flows/Returns.vue`), falling back to `item_code` only for legacy rows
  without a reference.
- **`loader.ts`** — the return payload carries a `batch_no` string but
  neither `batch_no_data` nor `has_batch_no`, so on return load both the
  batch dropdown (expanded row) and the blue **"Batch: …"** chip (cart row)
  stayed hidden until the qty was touched. Set `has_batch_no` and seed a
  single `batch_no_data` option with a positive qty (since
  `getDisplayableBatchOptions` filters out non-positive batches). Display
  only — `set_batch_qty` is intentionally **not** called here as it would
  refetch item details and could reset the locked return price.

## Notes

- Backend is not the blocker: `stock.py` skips negative-qty rows, and
  `_auto_set_return_batches` early-returns when `return_against` is set.
- No schema / backend changes. Two frontend files only.

## How to test

1. Create an invoice for a batch item sold from **two batches** (two rows,
   same `item_code`).
2. Open it as a return, delete the other rows, keep only the second batch's
   row.
3. The batch shows in the cart immediately, and submitting no longer raises
   the false *"qty > original"* error; the credit note posts with the correct
   batch and a negative qty.

Verified locally against a production data snapshot (bug reproduced without
the patch, resolved with it).