### PR TITLE
fix(items-selector): pass setBatchQty into the add-item context

### DIFF
--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -230,6 +230,7 @@ import { useScannerInput } from "../../../composables/pos/items/useScannerInput"
 import { useItemAvailability } from "../../../composables/pos/items/useItemAvailability";
 import { useItemDetailFetcher } from "../../../composables/pos/items/useItemDetailFetcher";
 import { useItemAddition } from "../../../composables/pos/items/useItemAddition";
+import { useBatchSerial } from "../../../composables/pos/shared/useBatchSerial";
 import { useItemSelection } from "../../../composables/pos/items/useItemSelection";
 import { useItemSelectorLayout } from "../../../composables/pos/items/useItemSelectorLayout";
 import { useLastInvoiceRate } from "../../../composables/pos/items/useLastInvoiceRate";
@@ -289,6 +290,7 @@ const toastStore = useToastStore();
 const uiStore = useUIStore();
 const invoiceStore = useInvoiceStore();
 const employeeStore = useEmployeeStore();
+const batchSerial = useBatchSerial();
 const { selectedCustomer } = storeToRefs(customersStore);
 const {
 	posProfile: uiPosProfile,
@@ -662,7 +664,7 @@ const add_item = async (item, optionsOrQty: any = {}) => {
 			return;
 		}
 
-		const context = {
+		const context: any = {
 			pos_profile: pos_profile.value,
 			stock_settings: stock_settings.value,
 			customer: selectedCustomer.value,
@@ -677,6 +679,16 @@ const add_item = async (item, optionsOrQty: any = {}) => {
 			isReturnInvoice: isReturnInvoice.value,
 			...options,
 			new_line: typeof options?.new_line === "boolean" ? options.new_line : !!new_line.value,
+			// `shouldAutoSetBatch` refuses to auto-assign unless the context exposes
+			// a setter, and this context never did, so posa_auto_set_batch was inert
+			// for every add from the selector: no batch was assigned on click, and
+			// `shouldAllocateAcrossBatches` stayed false, which left the cross-batch
+			// split running only when qty > 1. Clicking a batch item one unit at a
+			// time therefore piled the whole quantity onto a single batch, past what
+			// that batch holds. showBatchDialog calls this setter directly too, so a
+			// return-without-invoice on a batch item used to throw here.
+			setBatchQty: (line: any, value: any, update = false) =>
+				batchSerial.setBatchQty(line, value, update, context),
 		};
 
 		const isValid = await cartValidation.validateCartItem(


### PR DESCRIPTION
## The bug

`posa_auto_set_batch` is inert for every add from the items selector.

`shouldAutoSetBatch` bails out on `!context?.setBatchQty` before it ever reads the profile flag:

```js
const shouldAutoSetBatch = (context: any, item: any) => {
    if (!context?.setBatchQty || !context?.pos_profile?.posa_auto_set_batch) {
        return false;
    }
    ...
```

The context built in `ItemsSelector.vue` never carried a setter, so this always returns `false`.

Two things follow:

1. No batch is assigned when a batch item is clicked.
2. `shouldAllocateAcrossBatches` is `has_batch_no && !batch_no && (shouldAutoSetBatch || qty > 1)`, so the cross-batch split only ever ran when `qty > 1`. Clicking a batch item **one unit at a time** piles the entire quantity onto a single batch, past what that batch holds.

## Reproducing

Profile with `posa_auto_set_batch = 1`. An item stocked in two batches in the same warehouse: **1** unit in the first, **15** in the second. Click the item 16 times.

- **Expected:** two rows, 1 on the first batch and 15 on the second.
- **Actual:** one row of 16 against the 15-unit batch.

Console trace from the run (`[POS BatchFlow]`) shows `Batch allocation prepared` never fires, and a probe on the gate showed why:

```
has_batch_no: 1, batch_no: undefined, batch_no_data_len: 2,
ctx_has_setBatchQty: "undefined", profile_auto_set_batch: 1,
shouldAutoSetBatch: false, shouldAllocateAcrossBatches: false
```

Batch data is present and the profile flag is on. Only the missing setter closes the gate.

## The fix

Supply the setter on the context. It is the same function `callSetBatchQty` already falls back to, so the only behavioural change is that the gate opens.

The allocation code itself needed no changes — it reads per-batch availability net of the cart and moves to the next batch once one is exhausted. It was simply never reached.

## Scope

- Profiles with `posa_auto_set_batch = 0` are unaffected: the second condition still short-circuits.
- `qty > 1` adds already worked and are unchanged.
- `showBatchDialog` calls `context.setBatchQty` directly, so a return-without-invoice on a batch item used to throw a `TypeError` from this context. That path works now too.

## Testing

Verified on a live v15 bench against the case above: two rows, 1 + 15. Re-tested with `posa_auto_set_batch = 0` profiles with no change in behaviour. `vue-tsc --noEmit` clean, build clean.

Independent of #3114 — different root cause, no overlapping hunks.