### PR TITLE
fix(returns): allow cash refund on a returned credit invoice that was paid off

### DIFF
--- a/frontend/src/posapp/components/pos/Invoice.vue
+++ b/frontend/src/posapp/components/pos/Invoice.vue
@@ -1133,19 +1133,20 @@ export default {
 			this.invoiceType = "Return";
 			this.invoiceTypes = ["Return"];
 			this.invoice_doc.is_return = 1;
-			// Cap on cash refundable for this return = amount actually paid on the
-			// original invoice. 0 for an unpaid/credit invoice, so the payment screen
-			// defaults to no cash refund and the return becomes a credit note that
-			// reduces the customer's balance. Derived here so it covers every entry
-			// point that loads a return (returns dialog + invoice management).
+			// Cap on cash refundable for this return. The backend
+			// (get_invoice_for_return) computes it authoritatively as
+			// grand_total - outstanding - returns-already-issued; use that value.
+			// Covers every entry point that loads a return (returns dialog + invoice
+			// management). Falls back to grand - outstanding only if neither the
+			// carried value nor the backend field is present (e.g. older payload).
 			{
 				const od = data.invoice_doc || {};
 				const rd = data.return_doc || {};
 				let refundable =
 					od.posa_refundable_amount != null
 						? od.posa_refundable_amount
-						: rd.paid_amount != null
-							? rd.paid_amount
+						: rd.posa_refundable_amount != null
+							? rd.posa_refundable_amount
 							: (rd.grand_total || 0) - (rd.outstanding_amount || 0);
 				refundable = this.flt(refundable, this.currency_precision);
 				this.invoice_doc.posa_refundable_amount = refundable > 0 ? refundable : 0;

--- a/frontend/src/posapp/components/pos/flows/Returns.vue
+++ b/frontend/src/posapp/components/pos/flows/Returns.vue
@@ -801,16 +801,16 @@ export default {
 					invoice_doc.grand_total = return_doc.grand_total;
 				}
 
-				// Cap on how much of this return may be refunded as cash: only what
-				// the customer actually paid on the original invoice. For an unpaid
-				// (credit) invoice this is 0, so the return defaults to a credit note
-				// that reduces the customer's balance instead of paying out cash.
-				const originalPaid = this.flt(
-					return_doc.paid_amount != null
-						? return_doc.paid_amount
-						: (return_doc.grand_total || 0) - (return_doc.outstanding_amount || 0),
-					this.currency_precision,
-				);
+				// Cap on how much of this return may be refunded as cash. The backend
+				// (get_invoice_for_return) computes it authoritatively as
+				// grand_total - outstanding - returns-already-issued; use it directly
+				// so the rule lives in one place. Fall back to grand - outstanding only
+				// if the field is absent (e.g. an older cached payload).
+				const settled =
+					return_doc.posa_refundable_amount != null
+						? return_doc.posa_refundable_amount
+						: (return_doc.grand_total || 0) - (return_doc.outstanding_amount || 0);
+				const originalPaid = this.flt(settled, this.currency_precision);
 				invoice_doc.posa_refundable_amount = originalPaid > 0 ? originalPaid : 0;
 
 				// These fields ensure proper return handling

--- a/posawesome/posawesome/api/invoice_processing/creation.py
+++ b/posawesome/posawesome/api/invoice_processing/creation.py
@@ -1428,9 +1428,15 @@ def _guard_return_cash_refund(invoice_doc):
     if refund <= 0:
         return
 
-    original_paid = flt(
-        frappe.db.get_value(invoice_doc.doctype, return_against, "paid_amount")
+    # Cap the refund at the cash the customer can still get back on this original,
+    # computed by the single shared rule (see compute_original_refundable_cash):
+    # grand_total - outstanding_amount - returns already issued. NOT paid_amount,
+    # which stays 0 for a credit invoice settled later via a Payment Entry.
+    from posawesome.posawesome.api.invoice_processing.returns import (
+        compute_original_refundable_cash,
     )
+
+    original_paid = compute_original_refundable_cash(invoice_doc.doctype, return_against)
     tolerance = 1.0 / (10 ** (cint(invoice_doc.precision("paid_amount")) or 2))
     if refund > original_paid + tolerance:
         frappe.throw(

--- a/posawesome/posawesome/api/invoice_processing/returns.py
+++ b/posawesome/posawesome/api/invoice_processing/returns.py
@@ -218,6 +218,52 @@ def search_invoices_for_return(
     return result
 
 
+def compute_original_refundable_cash(doctype, invoice_name):
+    """Net cash still refundable on returns of an original invoice.
+
+    Formula: grand_total - outstanding_amount - |returns already issued|,
+    clamped to >= 0. This is the single source of truth used by both the
+    return-load endpoint (to cap the payment screen) and the submit guard.
+
+    Why not paid_amount: it only counts payments made through the invoice's own
+    payment table (POS-style). A credit (on-account) invoice settled later via a
+    Payment Entry keeps paid_amount = 0 while outstanding drops to 0, so it wrongly
+    reads as unpaid.
+
+    Why subtract prior returns: a return credit note ALSO reduces the original's
+    outstanding_amount, so `grand - outstanding` alone counts already-returned
+    value as if it were cash paid. That would let an UNPAID, partially-returned
+    invoice leak a cash refund on money the customer never paid. Subtracting the
+    returns already issued isolates real payments and, as a bonus, tracks the
+    remaining refundable balance across multiple partial returns.
+    """
+    original = (
+        frappe.db.get_value(
+            doctype,
+            invoice_name,
+            ["grand_total", "outstanding_amount"],
+            as_dict=True,
+        )
+        or {}
+    )
+    returned = frappe.get_all(
+        doctype,
+        filters={
+            "return_against": invoice_name,
+            "docstatus": 1,
+            "is_return": 1,
+        },
+        fields=["sum(grand_total) as total"],
+    )
+    returned_total = abs(flt(returned[0].get("total"))) if returned else 0.0
+    refundable = (
+        flt(original.get("grand_total"))
+        - flt(original.get("outstanding_amount"))
+        - returned_total
+    )
+    return refundable if refundable > 0 else 0.0
+
+
 @frappe.whitelist()
 def get_invoice_for_return(invoice_name, pos_profile=None, doctype="Sales Invoice"):
     """Return one invoice with returnable item quantities after past returns."""
@@ -235,6 +281,10 @@ def get_invoice_for_return(invoice_name, pos_profile=None, doctype="Sales Invoic
         # of a return may be refunded as cash vs. applied as a credit note.
         "outstanding_amount": flt(invoice_doc.get("outstanding_amount")),
         "paid_amount": flt(invoice_doc.get("paid_amount")),
+        # Authoritative cash-refund cap for this return. The frontend uses this
+        # directly instead of recomputing from paid_amount/outstanding, so the
+        # rule lives in one place (see compute_original_refundable_cash).
+        "posa_refundable_amount": compute_original_refundable_cash(doctype, invoice_name),
         "status": invoice_doc.get("status"),
         "total": invoice_doc.total,
         "net_total": invoice_doc.net_total,


### PR DESCRIPTION
Targeting `stage-develop` per the current contribution flow. Branched off latest `stage-develop`, two commits (backend rule + frontend consumption).

## The bug

A follow-up to the #3082 refund guard. That guard caps a return's cash refund at the original invoice's `paid_amount`. But `paid_amount` only counts payments made through the invoice's own payment table (POS-style). A credit (on-account / آجلة) invoice that the customer settles **later via a Payment Entry** keeps `paid_amount = 0` while `outstanding_amount` drops to 0 and status becomes `Paid`.

Result: the customer paid in full, returns an item, and the POS refuses any cash refund — forcing a credit note. The customer is now owed the returned amount but the system records it as store credit, effectively leaving them owing us. This was hit on a real, fully-paid credit invoice.

## Root cause — two flaws

1. **Wrong signal.** `paid_amount` misses external Payment-Entry settlements.
2. **Duplicated logic.** The cap was recomputed in three places — the backend guard, `Returns.vue`, and `Invoice.vue` — each with the same flaw. (The `Invoice.vue` copy is the one that actually runs for the invoice-management path.)

## The fix

A single shared backend rule, `compute_original_refundable_cash`:

```
refundable = grand_total - outstanding_amount - |returns already issued|   (clamped ≥ 0)
```

- `grand_total - outstanding` = money actually settled. Equals `paid_amount` for a POS cash sale; correctly reflects a credit invoice settled via a Payment Entry.
- **Subtracting prior returns is essential.** A return credit note *also* reduces the original's `outstanding_amount`, so `grand - outstanding` alone counts already-returned value as if it were cash paid — which would let an **unpaid, partially-returned** invoice leak a cash refund on money the customer never paid (directly undermining #3082). Verified against a real unpaid+partially-returned invoice: the naive formula gave a 2052 cap; this rule correctly gives 0. It also tracks the remaining refundable balance across multiple partial returns.

The guard and `get_invoice_for_return` both call this one function; `get_invoice_for_return` returns it as `posa_refundable_amount`, and the two frontend paths now use that value directly instead of recomputing (grand − outstanding kept only as a fallback for an older payload).

## Testing

Verified on a live v15 bench against real invoices:

| Original | State | Refundable cap | Cash refund |
| --- | --- | --- | --- |
| Credit, paid via Payment Entry | grand 2025, outstanding 0 | 2025 | allowed ✅ |
| Credit, never paid | grand 50, outstanding 50 | 0 | blocked → credit note ✅ |
| Credit, unpaid, partial return already issued | grand 13752, outstanding 11700 | **0** (naive would be 2052) | blocked ✅ |

`vue-tsc --noEmit` clean, production build clean, Python syntax verified.