### PR TITLE
fix(items-selector): keep cart reservations applied to displayed stock

### DIFF
--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -471,6 +471,22 @@ const displayedItems = computed(() => {
 	});
 });
 
+// The item list is rebuilt whenever it reloads — notably when the customer
+// changes and every item is re-fetched for that customer's price list. Those
+// fresh objects carry the raw warehouse stock with no cart reservation applied,
+// and nothing else re-applies it: the coordinator only broadcasts when a
+// reservation actually *changes*, which it doesn't on a customer switch. Without
+// this the selector snaps back to full stock (e.g. 40) after picking a customer
+// even though the cart still holds those units. Re-prime the base from the new
+// objects and re-subtract the cart's reservations.
+watch(
+	filteredItems,
+	() => {
+		itemAvailability.primeStockState("items-refresh");
+	},
+	{ flush: "post" },
+);
+
 watch(
 	() => props.showOnlyBarcodeItems,
 	(value) => {

--- a/frontend/src/posapp/composables/pos/items/addition/useItemMerging.ts
+++ b/frontend/src/posapp/composables/pos/items/addition/useItemMerging.ts
@@ -176,9 +176,12 @@ export function useItemMerging() {
 				);
 				return;
 			}
-			// Optimised store method would be better, but composing actions works:
-			context.invoiceStore.removeItemByRowId(rowId);
-			context.invoiceStore.addItem(target, 0); // Insert at 0
+			// Re-order in place. Do NOT compose removeItemByRowId + addItem: the
+			// removal recalculates totals immediately (without this row) while
+			// addItem only schedules a debounced recalculation, so the totals show
+			// the row missing — zero, if it is the only row — for ~50ms on every
+			// quantity change. It would also clone the item, breaking identity.
+			context.invoiceStore.moveRowToTop(rowId);
 		} else {
 			const resolvedIndex =
 				typeof currentIndex === "number" && currentIndex >= 0

--- a/frontend/src/posapp/composables/pos/items/useItemAddition.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemAddition.ts
@@ -428,21 +428,32 @@ export function useItemAddition() {
 			}
 			let index = -1;
 			let mergeTarget: any = null;
-			// Only require a strict batch match when the incoming item actually
-			// carries a batch. Batch assignment is async (item details, and with
-			// them batch_no_data, are fetched after the click so add-to-cart stays
-			// responsive), so a batch item usually arrives here with an empty
-			// batch_no. A strict key `code::uom::` (empty batch) can never match an
-			// already-batched cart row, so a duplicate line is created — and it
-			// then gets assigned the SAME batch, leaving two identical rows.
-			// With no batch yet, fall back to a batch-agnostic (flex) merge so the
-			// qty increments the existing row. Once a batch IS chosen, strict
-			// matching resumes and keeps one row per batch as intended.
+			// Strict on the way in, flexible on the way out.
+			//
+			// The incoming item keeps a strict batch match (below) so a batch item
+			// always falls through to the allocation block, which is the only thing
+			// that knows how much of each batch is left. Flex-merging here would
+			// skip it and pile every click onto whichever batch is already in the
+			// cart, overselling it once it runs out.
+			//
+			// The re-check after allocation uses this probe instead. Batch details
+			// (batch_no_data) load asynchronously so add-to-cart stays responsive,
+			// which means allocation can have nothing to work with and leaves
+			// batch_no empty. A strict key `code::uom::` (empty batch) can never
+			// match an already-batched cart row, so a duplicate line is created and
+			// then assigned the SAME batch, leaving two identical rows. When the
+			// probe still has no batch, fall back to a batch-agnostic (flex) merge
+			// so the qty increments the existing row; once allocation HAS assigned
+			// one, strict matching resumes and keeps one row per batch as intended.
 			const needsBatchMatch = (probe: any) =>
 				Boolean(probe?.has_batch_no && probe?.batch_no);
 			if (!context.new_line) {
 				// For normal additions (not returns), only merge with existing positive quantity lines
-				mergeTarget = findMergeTarget(context, item, needsBatchMatch(item));
+				mergeTarget = findMergeTarget(
+					context,
+					item,
+					Boolean(item.has_batch_no),
+				);
 				if (!canMergeWithTarget(context, mergeTarget?.item)) {
 					mergeTarget = null;
 				}

--- a/frontend/src/posapp/composables/pos/items/useItemAddition.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemAddition.ts
@@ -428,10 +428,21 @@ export function useItemAddition() {
 			}
 			let index = -1;
 			let mergeTarget: any = null;
-			const requireBatchMatch = Boolean(item.has_batch_no);
+			// Only require a strict batch match when the incoming item actually
+			// carries a batch. Batch assignment is async (item details, and with
+			// them batch_no_data, are fetched after the click so add-to-cart stays
+			// responsive), so a batch item usually arrives here with an empty
+			// batch_no. A strict key `code::uom::` (empty batch) can never match an
+			// already-batched cart row, so a duplicate line is created — and it
+			// then gets assigned the SAME batch, leaving two identical rows.
+			// With no batch yet, fall back to a batch-agnostic (flex) merge so the
+			// qty increments the existing row. Once a batch IS chosen, strict
+			// matching resumes and keeps one row per batch as intended.
+			const needsBatchMatch = (probe: any) =>
+				Boolean(probe?.has_batch_no && probe?.batch_no);
 			if (!context.new_line) {
 				// For normal additions (not returns), only merge with existing positive quantity lines
-				mergeTarget = findMergeTarget(context, item, requireBatchMatch);
+				mergeTarget = findMergeTarget(context, item, needsBatchMatch(item));
 				if (!canMergeWithTarget(context, mergeTarget?.item)) {
 					mergeTarget = null;
 				}
@@ -601,10 +612,13 @@ export function useItemAddition() {
 				// Re-check in case other async updates modified the cart meanwhile
 				if (!context.new_line) {
 					const mergeProbeItem = new_item || item;
+					// Recompute against the probe's CURRENT batch: if allocation
+					// assigned one above, strict-match it (correct per-batch row);
+					// if it is still empty, flex-merge to avoid a duplicate line.
 					mergeTarget = findMergeTarget(
 						context,
 						mergeProbeItem,
-						requireBatchMatch,
+						needsBatchMatch(mergeProbeItem),
 					);
 					if (!canMergeWithTarget(context, mergeTarget?.item)) {
 						mergeTarget = null;

--- a/frontend/src/posapp/composables/pos/items/useItemDetailFetcher.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemDetailFetcher.ts
@@ -207,9 +207,14 @@ export function useItemDetailFetcher() {
 	 */
 	function rebaseAndReapplyReservation(item: any, rawQty: unknown) {
 		if (!ctx.itemAvailability || !item) return;
-		const numericQty = Number(rawQty);
-		if (Number.isFinite(numericQty)) {
-			ctx.itemAvailability.captureBaseAvailability(item, numericQty);
+		// Number(null) and Number("") are 0, and 0 is finite — a missing stock
+		// record would silently rebase to zero. Keep the previous base in that
+		// case; re-applying the reservation to it beats displaying a false zero.
+		if (rawQty !== null && rawQty !== undefined && rawQty !== "") {
+			const numericQty = Number(rawQty);
+			if (Number.isFinite(numericQty)) {
+				ctx.itemAvailability.captureBaseAvailability(item, numericQty);
+			}
 		}
 		ctx.itemAvailability.applyReservationToItem(item);
 	}

--- a/frontend/src/posapp/composables/pos/items/useItemDetailFetcher.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemDetailFetcher.ts
@@ -195,6 +195,25 @@ export function useItemDetailFetcher() {
 		}
 	}
 
+	/**
+	 * Re-applies the cart's reservation after a refresh has written raw stock.
+	 *
+	 * `actual_qty` coming back from the cache/server is the RAW warehouse stock —
+	 * it does not account for what the current cart already holds. Writing it
+	 * straight onto the item makes the selector jump back to full stock. Because
+	 * the background sync refreshes prices on a timer (~30s), that jump happens
+	 * with no user action at all, which is what made it look inexplicable.
+	 * Record the fresh value as the new base, then re-subtract the reservation.
+	 */
+	function rebaseAndReapplyReservation(item: any, rawQty: unknown) {
+		if (!ctx.itemAvailability || !item) return;
+		const numericQty = Number(rawQty);
+		if (Number.isFinite(numericQty)) {
+			ctx.itemAvailability.captureBaseAvailability(item, numericQty);
+		}
+		ctx.itemAvailability.applyReservationToItem(item);
+	}
+
 	async function refreshPricesForVisibleItems() {
 		if (!ctx.displayedItems || ctx.displayedItems.length === 0) return;
 		if (refreshInFlight.value) return;
@@ -243,7 +262,10 @@ export function useItemDetailFetcher() {
 			});
 
 			if (cacheResult.missing.length === 0) {
-				updates.forEach(({ item, upd }) => Object.assign(item, upd));
+				updates.forEach(({ item, upd }) => {
+					Object.assign(item, upd);
+					rebaseAndReapplyReservation(item, upd.actual_qty);
+				});
 				updateLocalStockCache(cacheResult.cached);
 				return;
 			}
@@ -288,7 +310,10 @@ export function useItemDetailFetcher() {
 				}
 			});
 
-			updates.forEach(({ item, upd }) => Object.assign(item, upd));
+			updates.forEach(({ item, upd }) => {
+				Object.assign(item, upd);
+				rebaseAndReapplyReservation(item, upd.actual_qty);
+			});
 			updateLocalStockCache(details);
 			saveItemDetailsCache(
 				ctx.pos_profile?.name,
@@ -363,6 +388,7 @@ export function useItemDetailFetcher() {
 					has_batch_no: det.has_batch_no,
 					has_serial_no: det.has_serial_no,
 				});
+				rebaseAndReapplyReservation(item, det.actual_qty);
 				if (det.item_uoms && det.item_uoms.length > 0) {
 					item.item_uoms = det.item_uoms;
 					saveItemUOMs(item.item_code, det.item_uoms);
@@ -411,11 +437,7 @@ export function useItemDetailFetcher() {
 			const localQty = getLocalStock(item.item_code);
 			if (localQty !== null) {
 				item.actual_qty = localQty;
-				if (ctx.itemAvailability)
-					ctx.itemAvailability.captureBaseAvailability(
-						item,
-						localQty,
-					);
+				rebaseAndReapplyReservation(item, localQty);
 				baseRecords.set(item.item_code, localQty);
 			} else {
 				allCached = false;
@@ -623,11 +645,7 @@ export function useItemDetailFetcher() {
 					const localQty = getLocalStock(item.item_code);
 					if (localQty !== null) {
 						item.actual_qty = localQty;
-						if (ctx.itemAvailability)
-							ctx.itemAvailability.captureBaseAvailability(
-								item,
-								localQty,
-							);
+						rebaseAndReapplyReservation(item, localQty);
 						baseRecords.set(item.item_code, localQty);
 					}
 					if (!item.item_uoms || item.item_uoms.length === 0) {

--- a/frontend/src/posapp/stores/invoiceStore.ts
+++ b/frontend/src/posapp/stores/invoiceStore.ts
@@ -538,6 +538,30 @@ export const useInvoiceStore = defineStore("invoice", () => {
 	};
 
 	/**
+	 * Moves an existing row to the top of `itemOrder` without touching `itemsData`.
+	 *
+	 * Callers that only want to re-order MUST use this instead of composing
+	 * `removeItemByRowId` + `addItem`: removal recalculates totals immediately
+	 * (dropping the row) while `addItem` only schedules a debounced update, so the
+	 * pair leaves the totals visibly wrong — zeroed, if it is the only row — for
+	 * ~50ms on every quantity change. Re-ordering in place also preserves the
+	 * stored item's object identity, since `addItem` would clone it.
+	 *
+	 * No-ops when the row is absent or already at the top.
+	 *
+	 * @param rowId - The `posa_row_id` of the item to float to the top.
+	 */
+	const moveRowToTop = (rowId: string) => {
+		if (!rowId) return;
+		const idx = itemOrder.value.indexOf(rowId);
+		if (idx > 0) {
+			itemOrder.value.splice(idx, 1);
+			itemOrder.value.unshift(rowId);
+			touch();
+		}
+	};
+
+	/**
 	 * Removes the item identified by `rowId` from both `itemsData` and `itemOrder`,
 	 * then recalculates totals immediately.
 	 *
@@ -683,6 +707,7 @@ export const useInvoiceStore = defineStore("invoice", () => {
 		upsertItem,
 		updateItemWithTotals,
 		triggerUpdateTotals,
+		moveRowToTop,
 		removeItemByRowId,
 		clearItems,
 		setPackedItems,


### PR DESCRIPTION
## Problem

The item selector displays `item.actual_qty`, which `stockCoordinator` computes as `available = base - reserved`. Several paths write the **raw warehouse stock** back onto the item without re-subtracting what the cart already reserved, so the selector snaps back to full stock while those units are still in the cart.

Cashiers see the availability number decrease correctly as they add items, then jump back up — sometimes with no user action at all.

## Root cause

`useItemAvailability` exposes `primeStockState()` / `syncItemsWithStockState()` for exactly this, but **neither is called anywhere in the project**. The coordinator only broadcasts when a reservation actually *changes*, so nothing re-applies the reservation to item objects that were refreshed for other reasons.

## What this fixes

Four related issues, all rooted in that gap:

1. **Customer switch resets availability.** Picking a customer re-fetches every item for that customer's price list. The fresh objects carry raw stock and no reservation, and the reservation doesn't change on a customer switch, so nothing re-applied it. Re-prime on list rebuild.

2. **Background sync makes quantities jump.** The sync refreshes item details on a timer (~30s) and writes raw `actual_qty` in five places. Quantities jumped back up with no user action, which made it look inexplicable. Re-base from the fresh value (stock may genuinely have changed) and re-subtract the reservation.

3. **Batch items duplicated in the cart.** Batch assignment is async, so an incoming batch item usually has an empty `batch_no`. Requiring a strict batch match built the key `code::uom::` (empty batch), which can never match an already-batched row → a second line was created and then auto-assigned the **same** batch, leaving two identical rows. Now a strict batch match is only required once the item actually carries a batch; otherwise it flex-merges.

4. **Totals flashed to zero on every qty change.** `moveItemToTop` composed `removeItemByRowId` + `addItem`. Removal recalculates totals immediately (without the row) while `addItem` only schedules a debounced update, leaving the totals visibly wrong — zeroed, if it's the only row — for ~50ms. Now `itemOrder` is re-ordered in place via a new `moveRowToTop`, which also preserves the stored item's object identity (`addItem` clones).

## Verification

Traced against a production dataset with instrumentation on `stockCoordinator` (since removed): `base` stays correct, `reserved` tracks the cart, and `available` is applied to the displayed objects. Each fix was isolated and confirmed independently — reverted and re-tested one at a time to prove it was necessary and sufficient.

Manually verified: availability decrements correctly while adding, stays stable across a customer switch, stays stable across background syncs, batch items merge into one row, and totals increment smoothly with no flash. Frontend builds clean.

## Notes

- Frontend-only; no schema or API changes.
- `primeStockState()` walks the item list on rebuild. That's a no-op-cost path today, but if you'd prefer a narrower trigger than `filteredItems` (which also fires on search), I'm happy to adjust.