### PR TITLE
fix(items-selector): batch allocation + cart-reservation display fixes

### DIFF
--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -471,6 +471,22 @@ const displayedItems = computed(() => {
 	});
 });
 
+// The item list is rebuilt whenever it reloads — notably when the customer
+// changes and every item is re-fetched for that customer's price list. Those
+// fresh objects carry the raw warehouse stock with no cart reservation applied,
+// and nothing else re-applies it: the coordinator only broadcasts when a
+// reservation actually *changes*, which it doesn't on a customer switch. Without
+// this the selector snaps back to full stock (e.g. 40) after picking a customer
+// even though the cart still holds those units. Re-prime the base from the new
+// objects and re-subtract the cart's reservations.
+watch(
+	filteredItems,
+	() => {
+		itemAvailability.primeStockState("items-refresh");
+	},
+	{ flush: "post" },
+);
+
 watch(
 	() => props.showOnlyBarcodeItems,
 	(value) => {

--- a/frontend/src/posapp/components/pos/items/ItemsSelector.vue
+++ b/frontend/src/posapp/components/pos/items/ItemsSelector.vue
@@ -230,6 +230,8 @@ import { useScannerInput } from "../../../composables/pos/items/useScannerInput"
 import { useItemAvailability } from "../../../composables/pos/items/useItemAvailability";
 import { useItemDetailFetcher } from "../../../composables/pos/items/useItemDetailFetcher";
 import { useItemAddition } from "../../../composables/pos/items/useItemAddition";
+import { useBatchSerial } from "../../../composables/pos/shared/useBatchSerial";
+import { useFormat } from "../../../format";
 import { useItemSelection } from "../../../composables/pos/items/useItemSelection";
 import { useItemSelectorLayout } from "../../../composables/pos/items/useItemSelectorLayout";
 import { useLastInvoiceRate } from "../../../composables/pos/items/useLastInvoiceRate";
@@ -289,6 +291,8 @@ const toastStore = useToastStore();
 const uiStore = useUIStore();
 const invoiceStore = useInvoiceStore();
 const employeeStore = useEmployeeStore();
+const batchSerial = useBatchSerial();
+const { flt: fmtFlt, currency_precision: fmtCurrencyPrecision } = useFormat();
 const { selectedCustomer } = storeToRefs(customersStore);
 const {
 	posProfile: uiPosProfile,
@@ -678,7 +682,7 @@ const add_item = async (item, optionsOrQty: any = {}) => {
 			return;
 		}
 
-		const context = {
+		const context: any = {
 			pos_profile: pos_profile.value,
 			stock_settings: stock_settings.value,
 			customer: selectedCustomer.value,
@@ -694,6 +698,25 @@ const add_item = async (item, optionsOrQty: any = {}) => {
 			isReturnInvoice: isReturnInvoice.value,
 			...options,
 			new_line: typeof options?.new_line === "boolean" ? options.new_line : !!new_line.value,
+			// Defensive precision: setBatchQty rounds amount/base_amount with these.
+			// Without them it falls back to a bare Number() and leaves float tails
+			// on the in-memory line object. The cart display masks it (it re-derives
+			// formatCurrency(qty*rate)) and the backend re-rounds on save, so this is
+			// not a visible bug — but it keeps the line data clean at the source and
+			// honours the profile's posa_decimal_precision, matching every other
+			// context that passes these.
+			flt: fmtFlt,
+			currency_precision: fmtCurrencyPrecision.value,
+			// `shouldAutoSetBatch` refuses to auto-assign unless the context exposes
+			// a setter, and this context never did, so posa_auto_set_batch was inert
+			// for every add from the selector: no batch was assigned on click, and
+			// `shouldAllocateAcrossBatches` stayed false, which left the cross-batch
+			// split running only when qty > 1. Clicking a batch item one unit at a
+			// time therefore piled the whole quantity onto a single batch, past what
+			// that batch holds. showBatchDialog calls this setter directly too, so a
+			// return-without-invoice on a batch item used to throw here.
+			setBatchQty: (line: any, value: any, update = false) =>
+				batchSerial.setBatchQty(line, value, update, context),
 		};
 
 		const isValid = await cartValidation.validateCartItem(

--- a/frontend/src/posapp/composables/pos/items/addition/useItemMerging.ts
+++ b/frontend/src/posapp/composables/pos/items/addition/useItemMerging.ts
@@ -176,9 +176,12 @@ export function useItemMerging() {
 				);
 				return;
 			}
-			// Optimised store method would be better, but composing actions works:
-			context.invoiceStore.removeItemByRowId(rowId);
-			context.invoiceStore.addItem(target, 0); // Insert at 0
+			// Re-order in place. Do NOT compose removeItemByRowId + addItem: the
+			// removal recalculates totals immediately (without this row) while
+			// addItem only schedules a debounced recalculation, so the totals show
+			// the row missing — zero, if it is the only row — for ~50ms on every
+			// quantity change. It would also clone the item, breaking identity.
+			context.invoiceStore.moveRowToTop(rowId);
 		} else {
 			const resolvedIndex =
 				typeof currentIndex === "number" && currentIndex >= 0

--- a/frontend/src/posapp/composables/pos/items/useItemAddition.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemAddition.ts
@@ -428,10 +428,32 @@ export function useItemAddition() {
 			}
 			let index = -1;
 			let mergeTarget: any = null;
-			const requireBatchMatch = Boolean(item.has_batch_no);
+			// Strict on the way in, flexible on the way out.
+			//
+			// The incoming item keeps a strict batch match (below) so a batch item
+			// always falls through to the allocation block, which is the only thing
+			// that knows how much of each batch is left. Flex-merging here would
+			// skip it and pile every click onto whichever batch is already in the
+			// cart, overselling it once it runs out.
+			//
+			// The re-check after allocation uses this probe instead. Batch details
+			// (batch_no_data) load asynchronously so add-to-cart stays responsive,
+			// which means allocation can have nothing to work with and leaves
+			// batch_no empty. A strict key `code::uom::` (empty batch) can never
+			// match an already-batched cart row, so a duplicate line is created and
+			// then assigned the SAME batch, leaving two identical rows. When the
+			// probe still has no batch, fall back to a batch-agnostic (flex) merge
+			// so the qty increments the existing row; once allocation HAS assigned
+			// one, strict matching resumes and keeps one row per batch as intended.
+			const needsBatchMatch = (probe: any) =>
+				Boolean(probe?.has_batch_no && probe?.batch_no);
 			if (!context.new_line) {
 				// For normal additions (not returns), only merge with existing positive quantity lines
-				mergeTarget = findMergeTarget(context, item, requireBatchMatch);
+				mergeTarget = findMergeTarget(
+					context,
+					item,
+					Boolean(item.has_batch_no),
+				);
 				if (!canMergeWithTarget(context, mergeTarget?.item)) {
 					mergeTarget = null;
 				}
@@ -601,10 +623,13 @@ export function useItemAddition() {
 				// Re-check in case other async updates modified the cart meanwhile
 				if (!context.new_line) {
 					const mergeProbeItem = new_item || item;
+					// Recompute against the probe's CURRENT batch: if allocation
+					// assigned one above, strict-match it (correct per-batch row);
+					// if it is still empty, flex-merge to avoid a duplicate line.
 					mergeTarget = findMergeTarget(
 						context,
 						mergeProbeItem,
-						requireBatchMatch,
+						needsBatchMatch(mergeProbeItem),
 					);
 					if (!canMergeWithTarget(context, mergeTarget?.item)) {
 						mergeTarget = null;

--- a/frontend/src/posapp/composables/pos/items/useItemDetailFetcher.ts
+++ b/frontend/src/posapp/composables/pos/items/useItemDetailFetcher.ts
@@ -195,6 +195,30 @@ export function useItemDetailFetcher() {
 		}
 	}
 
+	/**
+	 * Re-applies the cart's reservation after a refresh has written raw stock.
+	 *
+	 * `actual_qty` coming back from the cache/server is the RAW warehouse stock —
+	 * it does not account for what the current cart already holds. Writing it
+	 * straight onto the item makes the selector jump back to full stock. Because
+	 * the background sync refreshes prices on a timer (~30s), that jump happens
+	 * with no user action at all, which is what made it look inexplicable.
+	 * Record the fresh value as the new base, then re-subtract the reservation.
+	 */
+	function rebaseAndReapplyReservation(item: any, rawQty: unknown) {
+		if (!ctx.itemAvailability || !item) return;
+		// Number(null) and Number("") are 0, and 0 is finite — a missing stock
+		// record would silently rebase to zero. Keep the previous base in that
+		// case; re-applying the reservation to it beats displaying a false zero.
+		if (rawQty !== null && rawQty !== undefined && rawQty !== "") {
+			const numericQty = Number(rawQty);
+			if (Number.isFinite(numericQty)) {
+				ctx.itemAvailability.captureBaseAvailability(item, numericQty);
+			}
+		}
+		ctx.itemAvailability.applyReservationToItem(item);
+	}
+
 	async function refreshPricesForVisibleItems() {
 		if (!ctx.displayedItems || ctx.displayedItems.length === 0) return;
 		if (refreshInFlight.value) return;
@@ -243,7 +267,10 @@ export function useItemDetailFetcher() {
 			});
 
 			if (cacheResult.missing.length === 0) {
-				updates.forEach(({ item, upd }) => Object.assign(item, upd));
+				updates.forEach(({ item, upd }) => {
+					Object.assign(item, upd);
+					rebaseAndReapplyReservation(item, upd.actual_qty);
+				});
 				updateLocalStockCache(cacheResult.cached);
 				return;
 			}
@@ -288,7 +315,10 @@ export function useItemDetailFetcher() {
 				}
 			});
 
-			updates.forEach(({ item, upd }) => Object.assign(item, upd));
+			updates.forEach(({ item, upd }) => {
+				Object.assign(item, upd);
+				rebaseAndReapplyReservation(item, upd.actual_qty);
+			});
 			updateLocalStockCache(details);
 			saveItemDetailsCache(
 				ctx.pos_profile?.name,
@@ -363,6 +393,7 @@ export function useItemDetailFetcher() {
 					has_batch_no: det.has_batch_no,
 					has_serial_no: det.has_serial_no,
 				});
+				rebaseAndReapplyReservation(item, det.actual_qty);
 				if (det.item_uoms && det.item_uoms.length > 0) {
 					item.item_uoms = det.item_uoms;
 					saveItemUOMs(item.item_code, det.item_uoms);
@@ -411,11 +442,7 @@ export function useItemDetailFetcher() {
 			const localQty = getLocalStock(item.item_code);
 			if (localQty !== null) {
 				item.actual_qty = localQty;
-				if (ctx.itemAvailability)
-					ctx.itemAvailability.captureBaseAvailability(
-						item,
-						localQty,
-					);
+				rebaseAndReapplyReservation(item, localQty);
 				baseRecords.set(item.item_code, localQty);
 			} else {
 				allCached = false;
@@ -623,11 +650,7 @@ export function useItemDetailFetcher() {
 					const localQty = getLocalStock(item.item_code);
 					if (localQty !== null) {
 						item.actual_qty = localQty;
-						if (ctx.itemAvailability)
-							ctx.itemAvailability.captureBaseAvailability(
-								item,
-								localQty,
-							);
+						rebaseAndReapplyReservation(item, localQty);
 						baseRecords.set(item.item_code, localQty);
 					}
 					if (!item.item_uoms || item.item_uoms.length === 0) {

--- a/frontend/src/posapp/stores/invoiceStore.ts
+++ b/frontend/src/posapp/stores/invoiceStore.ts
@@ -564,6 +564,22 @@ export const useInvoiceStore = defineStore("invoice", () => {
 	};
 
 	/**
+	 * Moves an existing row to the top of `itemOrder` in place, preserving its
+	 * object identity and totals. Used instead of remove + re-add, which would
+	 * recompute totals immediately without the row (a brief zeroed-total flash)
+	 * and clone the item.
+	 */
+	const moveRowToTop = (rowId: string) => {
+		if (!rowId) return;
+		const idx = itemOrder.value.indexOf(rowId);
+		if (idx > 0) {
+			itemOrder.value.splice(idx, 1);
+			itemOrder.value.unshift(rowId);
+			touch();
+		}
+	};
+
+	/**
 	 * Empties all cart items and resets `totalQty`, `grossTotal`, and `discountTotal` to `0`.
 	 * No-ops (without calling `touch()`) when the cart is already empty.
 	 */
@@ -683,6 +699,7 @@ export const useInvoiceStore = defineStore("invoice", () => {
 		updateItemWithTotals,
 		triggerUpdateTotals,
 		removeItemByRowId,
+		moveRowToTop,
 		clearItems,
 		setPackedItems,
 		clear,


### PR DESCRIPTION
Re-submitting the work from #3114 and #3115 as a single PR against `stage-develop`, per @defendicon's request after the base-branch migration. Rebased onto current `stage-develop`, four self-contained commits.

All fixes are in the items-selector / cart add-item path and have been verified on a live v15 bench.

### Commits

**1. Keep cart reservations applied to displayed stock**
The selector shows `base − cart reservation`, but the stock coordinator only broadcasts when a reservation *changes*. Two paths overwrote the shown number with raw warehouse stock:
- Switching customer re-fetches items for the new price list → selector snaps back to full stock while the cart still holds units. Fixed with a post-flush `watch(filteredItems)` that re-primes stock state.
- Background price sync (~30s) writes raw `actual_qty` in several places → number jumps with no user action. Each write now goes through `rebaseAndReapplyReservation` (records the fresh value as base, re-subtracts the reservation, guards `null`/`undefined`/`""` so `Number(null) === 0` can't rebase a missing record to zero).

`primeStockState`/`syncItemsWithStockState` already existed for this but were never called.

**2. Correct batch matching to avoid duplicate rows**
`batch_no_data` loads async, so a batch item usually hits the merge check with an empty `batch_no`. A strict key `code::uom::batch` was used for both the initial check and the re-check, so an empty batch never matched an already-batched row → duplicate line, then assigned the same batch. Now: strict on the way in (falls through to allocation), flex on the re-check only while the probe has no batch.

**3. Avoid zeroed-totals flash when moving a merged row to top**
`moveItemToTop` composed `removeItemByRowId` + `addItem`. Removal recomputes totals immediately (without the row) while `addItem` debounces, so totals flashed the row missing — zero if it was the only row — for ~50ms per qty change, and the item was cloned. New `moveRowToTop` re-orders `itemOrder` in place, preserving identity and totals.

**4. Pass setBatchQty into the add-item context**
`shouldAutoSetBatch` bails on `!context?.setBatchQty` before reading the profile flag, and this context never carried a setter — so `posa_auto_set_batch` was **inert for every add from the selector**. No batch assigned on click, and `shouldAllocateAcrossBatches` stayed false, so the cross-batch split only ran when `qty > 1`. Clicking a batch item one unit at a time piled the whole quantity onto one batch, past what it holds (batches of 1 and 15, clicked 16× → one row of 16 on the 15 batch instead of 1 + 15). The allocation code was fine — just never reached. Supplying the setter (the same function `callSetBatchQty` already falls back to) opens the gate; `posa_auto_set_batch = 0` profiles are unaffected. Also fixes a `TypeError` when `showBatchDialog` runs for a return-without-invoice. Passes `flt`/`currency_precision` from `useFormat` too, so amounts round instead of leaving float tails (defensive — the cart display masks the tail today).

### Testing
Verified on a live v15 bench: customer-switch no longer resets stock; background sync no longer jumps; no duplicate batch rows; no totals flash; batch item of 1 + 15 clicked 16× yields the 1 + 15 split. `posa_auto_set_batch = 0` profiles unchanged. `vue-tsc --noEmit` clean, production build clean.

Supersedes #3114 and #3115 (closed).