### PR TITLE
fix(pos): recover item catalog after cache failures

### DIFF
--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -316,6 +316,8 @@ let cleanupItemsSelectorEvents: (() => void) | null = null;
 let cleanupTypeToSearch: (() => void) | null = null;
 let cleanupLayoutLifecycle: (() => void) | null = null;
 let cleanupSearchInput: (() => void) | null = null;
+let itemCatalogRecoveryTimer: number | null = null;
+let lastItemCatalogResumeCheckAt = Date.now();
 
 const responsive = useResponsive();
 const rtl = useRtl();
@@ -341,7 +343,13 @@ const itemSync = useItemSync();
 const itemDisplay = useItemDisplay();
 const itemsLoader = useItemsLoader();
 const itemCurrencyUtils = useItemCurrency();
-const { startItemWorker, itemWorker, storageAvailable, markStorageUnavailable } = useItemStorageSafety();
+const {
+	startItemWorker,
+	itemWorker,
+	storageAvailable,
+	ensureStorageHealth,
+	markStorageUnavailable,
+} = useItemStorageSafety();
 const {
 	ensureBarcodeIndex,
 	resetBarcodeIndex,
@@ -494,6 +502,67 @@ const isLoadingOrSyncing = computed(() => {
 	if (isBackgroundLoading.value && items.value.length === 0) return true;
 	return false;
 });
+
+const scheduleItemCatalogRecovery = (reason: string) => {
+	if (itemCatalogRecoveryTimer) {
+		return;
+	}
+	itemCatalogRecoveryTimer = window.setTimeout(async () => {
+		itemCatalogRecoveryTimer = null;
+		try {
+			await ensureStorageHealth();
+			await itemsIntegration.recoverItemCatalogIfUnhealthy(reason);
+		} catch (error) {
+			console.warn("Item catalog recovery failed:", error);
+		}
+	}, 250);
+};
+
+const handleItemCatalogResume = (reason: string) => {
+	if (typeof document !== "undefined" && document.hidden) {
+		lastItemCatalogResumeCheckAt = Date.now();
+		return;
+	}
+
+	const now = Date.now();
+	const elapsedMs = now - lastItemCatalogResumeCheckAt;
+	lastItemCatalogResumeCheckAt = now;
+	const wokeFromSleep = elapsedMs > 2 * 60 * 1000;
+	const hasNoVisibleItems = items.value.length === 0 && displayedItems.value.length === 0;
+
+	if (reason === "online" || wokeFromSleep || hasNoVisibleItems || isLoadingOrSyncing.value) {
+		scheduleItemCatalogRecovery(reason);
+	}
+};
+
+const handleItemCatalogFocus = () => handleItemCatalogResume("focus");
+const handleItemCatalogPageShow = () => handleItemCatalogResume("pageshow");
+const handleItemCatalogOnline = () => handleItemCatalogResume("online");
+const handleItemCatalogVisibility = () => handleItemCatalogResume("visibility");
+
+const bindItemCatalogRecoveryListeners = () => {
+	if (typeof window === "undefined") {
+		return;
+	}
+	window.addEventListener("focus", handleItemCatalogFocus);
+	window.addEventListener("pageshow", handleItemCatalogPageShow);
+	window.addEventListener("online", handleItemCatalogOnline);
+	if (typeof document !== "undefined") {
+		document.addEventListener("visibilitychange", handleItemCatalogVisibility);
+	}
+};
+
+const unbindItemCatalogRecoveryListeners = () => {
+	if (typeof window === "undefined") {
+		return;
+	}
+	window.removeEventListener("focus", handleItemCatalogFocus);
+	window.removeEventListener("pageshow", handleItemCatalogPageShow);
+	window.removeEventListener("online", handleItemCatalogOnline);
+	if (typeof document !== "undefined") {
+		document.removeEventListener("visibilitychange", handleItemCatalogVisibility);
+	}
+};
 
 const syncStatus = computed(() => {
 	if (loading.value) return __("Loading items...");
@@ -920,6 +989,9 @@ onMounted(async () => {
 		get loading() {
 			return loading.value;
 		},
+		ensureStorageHealth: async () => {
+			await ensureStorageHealth();
+		},
 	});
 
 	itemSelection.registerContext({
@@ -1020,9 +1092,15 @@ onMounted(async () => {
 		requestForegroundItemSearchFocus,
 		appendSearchCharacter,
 	});
+	bindItemCatalogRecoveryListeners();
 });
 
 onBeforeUnmount(() => {
+	unbindItemCatalogRecoveryListeners();
+	if (itemCatalogRecoveryTimer) {
+		clearTimeout(itemCatalogRecoveryTimer);
+		itemCatalogRecoveryTimer = null;
+	}
 	stopItemInitializationWatcher?.();
 	stopItemInitializationWatcher = null;
 	if (initTimeout.value) clearTimeout(initTimeout.value);
@@ -1151,7 +1229,7 @@ const {
 	startCameraScanning,
 	requestForegroundItemSearchFocus,
 	onBarcodeScannedFromScannerInput,
-	reloadItems: () => itemsIntegration.get_items(true),
+	reloadItems: () => itemsIntegration.forceReloadItems(),
 });
 
 // Proxy functions for template
@@ -1163,7 +1241,7 @@ const searchItems = (term) => itemsIntegration.searchItems(term);
 const get_items = (force = false) => itemsIntegration.get_items(force);
 const loadVisibleItems = (reset = false) => itemsLoader.loadVisibleItems(reset);
 const verifyServerItemCount = () => {};
-const forceReloadItems = () => itemsIntegration.get_items(true);
+const forceReloadItems = () => itemsIntegration.forceReloadItems();
 const cancelItemDetailsRequest = () => itemDetailFetcher.cancelItemDetailsRequest();
 
 const select_item = (e: any, item: any) => {

--- a/frontend/src/posapp/composables/pos/items/useItemStorageSafety.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemStorageSafety.ts
@@ -11,29 +11,54 @@ declare const frappe: any;
  * Ensuring storage is available before attempting heavy operations prevents crashes.
  */
 export function useItemStorageSafety() {
+	const STORAGE_RECHECK_COOLDOWN_MS = 5 * 1000;
 	// State
 	const storageAvailable = ref(true);
 	const itemWorker = ref<Worker | null>(null);
+	let lastFailedHealthCheckAt = 0;
 
 	/**
 	 * Checks if the database is healthy and actionable.
 	 * @returns {Promise<boolean>}
 	 */
 	async function ensureStorageHealth() {
-		// If we already know storage is broken, don't keep checking unless we want to implement retry logic.
-		// For now, we assume if it failed once, it's safer to degrade gracefully.
-		if (!storageAvailable.value) return false;
+		if (!storageAvailable.value) {
+			const now = Date.now();
+			if (now - lastFailedHealthCheckAt < STORAGE_RECHECK_COOLDOWN_MS) {
+				return false;
+			}
+		}
 
 		const isHealthy = await checkDbHealth();
+		if (isHealthy) {
+			if (!storageAvailable.value) {
+				markStorageAvailable();
+			}
+			return true;
+		}
+
+		lastFailedHealthCheckAt = Date.now();
 		if (!isHealthy) {
 			console.warn("Storage health check failed");
 			markStorageUnavailable({
 				error: "Storage health check failed",
 				details: "Database could not be accessed or recovered.",
 			});
-			return false;
 		}
-		return true;
+		return false;
+	}
+
+	function markStorageAvailable() {
+		storageAvailable.value = true;
+		lastFailedHealthCheckAt = 0;
+		startItemWorker();
+
+		if (window.frappe) {
+			frappe.show_alert({
+				message: __("Local item storage recovered. Background sync resumed."),
+				indicator: "green",
+			});
+		}
 	}
 
 	/**
@@ -45,6 +70,7 @@ export function useItemStorageSafety() {
 
 		console.error("Marking storage as unavailable", args);
 		storageAvailable.value = false;
+		lastFailedHealthCheckAt = Date.now();
 
 		// Terminate worker to prevent it from trying to access broken DB
 		if (itemWorker.value) {
@@ -127,6 +153,7 @@ export function useItemStorageSafety() {
 		// Methods
 		ensureStorageHealth,
 		markStorageUnavailable,
+		markStorageAvailable,
 		startItemWorker,
 	};
 }

--- a/frontend/src/posapp/composables/pos/items/useItemsIntegration.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemsIntegration.ts
@@ -98,7 +98,21 @@ export function useItemsIntegration(options: IntegrationOptions = {}) {
 	};
 
 	const forceReloadItems = async () => {
-		return await itemsStore.refreshItems();
+		return await itemsStore.recoverItemCatalog({
+			reason: "reload_button",
+			preserveSearch: true,
+		});
+	};
+
+	const recoverItemCatalog = async (reason = "manual") => {
+		return await itemsStore.recoverItemCatalog({
+			reason,
+			preserveSearch: true,
+		});
+	};
+
+	const recoverItemCatalogIfUnhealthy = async (reason = "resume") => {
+		return await itemsStore.recoverItemCatalogIfUnhealthy(reason);
 	};
 
 	const refreshModifiedItems = async (
@@ -301,6 +315,8 @@ export function useItemsIntegration(options: IntegrationOptions = {}) {
 		filterByGroup: itemsStore.filterByGroup,
 		updatePriceList: itemsStore.updatePriceList,
 		refreshItems: itemsStore.refreshItems,
+		recoverItemCatalog,
+		recoverItemCatalogIfUnhealthy,
 		appendCachedItemsPage: itemsStore.appendCachedItemsPage,
 		resetCachedItemsForGroup: itemsStore.resetCachedItemsForGroup,
 		backgroundSyncItems: itemsStore.backgroundSyncItems,

--- a/frontend/src/posapp/stores/itemsStore.ts
+++ b/frontend/src/posapp/stores/itemsStore.ts
@@ -19,11 +19,13 @@ import {
 	buildLoadItemsRequest,
 	type LoadItemsOptions,
 } from "./items/loadItemsRequest";
+import { resetItemLoadingCoordinator } from "../modules/items/itemLoadingCoordinator";
 
 export const useItemsStore = defineStore("items", () => {
 	const SERVER_SEARCH_FALLBACK_DEBOUNCE_MS = 450;
 	const SERVER_SEARCH_MISS_CACHE_TTL_MS = 30 * 1000;
-	const SERVER_SEARCH_FALLBACK_MIN_LENGTH = 3;
+	const SERVER_SEARCH_FALLBACK_MIN_LENGTH = 2;
+	const RESUME_RECOVERY_COOLDOWN_MS = 10 * 1000;
 	const HOT_CATALOG_DEFAULT_LIMIT = 5000;
 	const HOT_CATALOG_MAX_LIMIT = 10000;
 	const HOT_CATALOG_DAYS = 120;
@@ -34,6 +36,7 @@ export const useItemsStore = defineStore("items", () => {
 		| ((_items: Item[]) => void)
 		| null = null;
 	let serverSearchFallbackToken = 0;
+	let lastRecoveryAt = 0;
 	const serverSearchMissCache = new Map<string, number>();
 	const activeServerSearchKeys = new Set<string>();
 
@@ -317,6 +320,24 @@ export const useItemsStore = defineStore("items", () => {
 			resolvePendingServerSearchFallback(result);
 			resolvePendingServerSearchFallback = null;
 		}
+	};
+
+	const abortAllItemRequests = () => {
+		for (const controller of abortControllers.value.values()) {
+			controller.abort();
+		}
+		abortControllers.value.clear();
+		activeServerSearchKeys.clear();
+	};
+
+	const resetRuntimeLoadingState = () => {
+		cancelPendingServerSearchFallback();
+		cancelBackgroundSync();
+		abortAllItemRequests();
+		isLoading.value = false;
+		cachedPagination.value.loading = false;
+		backgroundSyncState.value.running = false;
+		resetItemLoadingCoordinator();
 	};
 
 	const shouldTryServerSearchFallback = (term: string, group: string) => {
@@ -741,7 +762,9 @@ export const useItemsStore = defineStore("items", () => {
 			syncBootstrapItemReadiness(resolvedCount);
 		} catch (error) {
 			console.warn("Failed to load cached items:", error);
-			itemsLoaded.value = true;
+			itemsLoaded.value = false;
+			resetCachedPagination();
+			syncBootstrapItemReadiness(0);
 		}
 	};
 
@@ -815,8 +838,12 @@ export const useItemsStore = defineStore("items", () => {
 			);
 			const isServerSearchRequest = forceServer && !!searchValue;
 
+			const shouldForceServerItems = normalizeBooleanSetting(
+				posProfile.value?.posa_force_server_items,
+			);
 			const canReadFromCache =
 				!forceServer &&
+				!shouldForceServerItems &&
 				!limitSearchEnabled.value &&
 				!isLargeCatalogWindow();
 
@@ -897,13 +924,15 @@ export const useItemsStore = defineStore("items", () => {
 			itemsLoaded.value = true;
 
 			const shouldCacheFetchedItems =
-				!limitSearchEnabled.value && !isInitialBootstrapRequest;
+				!limitSearchEnabled.value &&
+				!isInitialBootstrapRequest &&
+				!shouldForceServerItems;
 
 			if (shouldCacheFetchedItems) {
 				await cacheItems(cacheKey, fetchedItems);
 			}
 
-			if (!searchValue && shouldPersistItems()) {
+			if (!searchValue && shouldPersistItems() && !shouldForceServerItems) {
 				await persistItemsToStorage(
 					fetchedItems,
 					shouldPersistItems(),
@@ -955,7 +984,9 @@ export const useItemsStore = defineStore("items", () => {
 				throw error;
 			}
 		} finally {
-			isLoading.value = false;
+			if (requestToken.value === currentRequestToken) {
+				isLoading.value = false;
+			}
 			if (cacheKey) {
 				abortControllers.value.delete(cacheKey);
 				activeServerSearchKeys.delete(cacheKey);
@@ -1098,7 +1129,6 @@ export const useItemsStore = defineStore("items", () => {
 			let searchResults: Item[] = [];
 
 			if (shouldUseIndexed) {
-				cancelPendingServerSearchFallback();
 				const normalizedGroup =
 					typeof itemGroup.value === "string" &&
 					itemGroup.value.length > 0
@@ -1116,6 +1146,25 @@ export const useItemsStore = defineStore("items", () => {
 					[hotSearchResults, Array.isArray(results) ? results : []],
 					cachedPagination.value.pageSize,
 				);
+
+				if (
+					searchResults.length === 0 &&
+					shouldTryServerSearchFallback(term, normalizedGroup)
+				) {
+					searchResults = await scheduleServerSearchFallback(
+						term,
+						normalizedGroup,
+					);
+					if (
+						normalizeSearchScope(searchTerm.value) !==
+						requestedSearchScope
+					) {
+						return [];
+					}
+				} else {
+					cancelPendingServerSearchFallback(searchResults);
+				}
+
 				cachedPagination.value.search = term;
 				cachedPagination.value.offset = searchResults.length;
 				cachedPagination.value.total = Math.max(
@@ -1361,6 +1410,7 @@ export const useItemsStore = defineStore("items", () => {
 	};
 
 	const refreshItems = async () => {
+		resetRuntimeLoadingState();
 		await clearAllCaches();
 		itemsLoaded.value = false;
 		resetCachedPagination();
@@ -1370,6 +1420,91 @@ export const useItemsStore = defineStore("items", () => {
 		} else {
 			clearHotCatalog();
 		}
+	};
+
+	const recoverItemCatalog = async (
+		options: {
+			reason?: string;
+			preserveSearch?: boolean;
+			allowCooldown?: boolean;
+		} = {},
+	) => {
+		const now = Date.now();
+		if (
+			options.allowCooldown &&
+			lastRecoveryAt &&
+			now - lastRecoveryAt < RESUME_RECOVERY_COOLDOWN_MS
+		) {
+			return items.value;
+		}
+		lastRecoveryAt = now;
+
+		const activeSearch = options.preserveSearch ? searchTerm.value : "";
+		const activeGroup = itemGroup.value || "ALL";
+		console.info("[POSA][Items] recovering item catalog", {
+			reason: options.reason || "manual",
+			search: activeSearch,
+			group: activeGroup,
+		});
+
+		resetRuntimeLoadingState();
+		clearSearchCache();
+		await assessCacheHealth().catch((error) => {
+			console.warn("Failed to assess item cache during recovery:", error);
+		});
+
+		try {
+			const fetchedItems = await loadItems({
+				forceServer: true,
+				searchValue: activeSearch,
+				groupFilter: activeGroup,
+			});
+			if (fastCounterEnabled.value) {
+				await loadHotCatalog({ force: true });
+			} else {
+				clearHotCatalog();
+			}
+			return Array.isArray(fetchedItems) ? fetchedItems : items.value;
+		} catch (error) {
+			console.error("[POSA][Items] item catalog recovery failed:", error);
+			itemsLoaded.value = items.value.length > 0;
+			if (!activeSearch && items.value.length === 0) {
+				await loadCachedItems();
+			}
+			throw error;
+		}
+	};
+
+	const recoverItemCatalogIfUnhealthy = async (reason = "resume") => {
+		if (typeof navigator !== "undefined" && navigator.onLine === false) {
+			return items.value;
+		}
+
+		const hasVisibleItems =
+			items.value.length > 0 || filteredItems.value.length > 0;
+		const expectsBrowseCatalog = !limitSearchEnabled.value;
+		const hasStuckLoading =
+			(isLoading.value || isBackgroundLoading.value) && !hasVisibleItems;
+		const hasEmptyLoadedCatalog =
+			expectsBrowseCatalog &&
+			itemsLoaded.value &&
+			items.value.length === 0 &&
+			totalItemCount.value === 0;
+		const hasMissingCache =
+			expectsBrowseCatalog &&
+			!hasVisibleItems &&
+			(cacheHealth.value.items === "missing" ||
+				cacheHealth.value.items === "error");
+
+		if (!hasStuckLoading && !hasEmptyLoadedCatalog && !hasMissingCache) {
+			return items.value;
+		}
+
+		return await recoverItemCatalog({
+			reason,
+			preserveSearch: true,
+			allowCooldown: true,
+		});
 	};
 
 	const addScannedItem = async (barcode: string) => {
@@ -1594,6 +1729,8 @@ export const useItemsStore = defineStore("items", () => {
 		filterByGroup,
 		updatePriceList,
 		refreshItems,
+		recoverItemCatalog,
+		recoverItemCatalogIfUnhealthy,
 		loadHotCatalog,
 		appendCachedItemsPage,
 		resetCachedItemsForGroup,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic item-catalog recovery when the app resumes, regains focus, reconnects, or returns from the background.
  * Added safer recovery from unavailable or unhealthy local storage, including online-only mode notifications.
  * Item reloads now preserve the active search when possible.
  * Server search fallback now activates for shorter search terms.

* **Bug Fixes**
  * Prevented stale requests from incorrectly affecting loading indicators.
  * Improved handling of failed cache loads and interrupted item requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->